### PR TITLE
Fix ScrollPanel being scrollable when starting to drag outside its bounds

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/widget/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ScrollPanel.java
@@ -242,7 +242,7 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         if (super.mouseClicked(mouseX, mouseY, button))
             return true;
 
-        this.scrolling = button == 0 && mouseX >= barLeft && mouseX < barLeft + barWidth;
+        this.scrolling = button == 0 && mouseX >= barLeft && mouseX < barLeft + barWidth && mouseY >= top && mouseY <= bottom;
         if (this.scrolling)
         {
             return true;

--- a/src/main/java/net/minecraftforge/client/gui/widget/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/widget/ScrollPanel.java
@@ -232,8 +232,8 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
     @Override
     public boolean isMouseOver(double mouseX, double mouseY)
     {
-        return mouseX >= this.left && mouseX <= this.left + this.width &&
-                mouseY >= this.top && mouseY <= this.bottom;
+        return mouseX >= this.left && mouseX < this.right &&
+                mouseY >= this.top && mouseY < this.bottom;
     }
 
     @Override
@@ -242,13 +242,13 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         if (super.mouseClicked(mouseX, mouseY, button))
             return true;
 
-        this.scrolling = button == 0 && mouseX >= barLeft && mouseX < barLeft + barWidth && mouseY >= top && mouseY <= bottom;
+        this.scrolling = button == 0 && mouseX >= barLeft && mouseX < right && mouseY >= top && mouseY < bottom;
         if (this.scrolling)
         {
             return true;
         }
         int mouseListY = ((int)mouseY) - this.top - this.getContentHeight() + (int)this.scrollDistance - border;
-        if (mouseX >= left && mouseX <= right && mouseListY < 0)
+        if (mouseX >= left && mouseX < right && mouseListY < 0)
         {
             return this.clickPanel(mouseX - left, mouseY - this.top + (int)this.scrollDistance - border, button);
         }


### PR DESCRIPTION
This PR fixes an oversight in the ScrollPanel code responsible for checking whether the user should be scrolling by dragging the mouse. The current behavior is that anywhere above or below the scroll bar, a click+drag action will initiate the scrolling - even when not clicking the scroll bar itself. The expected behavior would be that scrolling is only possible when clicking on the scroll bar itself. 
This can be problematic if a screen adds a slot above or below the scroll bar, leading to the slot not being clickable in the relevant area as the `mouseClicked` method returns early when scrolling is initiated.

Here is a video illustrating the issue, using the list on the ModMismatchDisconnectedScreen as an example:

https://github.com/neoforged/NeoForge/assets/5149876/4a6c4558-0ed8-4ed2-aaee-b10b7f264c93

Additionally, this PR resovles some off-by-one errors that were identified and discussed on Discord.