### PR TITLE
Provide clicked button as context to AbstractWidget#onClick

### DIFF
--- a/LICENSE-header.txt
+++ b/LICENSE-header.txt
@@ -1,2 +1,2 @@
-Copyright (c) Forge Development LLC and contributors
+Copyright (c) NeoForged and contributors
 SPDX-License-Identifier: LGPL-2.1-only

--- a/build.gradle
+++ b/build.gradle
@@ -1265,6 +1265,9 @@ project(':forge') {
                 files.from files("$rootDir/src/test/java")
             }
         }
+
+        // Skip legacy Forge Development LLC headers
+        skipExistingHeaders = true
     }
 
     tasks.register('genAllData') {

--- a/patches/minecraft/net/minecraft/client/gui/components/AbstractWidget.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/components/AbstractWidget.java.patch
@@ -1,5 +1,32 @@
 --- a/net/minecraft/client/gui/components/AbstractWidget.java
 +++ b/net/minecraft/client/gui/components/AbstractWidget.java
+@@ -30,7 +_,7 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public abstract class AbstractWidget implements Renderable, GuiEventListener, LayoutElement, NarratableEntry {
++public abstract class AbstractWidget implements Renderable, GuiEventListener, LayoutElement, NarratableEntry, net.minecraftforge.client.extensions.IAbstractWidgetExtension {
+    public static final ResourceLocation f_93617_ = new ResourceLocation("textures/gui/widgets.png");
+    public static final ResourceLocation f_267372_ = new ResourceLocation("textures/gui/accessibility.png");
+    private static final double f_273912_ = 0.5D;
+@@ -157,6 +_,8 @@
+       p_283546_.m_280163_(p_281674_, p_281808_, p_282444_, (float)p_283651_, (float)i, p_282390_, p_281441_, p_281711_, p_281541_);
+    }
+ 
++   /** @deprecated Neo: Use {@link #onClick(double, double, int)} instead. */
++   @Deprecated
+    public void m_5716_(double p_93634_, double p_93635_) {
+    }
+ 
+@@ -172,7 +_,7 @@
+             boolean flag = this.m_93680_(p_93641_, p_93642_);
+             if (flag) {
+                this.m_7435_(Minecraft.m_91087_().m_91106_());
+-               this.m_5716_(p_93641_, p_93642_);
++               this.onClick(p_93641_, p_93642_, p_93643_);
+                return true;
+             }
+          }
 @@ -234,6 +_,10 @@
        this.f_93618_ = p_93675_;
     }

--- a/src/main/java/net/minecraftforge/client/extensions/IAbstractWidgetExtension.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IAbstractWidgetExtension.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.client.extensions;
+
+import net.minecraft.client.gui.components.AbstractWidget;
+
+/**
+ * Extension interface for {@link AbstractWidget}.
+ */
+public interface IAbstractWidgetExtension
+{
+
+    private AbstractWidget self()
+    {
+        return (AbstractWidget) this;
+    }
+
+    /**
+     * Handles the logic for when this widget is clicked. Vanilla calls this after {@link AbstractWidget#mouseClicked(double, double, int)} validates that:
+     * <ul>
+     *     <li>this widget is {@link AbstractWidget#active active} and {@link AbstractWidget#visible visible}</li>
+     *     <li>the button {@link AbstractWidget#isValidClickButton(int) can be handled} by this widget</li>
+     *     <li>the mouse {@link AbstractWidget#clicked(double, double) is over} this widget</li>
+     * </ul>
+     *
+     * @param mouseX the X position of the mouse
+     * @param mouseY the Y position of the mouse
+     * @param button the mouse button being clicked
+     *
+     * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_LEFT
+     * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_RIGHT
+     * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_MIDDLE
+     * @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_4
+     */
+    default void onClick(double mouseX, double mouseY, int button)
+    {
+        self().onClick(mouseX, mouseY);
+    }
+}


### PR DESCRIPTION
This PR is relatively straightforward in that it just adds an extension overload for `AbstractWidget`'s `onClick` method that provides context to which button was clicked. The reason I am providing multiple `@see` declarations to try and nudge people towards where the constants for specific buttons are stored, but felt that when I just included left and right that it was unclear whether those were the only two things that might ever be passed to the method.

The more "complicated" things to note (and formalize the decision on) is that this PR:
- Changes the license header to NeoForged and skips checking existing licenses so that it doesn't override those that were attributed to forge. See [discord thread](https://discord.com/channels/313125603924639766/1131360720974524457) on license headers
- Sets a precedent of using `Neo:` for comments/javadocs related to NeoForge and descriptions/comments about what to use over this
- Sets a precedent for the naming of future extension interfaces as `I<Thing>Extension`. See [the comments](https://discord.com/channels/313125603924639766/1131782966989828156/1132832819446550601) from a discord thread on formatting and code style.