### PR TITLE
[1.20] Add `failGitChanges` verification task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,11 @@ def extraTxts = [
     rootProject.tasks.createChangelog.outputFile
 ]
 
+tasks.register('failGitChanges', FailGitChanges) {
+    group = 'verification'
+    description = 'Fails the build if there are any uncommitted Git changes'
+}
+
 task downloadVersionManifest(type: Download) {
     src 'https://piston-meta.mojang.com/mc/game/version_manifest_v2.json'
     dest file('build/versions/version_manifest.json')

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/FailGitChanges.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/FailGitChanges.groovy
@@ -1,9 +1,11 @@
 package net.minecraftforge.forge.tasks
 
+import groovy.transform.CompileStatic
 import org.eclipse.jgit.api.Git
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
+@CompileStatic
 abstract class FailGitChanges extends DefaultTask {
     @TaskAction
     void run() {

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/FailGitChanges.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/FailGitChanges.groovy
@@ -1,0 +1,19 @@
+package net.minecraftforge.forge.tasks
+
+import org.eclipse.jgit.api.Git
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+abstract class FailGitChanges extends DefaultTask {
+    @TaskAction
+    void run() {
+        try (var git = Git.open(project.rootProject.rootDir)) {
+            var statusResult = git.status().call()
+            if (statusResult.hasUncommittedChanges()) {
+                git.add().addFilepattern('.').call()
+                git.diff().setCached(true).setOutputStream(System.out).call()
+                throw new IllegalStateException("Uncommitted changes found: ${statusResult.uncommittedChanges}")
+            }
+        }
+    }
+}


### PR DESCRIPTION
This task will make it easier to implement a TeamCity PR check that will fail the build if patching artifacts are found after running `gradlew setup genPatches`.