### PR TITLE
Mod List Screen Cleanup

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/ModListScreen.java
@@ -12,20 +12,22 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
+import com.mojang.logging.LogUtils;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.server.packs.resources.IoSupplier;
 import net.minecraftforge.client.ConfigScreenHandler;
 import net.minecraftforge.client.gui.widget.ModListWidget;
 import net.minecraftforge.client.gui.widget.ScrollPanel;
-import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
 import net.minecraftforge.resource.PathPackResources;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -40,30 +42,27 @@ import net.minecraft.client.gui.components.ObjectSelectionList;
 import com.mojang.blaze3d.vertex.Tesselator;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import com.mojang.blaze3d.platform.NativeImage;
-import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.Util;
 import net.minecraftforge.common.ForgeHooks;
-import net.minecraftforge.common.util.Size2i;
-import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.common.util.MavenVersionStringHelper;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.fml.loading.StringUtils;
-import net.minecraftforge.resource.ResourcePackLoader;
 import net.minecraftforge.forgespi.language.IModInfo;
-
-import net.minecraft.locale.Language;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
+import net.minecraftforge.resource.ResourcePackLoader;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 
 public class ModListScreen extends Screen
 {
-    private static String stripControlCodes(String value) { return net.minecraft.util.StringUtil.stripColor(value); }
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static String stripControlCodes(String value) {return net.minecraft.util.StringUtil.stripColor(value);}
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     private enum SortType implements Comparator<IModInfo>
     {
         NORMAL,
@@ -71,22 +70,26 @@ public class ModListScreen extends Screen
         Z_TO_A{ @Override protected int compare(String name1, String name2){ return name2.compareTo(name1); }};
 
         Button button;
-        protected int compare(String name1, String name2){ return 0; }
+
+        protected int compare(String name1, String name2) {return 0;}
+
         @Override
-        public int compare(IModInfo o1, IModInfo o2) {
+        public int compare(IModInfo o1, IModInfo o2)
+        {
             String name1 = StringUtils.toLowerCase(stripControlCodes(o1.getDisplayName()));
             String name2 = StringUtils.toLowerCase(stripControlCodes(o2.getDisplayName()));
             return compare(name1, name2);
         }
 
-        Component getButtonText() {
+        Component getButtonText()
+        {
             return Component.translatable("fml.menu.mods." + StringUtils.toLowerCase(name()));
         }
     }
 
     private static final int PADDING = 6;
 
-    private Screen parentScreen;
+    private final Screen parentScreen;
 
     private ModListWidget modList;
     private InfoPanel modInfo;
@@ -94,10 +97,10 @@ public class ModListScreen extends Screen
     private int listWidth;
     private List<IModInfo> mods;
     private final List<IModInfo> unsortedMods;
-    private Button configButton, openModsFolderButton, doneButton;
+    private Button configButton;
 
-    private int buttonMargin = 1;
-    private int numButtons = SortType.values().length;
+    private final int buttonMargin = 1;
+    private final int numButtons = SortType.values().length;
     private String lastFilterText = "";
 
     private EditBox search;
@@ -110,12 +113,14 @@ public class ModListScreen extends Screen
         super(Component.translatable("fml.menu.mods.title"));
         this.parentScreen = parentScreen;
         this.mods = Collections.unmodifiableList(ModList.get().getMods());
-        this.unsortedMods = Collections.unmodifiableList(this.mods);
+        this.unsortedMods = List.copyOf(mods);
     }
 
-    class InfoPanel extends ScrollPanel {
+    class InfoPanel extends ScrollPanel
+    {
         private ResourceLocation logoPath;
-        private Size2i logoDims = new Size2i(0, 0);
+        private int logoWidth;
+        private int logoHeight;
         private List<FormattedCharSequence> lines = Collections.emptyList();
 
         InfoPanel(Minecraft mcIn, int widthIn, int heightIn, int topIn)
@@ -123,17 +128,19 @@ public class ModListScreen extends Screen
             super(mcIn, widthIn, heightIn, topIn, modList.getRight() + PADDING);
         }
 
-        void setInfo(List<String> lines, ResourceLocation logoPath, Size2i logoDims)
+        void setInfo(List<String> lines, ResourceLocation logoPath, int logoWidth, int logoHeight)
         {
             this.logoPath = logoPath;
-            this.logoDims = logoDims;
+            this.logoWidth = logoWidth;
+            this.logoHeight = logoHeight;
             this.lines = resizeContent(lines);
         }
 
         void clearInfo()
         {
             this.logoPath = null;
-            this.logoDims = new Size2i(0, 0);
+            this.logoHeight = 0;
+            this.logoWidth = 0;
             this.lines = Collections.emptyList();
         }
 
@@ -177,12 +184,13 @@ public class ModListScreen extends Screen
         @Override
         protected void drawPanel(GuiGraphics guiGraphics, int entryRight, int relativeY, Tesselator tess, int mouseX, int mouseY)
         {
-            if (logoPath != null) {
+            if (logoPath != null)
+            {
                 RenderSystem.enableBlend();
                 RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
                 // Draw the logo image inscribed in a rectangle with width entryWidth (minus some padding) and height 50
                 int headerHeight = 50;
-                guiGraphics.blitInscribed(logoPath, left + PADDING, relativeY, width - (PADDING * 2), headerHeight, logoDims.width, logoDims.height, false, true);
+                guiGraphics.blitInscribed(logoPath, left + PADDING, relativeY, width - (PADDING * 2), headerHeight, logoWidth, logoHeight, false, true);
                 relativeY += headerHeight + PADDING;
             }
 
@@ -198,17 +206,20 @@ public class ModListScreen extends Screen
             }
 
             final Style component = findTextLine(mouseX, mouseY);
-            if (component!=null) {
+            if (component != null)
+            {
                 guiGraphics.renderComponentHoverEffect(ModListScreen.this.font, component, mouseX, mouseY);
             }
         }
 
-        private Style findTextLine(final int mouseX, final int mouseY) {
+        private Style findTextLine(final int mouseX, final int mouseY)
+        {
             if (!isMouseOver(mouseX, mouseY))
                 return null;
 
             double offset = (mouseY - top) + border + scrollDistance + 1;
-            if (logoPath != null) {
+            if (logoPath != null)
+            {
                 offset -= 50;
             }
             if (offset <= 0)
@@ -218,7 +229,7 @@ public class ModListScreen extends Screen
             if (lineIdx >= lines.size() || lineIdx < 1)
                 return null;
 
-            FormattedCharSequence line = lines.get(lineIdx-1);
+            FormattedCharSequence line = lines.get(lineIdx - 1);
             if (line != null)
             {
                 return font.getSplitter().componentStyleAtWidth(line, mouseX - left - border);
@@ -227,9 +238,11 @@ public class ModListScreen extends Screen
         }
 
         @Override
-        public boolean mouseClicked(final double mouseX, final double mouseY, final int button) {
+        public boolean mouseClicked(final double mouseX, final double mouseY, final int button)
+        {
             final Style component = findTextLine((int) mouseX, (int) mouseY);
-            if (component != null) {
+            if (component != null)
+            {
                 ModListScreen.this.handleComponentClicked(component);
                 return true;
             }
@@ -237,13 +250,13 @@ public class ModListScreen extends Screen
         }
 
         @Override
-        public NarrationPriority narrationPriority() {
+        public NarrationPriority narrationPriority()
+        {
             return NarrationPriority.NONE;
         }
 
         @Override
-        public void updateNarration(NarrationElementOutput p_169152_) {
-        }
+        public void updateNarration(NarrationElementOutput output) { }
     }
 
     @Override
@@ -251,10 +264,10 @@ public class ModListScreen extends Screen
     {
         for (IModInfo mod : mods)
         {
-            listWidth = Math.max(listWidth,getFontRenderer().width(mod.getDisplayName()) + 10);
-            listWidth = Math.max(listWidth,getFontRenderer().width(MavenVersionStringHelper.artifactVersionToString(mod.getVersion())) + 5);
+            listWidth = Math.max(listWidth, getFontRenderer().width(mod.getDisplayName()) + 10);
+            listWidth = Math.max(listWidth, getFontRenderer().width(MavenVersionStringHelper.artifactVersionToString(mod.getVersion())) + 5);
         }
-        listWidth = Math.max(Math.min(listWidth, width/3), 100);
+        listWidth = Math.max(Math.min(listWidth, width / 3), 100);
         listWidth += listWidth % numButtons != 0 ? (numButtons - listWidth % numButtons) : 0;
 
         int modInfoWidth = this.width - this.listWidth - (PADDING * 3);
@@ -262,8 +275,8 @@ public class ModListScreen extends Screen
         int y = this.height - 20 - PADDING;
         int fullButtonHeight = PADDING + 20 + PADDING;
 
-        doneButton = Button.builder(Component.translatable("gui.done"), b -> ModListScreen.this.onClose()).bounds(((listWidth + PADDING + this.width - doneButtonWidth) / 2), y, doneButtonWidth, 20).build();
-        openModsFolderButton = Button.builder(Component.translatable("fml.menu.mods.openmodsfolder"), b -> Util.getPlatform().openFile(FMLPaths.MODSDIR.get().toFile())).bounds(6, y, this.listWidth, 20).build();
+        Button doneButton = Button.builder(Component.translatable("gui.done"), b -> ModListScreen.this.onClose()).bounds(((listWidth + PADDING + this.width - doneButtonWidth) / 2), y, doneButtonWidth, 20).build();
+        Button openModsFolderButton = Button.builder(Component.translatable("fml.menu.mods.openmodsfolder"), b -> Util.getPlatform().openFile(FMLPaths.MODSDIR.get().toFile())).bounds(6, y, this.listWidth, 20).build();
         y -= 20 + PADDING;
         configButton = Button.builder(Component.translatable("fml.menu.mods.config"), b -> ModListScreen.this.displayModConfig()).bounds(6, y, this.listWidth, 20).build();
         y -= 14 + PADDING;
@@ -300,7 +313,8 @@ public class ModListScreen extends Screen
         if (selected == null) return;
         try
         {
-            ConfigScreenHandler.getScreenFactoryFor(selected.getInfo()).map(f->f.apply(this.minecraft, this)).ifPresent(newScreen -> this.minecraft.setScreen(newScreen));
+            assert minecraft != null;
+            ConfigScreenHandler.getScreenFactoryFor(selected.getInfo()).map(f -> f.apply(this.minecraft, this)).ifPresent(newScreen -> this.minecraft.setScreen(newScreen));
         }
         catch (final Exception e)
         {
@@ -336,13 +350,13 @@ public class ModListScreen extends Screen
 
     public <T extends ObjectSelectionList.Entry<T>> void buildModList(Consumer<T> modListViewConsumer, Function<IModInfo, T> newEntry)
     {
-        mods.forEach(mod->modListViewConsumer.accept(newEntry.apply(mod)));
+        mods.forEach(mod -> modListViewConsumer.accept(newEntry.apply(mod)));
     }
 
     private void reloadMods()
     {
         this.mods = this.unsortedMods.stream().
-                filter(mi->StringUtils.toLowerCase(stripControlCodes(mi.getDisplayName())).contains(StringUtils.toLowerCase(search.getValue()))).collect(Collectors.toList());
+            filter(mi -> StringUtils.toLowerCase(stripControlCodes(mi.getDisplayName())).contains(StringUtils.toLowerCase(search.getValue()))).collect(Collectors.toList());
         lastFilterText = search.getValue();
     }
 
@@ -359,7 +373,7 @@ public class ModListScreen extends Screen
     }
 
     @Override
-    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick)
+    public void render(@NotNull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick)
     {
         this.modList.render(guiGraphics, mouseX, mouseY, partialTick);
         if (this.modInfo != null)
@@ -367,14 +381,15 @@ public class ModListScreen extends Screen
 
         Component text = Component.translatable("fml.menu.mods.search");
         int x = modList.getLeft() + ((modList.getRight() - modList.getLeft()) / 2) - (getFontRenderer().width(text) / 2);
-        this.search.render(guiGraphics, mouseX , mouseY, partialTick);
+        this.search.render(guiGraphics, mouseX, mouseY, partialTick);
         super.render(guiGraphics, mouseX, mouseY, partialTick);
         guiGraphics.drawString(getFontRenderer(), text.getVisualOrderText(), x, search.getY() - getFontRenderer().lineHeight, 0xFFFFFF, false);
     }
 
+    @NotNull
     public Minecraft getMinecraftInstance()
     {
-        return minecraft;
+        return Objects.requireNonNull(minecraft);
     }
 
     public Font getFontRenderer()
@@ -390,7 +405,8 @@ public class ModListScreen extends Screen
 
     private void updateCache()
     {
-        if (selected == null) {
+        if (selected == null)
+        {
             this.configButton.active = false;
             this.modInfo.clearInfo();
             return;
@@ -400,57 +416,50 @@ public class ModListScreen extends Screen
         List<String> lines = new ArrayList<>();
         VersionChecker.CheckResult vercheck = VersionChecker.getResult(selectedMod);
 
-        @SuppressWarnings("resource")
-        Pair<ResourceLocation, Size2i> logoData = selectedMod.getLogoFile().map(logoFile->
+        ResourceLocation logoPath = null;
+        int logoWidth = 0, logoHeight = 0;
+        final String logoFile = selectedMod.getLogoFile().orElse(null);
+        if (logoFile != null)
         {
-            TextureManager tm = this.minecraft.getTextureManager();
             final PathPackResources resourcePack = ResourcePackLoader.getPackFor(selectedMod.getModId())
-                    .orElse(ResourcePackLoader.getPackFor("forge").
-                            orElseThrow(()->new RuntimeException("Can't find forge, WHAT!")));
+                .orElse(ResourcePackLoader.getPackFor("forge")
+                    .orElseThrow(() -> new RuntimeException("Can't find forge, WHAT!")));
             try
             {
-                NativeImage logo = null;
-                IoSupplier<InputStream> logoResource = resourcePack.getRootResource(logoFile);
+                final IoSupplier<InputStream> logoResource = resourcePack.getRootResource(logoFile);
                 if (logoResource != null)
-                    logo = NativeImage.read(logoResource.get());
-                if (logo != null)
                 {
-
-                    return Pair.of(tm.register("modlogo", new DynamicTexture(logo) {
-
-                        @Override
-                        public void upload() {
-                            this.bind();
-                            NativeImage td = this.getPixels();
-                            // Use custom "blur" value which controls texture filtering (nearest-neighbor vs linear)
-                            this.getPixels().upload(0, 0, 0, 0, 0, td.getWidth(), td.getHeight(), selectedMod.getLogoBlur(), false, false, false);
-                        }
-                    }), new Size2i(logo.getWidth(), logo.getHeight()));
+                    try (InputStream input = logoResource.get())
+                    {
+                        final NativeImage logo = NativeImage.read(input);
+                        final ResourceLocation textureName = new ResourceLocation(selectedMod.getModId(), "modlogo");
+                        assert minecraft != null;
+                        minecraft.getTextureManager().register(textureName, new DynamicTexture(logo));
+                        logoPath = textureName;
+                        logoWidth = logo.getWidth();
+                        logoHeight = logo.getHeight();
+                    }
                 }
             }
-            catch (IOException e) { }
-            return Pair.<ResourceLocation, Size2i>of(null, new Size2i(0, 0));
-        }).orElse(Pair.of(null, new Size2i(0, 0)));
+            catch (IOException ignored) {}
+        }
 
         lines.add(selectedMod.getDisplayName());
-        lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.version", MavenVersionStringHelper.artifactVersionToString(selectedMod.getVersion())));
-        lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.idstate", selectedMod.getModId(), ModList.get().getModContainerById(selectedMod.getModId()).
-                map(ModContainer::getCurrentState).map(Object::toString).orElse("NONE")));
+        addLine(lines, "fml.menu.mods.info.version", MavenVersionStringHelper.artifactVersionToString(selectedMod.getVersion()));
+        addLine(lines, "fml.menu.mods.info.idstate", selectedMod.getModId(), ModList.get().getModContainerById(selectedMod.getModId())
+            .map(ModContainer::getCurrentState).map(Object::toString).orElse("NONE"));
 
-        selectedMod.getConfig().getConfigElement("credits").ifPresent(credits->
-                lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.credits", credits)));
-        selectedMod.getConfig().getConfigElement("authors").ifPresent(authors ->
-                lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.authors", authors)));
-        selectedMod.getConfig().getConfigElement("displayURL").ifPresent(displayURL ->
-                lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.displayurl", displayURL)));
-        if (selectedMod.getOwningFile() == null || selectedMod.getOwningFile().getMods().size()==1)
-            lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.nochildmods"));
+        selectedMod.getConfig().getConfigElement("credits").ifPresent(credits -> addLine(lines, "fml.menu.mods.info.credits", credits));
+        selectedMod.getConfig().getConfigElement("authors").ifPresent(authors -> addLine(lines, "fml.menu.mods.info.authors", authors));
+        selectedMod.getConfig().getConfigElement("displayURL").ifPresent(displayURL -> addLine(lines, "fml.menu.mods.info.displayurl", displayURL));
+        if (selectedMod.getOwningFile() == null || selectedMod.getOwningFile().getMods().size() == 1)
+            addLine(lines, "fml.menu.mods.info.nochildmods");
         else
-            lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.childmods", selectedMod.getOwningFile().getMods().stream().map(IModInfo::getDisplayName).collect(Collectors.joining(","))));
+            addLine(lines, "fml.menu.mods.info.childmods", selectedMod.getOwningFile().getMods().stream().map(IModInfo::getDisplayName).collect(Collectors.joining(",")));
 
         if (vercheck.status() == VersionChecker.Status.OUTDATED || vercheck.status() == VersionChecker.Status.BETA_OUTDATED)
-            lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.updateavailable", vercheck.url() == null ? "" : vercheck.url()));
-        lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.license", ((ModFileInfo) selectedMod.getOwningFile()).getLicense()));
+            addLine(lines, "fml.menu.mods.info.updateavailable", vercheck.url() == null ? "" : vercheck.url());
+        addLine(lines, "fml.menu.mods.info.license", selectedMod.getOwningFile().getLicense());
         lines.add(null);
         lines.add(selectedMod.getDescription());
 
@@ -467,7 +476,7 @@ public class ModListScreen extends Screen
         if ((vercheck.status() == VersionChecker.Status.OUTDATED || vercheck.status() == VersionChecker.Status.BETA_OUTDATED) && vercheck.changes().size() > 0)
         {
             lines.add(null);
-            lines.add(ForgeI18n.parseMessage("fml.menu.mods.info.changelogheader"));
+            addLine(lines, "fml.menu.mods.info.changelogheader");
             for (Entry<ComparableVersion, String> entry : vercheck.changes().entrySet())
             {
                 lines.add("  " + entry.getKey() + ":");
@@ -476,11 +485,13 @@ public class ModListScreen extends Screen
             }
         }
 
-        modInfo.setInfo(lines, logoData.getLeft(), logoData.getRight());
+        Preconditions.checkArgument(logoWidth > -1, "Logo width must be non-negative");
+        Preconditions.checkArgument(logoHeight > -1, "Logo height must be non-negative");
+        modInfo.setInfo(lines, logoPath, logoWidth, logoHeight);
     }
 
     @Override
-    public void resize(Minecraft mc, int width, int height)
+    public void resize(@NotNull Minecraft mc, int width, int height)
     {
         String s = this.search.getValue();
         SortType sort = this.sortType;
@@ -498,6 +509,12 @@ public class ModListScreen extends Screen
     @Override
     public void onClose()
     {
+        assert minecraft != null;
         this.minecraft.setScreen(this.parentScreen);
+    }
+
+    private void addLine(List<String> lines, String key, Object... args)
+    {
+        lines.add(Component.translatable(key, args).getString());
     }
 }

--- a/src/main/java/net/minecraftforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ModListWidget.java
@@ -5,28 +5,28 @@
 
 package net.minecraftforge.client.gui.widget;
 
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.ObjectSelectionList;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
-import net.minecraft.locale.Language;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.gui.ModListScreen;
-import net.minecraftforge.versions.forge.ForgeVersion;
 import net.minecraftforge.common.util.MavenVersionStringHelper;
 import net.minecraftforge.fml.VersionChecker;
 import net.minecraftforge.forgespi.language.IModInfo;
-
-import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraftforge.versions.forge.ForgeVersion;
+import org.jetbrains.annotations.NotNull;
 
 public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry>
 {
-    private static String stripControlCodes(String value) { return net.minecraft.util.StringUtil.stripColor(value); }
+    private static String stripControlCodes(String value) {return net.minecraft.util.StringUtil.stripColor(value);}
     private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeVersion.MOD_ID, "textures/gui/version_check_icons.png");
     private final int listWidth;
 
-    private ModListScreen parent;
+    private final ModListScreen parent;
 
     public ModListWidget(ModListScreen parent, int listWidth, int top, int bottom)
     {
@@ -48,28 +48,33 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry>
         return this.listWidth;
     }
 
-    public void refreshList() {
+    public void refreshList()
+    {
         this.clearEntries();
-        parent.buildModList(this::addEntry, mod->new ModEntry(mod, this.parent));
+        parent.buildModList(this::addEntry, mod -> new ModEntry(mod, this.parent));
     }
 
     @Override
-    protected void renderBackground(GuiGraphics guiGraphics)
+    protected void renderBackground(@NotNull GuiGraphics guiGraphics)
     {
         this.parent.renderBackground(guiGraphics);
     }
 
-    public class ModEntry extends ObjectSelectionList.Entry<ModEntry> {
+    public class ModEntry extends ObjectSelectionList.Entry<ModEntry>
+    {
         private final IModInfo modInfo;
         private final ModListScreen parent;
 
-        ModEntry(IModInfo info, ModListScreen parent) {
+        ModEntry(IModInfo info, ModListScreen parent)
+        {
             this.modInfo = info;
             this.parent = parent;
         }
 
         @Override
-        public Component getNarration() {
+        @NotNull
+        public Component getNarration()
+        {
             return Component.translatable("narrator.select", modInfo.getDisplayName());
         }
 
@@ -80,7 +85,7 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry>
             Component version = Component.literal(stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion())));
             VersionChecker.CheckResult vercheck = VersionChecker.getResult(modInfo);
             Font font = this.parent.getFontRenderer();
-            guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(name,    listWidth))), left + 3, top + 2, 0xFFFFFF, false);
+            guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(name, listWidth))), left + 3, top + 2, 0xFFFFFF, false);
             guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(version, listWidth))), left + 3, top + 2 + font.lineHeight, 0xCCCCCC, false);
             if (vercheck.status().shouldDraw())
             {
@@ -93,7 +98,7 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry>
         }
 
         @Override
-        public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_)
+        public boolean mouseClicked(double mouseX, double mouseY, int buttonId)
         {
             parent.setSelected(this);
             ModListWidget.this.setSelected(this);


### PR DESCRIPTION
In these changes I've not made any changes to the appearance of the screen, it just is cleaning up the param names, code style, and then standardizing some of the repeated methods. Any further changes to the screen would need something like this so it's better to submit it separately.

The two interesting things are changing how the logo image is constructed, (now it matches how vanilla does it, eg. PackSelectionScreen), and using Component, since the screen class already seemed to switch between them freely and since the class is client side anyway.