### PR TITLE
[1.20.x] Pull `onInventoryTick` from MCF/1.20.x

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -19,26 +19,19 @@
           if (p_36049_.m_41782_()) {
              itemstack.m_41751_(p_36049_.m_41783_().m_6426_());
           }
-@@ -225,11 +_,17 @@
+@@ -223,9 +_,11 @@
+ 
+    public void m_36068_() {
        for(NonNullList<ItemStack> nonnulllist : this.f_35979_) {
++         var id = net.minecraftforge.common.context.InventoryTickContext.PlayerInvContext.getCompartmentId(this, nonnulllist);
           for(int i = 0; i < nonnulllist.size(); ++i) {
              if (!nonnulllist.get(i).m_41619_()) {
 -               nonnulllist.get(i).m_41666_(this.f_35978_.m_9236_(), this.f_35978_, i, this.f_35977_ == i);
-+               var itemsId = net.minecraftforge.common.extensions.IForgeItem.PLAYER_ITEMS;
-+               var armorId = net.minecraftforge.common.extensions.IForgeItem.PLAYER_ARMOR;
-+               var offhandId = net.minecraftforge.common.extensions.IForgeItem.PLAYER_OFFHAND;
-+               var compartmentId = nonnulllist == this.f_35974_ ? itemsId : nonnulllist == this.f_35975_ ? armorId : offhandId;
-+               int selected = nonnulllist == this.f_35974_ ? this.f_35977_ : -1;
-+               nonnulllist.get(i).inventoryTick(this.f_35978_.m_9236_(), this.f_35978_, nonnulllist, i, compartmentId, selected);
++               var ctx = net.minecraftforge.common.context.InventoryTickContext.PlayerInvContext.create(this, nonnulllist, id, i, this.f_35977_);
++               nonnulllist.get(i).inventoryTick(this.f_35978_.m_9236_(), ctx);
              }
           }
        }
--
-+      // TODO: Remove in 1.20.2+
-+      f_35975_.forEach(e -> e.onArmorTick(f_35978_.m_9236_(), f_35978_));
-    }
- 
-    public boolean m_36054_(ItemStack p_36055_) {
 @@ -277,6 +_,8 @@
           } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.m_127521_(throwable, "Adding item to inventory");

--- a/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Inventory.java.patch
@@ -19,11 +19,22 @@
           if (p_36049_.m_41782_()) {
              itemstack.m_41751_(p_36049_.m_41783_().m_6426_());
           }
-@@ -229,7 +_,7 @@
+@@ -225,11 +_,17 @@
+       for(NonNullList<ItemStack> nonnulllist : this.f_35979_) {
+          for(int i = 0; i < nonnulllist.size(); ++i) {
+             if (!nonnulllist.get(i).m_41619_()) {
+-               nonnulllist.get(i).m_41666_(this.f_35978_.m_9236_(), this.f_35978_, i, this.f_35977_ == i);
++               var itemsId = net.minecraftforge.common.extensions.IForgeItem.PLAYER_ITEMS;
++               var armorId = net.minecraftforge.common.extensions.IForgeItem.PLAYER_ARMOR;
++               var offhandId = net.minecraftforge.common.extensions.IForgeItem.PLAYER_OFFHAND;
++               var compartmentId = nonnulllist == this.f_35974_ ? itemsId : nonnulllist == this.f_35975_ ? armorId : offhandId;
++               int selected = nonnulllist == this.f_35974_ ? this.f_35977_ : -1;
++               nonnulllist.get(i).inventoryTick(this.f_35978_.m_9236_(), this.f_35978_, nonnulllist, i, compartmentId, selected);
              }
           }
        }
 -
++      // TODO: Remove in 1.20.2+
 +      f_35975_.forEach(e -> e.onArmorTick(f_35978_.m_9236_(), f_35978_));
     }
  

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -72,7 +72,7 @@
        return Mth.m_14169_(f / 3.0F, 1.0F, 1.0F);
     }
  
-@@ -229,14 +_,17 @@
+@@ -229,14 +_,20 @@
     }
  
     @Nullable
@@ -86,7 +86,10 @@
        return this.f_41378_ != null;
     }
  
-+   @Deprecated // Neo: Use IForgeItem#inventoryTick(ItemStack, Level, Entity, NonNullList, int, ResourceLocation, int)
++   /**
++    * @deprecated Use {@link net.minecraftforge.common.extensions.IForgeItem#inventoryTick} instead.
++    */
++   @Deprecated(since = "1.20.1")
     public void m_6883_(ItemStack p_41404_, Level p_41405_, Entity p_41406_, int p_41407_, boolean p_41408_) {
     }
  

--- a/patches/minecraft/net/minecraft/world/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/Item.java.patch
@@ -72,7 +72,7 @@
        return Mth.m_14169_(f / 3.0F, 1.0F, 1.0F);
     }
  
-@@ -229,10 +_,12 @@
+@@ -229,14 +_,17 @@
     }
  
     @Nullable
@@ -85,6 +85,11 @@
     public boolean m_41470_() {
        return this.f_41378_ != null;
     }
+ 
++   @Deprecated // Neo: Use IForgeItem#inventoryTick(ItemStack, Level, Entity, NonNullList, int, ResourceLocation, int)
+    public void m_6883_(ItemStack p_41404_, Level p_41405_, Entity p_41406_, int p_41407_, boolean p_41408_) {
+    }
+ 
 @@ -253,7 +_,7 @@
  
     public int m_8105_(ItemStack p_41454_) {

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -192,11 +192,14 @@
        }
     }
  
-@@ -442,6 +_,7 @@
+@@ -442,6 +_,10 @@
        return this.m_41613_() + " " + this.m_41720_();
     }
  
-+   @Deprecated // Neo: Use IForgeItemStack#inventoryTick(Level, Entity, NonNullList, int, ResourceLocation, int)
++   /**
++    * @deprecated Use {@link net.minecraftforge.common.extensions.IForgeItemStack#inventoryTick} instead.
++    */
++   @Deprecated(since = "1.20.1")
     public void m_41666_(Level p_41667_, Entity p_41668_, int p_41669_, boolean p_41670_) {
        if (this.f_41588_ > 0) {
           --this.f_41588_;

--- a/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/ItemStack.java.patch
@@ -192,6 +192,14 @@
        }
     }
  
+@@ -442,6 +_,7 @@
+       return this.m_41613_() + " " + this.m_41720_();
+    }
+ 
++   @Deprecated // Neo: Use IForgeItemStack#inventoryTick(Level, Entity, NonNullList, int, ResourceLocation, int)
+    public void m_41666_(Level p_41667_, Entity p_41668_, int p_41669_, boolean p_41670_) {
+       if (this.f_41588_ > 0) {
+          --this.f_41588_;
 @@ -522,7 +_,7 @@
  
     public void m_41751_(@Nullable CompoundTag p_41752_) {

--- a/src/main/java/net/minecraftforge/common/context/ContextKey.java
+++ b/src/main/java/net/minecraftforge/common/context/ContextKey.java
@@ -1,0 +1,126 @@
+package net.minecraftforge.common.context;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.google.common.collect.MapMaker;
+
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * A Context Key is a key used when passing arbitrary context to a method.<br>
+ * It retains the ability to cast the underlying context Object to the target type.
+ * 
+ * @param <T> The type of the target context object.
+ */
+public final class ContextKey<T>
+{
+    private static final ConcurrentMap<InternKey<?>, ContextKey<?>> VALUES = new MapMaker().weakValues().makeMap();
+
+    private final ResourceLocation location;
+    private final Class<T> clazz;
+
+    /**
+     * Gets a context key, creating it if it does not exist. Created keys are interned and reference (==) comparable.
+     * 
+     * @param <T>      The type of the underlying context object.
+     * @param location The ID of the context key.
+     * @param clazz    The class of the underlying context object.
+     * @return An interned context key.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> ContextKey<T> getOrCreate(ResourceLocation location, Class<T> clazz)
+    {
+        return (ContextKey<T>) VALUES.computeIfAbsent(new InternKey<>(location, clazz), ContextKey::new);
+    }
+
+    private ContextKey(InternKey<T> key)
+    {
+        this.location = key.location;
+        this.clazz = key.clazz;
+    }
+
+    /**
+     * Creates a {@link Context} object with this key and the specified value.
+     */
+    public <V extends T> ContextKey.Context<T, V> createCtx(V ctx)
+    {
+        return new Context<>(this, ctx);
+    }
+
+    public ResourceLocation location()
+    {
+        return this.location;
+    }
+
+    private T cast(Object o)
+    {
+        return this.clazz.cast(o);
+    }
+
+    /**
+     * ContextKey is interned and thus reference comparable, so additional logic is unnecessary.
+     */
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this;
+    }
+
+    private static record InternKey<T>(ResourceLocation location, Class<T> clazz)
+    {
+    }
+
+    /**
+     * Bundled {@link ContextKey} and associated context object.
+     * <p>
+     * The generics on this class are intended for construction time type-safety, even though the receiver will have both erased to a wildcard.
+     * <p>
+     * The intended usage for the receiver side is as follows:
+     * <p>
+     * <code><pre>
+     * MyContext myCtx = context.getContext(MY_CONTEXT_KEY); 
+     * if (myCtx != null)
+     * { 
+     *     doThings(myCtx); 
+     * }
+     * </pre></code>
+     * 
+     * @param <K> Type of the ContextKey.
+     * @param <V> Type of the context object, which may be a subclass of K.
+     */
+    public static record Context<K, V extends K>(ContextKey<K> key, V ctx)
+    {
+        /**
+         * Performs an operation on the context object if it is the specified type.
+         */
+        public <C> void ifPresent(ContextKey<C> key, Consumer<C> consumer)
+        {
+            if (this.key == key)
+            {
+                consumer.accept(key.cast(this.ctx));
+            }
+        }
+
+        /**
+         * @return The context if it is the specified type, otherwise returns null.
+         */
+        @Nullable
+        public <C> C get(ContextKey<C> key)
+        {
+            return this.key == key ? key.cast(this.ctx) : null;
+        }
+
+        /**
+         * @return An {@link Optional} containing the context if it is the specified type, otherwise returns {@link Optional#empty()}.
+         */
+        public <C> Optional<C> getOptional(ContextKey<C> key)
+        {
+            return Optional.ofNullable(get(key));
+        }
+    }
+
+}

--- a/src/main/java/net/minecraftforge/common/context/InventoryTickContext.java
+++ b/src/main/java/net/minecraftforge/common/context/InventoryTickContext.java
@@ -1,0 +1,108 @@
+package net.minecraftforge.common.context;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.extensions.IForgeItem;
+
+public class InventoryTickContext
+{
+
+    public static final ContextKey<PlayerInvContext> KEY = ContextKey.getOrCreate(new ResourceLocation("forge", "player_inv"), PlayerInvContext.class);
+
+    /**
+     * Implementing this on a context object passed to {@link IForgeItem#inventoryTick} will cause the vanilla {@link Item#inventoryTick(ItemStack, Level, Entity, int, boolean)} to be called.
+     */
+    public static interface VanillaCompatible
+    {
+        /**
+         * The entity that owns the inventory.
+         */
+        Entity getEntity();
+
+        /**
+         * The slot of the compartment being ticked (not the global slot index)
+         */
+        int getSlot();
+
+        /**
+         * If the current slot is the selected hotbar slot.
+         */
+        boolean isSelected();
+    }
+
+    /**
+     * Additional Player Inventory Context for use in {@link IForgeItem#inventoryTick}.
+     * 
+     * @param player      The player whose inventory is being ticked.
+     * @param compartment The inventory compartment being ticked.
+     * @param invId       The name of the player inventory compartment being ticked. See the static fields in this class.
+     * @param slot        The slot in the compartment where the current item is.
+     * @param selected    If the compartment is {@link #PLAYER_ITEMS}, this is the index of the selected hotbar slot, otherwise -1.
+     */
+    public static record PlayerInvContext(Player player, NonNullList<ItemStack> compartment, ResourceLocation invId, int slot, int selected) implements VanillaCompatible
+    {
+
+        /**
+         * Compartment ID for the player main inventory.
+         * 
+         * @see Inventory#items
+         */
+        public static final ResourceLocation PLAYER_ITEMS = new ResourceLocation("items");
+
+        /**
+         * Compartment ID for the player armor inventory.
+         * 
+         * @see Inventory#armor
+         */
+        public static final ResourceLocation PLAYER_ARMOR = new ResourceLocation("armor");
+
+        /**
+         * Compartment ID for the player offhand inventory.
+         * 
+         * @see Inventory#offhand
+         */
+        public static final ResourceLocation PLAYER_OFFHAND = new ResourceLocation("offhand");
+
+        @Override
+        public Entity getEntity()
+        {
+            return this.player;
+        }
+
+        @Override
+        public int getSlot()
+        {
+            return this.slot;
+        }
+
+        @Override
+        public boolean isSelected()
+        {
+            return this.slot == this.selected;
+        }
+
+        /**
+         * This is in a separate method so it is only invoked once per compartment instead of once per slot.
+         */
+        @ApiStatus.Internal
+        public static ResourceLocation getCompartmentId(Inventory inv, NonNullList<ItemStack> compartment)
+        {
+            return compartment == inv.items ? PLAYER_ITEMS : compartment == inv.armor ? PLAYER_ARMOR : PLAYER_OFFHAND;
+        }
+
+        @ApiStatus.Internal
+        public static final ContextKey.Context<PlayerInvContext, PlayerInvContext> create(Inventory inv, NonNullList<ItemStack> compartment, ResourceLocation id, int slot, int selected)
+        {
+            return KEY.createCtx(new PlayerInvContext(inv.player, compartment, id, slot, compartment == inv.items ? selected : -1));
+        }
+    }
+
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -330,8 +330,26 @@ public interface IForgeItem
     /**
      * Called to tick armor in the armor slot. Override to do something
      */
+    @Deprecated(forRemoval = true, since = "1.20.1") // Use onInventoryTick
     default void onArmorTick(ItemStack stack, Level level, Player player)
     {
+    }
+
+    /**
+     * Called to tick this items in a players inventory, the indexes are the global slot index.
+     */
+    default void onInventoryTick(ItemStack stack, Level level, Player player, int slotIndex, int selectedIndex)
+    {
+    	// For compatibility reasons we have to use non-local index values, I think this is a vanilla bug but lets maintain compatibility
+    	int vanillaIndex = slotIndex;
+    	if (slotIndex >= 36) {
+    		vanillaIndex -= 36;
+    		if (vanillaIndex >= 4)
+    			vanillaIndex -= 4;
+			else
+				onArmorTick(stack, level, player);
+    	}
+		stack.inventoryTick(level, player, vanillaIndex, selectedIndex == vanillaIndex);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -36,6 +36,9 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.context.ContextKey;
+import net.minecraftforge.items.IItemHandler;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -292,20 +295,20 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Called to tick armor in the armor slot. Override to do something
+     * @deprecated Use {@link #inventoryTick(Level, ContextKey.Context)}
      */
-    @Deprecated(forRemoval = true, since = "1.20.1") // Use onInventoryTick
+    @Deprecated(forRemoval = true, since = "1.20.1")
     default void onArmorTick(Level level, Player player)
     {
         self().getItem().onArmorTick(self(), level, player);
     }
 
     /**
-     * @see {@link IForgeItem#inventoryTick(ItemStack, Level, Entity, NonNullList, int, ResourceLocation, int)}
+     * @see {@link IForgeItem#inventoryTick(ItemStack, Level, ContextKey.Context)}
      */
-    default void inventoryTick(Level level, Entity entity, NonNullList<ItemStack> compartment, int slotIndex, ResourceLocation compartmentId, int selectedIndex)
+    default void inventoryTick(Level level, ContextKey.Context<?, ?> context)
     {
-    	self().getItem().inventoryTick(self(), level, entity, compartment, slotIndex, compartmentId, selectedIndex);
+    	self().getItem().inventoryTick(self(), level, context);
     }
 
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -29,7 +29,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
@@ -299,11 +301,11 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Called to tick this items in a players inventory, the indexes are the global slot index.
+     * @see {@link IForgeItem#inventoryTick(ItemStack, Level, Entity, NonNullList, int, ResourceLocation, int)}
      */
-    default void onInventoryTick(Level level, Player player, int slotIndex, int selectedIndex)
+    default void inventoryTick(Level level, Entity entity, NonNullList<ItemStack> compartment, int slotIndex, ResourceLocation compartmentId, int selectedIndex)
     {
-    	self().getItem().onInventoryTick(self(), level, player, slotIndex, selectedIndex);
+    	self().getItem().inventoryTick(self(), level, entity, compartment, slotIndex, compartmentId, selectedIndex);
     }
 
 

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -292,10 +292,20 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     /**
      * Called to tick armor in the armor slot. Override to do something
      */
+    @Deprecated(forRemoval = true, since = "1.20.1") // Use onInventoryTick
     default void onArmorTick(Level level, Player player)
     {
         self().getItem().onArmorTick(self(), level, player);
     }
+
+    /**
+     * Called to tick this items in a players inventory, the indexes are the global slot index.
+     */
+    default void onInventoryTick(Level level, Player player, int slotIndex, int selectedIndex)
+    {
+    	self().getItem().onInventoryTick(self(), level, player, slotIndex, selectedIndex);
+    }
+
 
     /**
      * Called every tick from {@code Horse#playGallopSound(SoundEvent)} on the item in the


### PR DESCRIPTION
This PR is a subset of #14 which deals explicitly with https://github.com/MinecraftForge/MinecraftForge/pull/9453

The initial synopsis is that this new method would be DOA - it has to be deprecated for removal since the vanilla bug can be fixed in the next BC window, and the patch which would hook it up is absent.

However, that does not mean this has no merit or that it could not be improved. A better version of this hook can involve passing three additional parameters: The "compartment" list, the index within that list, and the name of that list.

This addition of parameters would allow items to identify which inventory they are in, as well as allowing mods which tick items (such as [Curios](https://github.com/TheIllusiveC4/Curios/blob/1.20.x/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java#L549)) to provide relevant information, instead of index -1 and no context.

This PR will be updated to include such an expansion, and as such will end up as a deviation from MCF upstream.