### PR TITLE
[1.20.1] Pull `ProjectileHitEvent` changes from MCF/1.20.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,9 +265,8 @@ project(':forge') {
     apply plugin: 'org.cadixdev.licenser'
 
     applyPatches { 
-		verbose = true 
-		//failOnError = false
-	}
+        level 'WARNING'
+    }
 
     sourceSets {
         main {

--- a/patches/minecraft/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/projectile/AbstractArrow.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/net/minecraft/world/entity/projectile/AbstractArrow.java
+@@ -66,6 +_,8 @@
+    @Nullable
+    private List<Entity> f_36702_;
+ 
++   private final IntOpenHashSet ignoredEntities = new IntOpenHashSet();
++
+    protected AbstractArrow(EntityType<? extends AbstractArrow> p_36721_, Level p_36722_) {
+       super(p_36721_, p_36722_);
+    }
 @@ -150,7 +_,7 @@
           --this.f_36706_;
        }
@@ -9,14 +18,54 @@
           this.m_20095_();
        }
  
-@@ -186,7 +_,9 @@
+@@ -186,9 +_,28 @@
                 }
              }
  
 -            if (hitresult != null && !flag) {
+-               this.m_6532_(hitresult);
+-               this.f_19812_ = true;
 +            if (hitresult != null && hitresult.m_6662_() != HitResult.Type.MISS && !flag) {
-+               if (net.minecraftforge.event.ForgeEventFactory.onProjectileImpact(this, hitresult))
-+                  break;
-                this.m_6532_(hitresult);
-                this.f_19812_ = true;
++               switch (net.minecraftforge.event.ForgeEventFactory.onProjectileImpactResult(this, hitresult)) {
++                  case SKIP_ENTITY:
++                     if (hitresult.m_6662_() != HitResult.Type.ENTITY) { // If there is no entity, we just return default behaviour
++                        this.m_6532_(hitresult);
++                        this.f_19812_ = true;
++                        break;
++                     }
++                     ignoredEntities.add(entityhitresult.m_82443_().m_19879_());
++                     entityhitresult = null; // Don't process any further
++                     break;
++                  case STOP_AT_CURRENT_NO_DAMAGE:
++                     this.m_146870_();
++                     entityhitresult = null; // Don't process any further
++                     break;
++                  case STOP_AT_CURRENT:
++                     this.m_36767_((byte) 0);
++                  case DEFAULT:
++                     this.m_6532_(hitresult);
++                     this.f_19812_ = true;
++                     break;
++               }
              }
+ 
+             if (entityhitresult == null || this.m_36796_() <= 0) {
+@@ -198,6 +_,9 @@
+             hitresult = null;
+          }
+ 
++         if (this.m_213877_())
++            return;
++
+          vec3 = this.m_20184_();
+          double d5 = vec3.f_82479_;
+          double d6 = vec3.f_82480_;
+@@ -422,7 +_,7 @@
+    }
+ 
+    protected boolean m_5603_(Entity p_36743_) {
+-      return super.m_5603_(p_36743_) && (this.f_36701_ == null || !this.f_36701_.contains(p_36743_.m_19879_()));
++      return super.m_5603_(p_36743_) && (this.f_36701_ == null || !this.f_36701_.contains(p_36743_.m_19879_())) && !this.ignoredEntities.contains(p_36743_.m_19879_());
+    }
+ 
+    public void m_7380_(CompoundTag p_36772_) {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -667,9 +667,20 @@ public class ForgeEventFactory
         return event.getCharge();
     }
 
+    public static ProjectileImpactEvent.ImpactResult onProjectileImpactResult(Projectile projectile, HitResult ray)
+    {
+        ProjectileImpactEvent event = new ProjectileImpactEvent(projectile, ray);
+
+        // Remove this when the event is no longer cancelable
+        if (MinecraftForge.EVENT_BUS.post(event))
+            return ProjectileImpactEvent.ImpactResult.SKIP_ENTITY;
+
+        return event.getImpactResult();
+    }
+
     public static boolean onProjectileImpact(Projectile projectile, HitResult ray)
     {
-        return MinecraftForge.EVENT_BUS.post(new ProjectileImpactEvent(projectile, ray));
+        return onProjectileImpactResult(projectile, ray) != ProjectileImpactEvent.ImpactResult.DEFAULT;
     }
 
     public static LootTable loadLootTable(ResourceLocation name, LootTable table)

--- a/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/ProjectileImpactEvent.java
@@ -10,6 +10,9 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.eventbus.api.Cancelable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 /**
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
@@ -19,6 +22,8 @@ import net.minecraftforge.eventbus.api.Cancelable;
  * custom projectiles should fire this event and check the result in a similar fashion.
  * This event is cancelable. When canceled, the impact will not be processed and the projectile will continue flying.
  * Killing or other handling of the entity after event cancellation is up to the modder.
+ * You can also directly set the {@link ImpactResult} to change the impact behaviour.
+ * @see #setImpactResult(ImpactResult)
  */
 @Cancelable
 public class ProjectileImpactEvent extends EntityEvent
@@ -26,11 +31,23 @@ public class ProjectileImpactEvent extends EntityEvent
     private final HitResult ray;
     private final Projectile projectile;
 
+    private ImpactResult result = ImpactResult.DEFAULT;
+
     public ProjectileImpactEvent(Projectile projectile, HitResult ray)
     {
         super(projectile);
         this.ray = ray;
         this.projectile = projectile;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated Use {@link #setImpactResult(ImpactResult)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void setCanceled(boolean cancel)
+    {
+        super.setCanceled(cancel);
     }
 
     public HitResult getRayTraceResult()
@@ -41,5 +58,35 @@ public class ProjectileImpactEvent extends EntityEvent
     public Projectile getProjectile()
     {
         return projectile;
+    }
+
+    public void setImpactResult(@NotNull ImpactResult newResult)
+    {
+        this.result = Objects.requireNonNull(newResult, "ImpactResult cannot be null");
+    }
+
+    public ImpactResult getImpactResult()
+    {
+        return result;
+    }
+
+    public enum ImpactResult
+    {
+        /**
+         * The default behaviour, the projectile will be destroyed and the hit will be processed.
+         */
+        DEFAULT,
+        /**
+         * The projectile will pass through the current entity as if it wasn't there. This will return default behaviour if there is no entity.
+         */
+        SKIP_ENTITY,
+        /**
+         * Damage the entity and stop the projectile here, the projectile will not pierce.
+         */
+        STOP_AT_CURRENT,
+        /**
+         * Cancel the piercing aspect of the projectile, and do not damage the entity.
+         */
+        STOP_AT_CURRENT_NO_DAMAGE
     }
 }


### PR DESCRIPTION
This PR is a subset of #14 which pulls only the changes from https://github.com/MinecraftForge/MinecraftForge/pull/9642