### PR TITLE
[1.20.x] Pull `EntityEvent$Size` changes from MCF/1.20.x

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -604,7 +604,7 @@
     public float m_274421_() {
        return this.f_19793_;
     }
-@@ -3319,6 +_,103 @@
+@@ -3319,6 +_,111 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -701,6 +701,14 @@
 +   @Override
 +   public net.minecraftforge.fluids.FluidType getMaxHeightFluidType() {
 +      return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.minecraftforge.common.ForgeMod.EMPTY_TYPE);
++   }
++
++   public EntityDimensions getDimensionsForge(Pose pose) {
++       EntityDimensions size = m_6972_(pose);
++       if (size == null) size = this.f_19815_; // this is called in the entity constructor so it is possible that subclasses are not initalized and dont return anything here. Souse the default.
++       var evt = new net.minecraftforge.event.entity.EntityEvent.Size(this, pose, size);
++       net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
++       return evt.getNewSize();
 +   }
 +
 +   /* ================================== Forge End =====================================*/

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -436,7 +436,7 @@
     }
  
 +   /**
-+    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntitySize)} instead.
++    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntityDimensions)} instead.
 +    */
 +   @Deprecated
     protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -649,7 +649,7 @@
 +   /**
 +    * Accessor method for {@link #getEyeHeight(Pose, EntityDimensions)}
 +    */
-+   public final float getEyeHeightAccess(Pose pose, EntityDimensions size) {
++   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
 +   }
 +

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -146,7 +146,7 @@
        this.m_5496_(soundtype.m_56776_(), soundtype.m_56773_() * 0.15F, soundtype.m_56774_());
     }
  
-@@ -1176,19 +_,22 @@
+@@ -1176,31 +_,38 @@
  
     public void m_5844_() {
        if (this.m_6069_()) {
@@ -174,6 +174,24 @@
     }
  
     void m_20074_() {
+       Entity entity = this.m_20202_();
++      java.util.function.BooleanSupplier updateFluidHeight = () -> this.m_204031_(FluidTags.f_13131_, 0.014D);
+       if (entity instanceof Boat boat) {
+          if (!boat.m_5842_()) {
+             this.f_19798_ = false;
+-            return;
++            updateFluidHeight = () -> {
++               this.updateFluidHeightAndDoFluidPushing(state -> this.shouldUpdateFluidWhileBoating(state, boat));
++               return false;
++            };
+          }
+       }
+ 
+-      if (this.m_204031_(FluidTags.f_13131_, 0.014D)) {
++      if (updateFluidHeight.getAsBoolean()) {
+          if (!this.f_19798_ && !this.f_19803_) {
+             this.m_5841_();
+          }
 @@ -1217,6 +_,7 @@
     private void m_20323_() {
        this.f_19800_ = this.m_204029_(FluidTags.f_13131_);
@@ -449,11 +467,11 @@
     }
  
     public final float m_20192_() {
-@@ -2980,9 +_,17 @@
+@@ -2980,9 +_,22 @@
        this.f_19859_ = this.m_146908_();
     }
  
-+   @Deprecated // Forge: Use no parameter version instead, only for vanilla Tags
++   @Deprecated // Forge: Use predicate version instead, only for vanilla Tags
     public boolean m_204031_(TagKey<Fluid> p_204032_, double p_204033_) {
 +      this.updateFluidHeightAndDoFluidPushing();
 +      if(p_204032_ == FluidTags.f_13131_) return this.isInFluidType(net.minecraftforge.common.ForgeMod.WATER_TYPE.get());
@@ -461,7 +479,12 @@
 +      else return false;
 +   }
 +
++   @Deprecated(forRemoval = true, since = "1.20.1")
 +   public void updateFluidHeightAndDoFluidPushing() {
++      this.updateFluidHeightAndDoFluidPushing(com.google.common.base.Predicates.alwaysTrue());
++   }
++
++   public void updateFluidHeightAndDoFluidPushing(Predicate<FluidState> shouldUpdate) {
        if (this.m_146899_()) {
 -         return false;
 +         return;
@@ -481,7 +504,7 @@
                    FluidState fluidstate = this.m_9236_().m_6425_(blockpos$mutableblockpos);
 -                  if (fluidstate.m_205070_(p_204032_)) {
 +                  net.minecraftforge.fluids.FluidType fluidType = fluidstate.getFluidType();
-+                  if (!fluidType.isAir()) {
++                  if (!fluidType.isAir() && shouldUpdate.test(fluidstate)) {
                       double d1 = (double)((float)i2 + fluidstate.m_76155_(this.m_9236_(), blockpos$mutableblockpos));
                       if (d1 >= aabb.f_82289_) {
                          flag1 = true;

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -36,14 +36,13 @@
        this.f_19847_ = p_19870_;
        this.f_19853_ = p_19871_;
        this.f_19815_ = p_19870_.m_20680_();
-@@ -254,7 +_,11 @@
+@@ -254,7 +_,10 @@
        this.f_19804_.m_135372_(f_146800_, 0);
        this.m_8097_();
        this.m_6034_(0.0D, 0.0D, 0.0D);
 -      this.f_19816_ = this.m_6380_(Pose.STANDING, this.f_19815_);
-+      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, Pose.STANDING, this.f_19815_, this.m_6380_(Pose.STANDING, this.f_19815_));
-+      this.f_19815_ = sizeEvent.getNewSize();
-+      this.f_19816_ = sizeEvent.getNewEyeHeight();
++      this.f_19815_ = this.getDimensionsForge(Pose.STANDING);
++      this.f_19816_ = this.getEyeHeightForge(Pose.STANDING, this.f_19815_);
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
 +      this.gatherCapabilities();
     }
@@ -373,6 +372,15 @@
           }
        } else {
           return null;
+@@ -2489,7 +_,7 @@
+    }
+ 
+    protected Vec3 m_7643_(Direction.Axis p_20045_, BlockUtil.FoundRectangle p_20046_) {
+-      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.m_6972_(this.m_20089_()));
++      return PortalShape.m_77738_(p_20046_, p_20045_, this.m_20182_(), this.getDimensionsForge(this.m_20089_()));
+    }
+ 
+    protected Optional<BlockUtil.FoundRectangle> m_183318_(ServerLevel p_185935_, BlockPos p_185936_, boolean p_185937_, WorldBorder p_185938_) {
 @@ -2557,6 +_,7 @@
        return this.f_19821_;
     }
@@ -381,15 +389,25 @@
     public boolean m_6063_() {
        return true;
     }
-@@ -2679,8 +_,10 @@
+@@ -2670,17 +_,17 @@
+    @Deprecated
+    protected void m_252801_() {
+       Pose pose = this.m_20089_();
+-      EntityDimensions entitydimensions = this.m_6972_(pose);
++      EntityDimensions entitydimensions = this.getDimensionsForge(pose);
+       this.f_19815_ = entitydimensions;
+-      this.f_19816_ = this.m_6380_(pose, entitydimensions);
++      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions);
+    }
+ 
+    public void m_6210_() {
        EntityDimensions entitydimensions = this.f_19815_;
        Pose pose = this.m_20089_();
-       EntityDimensions entitydimensions1 = this.m_6972_(pose);
-+      net.minecraftforge.event.entity.EntityEvent.Size sizeEvent = net.minecraftforge.event.ForgeEventFactory.getEntitySizeForge(this, pose, entitydimensions, entitydimensions1, this.m_6380_(pose, entitydimensions1));
-+      entitydimensions1 = sizeEvent.getNewSize();
+-      EntityDimensions entitydimensions1 = this.m_6972_(pose);
++      EntityDimensions entitydimensions1 = this.getDimensionsForge(pose);
        this.f_19815_ = entitydimensions1;
 -      this.f_19816_ = this.m_6380_(pose, entitydimensions1);
-+      this.f_19816_ = sizeEvent.getNewEyeHeight();
++      this.f_19816_ = this.getEyeHeightForge(pose, entitydimensions1);
        this.m_20090_();
        boolean flag = (double)entitydimensions1.f_20377_ <= 4.0D && (double)entitydimensions1.f_20378_ <= 4.0D;
        if (!this.m_9236_().f_46443_ && !this.f_19803_ && !this.f_19794_ && flag && (entitydimensions1.f_20377_ > entitydimensions.f_20377_ || entitydimensions1.f_20378_ > entitydimensions.f_20378_) && !(this instanceof Player)) {
@@ -404,6 +422,33 @@
           });
        }
  
+@@ -2720,7 +_,7 @@
+    }
+ 
+    protected AABB m_20217_(Pose p_20218_) {
+-      EntityDimensions entitydimensions = this.m_6972_(p_20218_);
++      EntityDimensions entitydimensions = this.getDimensionsForge(p_20218_);
+       float f = entitydimensions.f_20377_ / 2.0F;
+       Vec3 vec3 = new Vec3(this.m_20185_() - (double)f, this.m_20186_(), this.m_20189_() - (double)f);
+       Vec3 vec31 = new Vec3(this.m_20185_() + (double)f, this.m_20186_() + (double)entitydimensions.f_20378_, this.m_20189_() + (double)f);
+@@ -2731,12 +_,16 @@
+       this.f_19828_ = p_20012_;
+    }
+ 
++   /**
++    * @deprecated Can be overridden. Use {@link #getEyeHeightForge(Pose, EntitySize)} instead.
++    */
++   @Deprecated
+    protected float m_6380_(Pose p_19976_, EntityDimensions p_19977_) {
+       return p_19977_.f_20378_ * 0.85F;
+    }
+ 
+    public float m_20236_(Pose p_20237_) {
+-      return this.m_6380_(p_20237_, this.m_6972_(p_20237_));
++      return this.getEyeHeightForge(p_20237_, this.getDimensionsForge(p_20237_));
+    }
+ 
+    public final float m_20192_() {
 @@ -2980,9 +_,17 @@
        this.f_19859_ = this.m_146908_();
     }
@@ -509,6 +554,17 @@
        return this.f_19799_.getDouble(p_204037_);
     }
  
+@@ -3080,6 +_,10 @@
+       return new ClientboundAddEntityPacket(this);
+    }
+ 
++   /**
++    * @deprecated Can be overridden. Use {@link #getDimensionsForge(Pose)} instead.
++    */
++   @Deprecated
+    public EntityDimensions m_6972_(Pose p_19975_) {
+       return this.f_19847_.m_20680_();
+    }
 @@ -3192,6 +_,7 @@
  
           this.f_146801_.m_142044_();
@@ -593,7 +649,7 @@
 +   /**
 +    * Accessor method for {@link #getEyeHeight(Pose, EntityDimensions)}
 +    */
-+   public float getEyeHeightAccess(Pose pose, EntityDimensions size) {
++   public final float getEyeHeightAccess(Pose pose, EntityDimensions size) {
 +      return this.m_6380_(pose, size);
 +   }
 +

--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -705,8 +705,8 @@
 +
 +   public EntityDimensions getDimensionsForge(Pose pose) {
 +       EntityDimensions size = m_6972_(pose);
-+       if (size == null) size = this.f_19815_; // this is called in the entity constructor so it is possible that subclasses are not initalized and dont return anything here. Souse the default.
-+       var evt = new net.minecraftforge.event.entity.EntityEvent.Size(this, pose, size);
++       if (size == null) size = this.f_19815_; // this is called in the entity constructor so it is possible that subclasses are not initalized and dont return anything here. So use the default.
++       var evt = new net.minecraftforge.event.entity.EntityEvent.Size(this, pose, size, this.m_6380_(pose, size));
 +       net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
 +       return evt.getNewSize();
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -659,15 +659,7 @@
     }
  
     public boolean m_5830_() {
-@@ -3187,11 +_,14 @@
-    }
- 
-    protected float m_6431_(Pose p_21131_, EntityDimensions p_21132_) {
--      return super.m_6380_(p_21131_, p_21132_);
-+       float eyeHeight = super.m_6380_(p_21131_, p_21132_);
-+       var evt = new net.minecraftforge.event.entity.EntityEvent.EyeHeight(self(), p_21131_, p_21132_, eyeHeight);
-+       net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
-+       return evt.getNewEyeHeight();
+@@ -3191,7 +_,7 @@
     }
  
     public ItemStack m_6298_(ItemStack p_21272_) {

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -659,12 +659,15 @@
     }
  
     public boolean m_5830_() {
-@@ -3187,11 +_,11 @@
+@@ -3187,11 +_,14 @@
     }
  
     protected float m_6431_(Pose p_21131_, EntityDimensions p_21132_) {
 -      return super.m_6380_(p_21131_, p_21132_);
-+      return this.getEyeHeightForge(p_21131_, p_21132_);
++       float eyeHeight = super.m_6380_(p_21131_, p_21132_);
++       var evt = new net.minecraftforge.event.entity.EntityEvent.EyeHeight(self(), p_21131_, p_21132_, eyeHeight);
++       net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt);
++       return evt.getNewEyeHeight();
     }
  
     public ItemStack m_6298_(ItemStack p_21272_) {

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -659,7 +659,12 @@
     }
  
     public boolean m_5830_() {
-@@ -3191,7 +_,7 @@
+@@ -3187,11 +_,11 @@
+    }
+ 
+    protected float m_6431_(Pose p_21131_, EntityDimensions p_21132_) {
+-      return super.m_6380_(p_21131_, p_21132_);
++      return this.getEyeHeightForge(p_21131_, p_21132_);
     }
  
     public ItemStack m_6298_(ItemStack p_21272_) {

--- a/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/portal/PortalShape.java.patch
@@ -9,3 +9,12 @@
     };
     private static final float f_256985_ = 4.0F;
     private static final double f_256802_ = 1.0D;
+@@ -207,7 +_,7 @@
+       Direction.Axis direction$axis = blockstate.m_61145_(BlockStateProperties.f_61364_).orElse(Direction.Axis.X);
+       double d0 = (double)p_259931_.f_124349_;
+       double d1 = (double)p_259931_.f_124350_;
+-      EntityDimensions entitydimensions = p_259166_.m_6972_(p_259166_.m_20089_());
++      EntityDimensions entitydimensions = p_259166_.getDimensionsForge(p_259166_.m_20089_());
+       int i = p_259901_ == direction$axis ? 0 : 90;
+       Vec3 vec3 = p_259901_ == direction$axis ? p_260043_ : new Vec3(p_260043_.f_82481_, p_260043_.f_82480_, -p_260043_.f_82479_);
+       double d2 = (double)entitydimensions.f_20377_ / 2.0D + (d0 - (double)entitydimensions.f_20377_) * p_259630_.m_7096_();

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBoat.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBoat.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.common.extensions;
 
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.fluids.FluidType;
@@ -36,5 +37,18 @@ public interface IForgeBoat
     default boolean canBoatInFluid(FluidType type)
     {
         return type.supportsBoating(self());
+    }
+
+    /**
+     * When {@code false}, the fluid will no longer update its height value while
+     * within a boat while it is not within a fluid ({@link Boat#isUnderWater()}.
+     *
+     * @param state the state of the fluid the rider is within
+     * @param rider the rider of the boat
+     * @return {@code true} if the fluid height should be updated, {@code false} otherwise
+     */
+    default boolean shouldUpdateFluidWhileRiding(FluidState state, Entity rider)
+    {
+        return state.shouldUpdateWhileBoating(self(), rider);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -13,6 +13,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
@@ -443,5 +444,18 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
         EntityEvent.EyeHeight evt = new EntityEvent.EyeHeight(self(), pose, size, eyeHeight);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt.getNewEyeHeight();
+    }
+
+    /**
+     * When {@code false}, the fluid will no longer update its height value while
+     * within a boat while it is not within a fluid ({@link Boat#isUnderWater()}.
+     *
+     * @param state the state of the fluid the rider is within
+     * @param boat the boat the rider is within that is not inside a fluid
+     * @return {@code true} if the fluid height should be updated, {@code false} otherwise
+     */
+    default boolean shouldUpdateFluidWhileBoating(FluidState state, Boat boat)
+    {
+        return boat.shouldUpdateFluidWhileRiding(state, self());
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -16,7 +16,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.SpawnEggItem;
 import net.minecraft.world.item.ItemStack;
@@ -26,9 +28,11 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.ForgeSpawnEggItem;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.SoundAction;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.entity.PartEntity;
+import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.fluids.FluidType;
 import org.jetbrains.annotations.Nullable;
 
@@ -423,5 +427,21 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
     default boolean hasCustomOutlineRendering(Player player)
     {
         return false;
+    }
+
+    default EntityDimensions getDimensionsForge(Pose pose)
+    {
+        EntityDimensions size = self().getDimensions(pose);
+        EntityEvent.Size evt = new EntityEvent.Size(self(), pose, size);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getNewSize();
+    }
+
+    default float getEyeHeightForge(Pose pose, EntityDimensions size)
+    {
+        float eyeHeight = self().getEyeHeightAccess(pose, size);
+        EntityEvent.EyeHeight evt = new EntityEvent.EyeHeight(self(), pose, size, eyeHeight);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getNewEyeHeight();
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -430,14 +430,6 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
         return false;
     }
 
-    default EntityDimensions getDimensionsForge(Pose pose)
-    {
-        EntityDimensions size = self().getDimensions(pose);
-        EntityEvent.Size evt = new EntityEvent.Size(self(), pose, size);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt.getNewSize();
-    }
-
     default float getEyeHeightForge(Pose pose, EntityDimensions size)
     {
         float eyeHeight = self().getEyeHeightAccess(pose, size);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluid.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluid.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.vehicle.Boat;
@@ -92,6 +93,20 @@ public interface IForgeFluid
     default boolean supportsBoating(FluidState state, Boat boat)
     {
         return getFluidType().supportsBoating(state, boat);
+    }
+
+    /**
+     * When {@code false}, the fluid will no longer update its height value while
+     * within a boat while it is not within a fluid ({@link Boat#isUnderWater()}.
+     *
+     * @param state the state of the fluid the rider is within
+     * @param boat the boat the rider is within that is not inside a fluid
+     * @param rider the rider of the boat
+     * @return {@code true} if the fluid height should be updated, {@code false} otherwise
+     */
+    default boolean shouldUpdateWhileBoating(FluidState state, Boat boat, Entity rider)
+    {
+        return getFluidType().shouldUpdateWhileBoating(state, boat, rider);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeFluidState.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.common.extensions;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.vehicle.Boat;
@@ -86,6 +87,19 @@ public interface IForgeFluidState
     default boolean supportsBoating(Boat boat)
     {
         return self().getType().supportsBoating(self(), boat);
+    }
+
+    /**
+     * When {@code false}, the fluid will no longer update its height value while
+     * within a boat while it is not within a fluid ({@link Boat#isUnderWater()}.
+     *
+     * @param boat the boat the rider is within that is not inside a fluid
+     * @param rider the rider of the boat
+     * @return {@code true} if the fluid height should be updated, {@code false} otherwise
+     */
+    default boolean shouldUpdateWhileBoating(Boat boat, Entity rider)
+    {
+        return self().getType().shouldUpdateWhileBoating(self(), boat, rider);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -39,10 +39,8 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.SpawnPlacements;
-import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
@@ -90,7 +88,6 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
-import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityMobGriefingEvent;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
@@ -770,20 +767,6 @@ public class ForgeEventFactory
     {
         RegisterCommandsEvent event = new RegisterCommandsEvent(dispatcher, environment, context);
         MinecraftForge.EVENT_BUS.post(event);
-    }
-
-    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
-    {
-        EntityEvent.Size evt = new EntityEvent.Size(entity, pose, size, eyeHeight);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
-    }
-
-    public static net.minecraftforge.event.entity.EntityEvent.Size getEntitySizeForge(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float newEyeHeight)
-    {
-        EntityEvent.Size evt = new EntityEvent.Size(entity, pose, oldSize, newSize, entity.getEyeHeight(), newEyeHeight);
-        MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
     }
 
     public static boolean canLivingConvert(LivingEntity entity, EntityType<? extends LivingEntity> outcome, Consumer<Integer> timer)

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -128,8 +128,8 @@ public class EntityEvent extends Event
     }
 
     /**
-     * This event is fired whenever {@link IForgeEntity#getDimensionsForge(Pose)} gets called.<br>
-     * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
+     * This event is fired whenever {@link Entity#getDimensionsForge(Pose)} gets called.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore, the entity (subclass) might not be fully initialized. Check {@link Entity#isAddedToWorld()} or {@code !Entity.firstUpdate}.<br>
      * If you change the player's size, you probably want to set the eye height accordingly as well<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
@@ -143,24 +143,60 @@ public class EntityEvent extends Event
         private final Pose pose;
         private final EntityDimensions originalSize;
         private EntityDimensions newSize;
+        private final float oldEyeHeight;
+        private float newEyeHeight;
 
         public Size(Entity entity, Pose pose, EntityDimensions size)
         {
+            this(entity, pose, size, 1.0f); // Eye height doesn't matter this is just for binary compatibility.
+        }
+
+        @Deprecated(forRemoval = true, since = "1.20.1")
+        public Size(Entity entity, Pose pose, EntityDimensions size, float defaultEyeHeight)
+        {
+            this(entity, pose, size, size, defaultEyeHeight, defaultEyeHeight);
+        }
+
+        @Deprecated(forRemoval = true, since = "1.20.1")
+        public Size(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float oldEyeHeight, float newEyeHeight)
+        {
             super(entity);
             this.pose = pose;
-            this.originalSize = size;
-            this.newSize = size;
+            this.originalSize = oldSize;
+            this.newSize = newSize;
+            this.oldEyeHeight = oldEyeHeight;
+            this.newEyeHeight = newEyeHeight;
         }
 
         public Pose getPose() { return pose; }
+        /** @deprecated Use {@link #getOriginalSize()} */
+        @Deprecated(forRemoval = true, since = "1.20.1")
+        public EntityDimensions getOldSize() { return this.getOriginalSize(); }
         public EntityDimensions getOriginalSize() { return originalSize; }
         public EntityDimensions getNewSize() { return newSize; }
-        public void setNewSize(EntityDimensions newSize) { this.newSize = newSize; }
+        public void setNewSize(EntityDimensions size) { this.newSize = size; }
+
+        /** @deprecated Use {@link EyeHeight} to hook into changes to eye height. Updating the eye height will not actually so anything anymore. */
+        @Deprecated(forRemoval = true)
+        public void setNewSize(EntityDimensions size, boolean updateEyeHeight)
+        {
+            this.setNewSize(size);
+            if (updateEyeHeight)
+            {
+                this.newEyeHeight = this.getEntity().getEyeHeightAccess(this.getPose(), this.newSize);
+            }
+        }
+        /** @deprecated Use {@link EyeHeight} to hook into changes to eye height. */
+        @Deprecated(forRemoval = true, since = "1.20.1")
+        public float getOldEyeHeight() { return oldEyeHeight; }
+        /** @deprecated Use {@link EyeHeight} to hook into changes to eye height. */
+        @Deprecated(forRemoval = true, since = "1.20.1")
+        public void setNewEyeHeight(float eyeHeight) { this.newEyeHeight = eyeHeight; }
     }
 
     /**
-     * This event is fired whenever {@link IForgeEntity#getEyeHeightForge(Pose)} gets called.<br>
-     * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
+     * This event is fired whenever {@link IForgeEntity#getEyeHeightForge(Pose, EntityDimensions)} gets called.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore, the entity (subclass) might not be fully initialized. Check {@link Entity#isAddedToWorld()} or {@code !Entity.firstUpdate}.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -10,6 +10,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.Pose;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.extensions.IForgeEntity;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -127,7 +128,7 @@ public class EntityEvent extends Event
     }
 
     /**
-     * This event is fired whenever the {@link Pose} changes, and in a few other hardcoded scenarios.<br>
+     * This event is fired whenever {@link IForgeEntity#getDimensionsForge(Pose)} gets called.<br>
      * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
      * If you change the player's size, you probably want to set the eye height accordingly as well<br>
      * <br>
@@ -140,48 +141,53 @@ public class EntityEvent extends Event
     public static class Size extends EntityEvent
     {
         private final Pose pose;
-        private final EntityDimensions oldSize;
+        private final EntityDimensions originalSize;
         private EntityDimensions newSize;
-        private final float oldEyeHeight;
-        private float newEyeHeight;
 
-        public Size(Entity entity, Pose pose, EntityDimensions size, float defaultEyeHeight)
-        {
-            this(entity, pose, size, size, defaultEyeHeight, defaultEyeHeight);
-        }
-
-        public Size(Entity entity, Pose pose, EntityDimensions oldSize, EntityDimensions newSize, float oldEyeHeight, float newEyeHeight)
+        public Size(Entity entity, Pose pose, EntityDimensions size)
         {
             super(entity);
             this.pose = pose;
-            this.oldSize = oldSize;
-            this.newSize = newSize;
-            this.oldEyeHeight = oldEyeHeight;
-            this.newEyeHeight = newEyeHeight;
+            this.originalSize = size;
+            this.newSize = size;
         }
-
 
         public Pose getPose() { return pose; }
-        public EntityDimensions getOldSize() { return oldSize; }
+        public EntityDimensions getOriginalSize() { return originalSize; }
         public EntityDimensions getNewSize() { return newSize; }
-        public void setNewSize(EntityDimensions size)
+        public void setNewSize(EntityDimensions newSize) { this.newSize = newSize; }
+    }
+
+    /**
+     * This event is fired whenever {@link IForgeEntity#getEyeHeightForge(Pose)} gets called.<br>
+     * CAREFUL: This is also fired in the Entity constructor. Therefore the entity(subclass) might not be fully initialized. Check Entity#isAddedToWorld() or !Entity#firstUpdate.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class EyeHeight extends EntityEvent
+    {
+        private final Pose pose;
+        private final EntityDimensions size;
+        private final float originalEyeHeight;
+        private float newEyeHeight;
+
+        public EyeHeight(Entity entity, Pose pose, EntityDimensions size, float eyeHeight)
         {
-            setNewSize(size, false);
+            super(entity);
+            this.pose = pose;
+            this.size = size;
+            this.originalEyeHeight = eyeHeight;
+            this.newEyeHeight = eyeHeight;
         }
 
-        /**
-         * Set the new size of the entity. Set updateEyeHeight to true to also update the eye height according to the new size.
-         */
-        public void setNewSize(EntityDimensions size, boolean updateEyeHeight)
-        {
-            this.newSize = size;
-            if (updateEyeHeight)
-            {
-                this.newEyeHeight = this.getEntity().getEyeHeightAccess(this.getPose(), this.newSize);
-            }
-        }
-        public float getOldEyeHeight() { return oldEyeHeight; }
+        public Pose getPose() { return pose; }
+        public EntityDimensions getSize() { return size; }
+        public float getOriginalEyeHeight() { return originalEyeHeight; }
         public float getNewEyeHeight() { return newEyeHeight; }
-        public void setNewEyeHeight(float newHeight) { this.newEyeHeight = newHeight; }
+        public void setNewEyeHeight(float newEyeHeight) { this.newEyeHeight = newEyeHeight; }
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -356,6 +356,20 @@ public class FluidType
     }
 
     /**
+     * When {@code false}, the fluid will no longer update its height value while
+     * within a boat while it is not within a fluid ({@link Boat#isUnderWater()}.
+     *
+     * @param state the state of the fluid the rider is within
+     * @param boat the boat the rider is within that is not inside a fluid
+     * @param rider the rider of the boat
+     * @return {@code true} if the fluid height should be updated, {@code false} otherwise
+     */
+    public boolean shouldUpdateWhileBoating(FluidState state, Boat boat, Entity rider)
+    {
+        return !this.supportsBoating(state, boat);
+    }
+
+    /**
      * Returns whether the entity can ride in this vehicle under the fluid.
      *
      * @param vehicle the vehicle being ridden in


### PR DESCRIPTION
This PR is a subset of #14 which pulls in all commits relating to `EntityEvent$Size`, and https://github.com/MinecraftForge/MinecraftForge/pull/9428 which depends on the commit history of those changes.