### PR TITLE
Fix air bubbles not regenerating - Closes #50

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1584,7 +1584,7 @@ public class ForgeHooks
         boolean isAir = entity.getEyeInFluidType().isAir() || entity.level().getBlockState(BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ())).is(Blocks.BUBBLE_COLUMN);
         boolean canBreathe = isAir;
         // The following effects cause the entity to not drown, but do not cause the air supply to be increased.
-        if (MobEffectUtil.hasWaterBreathing(entity) || !entity.canDrownInFluidType(entity.getEyeInFluidType()) || (entity instanceof Player player && player.getAbilities().invulnerable))
+        if (!isAir && (MobEffectUtil.hasWaterBreathing(entity) || !entity.canDrownInFluidType(entity.getEyeInFluidType()) || (entity instanceof Player player && player.getAbilities().invulnerable)))
         {
             canBreathe = true;
             refillAirAmount = 0;


### PR DESCRIPTION
This fixes the issue where air bubbles will not regenerate when out of water. This was happening because `!entity.canDrownInFluidType(entity.getEyeInFluidType())` evaluates to true when in the air. 

This entire condition should only be evaluated when in a liquid.