### PR TITLE
[1.20.x] Deprecate RegistryObject for removal

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -936,7 +936,7 @@ public class ForgeHooks
             return ForgeMod.WATER_TYPE.get();
         if (fluid == Fluids.LAVA || fluid == Fluids.FLOWING_LAVA)
             return ForgeMod.LAVA_TYPE.get();
-        if (ForgeMod.MILK.filter(milk -> milk == fluid).isPresent() || ForgeMod.FLOWING_MILK.filter(milk -> milk == fluid).isPresent())
+        if (ForgeMod.MILK.isPresent() && ForgeMod.MILK.get() == fluid || ForgeMod.FLOWING_MILK.isPresent() && ForgeMod.FLOWING_MILK.get() == fluid)
             return ForgeMod.MILK_TYPE.get();
         throw new RuntimeException("Mod fluids must override getFluidType.");
     }

--- a/src/main/java/net/minecraftforge/registries/DeferredHolder.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredHolder.java
@@ -85,6 +85,7 @@ public class DeferredHolder<T> implements Holder<T>
      * @param key The resource key of the target object.
      * @see #create(ResourceKey, ResourceLocation)
      * @see #create(ResourceLocation, ResourceLocation)
+     * @see #create(ResourceKey)
      */
     @SuppressWarnings("unchecked")
     protected DeferredHolder(ResourceKey<? super T> key)
@@ -112,7 +113,7 @@ public class DeferredHolder<T> implements Holder<T>
      */
     public Optional<T> getOptional()
     {
-        return isPresent() ? Optional.of(get()) : Optional.empty();
+        return isPresent() ? Optional.of(value()) : Optional.empty();
     }
 
     /**
@@ -166,7 +167,7 @@ public class DeferredHolder<T> implements Holder<T>
     }
 
     /**
-     * @return True if this DeferredHolder has been bound, and {@link #get()} may be called.
+     * @return True if this DeferredHolder has been bound, and {@link #get()} or {@link #value()} may be called.
      */
     public boolean isPresent()
     {
@@ -190,7 +191,7 @@ public class DeferredHolder<T> implements Holder<T>
     @Override
     public String toString()
     {
-        return String.format("DeferredHolder{%s}", this.key, Locale.ENGLISH);
+        return String.format(Locale.ENGLISH, "DeferredHolder{%s}", this.key);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/registries/DeferredHolder.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredHolder.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 /**
  * A Deferred Holder is a Holder that is constructed with only a ResourceKey.<br>
  * It will be populated with the underlying Holder from the registry when available.
+ * 
  * @param <T> The type of object being held by this DeferredHolder.
  */
 public class DeferredHolder<T> implements Holder<T>
@@ -42,12 +43,13 @@ public class DeferredHolder<T> implements Holder<T>
 
     /**
      * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
-     * @param <T> The registry type.
-     * @param <U> The type of the target value.
+     * 
+     * @param <T>         The registry type.
+     * @param <U>         The type of the target value.
      * @param registryKey The name of the registry the target value is a member of.
-     * @param valueName The name of the target value.
+     * @param valueName   The name of the target value.
      */
-    @SuppressWarnings({"unchecked","rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public static <T> DeferredHolder<T> create(ResourceKey<? extends Registry<? super T>> registryKey, ResourceLocation valueName)
     {
         // This cast has to stay inside ResourceKey.create, otherwise it will create a compile-time error.
@@ -56,10 +58,11 @@ public class DeferredHolder<T> implements Holder<T>
 
     /**
      * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
-     * @param <T> The registry type.
-     * @param <U> The type of the target value.
+     * 
+     * @param <T>          The registry type.
+     * @param <U>          The type of the target value.
      * @param registryName The name of the registry the target value is a member of.
-     * @param valueName The name of the target value.
+     * @param valueName    The name of the target value.
      */
     public static <T> DeferredHolder<T> create(ResourceLocation registryName, ResourceLocation valueName)
     {
@@ -69,6 +72,7 @@ public class DeferredHolder<T> implements Holder<T>
     /**
      * This constructor requires a ResourceKey which is strongly-typed to the underlying type.<br>
      * If you extend this class, you may want to provide static helper methods similar to the above ones.
+     * 
      * @param key The resource key of the target object.
      * @see #create(ResourceKey, ResourceLocation)
      * @see #create(ResourceLocation, ResourceLocation)
@@ -76,22 +80,19 @@ public class DeferredHolder<T> implements Holder<T>
     protected DeferredHolder(ResourceKey<T> key)
     {
         this.key = key;
-        this.bind();
+        this.bind(false);
     }
 
     /**
      * Gets the object stored by this DeferredHolder, if this holder {@linkplain #isPresent() is present}.<br>
+     * 
      * @throws IllegalStateException If the backing registry is unavailable.
-     * @throws NullPointerException If the underlying Holder has not been populated (the target object is not registered).
+     * @throws NullPointerException  If the underlying Holder has not been populated (the target object is not registered).
      */
     @Override
     public T value()
     {
-        if (getRegistry() == null)
-        {
-            throw new IllegalStateException("Registry not present for " + this + ": " + this.key.registry());
-        }
-        bind();
+        bind(true);
         Objects.requireNonNull(this.holder, () -> "Trying to access unbound value: " + this.key);
         return this.holder.get();
     }
@@ -103,9 +104,10 @@ public class DeferredHolder<T> implements Holder<T>
     {
         return isPresent() ? Optional.of(get()) : Optional.empty();
     }
-    
+
     /**
      * The type of the registry is really <? super T> but this saves us some additional ugly casting and doesn't break anything.
+     * 
      * @return The registry that this DeferredHolder is pointing at, or null if it doesn't exist.
      */
     @Nullable
@@ -118,8 +120,11 @@ public class DeferredHolder<T> implements Holder<T>
     /**
      * Binds this DeferredHolder to the underlying registry and target object.<br>
      * Has no effect if already bound.
+     * 
+     * @param throwOnMissingRegistry If true, an exception will be thrown if the registry is absent.
+     * @throws IllegalStateException If throwOnMissingRegistry is true and the backing registry is unavailable.
      */
-    protected void bind()
+    protected void bind(boolean throwOnMissingRegistry)
     {
         if (this.holder != null) return;
 
@@ -127,6 +132,10 @@ public class DeferredHolder<T> implements Holder<T>
         if (registry != null)
         {
             this.holder = registry.getHolder(this.key).orElse(null);
+        }
+        else if (throwOnMissingRegistry)
+        {
+            throw new IllegalStateException("Registry not present for " + this + ": " + this.key.registry());
         }
     }
 
@@ -151,7 +160,7 @@ public class DeferredHolder<T> implements Holder<T>
      */
     public boolean isPresent()
     {
-        bind();
+        bind(false);
         return this.holder != null;
     }
 
@@ -167,7 +176,7 @@ public class DeferredHolder<T> implements Holder<T>
     {
         return this.key.hashCode();
     }
-    
+
     @Override
     public String toString()
     {
@@ -231,6 +240,7 @@ public class DeferredHolder<T> implements Holder<T>
     /**
      * If this DH {@linkplain #isPresent() is present}, this method returns an {@link Either#right()} containing the underlying object.<br>
      * Otherwise, this method returns and {@link Either#left()} containing {@linkplain #getKey() this DH's resource key}.
+     * 
      * @return The unwrapped form of this DeferredHolder.
      */
     @Override

--- a/src/main/java/net/minecraftforge/registries/DeferredHolder.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredHolder.java
@@ -31,13 +31,13 @@ public class DeferredHolder<T> implements Holder<T>
     /**
      * The resource key of the target object.
      */
-    protected ResourceKey<T> key;
+    protected final ResourceKey<T> key;
 
     /**
      * The currently cached value.
      */
     @Nullable
-    protected Holder<T> holder;
+    protected Holder<T> holder = null;
 
     /**
      * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
@@ -125,10 +125,6 @@ public class DeferredHolder<T> implements Holder<T>
         if (registry != null && registry.containsKey(this.key.location()))
         {
             this.holder = registry.getHolder(this.key).get();
-        }
-        else
-        {
-            this.holder = null;
         }
     }
 

--- a/src/main/java/net/minecraftforge/registries/DeferredHolder.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredHolder.java
@@ -5,6 +5,16 @@
 
 package net.minecraftforge.registries;
 
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.mojang.datafixers.util.Either;
+
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderOwner;
 import net.minecraft.core.Registry;
@@ -12,15 +22,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import org.jetbrains.annotations.Nullable;
-
-import com.mojang.datafixers.util.Either;
-
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * A Deferred Holder is a Holder that is constructed with only a ResourceKey.<br>
@@ -44,23 +45,20 @@ public class DeferredHolder<T> implements Holder<T>
     /**
      * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
      * 
-     * @param <T>         The registry type.
-     * @param <U>         The type of the target value.
+     * @param <T>         The type of the target value.
+     * @param <R>         The registry type.
      * @param registryKey The name of the registry the target value is a member of.
      * @param valueName   The name of the target value.
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public static <T> DeferredHolder<T> create(ResourceKey<? extends Registry<? super T>> registryKey, ResourceLocation valueName)
+    public static <R, T extends R> DeferredHolder<T> create(ResourceKey<? extends Registry<R>> registryKey, ResourceLocation valueName)
     {
-        // This cast has to stay inside ResourceKey.create, otherwise it will create a compile-time error.
-        return new DeferredHolder<T>(ResourceKey.create((ResourceKey) registryKey, valueName));
+        return create(ResourceKey.create(registryKey, valueName));
     }
 
     /**
      * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
      * 
      * @param <T>          The registry type.
-     * @param <U>          The type of the target value.
      * @param registryName The name of the registry the target value is a member of.
      * @param valueName    The name of the target value.
      */
@@ -70,16 +68,28 @@ public class DeferredHolder<T> implements Holder<T>
     }
 
     /**
-     * This constructor requires a ResourceKey which is strongly-typed to the underlying type.<br>
-     * If you extend this class, you may want to provide static helper methods similar to the above ones.
+     * Creates a new DeferredHolder targeting the specified value.
+     * 
+     * @param <T> The type of the target value.
+     * @param key The resource key of the target value.
+     */
+    public static <T> DeferredHolder<T> create(ResourceKey<? super T> key)
+    {
+        return new DeferredHolder<>(key);
+    }
+
+    /**
+     * Creates a new DeferredHolder with a ResourceKey.<br>
+     * Attempts to bind immediately if possible.
      * 
      * @param key The resource key of the target object.
      * @see #create(ResourceKey, ResourceLocation)
      * @see #create(ResourceLocation, ResourceLocation)
      */
-    protected DeferredHolder(ResourceKey<T> key)
+    @SuppressWarnings("unchecked")
+    protected DeferredHolder(ResourceKey<? super T> key)
     {
-        this.key = key;
+        this.key = (ResourceKey<T>) Objects.requireNonNull(key);
         this.bind(false);
     }
 

--- a/src/main/java/net/minecraftforge/registries/DeferredHolder.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredHolder.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.registries;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderOwner;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import org.jetbrains.annotations.Nullable;
+
+import com.mojang.datafixers.util.Either;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * A Deferred Holder is a Holder that is constructed with only a ResourceKey.<br>
+ * It will be populated with the underlying Holder from the registry when available.
+ * @param <T> The type of object being held by this DeferredHolder.
+ */
+public class DeferredHolder<T> implements Holder<T>
+{
+    /**
+     * The resource key of the target object.
+     */
+    protected ResourceKey<T> key;
+
+    /**
+     * The currently cached value.
+     */
+    @Nullable
+    protected Holder<T> holder;
+
+    /**
+     * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
+     * @param <T> The registry type.
+     * @param <U> The type of the target value.
+     * @param registryKey The name of the registry the target value is a member of.
+     * @param valueName The name of the target value.
+     */
+    @SuppressWarnings({"unchecked","rawtypes"})
+    public static <T, U extends T> DeferredHolder<U> create(ResourceKey<? extends Registry<T>> registryKey, ResourceLocation valueName)
+    {
+        return new DeferredHolder<U>(ResourceKey.create((ResourceKey) registryKey, valueName));
+    }
+
+    /**
+     * Creates a new DeferredHolder targeting the value with the specified name in the specified registry.
+     * @param <T> The registry type.
+     * @param <U> The type of the target value.
+     * @param registryName The name of the registry the target value is a member of.
+     * @param valueName The name of the target value.
+     */
+    public static <T, U extends T> DeferredHolder<U> create(ResourceLocation registryName, ResourceLocation valueName)
+    {
+        return create(ResourceKey.<T>createRegistryKey(registryName), valueName);
+    }
+
+    /**
+     * This constructor requires a ResourceKey which is strongly-typed to the underlying type of this DH.<br>
+     * For this reason, use the static factory methods, which hide the generic cast.
+     * @param key The resource key of the target object.
+     * @see #create(ResourceKey, ResourceLocation)
+     * @see #create(ResourceLocation, ResourceLocation)
+     */
+    protected DeferredHolder(ResourceKey<T> key)
+    {
+        this.key = key;
+        this.bind();
+    }
+
+    /**
+     * Gets the object stored by this DeferredHolder, if this holder {@linkplain #isPresent() is present}.<br>
+     * @throws IllegalStateException If the backing registry is unavailable.
+     * @throws NullPointerException If the underlying Holder has not been populated (the target object is not registered).
+     */
+    @Override
+    public T get()
+    {
+        if (getRegistry() == null)
+        {
+            throw new IllegalStateException("Registry not present for " + this + ": " + this.key.registry());
+        }
+        bind();
+        Objects.requireNonNull(this.holder, () -> "Trying to access unbound value: " + this.key);
+        return this.holder.get();
+    }
+
+    /**
+     * @return If {@link #isPresent()}, an optional containing the target object, otherwise {@linkplain Optional#empty() an empty optional}.
+     */
+    public Optional<T> getOptional()
+    {
+        return isPresent() ? Optional.of(get()) : Optional.empty();
+    }
+    
+    /**
+     * The type of the registry is really <? super T> but this saves us some additional ugly casting and doesn't break anything.
+     * @return The registry that this DeferredHolder is pointing at, or null if it doesn't exist.
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    protected Registry<T> getRegistry()
+    {
+        return (Registry<T>) BuiltInRegistries.REGISTRY.get(this.key.registry());
+    }
+
+    /**
+     * Binds this DeferredHolder to the underlying registry and target object.<br>
+     * Has no effect if already bound.
+     */
+    protected void bind()
+    {
+        if (this.holder != null) return;
+
+        Registry<T> registry = getRegistry();
+        if (registry != null && registry.containsKey(this.key.location()))
+        {
+            this.holder = registry.getHolder(this.key).get();
+        }
+        else
+        {
+            this.holder = null;
+        }
+    }
+
+    /**
+     * @return The ID of the object pointed to by this DeferredHolder.
+     */
+    public ResourceLocation getId()
+    {
+        return this.key.location();
+    }
+
+    /**
+     * @return The ResourceKey of the object pointed to by this DeferredHolder.
+     */
+    public ResourceKey<T> getKey()
+    {
+        return this.key;
+    }
+
+    /**
+     * @return True if this DeferredHolder has been bound, and {@link #get()} may be called.
+     */
+    public boolean isPresent()
+    {
+        bind();
+        return this.holder != null;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) return true;
+        return obj instanceof DeferredHolder<?> dh ? dh.key == this.key : false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return this.key.hashCode();
+    }
+    
+    @Override
+    public String toString()
+    {
+        return String.format("DeferredHolder{%s}", this.key);
+    }
+
+    /**
+     * Fulfills standard Holder interface. Prefer using {@link #get()}
+     */
+    @Override
+    public T value()
+    {
+        return get();
+    }
+
+    /**
+     * @return True if this DH {@link #isPresent()} and the underlying holder {@linkplain Holder#isBound() is bound}.
+     */
+    @Override
+    public boolean isBound()
+    {
+        return isPresent() && this.holder.isBound();
+    }
+
+    /**
+     * @return True if the passed ResourceLocation is the same as the ID of the target object.
+     */
+    @Override
+    public boolean is(ResourceLocation id)
+    {
+        return id.equals(this.key.location());
+    }
+
+    /**
+     * @return True if the passed ResourceKey is the same as this DH's resource key.
+     */
+    @Override
+    public boolean is(ResourceKey<T> key)
+    {
+        return key == this.key;
+    }
+
+    /**
+     * @return True if the filter matches {@linkplain #getKey() this DH's resource key}.
+     */
+    @Override
+    public boolean is(Predicate<ResourceKey<T>> filter)
+    {
+        return filter.test(this.key);
+    }
+
+    /**
+     * @return True if this DH {@link #isPresent()} and the underlying object is a member of the passed tag.
+     */
+    @Override
+    public boolean is(TagKey<T> tag)
+    {
+        return isPresent() && this.holder.is(tag);
+    }
+
+    /**
+     * @return All tags present on the underlying object, if {@link #isPresent()}, otherwise {@linkplain Stream#empty() an empty stream}.
+     */
+    @Override
+    public Stream<TagKey<T>> tags()
+    {
+        return isPresent() ? this.holder.tags() : Stream.empty();
+    }
+
+    /**
+     * If this DH {@linkplain #isPresent() is present}, this method returns an {@link Either#right()} containing the underlying object.<br>
+     * Otherwise, this method returns and {@link Either#left()} containing {@linkplain #getKey() this DH's resource key}.
+     * @return The unwrapped form of this DeferredHolder.
+     */
+    @Override
+    public Either<ResourceKey<T>, T> unwrap()
+    {
+        return isPresent() ? this.holder.unwrap() : Either.left(this.key);
+    }
+
+    /**
+     * @return An optional containing {@linkplain #getKey() this DH's resource key}.
+     */
+    @Override
+    public Optional<ResourceKey<T>> unwrapKey()
+    {
+        return Optional.of(this.key);
+    }
+
+    @Override
+    public Kind kind()
+    {
+        return Kind.REFERENCE;
+    }
+
+    @Override
+    public boolean canSerializeIn(HolderOwner<T> owner)
+    {
+        return isPresent() && this.holder.canSerializeIn(owner);
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/DeferredHolder.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredHolder.java
@@ -29,6 +29,7 @@ import net.minecraft.tags.TagKey;
  * 
  * @param <T> The type of object being held by this DeferredHolder.
  */
+// TODO: (Breaking Change) - Add a second generic type for the base registry type
 public class DeferredHolder<T> implements Holder<T>
 {
     /**
@@ -279,5 +280,17 @@ public class DeferredHolder<T> implements Holder<T>
     public boolean canSerializeIn(HolderOwner<T> owner)
     {
         return isPresent() && this.holder.canSerializeIn(owner);
+    }
+
+    /**
+     * As a workaround, this method is provided to allow upcasting the generic type of this DeferredHolder to properly use the Holder methods.
+     * @param <R> The type of the registry this DeferredHolder is targeting.
+     * @return this
+     * @apiNote This method will be removed in a future release, and DeferredHolder will have two generic types.
+     */
+    @SuppressWarnings({"unchecked"})
+    public <R> Holder<R> cast()
+    {
+        return (Holder<R>) this;
     }
 }

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -194,7 +194,7 @@ public class DeferredRegister<T>
     }
 
     /**
-     * Calls {@link #createTagKey(ResourceLocation)} with the given path, using {@linkplain #namespace the provided namespace}.
+     * Creates a tag key with the given path, using {@linkplain #namespace the provided namespace}.
      *
      * @param path The path of the TagKey.
      * @see #createTagKey(ResourceLocation)
@@ -206,7 +206,7 @@ public class DeferredRegister<T>
     }
 
     /**
-     * Creates a tag key based on the provided resource location and the registry name linked to this DeferredRegister.
+     * Creates a tag key based on the provided resource location and the registry key of this DeferredRegister.
      *
      * @param location The resource location of the TagKey.
      * @see #createTagKey(String)
@@ -219,7 +219,7 @@ public class DeferredRegister<T>
     }
 
     /**
-     * Calls {@link #createOptionalTagKey(ResourceLocation, Set)} with the given path, using {@linkplain #namespace the provided namespace}.
+     * Creates an optional tag key with the given path, using {@linkplain #namespace the provided namespace}.
      * 
      * @param path     The path of the TagKey.
      * @param defaults A set of default entries that will populate the tag if it is not loaded.

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -7,6 +7,7 @@ package net.minecraftforge.registries;
 
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
@@ -170,6 +171,7 @@ public class DeferredRegister<T>
      * @param name The new entry's name, it will automatically have the modid prefixed.
      * @param sup A factory for the new entry, it should return a new instance every time it is called.
      * @return A RegistryObject that will be updated with when the entries in the registry change.
+     * @apiNote This method will return {@link Holder} in future versions.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public <I extends T> RegistryObject<I> register(final String name, final Supplier<? extends I> sup)
@@ -330,6 +332,7 @@ public class DeferredRegister<T>
     }
     /**
      * @return The unmodifiable view of registered entries. Useful for bulk operations on all values.
+     * @apiNote This method will return a collection of {@link Holder}s in future versions.
      */
     public Collection<RegistryObject<T>> getEntries()
     {
@@ -378,7 +381,7 @@ public class DeferredRegister<T>
 
     private void addEntries(RegisterEvent event)
     {
-        if (event.getRegistryKey().equals(this.registryKey))
+        if (event.getRegistryKey() == this.registryKey)
         {
             this.seenRegisterEvent = true;
             for (Entry<RegistryObject<T>, Supplier<? extends T>> e : entries.entrySet())

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -7,7 +7,6 @@ package net.minecraftforge.registries;
 
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
-import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
@@ -31,119 +30,85 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * Utility class to help with managing registry entries.
- * Maintains a list of all suppliers for entries and registers them during the proper Register event.
- * Suppliers should return NEW instances every time.
+ * Utility class to help with managing registry entries.<br>
+ * Maintains a list of all suppliers for entries and registers them during the proper event.<br>
+ * Suppliers should return new instances every time.
+ * <p>
+ * Example Usage:
+ * <code><pre>
+ * private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
+ * private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
  *
- *Example Usage:
- *<pre>{@code
- *   private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
- *   private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
+ * public static final DeferredHolder<Block> ROCK_BLOCK = BLOCKS.register("rock", () -> new Block(Block.Properties.create(Material.ROCK)));
+ * public static final DeferredHolder<Item> ROCK_ITEM = ITEMS.register("rock", () -> new BlockItem(ROCK_BLOCK.get(), new Item.Properties().group(ItemGroup.MISC)));
  *
- *   public static final RegistryObject<Block> ROCK_BLOCK = BLOCKS.register("rock", () -> new Block(Block.Properties.create(Material.ROCK)));
- *   public static final RegistryObject<Item> ROCK_ITEM = ITEMS.register("rock", () -> new BlockItem(ROCK_BLOCK.get(), new Item.Properties().group(ItemGroup.MISC)));
- *
- *   public ExampleMod() {
- *       ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
- *       BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
- *   }
- *}</pre>
+ * public ExampleMod() {
+ *     ITEMS.register(FMLJavaModLoadingContext.get().getModEventBus());
+ *     BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
+ * }
+ * </pre></code>
  *
  * @param <T> The base registry type
  */
+@SuppressWarnings("deprecation") // TODO 1.20.2+ - Find+Replace RegistryObject with DeferredHolder.
 public class DeferredRegister<T>
 {
     /**
-     * DeferredRegister factory for forge registries that exist <i>before</i> this DeferredRegister is created.
+     * Factory method for DeferredRegister. Supports both registries that already exist or do not exist yet.<br>
      * <p>
-     * If you have a supplier, <u>do not use this method.</u>
-     * Instead, use one of the other factories that takes in a registry key or registry name.
-     *
-     * @param reg the forge registry to wrap
-     * @param modid the namespace for all objects registered to this DeferredRegister
-     * @see #create(ResourceKey, String)
-     * @see #create(ResourceLocation, String)
-     */
-    public static <B> DeferredRegister<B> create(IForgeRegistry<B> reg, String modid)
-    {
-        return new DeferredRegister<>(reg, modid);
-    }
-
-    /**
-     * DeferredRegister factory for custom forge registries or {@link BuiltInRegistries vanilla registries}
-     * to lookup based on the provided registry key. Supports both registries that already exist or do not exist yet.
+     * If the registry is never created, any created {@link DeferredHolder}s will never become {@linkplain DeferredHolder#isPresent() present}.
      * <p>
-     * If the registry is never created, any {@link RegistryObject}s made from this DeferredRegister will throw an exception.
-     * To allow the optional existence of a registry without error, use {@link #createOptional(ResourceKey, String)}.
-     *
-     * @param key the key of the registry to reference. May come from another DeferredRegister through {@link #getRegistryKey()}.
-     * @param modid the namespace for all objects registered to this DeferredRegister
-     * @see #createOptional(ResourceKey, String)
-     * @see #create(IForgeRegistry, String)
-     * @see #create(ResourceLocation, String)
+     * This method requires a ResourceKey for a registry - how these are obtained varies by registry.<br>
+     * For {@linkplain IForgeRegistry forge registries}, use {@link IForgeRegistry#getRegistryKey()}.<br>
+     * For {@linkplain Registry vanilla registries}, use the static fields on {@link BuiltInRegistries}.<br>
+     * Additionally, the names of vanilla registries can be retrieved from {@link BuiltInRegistries#REGISTRY}.
+     * @param key The key of the registry to register objects to.
+     * @param modid The namespace for all objects registered to this DeferredRegister.
      */
     public static <B> DeferredRegister<B> create(ResourceKey<? extends Registry<B>> key, String modid)
     {
-        return new DeferredRegister<>(key, modid, false);
+        return new DeferredRegister<>(key, modid);
     }
 
     /**
-     * DeferredRegister factory for the optional existence of custom forge registries
-     * or {@link BuiltInRegistries vanilla registries} to lookup based on the provided registry key.
-     * Supports both registries that already exist or do not exist yet.
-     * <p>
-     * If the registry is never created, any {@link RegistryObject}s made from this DeferredRegister will never be filled but will not throw an exception.
-     *
-     * @param key the key of the registry to reference
-     * @param modid the namespace for all objects registered to this DeferredRegister
-     * @see #create(ResourceKey, String)
-     * @see #create(IForgeRegistry, String)
-     * @see #create(ResourceLocation, String)
+     * @deprecated Use {@link #create(ResourceKey, String)} via {@link IForgeRegistry#getRegistryKey()}
      */
+    @Deprecated
+    public static <B> DeferredRegister<B> create(IForgeRegistry<B> reg, String modid)
+    {
+        return create(reg.getRegistryKey(), modid);
+    }
+
+    /**
+     * @deprecated Use {@link #create(ResourceKey, String)}
+     */
+    @Deprecated(since = "1.20.1", forRemoval = true)
     public static <B> DeferredRegister<B> createOptional(ResourceKey<? extends Registry<B>> key, String modid)
     {
-        return new DeferredRegister<>(key, modid, true);
+        return create(key, modid);
     }
 
     /**
-     * DeferredRegister factory for custom forge registries or {@link BuiltInRegistries vanilla registries}
-     * to lookup based on the provided registry name. Supports both registries that already exist or do not exist yet.
-     * <p>
-     * If the registry is never created, any {@link RegistryObject}s made from this DeferredRegister will throw an exception.
-     * To allow the optional existence of a registry without error, use {@link #createOptional(ResourceLocation, String)}.
-     *
-     * @param registryName The name of the registry, should include namespace. May come from another DeferredRegister through {@link #getRegistryName()}.
-     * @param modid The namespace for all objects registered to this DeferredRegister
-     * @see #createOptional(ResourceLocation, String)
-     * @see #create(IForgeRegistry, String)
+     * Variant of {@link #create(ResourceKey, String)} that accepts a ResourceLocation instead of a ResourceKey.
      * @see #create(ResourceKey, String)
      */
     public static <B> DeferredRegister<B> create(ResourceLocation registryName, String modid)
     {
-        return new DeferredRegister<>(ResourceKey.createRegistryKey(registryName), modid, false);
+        return create(ResourceKey.createRegistryKey(registryName), modid);
     }
 
     /**
-     * DeferredRegister factory for the optional existence of custom forge registries
-     * or {@link BuiltInRegistries vanilla registries} to lookup based on the provided registry name.
-     * Supports both registries that already exist or do not exist yet.
-     * <p>
-     * If the registry is never created, any {@link RegistryObject}s made from this DeferredRegister will never be filled but will not throw an exception.
-     *
-     * @param registryName The name of the registry, should include namespace. May come from another DeferredRegister through {@link #getRegistryName()}.
-     * @param modid The namespace for all objects registered to this DeferredRegister
-     * @see #create(ResourceLocation, String)
-     * @see #create(IForgeRegistry, String)
-     * @see #create(ResourceKey, String)
+     * @deprecated Use {@link #create(ResourceLocation, String)}
      */
+    @Deprecated(since = "1.20.1", forRemoval = true)
     public static <B> DeferredRegister<B> createOptional(ResourceLocation registryName, String modid)
     {
-        return new DeferredRegister<>(ResourceKey.createRegistryKey(registryName), modid, true);
+        return create(ResourceKey.createRegistryKey(registryName), modid);
     }
 
     private final ResourceKey<? extends Registry<T>> registryKey;
     private final String modid;
-    private final boolean optionalRegistry;
+    // TODO: Replace with DeferredHolder
     private final Map<RegistryObject<T>, Supplier<? extends T>> entries = new LinkedHashMap<>();
     private final Set<RegistryObject<T>> entriesView = Collections.unmodifiableSet(entries.keySet());
 
@@ -153,28 +118,27 @@ public class DeferredRegister<T>
     private SetMultimap<TagKey<T>, Supplier<T>> optionalTags;
     private boolean seenRegisterEvent = false;
 
-    private DeferredRegister(ResourceKey<? extends Registry<T>> registryKey, String modid, boolean optionalRegistry)
+    private DeferredRegister(ResourceKey<? extends Registry<T>> registryKey, String modid)
     {
         this.registryKey = registryKey;
         this.modid = modid;
-        this.optionalRegistry = optionalRegistry;
     }
 
     private DeferredRegister(IForgeRegistry<T> reg, String modid)
     {
-        this(reg.getRegistryKey(), modid, false);
+        this(reg.getRegistryKey(), modid);
     }
 
     /**
-     * Adds a new supplier to the list of entries to be registered, and returns a RegistryObject that will be populated with the created entry automatically.
-     *
-     * @param name The new entry's name, it will automatically have the modid prefixed.
+     * Adds a new supplier to the list of entries to be registered, and returns a DeferredHolder pointing to the to-be-registered object.
+     * <p>
+     * @param name The new entry's name. The modid from the constructor will be used as the namespace.
      * @param sup A factory for the new entry, it should return a new instance every time it is called.
-     * @return A RegistryObject that will be updated with when the entries in the registry change.
-     * @apiNote This method will return {@link Holder} in future versions.
+     * @return A DeferredHolder that will be updated with when the entries in the registry change.
+     * @apiNote The return type of this method will be changed to DeferredHolder in the next breaking changes window.
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public <I extends T> RegistryObject<I> register(final String name, final Supplier<? extends I> sup)
+    @SuppressWarnings({ "unchecked" }) // TODO: Remove - Update this method to return DeferredHolder in next BC cycle.
+    public <I extends T> RegistryObject<I> register(String name, Supplier<? extends I> sup)
     {
         if (seenRegisterEvent)
             throw new IllegalStateException("Cannot register new entries to DeferredRegister after RegisterEvent has been fired.");
@@ -182,13 +146,7 @@ public class DeferredRegister<T>
         Objects.requireNonNull(sup);
         final ResourceLocation key = new ResourceLocation(modid, name);
 
-        RegistryObject<I> ret;
-        if (this.registryKey != null)
-            ret = this.optionalRegistry
-                    ? RegistryObject.createOptional(key, this.registryKey, this.modid)
-                    : RegistryObject.create(key, this.registryKey, this.modid);
-        else
-            throw new IllegalStateException("Could not create RegistryObject in DeferredRegister");
+        RegistryObject<I> ret = RegistryObject.create(key, this.registryKey, this.modid);
 
         if (entries.putIfAbsent((RegistryObject<T>) ret, sup) != null) {
             throw new IllegalArgumentException("Duplicate registration " + name);
@@ -212,15 +170,10 @@ public class DeferredRegister<T>
     }
 
     /**
-     * Creates a tag key based on the current modid and provided path as the location and the registry name linked to this DeferredRegister.
-     * To control the namespace, use {@link #createTagKey(ResourceLocation)}.
+     * Calls {@link #createTagKey(ResourceLocation)} with the given path, using the current modid as the namespace.
      *
-     * @throws IllegalStateException If the registry name was not set.
-     * Use the factories that take {@link #create(ResourceLocation, String) a registry name} or {@link #create(IForgeRegistry, String) forge registry}.
      * @see #createTagKey(ResourceLocation)
-     * @see #createOptionalTagKey(String, Set)
      */
-    @NotNull
     public TagKey<T> createTagKey(@NotNull String path)
     {
         Objects.requireNonNull(path);
@@ -236,7 +189,6 @@ public class DeferredRegister<T>
      * @see #createTagKey(String)
      * @see #createOptionalTagKey(ResourceLocation, Set)
      */
-    @NotNull
     public TagKey<T> createTagKey(@NotNull ResourceLocation location)
     {
         if (this.registryKey == null)
@@ -246,18 +198,10 @@ public class DeferredRegister<T>
     }
 
     /**
-     * Creates a tag key with the current modid and provided path that will use the set of defaults if the tag is not loaded from any datapacks.
-     * Useful on the client side when a server may not provide a specific tag.
-     * To control the namespace, use {@link #createOptionalTagKey(ResourceLocation, Set)}.
-     *
-     * @throws IllegalStateException If the registry name was not set.
-     * Use the factories that take {@link #create(ResourceLocation, String) a registry name} or {@link #create(IForgeRegistry, String) forge registry}.
-     * @see #createTagKey(String)
-     * @see #createTagKey(ResourceLocation)
+     * Calls {@link #createOptionalTagKey(ResourceLocation, Set)} with the given path, using the current modid as the namespace.
+     * 
      * @see #createOptionalTagKey(ResourceLocation, Set)
-     * @see #addOptionalTagDefaults(TagKey, Set)
      */
-    @NotNull
     public TagKey<T> createOptionalTagKey(@NotNull String path, @NotNull Set<? extends Supplier<T>> defaults)
     {
         Objects.requireNonNull(path);
@@ -276,7 +220,6 @@ public class DeferredRegister<T>
      * @see #createOptionalTagKey(String, Set)
      * @see #addOptionalTagDefaults(TagKey, Set)
      */
-    @NotNull
     public TagKey<T> createOptionalTagKey(@NotNull ResourceLocation location, @NotNull Set<? extends Supplier<T>> defaults)
     {
         TagKey<T> tagKey = createTagKey(location);
@@ -330,9 +273,10 @@ public class DeferredRegister<T>
             register.addEntries(event);
         }
     }
+
     /**
      * @return The unmodifiable view of registered entries. Useful for bulk operations on all values.
-     * @apiNote This method will return a collection of {@link Holder}s in future versions.
+     * @apiNote This method will return a collection of {@link DeferredHolder}s in future versions.
      */
     public Collection<RegistryObject<T>> getEntries()
     {
@@ -350,7 +294,6 @@ public class DeferredRegister<T>
     /**
      * @return The registry name stored in this deferred register. Useful for creating new deferred registers based on an existing one.
      */
-    @NotNull
     public ResourceLocation getRegistryName()
     {
         return Objects.requireNonNull(this.registryKey).location();
@@ -387,7 +330,7 @@ public class DeferredRegister<T>
             for (Entry<RegistryObject<T>, Supplier<? extends T>> e : entries.entrySet())
             {
                 event.register(this.registryKey, e.getKey().getId(), () -> e.getValue().get());
-                e.getKey().updateReference(event);
+                e.getKey().bind();
             }
         }
     }

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -328,7 +328,8 @@ public class DeferredRegister<T>
             for (Entry<RegistryObject<T>, Supplier<? extends T>> e : entries.entrySet())
             {
                 event.register(this.registryKey, e.getKey().getId(), () -> e.getValue().get());
-                e.getKey().bind();
+                // Throw on missing registry here because absence of the registry indicates something is very wrong.
+                e.getKey().bind(true);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -73,7 +73,7 @@ public class DeferredRegister<T>
     /**
      * @deprecated Use {@link #create(ResourceKey, String)} via {@link IForgeRegistry#getRegistryKey()}
      */
-    @Deprecated
+    @Deprecated(since = "1.20.1", forRemoval = true)
     public static <B> DeferredRegister<B> create(IForgeRegistry<B> reg, String modid)
     {
         return create(reg.getRegistryKey(), modid);
@@ -120,13 +120,8 @@ public class DeferredRegister<T>
 
     private DeferredRegister(ResourceKey<? extends Registry<T>> registryKey, String modid)
     {
-        this.registryKey = registryKey;
-        this.modid = modid;
-    }
-
-    private DeferredRegister(IForgeRegistry<T> reg, String modid)
-    {
-        this(reg.getRegistryKey(), modid);
+        this.registryKey = Objects.requireNonNull(registryKey);
+        this.modid = Objects.requireNonNull(modid);
     }
 
     /**
@@ -191,8 +186,6 @@ public class DeferredRegister<T>
      */
     public TagKey<T> createTagKey(@NotNull ResourceLocation location)
     {
-        if (this.registryKey == null)
-            throw new IllegalStateException("The registry name was not set, cannot create a tag key");
         Objects.requireNonNull(location);
         return TagKey.create(this.registryKey, location);
     }
@@ -256,11 +249,16 @@ public class DeferredRegister<T>
      */
     public void register(IEventBus bus)
     {
-        bus.register(new EventDispatcher(this));
+        bus.addListener(this::addEntries);
         if (this.registryFactory != null) {
             bus.addListener(this::createRegistry);
         }
     }
+
+    /**
+     * @deprecated Unused
+     */
+    @Deprecated(since = "1.20.1", forRemoval = true)
     public static class EventDispatcher {
         private final DeferredRegister<?> register;
 
@@ -296,7 +294,7 @@ public class DeferredRegister<T>
      */
     public ResourceLocation getRegistryName()
     {
-        return Objects.requireNonNull(this.registryKey).location();
+        return this.registryKey.location();
     }
 
     private Supplier<IForgeRegistry<T>> makeRegistry(final ResourceLocation registryName, final Supplier<RegistryBuilder<T>> sup) {

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -156,25 +156,25 @@ public class DeferredRegister<T>
     /**
      * Adds a new supplier to the list of entries to be registered, and returns a {@link DeferredHolder} pointing to the to-be-registered object.
      *
-     * @param name The path of the new entry. The namespace will be the one passed to the constructor.
+     * @param path The path of the new entry. The namespace will be {@linkplain #namespace the provided namespace}.
      * @param sup  A factory for the new entry. The factory should return a new instance on each invocation.
      * @return A DeferredHolder that will be updated with when the entries in the registry change.
      * @apiNote The return type of this method will be changed to DeferredHolder in the next breaking changes window.
      */
     @SuppressWarnings({"unchecked", "removal"}) // TODO: Remove - Update this method to return DeferredHolder in next BC cycle.
-    public <I extends T> RegistryObject<I> register(String name, Supplier<? extends I> sup)
+    public <I extends T> RegistryObject<I> register(String path, Supplier<? extends I> sup)
     {
         if (seenRegisterEvent)
             throw new IllegalStateException("Cannot register new entries to DeferredRegister after the RegisterEvent has been fired.");
-        Objects.requireNonNull(name);
+        Objects.requireNonNull(path);
         Objects.requireNonNull(sup);
-        final ResourceLocation key = new ResourceLocation(namespace, name);
+        final ResourceLocation key = new ResourceLocation(namespace, path);
 
         RegistryObject<I> ret = RegistryObject.create(key, this.registryKey, this.namespace);
 
         if (entries.putIfAbsent((RegistryObject<T>) ret, sup) != null)
         {
-            throw new IllegalArgumentException("Duplicate registration: " + name);
+            throw new IllegalArgumentException("Duplicate registration: " + path);
         }
 
         return ret;

--- a/src/main/java/net/minecraftforge/registries/DeferredRegister.java
+++ b/src/main/java/net/minecraftforge/registries/DeferredRegister.java
@@ -54,7 +54,7 @@ import java.util.function.Supplier;
 public class DeferredRegister<T>
 {
     /**
-     * Factory method for DeferredRegister. Supports both registries that already exist or do not exist yet.<br>
+     * Factory method for DeferredRegister. The target registry does not need to exist yet.<br>
      * <p>
      * If the registry is never created, any created {@link DeferredHolder}s will never become {@linkplain DeferredHolder#isPresent() present}.
      * <p>

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -178,15 +178,15 @@ public class GameData
 
     private static <T> RegistryBuilder<T> makeRegistry(ResourceKey<? extends Registry<T>> key)
     {
-        return new RegistryBuilder<T>().setName(key.location()).setMaxID(MAX_VARINT).hasWrapper();
+        return new RegistryBuilder<T>().setName(key.location()).setMaxID(MAX_VARINT);
     }
     private static <T> RegistryBuilder<T> makeRegistry(ResourceKey<? extends Registry<T>> key, int min, int max)
     {
-        return new RegistryBuilder<T>().setName(key.location()).setIDRange(min, max).hasWrapper();
+        return new RegistryBuilder<T>().setName(key.location()).setIDRange(min, max);
     }
     private static <T> RegistryBuilder<T> makeRegistry(ResourceKey<? extends Registry<T>> key, String _default)
     {
-        return new RegistryBuilder<T>().setName(key.location()).setMaxID(MAX_VARINT).hasWrapper().setDefaultKey(new ResourceLocation(_default));
+        return new RegistryBuilder<T>().setName(key.location()).setMaxID(MAX_VARINT).setDefaultKey(new ResourceLocation(_default));
     }
 
     public static <T> MappedRegistry<T> getWrapper(ResourceKey<? extends Registry<T>> key, Lifecycle lifecycle)

--- a/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/registries/NewRegistryEvent.java
@@ -90,7 +90,7 @@ public class NewRegistryEvent extends Event implements IModBusEvent
 
         builtRegistries.put(builder, registry);
 
-        if (builder.getHasWrapper() && !BuiltInRegistries.REGISTRY.containsKey(registry.getRegistryName()))
+        if (!BuiltInRegistries.REGISTRY.containsKey(registry.getRegistryName()))
             RegistryManager.registerToRootRegistry((ForgeRegistry<?>) registry);
 
         data.registryHolder.registry = registry;

--- a/src/main/java/net/minecraftforge/registries/RegisterEvent.java
+++ b/src/main/java/net/minecraftforge/registries/RegisterEvent.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
  * @see #register(ResourceKey, ResourceLocation, Supplier)
  * @see #register(ResourceKey, Consumer)
  */
+// TODO: Make register() methods return the newly-created Holder.Reference<T> or a bound DeferredHolder<T>
 public class RegisterEvent extends Event implements IModBusEvent
 {
     @NotNull

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -201,8 +201,7 @@ public class RegistryBuilder<T>
      * All forge registries with wrappers inherently support tags.
      *
      * @return this builder
-     * @see RegistryBuilder#hasWrapper()
-     * @deprecated All registries now have vanilla wrappers.
+     * @deprecated All registries now have vanilla wrappers, and thus have tags.
      */
     @Deprecated(since = "1.20.1", forRemoval = true)
     public RegistryBuilder<T> hasTags()

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -179,15 +179,6 @@ public class RegistryBuilder<T>
         return this;
     }
 
-    /**
-     * @deprecated All registries now have vanilla wrappers.
-     */
-    @Deprecated(since = "1.20.1", forRemoval = true)
-    RegistryBuilder<T> hasWrapper()
-    {
-        return this;
-    }
-
     public RegistryBuilder<T> legacyName(String name)
     {
         return legacyName(new ResourceLocation(name));

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -37,7 +37,6 @@ public class RegistryBuilder<T>
     private boolean sync = true;
     private boolean allowOverrides = true;
     private boolean allowModifications = false;
-    private boolean hasWrapper = false;
     private MissingFactory<T> missingFactory;
     private Set<ResourceLocation> legacyNames = new HashSet<>();
     @Nullable
@@ -180,9 +179,12 @@ public class RegistryBuilder<T>
         return this;
     }
 
+    /**
+     * @deprecated All registries now have vanilla wrappers.
+     */
+    @Deprecated(since = "1.20.1", forRemoval = true)
     RegistryBuilder<T> hasWrapper()
     {
-        this.hasWrapper = true;
         return this;
     }
 
@@ -209,11 +211,11 @@ public class RegistryBuilder<T>
      *
      * @return this builder
      * @see RegistryBuilder#hasWrapper()
+     * @deprecated All registries now have vanilla wrappers.
      */
+    @Deprecated(since = "1.20.1", forRemoval = true)
     public RegistryBuilder<T> hasTags()
     {
-        // Tag system heavily relies on Registry<?> objects, so we need a wrapper for this registry to take advantage
-        this.hasWrapper();
         return this;
     }
 
@@ -222,13 +224,10 @@ public class RegistryBuilder<T>
      */
     IForgeRegistry<T> create()
     {
-        if (hasWrapper)
-        {
-            if (getDefault() == null)
-                addCallback(new NamespacedWrapper.Factory<T>());
-            else
-                addCallback(new NamespacedDefaultedWrapper.Factory<T>());
-        }
+        if (getDefault() == null)
+            addCallback(new NamespacedWrapper.Factory<T>());
+        else
+            addCallback(new NamespacedDefaultedWrapper.Factory<T>());
         return RegistryManager.ACTIVE.createRegistry(registryName, this);
     }
 
@@ -357,10 +356,5 @@ public class RegistryBuilder<T>
     Function<T, Holder.Reference<T>> getIntrusiveHolderCallback()
     {
         return this.intrusiveHolderCallback;
-    }
-
-    boolean getHasWrapper()
-    {
-        return this.hasWrapper;
     }
 }

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -12,6 +12,8 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.ModLoadingContext;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -62,7 +64,7 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
      */
     public static <T, U extends T> RegistryObject<U> create(final ResourceLocation name, IForgeRegistry<T> registry)
     {
-        return create(name, registry.getRegistryKey(), "");
+        return create(name, registry.getRegistryKey(), ModLoadingContext.get().getActiveNamespace());
     }
 
     /**
@@ -281,7 +283,7 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
      * @return the resource key that points to the registry and name of this registry object
      */
     @Nullable
-    public ResourceKey<? super T> getKey()
+    public ResourceKey<T> getKey()
     {
         return this.key;
     }
@@ -470,10 +472,7 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
     public boolean equals(Object obj)
     {
         if (this == obj) return true;
-        if (obj instanceof RegistryObject) {
-            return ((RegistryObject<?>) obj).key == this.key;
-        }
-        return false;
+        return obj instanceof RegistryObject<?> ro ? ro.key == this.key : false;
     }
 
     @Override
@@ -526,7 +525,7 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
     }
 
     @Override
-    public Either<ResourceKey<T>,T> unwrap()
+    public Either<ResourceKey<T>, T> unwrap()
     {
         return isPresent() ? this.holder.unwrap() : Either.left(this.key);
     }

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -6,19 +6,9 @@
 package net.minecraftforge.registries;
 
 import net.minecraft.core.Holder;
-import net.minecraft.core.HolderOwner;
 import net.minecraft.core.Registry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
-import net.minecraftforge.fml.ModLoadingContext;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import com.mojang.datafixers.util.Either;
-
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -28,121 +18,41 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
- * This class is deprecated, for replacements, see the following options:
- * <ul>
- * <li>For objects typed to {@link RegistryObject} - replace their type with {@link Holder}</li>
- * <li>For {@link RegistryObject#create} - replace these with {@link Registry#getHolder(ResourceKey)}</li>
- * <li>For instance methods on {@link RegistryObject} - replace with equivalent functionality from {@link Holder}</li>
- * </ul>
+ * @deprecated Use {@link DeferredHolder}
  */
 @Deprecated(since = "1.20.1", forRemoval = true)
-public final class RegistryObject<T> implements Supplier<T>, Holder<T>
+public final class RegistryObject<T> extends DeferredHolder<T>
 {
-    /**
-     * The resource key of the target object.
-     */
-    private ResourceKey<T> key;
-
-    /**
-     * True if the value may refer to an unbound registry, and should not error if the registry is absent.
-     */
-    private final boolean optionalRegistry;
-
-    /**
-     * The currently cached value.
-     */
-    @Nullable
-    private Holder<T> holder;
-
-    /**
-     * Factory for a {@link RegistryObject} that stores the value of an object from the provided forge registry once it is ready.
-     *
-     * @param name the name of the object to look up in the forge registry
-     * @param registry the forge registry
-     * @return a {@link RegistryObject} that stores the value of an object from the provided forge registry once it is ready
-     */
     public static <T, U extends T> RegistryObject<U> create(final ResourceLocation name, IForgeRegistry<T> registry)
     {
-        return create(name, registry.getRegistryKey(), ModLoadingContext.get().getActiveNamespace());
+        return create(name, registry.getRegistryKey());
     }
 
-    /**
-     * Factory for a {@link RegistryObject} that stores the value of an object from a registry once it is ready based on a lookup of the provided registry key.
-     * <p>
-     * If a registry with the given key cannot be found, an exception will be thrown when trying to fill this RegistryObject.
-     * Use {@link #createOptional(ResourceLocation, ResourceKey, String)} for RegistryObjects of optional registries.
-     *
-     * @param name the name of the object to look up in a registry
-     * @param registryKey the key of the registry. Supports lookups on {@link BuiltInRegistries} and {@link RegistryManager#ACTIVE}.
-     * @param modid the mod id calling context
-     * @return a {@link RegistryObject} that stores the value of an object from a registry once it is ready
-     * @see #createOptional(ResourceLocation, ResourceKey, String)
-     * @see #create(ResourceLocation, IForgeRegistry)
-     * @see #create(ResourceLocation, ResourceLocation, String)
-     */
     public static <T, U extends T> RegistryObject<U> create(final ResourceLocation name, final ResourceKey<? extends Registry<T>> registryKey, String modid)
     {
-        return new RegistryObject<>(name, registryKey.location(), modid, false);
+        return create(name, registryKey);
     }
 
-    /**
-     * Factory for a {@link RegistryObject} that optionally stores the value of an object from a registry once it is ready if the registry exists
-     * based on a lookup of the provided registry key.
-     * <p>
-     * If a registry with the given key cannot be found, it will be silently ignored and this RegistryObject will not be filled.
-     * Use {@link #create(ResourceLocation, ResourceKey, String)} for RegistryObjects that should throw exceptions on missing registry.
-     *
-     * @param name the name of the object to look up in a registry
-     * @param registryKey the key of the registry. Supports lookups on {@link BuiltInRegistries} and {@link RegistryManager#ACTIVE}.
-     * @param modid the mod id calling context
-     * @return a {@link RegistryObject} that stores the value of an object from a registry once it is ready
-     * @see #create(ResourceLocation, ResourceKey, String)
-     * @see #create(ResourceLocation, IForgeRegistry)
-     * @see #create(ResourceLocation, ResourceLocation, String)
-     */
     public static <T, U extends T> RegistryObject<U> createOptional(final ResourceLocation name, final ResourceKey<? extends Registry<T>> registryKey,
             String modid)
     {
-        return new RegistryObject<>(name, registryKey.location(), modid, true);
+        return create(name, registryKey);
     }
 
-    /**
-     * Factory for a {@link RegistryObject} that stores the value of an object from a registry once it is ready based on a lookup of the provided registry name.
-     * <p>
-     * If a registry with the given name cannot be found, an exception will be thrown when trying to fill this RegistryObject.
-     * Use {@link #createOptional(ResourceLocation, ResourceLocation, String)} for RegistryObjects of optional registries.
-     *
-     * @param name the name of the object to look up in a registry
-     * @param registryName the name of the registry. Supports lookups on {@link BuiltInRegistries} and {@link RegistryManager#ACTIVE}.
-     * @param modid the mod id calling context
-     * @return a {@link RegistryObject} that stores the value of an object from a registry once it is ready
-     * @see #createOptional(ResourceLocation, ResourceLocation, String)
-     * @see #create(ResourceLocation, IForgeRegistry)
-     * @see #create(ResourceLocation, ResourceKey, String)
-     */
     public static <T, U extends T> RegistryObject<U> create(final ResourceLocation name, final ResourceLocation registryName, String modid)
     {
-        return new RegistryObject<>(name, registryName, modid, false);
+        return create(name, ResourceKey.createRegistryKey(registryName));
     }
 
-    /**
-     * Factory for a {@link RegistryObject} that optionally stores the value of an object from a registry once it is ready if the registry exists
-     * based on a lookup of the provided registry name.
-     * <p>
-     * If a registry with the given name cannot be found, it will be silently ignored and this RegistryObject will not be filled.
-     * Use {@link #create(ResourceLocation, ResourceLocation, String)} for RegistryObjects that should throw exceptions on missing registry.
-     *
-     * @param name the name of the object to look up in a registry
-     * @param registryName the name of the registry. Supports lookups on {@link BuiltInRegistries} and {@link RegistryManager#ACTIVE}.
-     * @param modid the mod id calling context
-     * @return a {@link RegistryObject} that stores the value of an object from a registry once it is ready
-     * @see #create(ResourceLocation, ResourceLocation, String)
-     * @see #create(ResourceLocation, IForgeRegistry)
-     * @see #create(ResourceLocation, ResourceKey, String)
-     */
     public static <T, U extends T> RegistryObject<U> createOptional(final ResourceLocation name, final ResourceLocation registryName, String modid)
     {
-        return new RegistryObject<>(name, registryName, modid, true);
+        return create(name, ResourceKey.createRegistryKey(registryName));
+    }
+
+    @SuppressWarnings({"unchecked","rawtypes"})
+    private static <T> RegistryObject<T> create(ResourceLocation name, ResourceKey registryKey)
+    {
+        return new RegistryObject<T>(ResourceKey.create(registryKey, name));
     }
 
     private static final RegistryObject<?> EMPTY = createOptional(new ResourceLocation("empty", "empty"), new ResourceLocation("empty", "empty"), "empty");
@@ -152,178 +62,22 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
         RegistryObject<T> t = (RegistryObject<T>) EMPTY;
         return t;
     }
-
-    private RegistryObject(final ResourceLocation name, final ResourceLocation registryName, final String modid, boolean optionalRegistry)
+    
+    public Stream<T> stream()
     {
-        this.key = ResourceKey.create(ResourceKey.createRegistryKey(registryName), name);
-        this.optionalRegistry = optionalRegistry;
-        final Throwable callerStack = new Throwable("Calling Site from mod: " + modid);
-        ObjectHolderRegistry.addHandler(new Consumer<>()
-        {
-            private boolean registryExists = false;
-            private boolean invalidRegistry = false;
-
-            @Override
-            public void accept(Predicate<ResourceLocation> pred)
-            {
-                if (invalidRegistry)
-                    return;
-                if (!RegistryObject.this.optionalRegistry && !registryExists)
-                {
-                    if (!registryExists(registryName))
-                    {
-                        invalidRegistry = true;
-                        throw new IllegalStateException("Unable to find registry with key " + registryName + " for mod \"" + modid + "\". Check the 'caused by' to see further stack.", callerStack);
-                    }
-                    registryExists = true;
-                }
-                if (pred.test(registryName))
-                    RegistryObject.this.updateReference(registryName);
-            }
-        });
-        this.updateReference(registryName);
-    }
-
-    /**
-     * Retrieves the wrapped object in the registry.
-     * This value will automatically be updated when the backing registry is updated.
-     *
-     * @throws NullPointerException If the value is null. Use {@link #isPresent()} to check if the value exists first.
-     * @see #isPresent()
-     * @see #orElse(Object)
-     * @see #orElseGet(Supplier)
-     * @see #orElseThrow(Supplier)
-     */
-    @NotNull
-    @Override
-    public T get()
-    {
-        Objects.requireNonNull(this.holder, () -> "Registry Object not present: " + this.key);
-        return this.holder.get();
-    }
-
-    @SuppressWarnings({"unchecked","rawtypes"})
-    void updateReference(IForgeRegistry<? super T> registry)
-    {
-        if (registry.containsKey(this.key.location()))
-        {
-            this.holder = (Holder<T>) registry.getHolder((ResourceKey) this.key).get();
-        }
-        else
-        {
-            this.holder = null;
-        }
-    }
-
-    @SuppressWarnings({"unchecked","rawtypes"})
-    void updateReference(Registry<? super T> registry)
-    {
-        if (registry.containsKey(this.key.location()))
-        {
-            this.holder = (Holder<T>) registry.getHolder((ResourceKey) this.key).get();
-        }
-        else
-        {
-            this.holder = null;
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    void updateReference(ResourceLocation registryName)
-    {
-        IForgeRegistry<? super T> forgeRegistry = RegistryManager.ACTIVE.getRegistry(registryName);
-        if (forgeRegistry != null)
-        {
-            updateReference(forgeRegistry);
-            return;
-        }
-
-        Registry<? super T> vanillaRegistry = (Registry<? super T>) BuiltInRegistries.REGISTRY.get(registryName);
-        if (vanillaRegistry != null)
-        {
-            updateReference(vanillaRegistry);
-            return;
-        }
-
-        this.holder = null;
-    }
-
-    void updateReference(RegisterEvent event)
-    {
-        IForgeRegistry<? super T> forgeRegistry = event.getForgeRegistry();
-        if (forgeRegistry != null)
-        {
-            updateReference(forgeRegistry);
-            return;
-        }
-
-        Registry<? super T> vanillaRegistry = event.getVanillaRegistry();
-        if (vanillaRegistry != null)
-            updateReference(vanillaRegistry);
-        else
-            this.holder = null;
-    }
-
-    private static boolean registryExists(ResourceLocation registryName)
-    {
-        return RegistryManager.ACTIVE.getRegistry(registryName) != null
-                || BuiltInRegistries.REGISTRY.containsKey(registryName);
-    }
-
-    public ResourceLocation getId()
-    {
-        return this.key.location();
-    }
-
-    /**
-     * Returns the resource key that points to the registry and name of this registry object.
-     * Nullable only if this RegistryObject is empty and has no name.
-     *
-     * @return the resource key that points to the registry and name of this registry object
-     */
-    @Nullable
-    public ResourceKey<T> getKey()
-    {
-        return this.key;
-    }
-
-    public Stream<T> stream() {
         return isPresent() ? Stream.of(get()) : Stream.of();
     }
-
-    /**
-     * Return {@code true} if there is a mod object present, otherwise {@code false}.
-     *
-     * @return {@code true} if there is a mod object present, otherwise {@code false}
-     */
-    public boolean isPresent() {
-        return this.holder != null;
+    
+    private RegistryObject(ResourceKey<T> key)
+    {
+        super(key);
     }
 
-    /**
-     * If a mod object is present, invoke the specified consumer with the object,
-     * otherwise do nothing.
-     *
-     * @param consumer block to be executed if a mod object is present
-     * @throws NullPointerException if mod object is present and {@code consumer} is
-     * null
-     */
     public void ifPresent(Consumer<? super T> consumer) {
         if (isPresent())
             consumer.accept(get());
     }
 
-    /**
-     * If a mod object is present, and the mod object matches the given predicate,
-     * return an {@code RegistryObject} describing the value, otherwise return an
-     * empty {@code RegistryObject}.
-     *
-     * @param predicate a predicate to apply to the mod object, if present
-     * @return an {@code RegistryObject} describing the value of this {@code RegistryObject}
-     * if a mod object is present and the mod object matches the given predicate,
-     * otherwise an empty {@code RegistryObject}
-     * @throws NullPointerException if the predicate is null
-     */
     public RegistryObject<T> filter(Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate);
         if (!isPresent())
@@ -332,21 +86,6 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
             return predicate.test(get()) ? this : empty();
     }
 
-    /**
-     * If a mod object is present, apply the provided mapping function to it,
-     * and if the result is non-null, return an {@code Optional} describing the
-     * result.  Otherwise return an empty {@code Optional}.
-     *
-     * @apiNote This method supports post-processing on optional values, without
-     * the need to explicitly check for a return status.
-     *
-     * @param <U> The type of the result of the mapping function
-     * @param mapper a mapping function to apply to the mod object, if present
-     * @return an {@code Optional} describing the result of applying a mapping
-     * function to the mod object of this {@code RegistryObject}, if a mod object is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null
-     */
     public<U> Optional<U> map(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper);
         if (!isPresent())
@@ -356,23 +95,6 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
         }
     }
 
-    /**
-     * If a value is present, apply the provided {@code Optional}-bearing
-     * mapping function to it, return that result, otherwise return an empty
-     * {@code Optional}.  This method is similar to {@link #map(Function)},
-     * but the provided mapper is one whose result is already an {@code Optional},
-     * and if invoked, {@code flatMap} does not wrap it with an additional
-     * {@code Optional}.
-     *
-     * @param <U> The type parameter to the {@code Optional} returned by
-     * @param mapper a mapping function to apply to the mod object, if present
-     *           the mapping function
-     * @return the result of applying an {@code Optional}-bearing mapping
-     * function to the value of this {@code Optional}, if a value is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null or returns
-     * a null result
-     */
     public<U> Optional<U> flatMap(Function<? super T, Optional<U>> mapper) {
         Objects.requireNonNull(mapper);
         if (!isPresent())
@@ -382,67 +104,19 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
         }
     }
 
-    /**
-     * If a mod object is present, lazily apply the provided mapping function to it,
-     * returning a supplier for the transformed result. If this object is empty, or the
-     * mapping function returns {@code null}, the supplier will return {@code null}.
-     *
-     * @apiNote This method supports post-processing on optional values, without
-     * the need to explicitly check for a return status.
-     *
-     * @param <U> The type of the result of the mapping function
-     * @param mapper A mapping function to apply to the mod object, if present
-     * @return A {@code Supplier} lazily providing the result of applying a mapping
-     * function to the mod object of this {@code RegistryObject}, if a mod object is present,
-     * otherwise a supplier returning {@code null}
-     * @throws NullPointerException if the mapping function is {@code null}
-     */
     public<U> Supplier<U> lazyMap(Function<? super T, ? extends U> mapper) {
         Objects.requireNonNull(mapper);
         return () -> isPresent() ? mapper.apply(get()) : null;
     }
 
-    /**
-     * Return the mod object if present, otherwise return {@code other}.
-     *
-     * @param other the mod object to be returned if there is no mod object present, may
-     * be null
-     * @return the mod object, if present, otherwise {@code other}
-     */
     public T orElse(T other) {
         return isPresent() ? get() : other;
     }
 
-    /**
-     * Return the mod object if present, otherwise invoke {@code other} and return
-     * the result of that invocation.
-     *
-     * @param other a {@code Supplier} whose result is returned if no mod object
-     * is present
-     * @return the mod object if present otherwise the result of {@code other.get()}
-     * @throws NullPointerException if mod object is not present and {@code other} is
-     * null
-     */
     public T orElseGet(Supplier<? extends T> other) {
         return isPresent() ? get() : other.get();
     }
 
-    /**
-     * Return the contained mod object, if present, otherwise throw an exception
-     * to be created by the provided supplier.
-     *
-     * @apiNote A method reference to the exception constructor with an empty
-     * argument list can be used as the supplier. For example,
-     * {@code IllegalStateException::new}
-     *
-     * @param <X> Type of the exception to be thrown
-     * @param exceptionSupplier The supplier which will return the exception to
-     * be thrown
-     * @return the present mod object
-     * @throws X if there is no mod object present
-     * @throws NullPointerException if no mod object is present and
-     * {@code exceptionSupplier} is null
-     */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
         if (isPresent()) {
             return get();
@@ -451,98 +125,8 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
         }
     }
 
-    /**
-     * Returns an optional {@link Holder} instance pointing to this RegistryObject's name and value.
-     * <p>
-     * This should <b>only</b> be used in cases where vanilla code requires passing in a Holder.
-     * Mod-written code should rely on RegistryObjects or Suppliers instead.
-     * <p>
-     * The returned optional will be empty if the registry does not exist or if {@link #isPresent() returns false}.
-     *
-     * @return an optional {@link Holder} instance pointing to this RegistryObject's name and value
-     * @deprecated Use the native methods, as this class now implements Holder.
-     */
     public Optional<Holder<T>> getHolder()
     {
         return Optional.of(this);
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (this == obj) return true;
-        return obj instanceof RegistryObject<?> ro ? ro.key == this.key : false;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return this.key.hashCode();
-    }
-
-    @Override
-    public T value()
-    {
-        return get();
-    }
-
-    @Override
-    public boolean isBound()
-    {
-        return isPresent() && this.holder.isBound();
-    }
-
-    @Override
-    public boolean is(ResourceLocation id)
-    {
-        return id.equals(this.key.location());
-    }
-
-    @Override
-    public boolean is(ResourceKey<T> key)
-    {
-        return key == this.key;
-    }
-
-    @Override
-    public boolean is(Predicate<ResourceKey<T>> filter)
-    {
-        return filter.test(this.key);
-    }
-
-    @Override
-    public boolean is(TagKey<T> tag)
-    {
-        return isPresent() && this.holder.is(tag);
-    }
-
-    @Override
-    public Stream<TagKey<T>> tags()
-    {
-        return isPresent() ? this.holder.tags() : Stream.empty();
-    }
-
-    @Override
-    public Either<ResourceKey<T>, T> unwrap()
-    {
-        return isPresent() ? this.holder.unwrap() : Either.left(this.key);
-    }
-
-    @Override
-    public Optional<ResourceKey<T>> unwrapKey()
-    {
-        return Optional.of(this.key);
-    }
-
-    @Override
-    public Kind kind()
-    {
-        return Kind.REFERENCE;
-    }
-
-    @Override
-    public boolean canSerializeIn(HolderOwner<T> owner)
-    {
-        return isPresent() && this.holder.canSerializeIn(owner);
     }
 }

--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -12,7 +12,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 
 import org.jetbrains.annotations.NotNull;
@@ -506,10 +505,9 @@ public final class RegistryObject<T> implements Supplier<T>, Holder<T>
     }
 
     @Override
-    @SuppressWarnings({"rawtypes","unchecked"})
     public boolean is(Predicate<ResourceKey<T>> filter)
     {
-        return filter.test((ResourceKey) this.key);
+        return filter.test(this.key);
     }
 
     @Override


### PR DESCRIPTION
This PR performs the following goals as an initial transition to the vanilla registry system, in accordance with #37:
1. Forces all forge registries to be backed by a vanilla registry.
2. Makes `RegistryObject` implement `Holder`.
3. Deprecates `RegistryObject` for removal, as all uses can be replaced with `Holder`.
4. Introduces `DeferredHolder` to replaces uses of `RegistryObject` not covered by `Holder$Reference`.

Due to method signatures, `DeferredRegister#register` must still return a `RegistryObject`, but callers can switch the return type of the stored value to `Holder` or `DeferredHolder`.
