### PR TITLE
[1.20.1] Extensible Damage Types

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -75,6 +75,17 @@
        }
     }
  
+@@ -789,6 +_,10 @@
+             return;
+          }
+ 
++         // Neo: Prevent screen shake if the damage type is marked as "forge:no_flinch"
++         var lastSrc = livingentity.m_21225_();
++         if (lastSrc != null && lastSrc.m_269533_(net.minecraftforge.common.Tags.DamageTypes.NO_FLINCH)) return;
++
+          f /= (float)livingentity.f_20917_;
+          f = Mth.m_14031_(f * f * f * f * (float)Math.PI);
+          float f3 = livingentity.m_264297_();
 @@ -907,12 +_,12 @@
  
           Window window = this.f_109059_.m_91268_();

--- a/patches/minecraft/net/minecraft/world/damagesource/CombatTracker.java.patch
+++ b/patches/minecraft/net/minecraft/world/damagesource/CombatTracker.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/damagesource/CombatTracker.java
++++ b/net/minecraft/world/damagesource/CombatTracker.java
+@@ -92,6 +_,11 @@
+          DamageSource damagesource = combatentry.f_19250_();
+          CombatEntry combatentry1 = this.m_19298_();
+          DeathMessageType deathmessagetype = damagesource.m_269415_().f_268472_();
++         // Neo: Implement IDeathMessageProvider#getDeathMessage
++         // Vanilla logic is replicated in IDeathMessageProvider.DEFAULT
++         if (true) {
++             return deathmessagetype.getMessageFunction().getDeathMessage(f_19277_, combatentry, combatentry1);
++         }
+          if (deathmessagetype == DeathMessageType.FALL_VARIANTS && combatentry1 != null) {
+             return this.m_289215_(combatentry1, damagesource.m_7639_());
+          } else if (deathmessagetype == DeathMessageType.INTENTIONAL_GAME_DESIGN) {

--- a/patches/minecraft/net/minecraft/world/damagesource/DamageEffects.java.patch
+++ b/patches/minecraft/net/minecraft/world/damagesource/DamageEffects.java.patch
@@ -1,0 +1,59 @@
+--- a/net/minecraft/world/damagesource/DamageEffects.java
++++ b/net/minecraft/world/damagesource/DamageEffects.java
+@@ -5,7 +_,7 @@
+ import net.minecraft.sounds.SoundEvents;
+ import net.minecraft.util.StringRepresentable;
+ 
+-public enum DamageEffects implements StringRepresentable {
++public enum DamageEffects implements StringRepresentable, net.minecraftforge.common.IExtensibleEnum {
+    HURT("hurt", SoundEvents.f_12323_),
+    THORNS("thorns", SoundEvents.f_12511_),
+    DROWNING("drowning", SoundEvents.f_12324_),
+@@ -13,13 +_,12 @@
+    POKING("poking", SoundEvents.f_12274_),
+    FREEZING("freezing", SoundEvents.f_144205_);
+ 
+-   public static final Codec<DamageEffects> f_268463_ = StringRepresentable.m_216439_(DamageEffects::values);
++   public static final Codec<DamageEffects> f_268463_ = net.minecraft.util.ExtraCodecs.m_184415_(() -> StringRepresentable.m_216439_(DamageEffects::values));
+    private final String f_268435_;
+    private final SoundEvent f_268660_;
+ 
+    private DamageEffects(String p_270875_, SoundEvent p_270383_) {
+-      this.f_268435_ = p_270875_;
+-      this.f_268660_ = p_270383_;
++      this(p_270875_, () -> p_270383_);
+    }
+ 
+    public String m_7912_() {
+@@ -27,6 +_,30 @@
+    }
+ 
+    public SoundEvent m_269402_() {
+-      return this.f_268660_;
++      return this.soundSupplier.get();
++   }
++
++   private final java.util.function.Supplier<SoundEvent> soundSupplier;
++
++   private DamageEffects(String id, java.util.function.Supplier<SoundEvent> sound) {
++      this.f_268435_ = id;
++      this.soundSupplier = sound;
++      this.f_268660_ = null;
++   }
++
++   /**
++    * Creates a new DamageEffects with the specified ID and sound.<br>
++    * Example usage:
++    * <code><pre>
++    * public static final DamageEffects ELECTRIFYING = DamageEffects.create("MYMOD_ELECTRIFYING", "mymod:electrifying", MySounds.ELECTRIFYING);
++    * </pre></code>
++    * @param name The {@linkplain Enum#name() true enum name}. Prefix this with your modid.
++    * @param id The {@linkplain StringRepresentable#getSerializedName() serialized name}. Prefix this with your modid and `:`
++    * @param sound The sound event that will play when a damage type with this effect deals damage to a player.
++    * @return A newly created DamageEffects. Store this result in a static final field.
++    * @apiNote This method must be called as early as possible, as if {@link #CODEC} is resolved before this is called, it will be unusable.
++    */
++   public static DamageEffects create(String name, String id, java.util.function.Supplier<SoundEvent> sound) {
++      throw new IllegalStateException("Enum not extended");
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/damagesource/DamageScaling.java.patch
+++ b/patches/minecraft/net/minecraft/world/damagesource/DamageScaling.java.patch
@@ -1,0 +1,56 @@
+--- a/net/minecraft/world/damagesource/DamageScaling.java
++++ b/net/minecraft/world/damagesource/DamageScaling.java
+@@ -3,19 +_,50 @@
+ import com.mojang.serialization.Codec;
+ import net.minecraft.util.StringRepresentable;
+ 
+-public enum DamageScaling implements StringRepresentable {
++public enum DamageScaling implements StringRepresentable, net.minecraftforge.common.IExtensibleEnum {
+    NEVER("never"),
+    WHEN_CAUSED_BY_LIVING_NON_PLAYER("when_caused_by_living_non_player"),
+    ALWAYS("always");
+ 
+-   public static final Codec<DamageScaling> f_268563_ = StringRepresentable.m_216439_(DamageScaling::values);
++   public static final Codec<DamageScaling> f_268563_ = net.minecraft.util.ExtraCodecs.m_184415_(() -> StringRepresentable.m_216439_(DamageScaling::values));
+    private final String f_268442_;
+ 
+    private DamageScaling(String p_270266_) {
+-      this.f_268442_ = p_270266_;
++      this(p_270266_, net.minecraftforge.common.damagesource.IScalingFunction.DEFAULT);
+    }
+ 
+    public String m_7912_() {
+       return this.f_268442_;
++   }
++
++   private final net.minecraftforge.common.damagesource.IScalingFunction scaling;
++
++   private DamageScaling(String id, net.minecraftforge.common.damagesource.IScalingFunction scaling) {
++      this.f_268442_ = id;
++      this.scaling = scaling;
++   }
++
++   /**
++    * The scaling function is used when a player is hurt by a damage type with this type of scaling.
++    * @return The {@link net.minecraftforge.common.damagesource.IScalingFunction} associated with this damage scaling.
++    */
++   public net.minecraftforge.common.damagesource.IScalingFunction getScalingFunction() {
++      return this.scaling;
++   }
++
++   /**
++    * Creates a new DamageScaling with the specified ID and scaling function.<br>
++    * Example usage:
++    * <code><pre>
++    * public static final DamageScaling CUSTOM_SCALING = DamageEffects.create("MYMOD_CUSTOM", "mymod:custom", MyMod.CUSTOM_SCALING_FUNCTION);
++    * </pre></code>
++    * @param name The {@linkplain Enum#name() true enum name}. Prefix this with your modid.
++    * @param id The {@linkplain StringRepresentable#getSerializedName() serialized name}. Prefix this with your modid and `:`
++    * @param scaling The scaling function that will be used when a player is hurt by a damage type with this type of scaling.
++    * @return A newly created DamageScaling. Store this result in a static final field.
++    * @apiNote This method must be called as early as possible, as if {@link #CODEC} is resolved before this is called, it will be unusable.
++    */
++   public static DamageScaling create(String name, String id, net.minecraftforge.common.damagesource.IScalingFunction scaling) {
++      throw new IllegalStateException("Enum not extended");
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/damagesource/DamageSource.java.patch
+++ b/patches/minecraft/net/minecraft/world/damagesource/DamageSource.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/damagesource/DamageSource.java
++++ b/net/minecraft/world/damagesource/DamageSource.java
+@@ -91,6 +_,10 @@
+       return this.m_269415_().f_268677_();
+    }
+ 
++   /**
++    * @deprecated Use {@link DamageScaling#getScalingFunction()}
++    */
++   @Deprecated(since = "1.20.1")
+    public boolean m_7986_() {
+       boolean flag;
+       switch (this.m_269415_().f_268501_()) {

--- a/patches/minecraft/net/minecraft/world/damagesource/DeathMessageType.java.patch
+++ b/patches/minecraft/net/minecraft/world/damagesource/DeathMessageType.java.patch
@@ -1,0 +1,56 @@
+--- a/net/minecraft/world/damagesource/DeathMessageType.java
++++ b/net/minecraft/world/damagesource/DeathMessageType.java
+@@ -3,19 +_,50 @@
+ import com.mojang.serialization.Codec;
+ import net.minecraft.util.StringRepresentable;
+ 
+-public enum DeathMessageType implements StringRepresentable {
++public enum DeathMessageType implements StringRepresentable, net.minecraftforge.common.IExtensibleEnum {
+    DEFAULT("default"),
+    FALL_VARIANTS("fall_variants"),
+    INTENTIONAL_GAME_DESIGN("intentional_game_design");
+ 
+-   public static final Codec<DeathMessageType> f_268483_ = StringRepresentable.m_216439_(DeathMessageType::values);
++   public static final Codec<DeathMessageType> f_268483_ = net.minecraft.util.ExtraCodecs.m_184415_(() -> StringRepresentable.m_216439_(DeathMessageType::values));
+    private final String f_268617_;
+ 
+    private DeathMessageType(String p_270201_) {
+-      this.f_268617_ = p_270201_;
++      this(p_270201_, net.minecraftforge.common.damagesource.IDeathMessageProvider.DEFAULT);
+    }
+ 
+    public String m_7912_() {
+       return this.f_268617_;
++   }
++
++   private final net.minecraftforge.common.damagesource.IDeathMessageProvider msgFunction;
++
++   private DeathMessageType(String id, net.minecraftforge.common.damagesource.IDeathMessageProvider msgFunction) {
++      this.f_268617_ = id;
++      this.msgFunction = msgFunction;
++   }
++
++   /**
++    * The death message function is used when an entity dies to a damage type with this death message type.
++    * @return The {@link net.minecraftforge.common.damagesource.IDeathMessageProvider} associated with this death message type.
++    */
++   public net.minecraftforge.common.damagesource.IDeathMessageProvider getMessageFunction() {
++      return this.msgFunction;
++   }
++
++   /**
++    * Creates a new DeathMessageType with the specified ID and death message provider.<br>
++    * Example usage:
++    * <code><pre>
++    * public static final DeathMessageType CUSTOM_FUNCTION = DeathMessageType.create("MYMOD_CUSTOM", "mymod:custom", MyMod.CUSTOM_MESSAGE_PROVIDER);
++    * </pre></code>
++    * @param name The {@linkplain Enum#name() true enum name}. Prefix this with your modid.
++    * @param id The {@linkplain StringRepresentable#getSerializedName() serialized name}. Prefix this with your modid and `:`
++    * @param scaling The scaling function that will be used when a player is hurt by a damage type with this type of scaling.
++    * @return A newly created DamageScaling. Store this result in a static final field.
++    * @apiNote This method must be called as early as possible, as if {@link #CODEC} is resolved before this is called, it will be unusable.
++    */
++   public static DeathMessageType create(String name, String id, net.minecraftforge.common.damagesource.IDeathMessageProvider msgFunction) {
++      throw new IllegalStateException("Enum not extended");
+    }
+ }

--- a/patches/minecraft/net/minecraft/world/effect/MobEffect.java.patch
+++ b/patches/minecraft/net/minecraft/world/effect/MobEffect.java.patch
@@ -17,6 +17,16 @@
     }
  
     public Optional<MobEffectInstance.FactorData> m_216881_() {
+@@ -56,7 +_,8 @@
+          }
+       } else if (this == MobEffects.f_19614_) {
+          if (p_19467_.m_21223_() > 1.0F) {
+-            p_19467_.m_6469_(p_19467_.m_269291_().m_269425_(), 1.0F);
++            // Neo: Replace DamageSources#magic() with forge:poison to allow differentiating poison damage.
++            p_19467_.m_6469_(p_19467_.m_269291_().m_269079_(net.minecraftforge.common.ForgeMod.POISON_DAMAGE), 1.0F);
+          }
+       } else if (this == MobEffects.f_19615_) {
+          p_19467_.m_6469_(p_19467_.m_269291_().m_269251_(), 1.0F);
 @@ -194,4 +_,29 @@
     public boolean m_19486_() {
        return this.f_19447_ == MobEffectCategory.BENEFICIAL;

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -117,6 +117,16 @@
        if (this.m_6673_(p_36154_)) {
           return false;
        } else if (this.f_36077_.f_35934_ && !p_36154_.m_269533_(DamageTypeTags.f_268738_)) {
+@@ -805,7 +_,8 @@
+                this.m_36328_();
+             }
+ 
+-            if (p_36154_.m_7986_()) {
++            p_36155_ = Math.max(0.0F, p_36154_.m_269415_().f_268501_().getScalingFunction().scaleDamage(p_36154_, this, p_36155_, this.m_9236_().m_46791_()));
++            if (false && p_36154_.m_7986_()) {
+                if (this.m_9236_().m_46791_() == Difficulty.PEACEFUL) {
+                   p_36155_ = 0.0F;
+                }
 @@ -826,7 +_,7 @@
  
     protected void m_6728_(LivingEntity p_36295_) {

--- a/src/generated/resources/data/forge/tags/damage_type/is_environment.json
+++ b/src/generated/resources/data/forge/tags/damage_type/is_environment.json
@@ -1,0 +1,22 @@
+{
+  "values": [
+    "minecraft:in_fire",
+    "minecraft:on_fire",
+    "minecraft:lava",
+    "minecraft:hot_floor",
+    "minecraft:drown",
+    "minecraft:starve",
+    "minecraft:dry_out",
+    "minecraft:freeze",
+    "minecraft:lightning_bolt",
+    "minecraft:cactus",
+    "minecraft:stalagmite",
+    "minecraft:falling_stalactite",
+    "minecraft:falling_block",
+    "minecraft:falling_anvil",
+    "minecraft:cramming",
+    "minecraft:fly_into_wall",
+    "minecraft:sweet_berry_bush",
+    "minecraft:in_wall"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/damage_type/is_magic.json
+++ b/src/generated/resources/data/forge/tags/damage_type/is_magic.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "minecraft:magic",
+    "minecraft:indirect_magic",
+    "minecraft:thorns",
+    "minecraft:dragon_breath",
+    "#forge:is_poison",
+    "#forge:is_wither"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/damage_type/is_physical.json
+++ b/src/generated/resources/data/forge/tags/damage_type/is_physical.json
@@ -1,0 +1,24 @@
+{
+  "values": [
+    "minecraft:cactus",
+    "minecraft:stalagmite",
+    "minecraft:falling_stalactite",
+    "minecraft:falling_block",
+    "minecraft:falling_anvil",
+    "minecraft:cramming",
+    "minecraft:fly_into_wall",
+    "minecraft:sweet_berry_bush",
+    "minecraft:fall",
+    "minecraft:sting",
+    "minecraft:mob_attack",
+    "minecraft:player_attack",
+    "minecraft:mob_attack_no_aggro",
+    "minecraft:arrow",
+    "minecraft:thrown",
+    "minecraft:trident",
+    "minecraft:mob_projectile",
+    "minecraft:sonic_boom",
+    "minecraft:in_wall",
+    "minecraft:generic"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/damage_type/is_poison.json
+++ b/src/generated/resources/data/forge/tags/damage_type/is_poison.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "forge:poison"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/damage_type/is_technical.json
+++ b/src/generated/resources/data/forge/tags/damage_type/is_technical.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:generic_kill",
+    "minecraft:outside_border",
+    "minecraft:out_of_world"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/damage_type/is_wither.json
+++ b/src/generated/resources/data/forge/tags/damage_type/is_wither.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:wither",
+    "minecraft:wither_skull"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -21,9 +21,12 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.commands.Commands;
+import net.minecraft.world.damagesource.DamageSources;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -49,6 +52,7 @@ import net.minecraftforge.common.crafting.DifferenceIngredient;
 import net.minecraftforge.common.crafting.IntersectionIngredient;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.common.data.ForgeBiomeTagsProvider;
+import net.minecraftforge.common.data.ForgeDamageTypeTagsProvider;
 import net.minecraftforge.common.data.ForgeFluidTagsProvider;
 import net.minecraftforge.common.data.ForgeSpriteSourceProvider;
 import net.minecraftforge.common.data.VanillaSoundDefinitionsProvider;
@@ -94,6 +98,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.data.DataGenerator;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.common.crafting.CompoundIngredient;
 import net.minecraftforge.common.crafting.ConditionalRecipe;
@@ -407,6 +412,12 @@ public class ForgeMod
     public static final RegistryObject<Fluid> MILK = RegistryObject.create(new ResourceLocation("milk"), ForgeRegistries.FLUIDS);
     public static final RegistryObject<Fluid> FLOWING_MILK = RegistryObject.create(new ResourceLocation("flowing_milk"), ForgeRegistries.FLUIDS);
 
+    /**
+     * Used in place of {@link DamageSources#magic()} for damage dealt by {@link MobEffects#POISON}.
+     * @see {@link Tags.DamageTypes#IS_POISON}
+     */
+    public static final ResourceKey<DamageType> POISON_DAMAGE = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation("forge", "poison"));
+
     private static ForgeMod INSTANCE;
     public static ForgeMod getInstance()
     {
@@ -526,6 +537,7 @@ public class ForgeMod
         gen.addProvider(event.includeServer(), new ForgeRecipeProvider(packOutput));
         gen.addProvider(event.includeServer(), new ForgeLootTableProvider(packOutput));
         gen.addProvider(event.includeServer(), new ForgeBiomeTagsProvider(packOutput, lookupProvider, existingFileHelper));
+        gen.addProvider(event.includeServer(), new ForgeDamageTypeTagsProvider(packOutput, lookupProvider, existingFileHelper));
 
         gen.addProvider(event.includeClient(), new ForgeSpriteSourceProvider(packOutput, existingFileHelper));
         gen.addProvider(event.includeClient(), new VanillaSoundDefinitionsProvider(packOutput, existingFileHelper));

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
@@ -572,7 +573,7 @@ public class Tags
             return TagKey.create(Registries.BIOME, new ResourceLocation("forge", name));
         }
     }
-    
+
     public static class DamageTypes
     {
         private static void init() {}
@@ -609,6 +610,13 @@ public class Tags
          * Damage from these types should not be reduced, and bypasses invulnerability.
          */
         public static final TagKey<DamageType> IS_TECHNICAL = tag("is_technical");
+
+        /**
+         * Damage types that will not cause the red flashing effect.<br>
+         * This tag is empty by default.
+         * @see GameRenderer#bobHurt
+         */
+        public static final TagKey<DamageType> NO_FLINCH = tag("no_flinch");
 
         private static TagKey<DamageType> tag(String name)
         {

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -11,6 +11,7 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
@@ -27,6 +28,7 @@ public class Tags
         Items.init();
         Fluids.init();
         Biomes.init();
+        DamageTypes.init();
     }
 
     public static class Blocks
@@ -568,6 +570,49 @@ public class Tags
         private static TagKey<Biome> tag(String name)
         {
             return TagKey.create(Registries.BIOME, new ResourceLocation("forge", name));
+        }
+    }
+    
+    public static class DamageTypes
+    {
+        private static void init() {}
+
+        /**
+         * Damage types representing magic damage.
+         */
+        public static final TagKey<DamageType> IS_MAGIC = tag("is_magic");
+
+        /**
+         * Damage types representing poison damage.
+         */
+        public static final TagKey<DamageType> IS_POISON = tag("is_poison");
+
+        /**
+         * Damage types representing damage that can be attributed to withering or the wither.
+         */
+        public static final TagKey<DamageType> IS_WITHER = tag("is_wither");
+
+        /**
+         * Damage types representing environmental damage, such as fire, lava, magma, cactus, lightning, etc.
+         */
+        public static final TagKey<DamageType> IS_ENVIRONMENT = tag("is_environment");
+
+        /**
+         * Damage types representing physical damage.<br>
+         * These are types that do not fit other #is_x tags (except #is_fall)
+         * and would meet the general definition of physical damage.
+         */
+        public static final TagKey<DamageType> IS_PHYSICAL = tag("is_physical");
+
+        /**
+         * Damage types representing damage from commands or other non-gameplay sources.<br>
+         * Damage from these types should not be reduced, and bypasses invulnerability.
+         */
+        public static final TagKey<DamageType> IS_TECHNICAL = tag("is_technical");
+
+        private static TagKey<DamageType> tag(String name)
+        {
+            return TagKey.create(Registries.DAMAGE_TYPE, new ResourceLocation("forge", name));
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/damagesource/IDeathMessageProvider.java
+++ b/src/main/java/net/minecraftforge/common/damagesource/IDeathMessageProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.damagesource;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentUtils;
+import net.minecraft.world.damagesource.CombatEntry;
+import net.minecraft.world.damagesource.CombatTracker;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DeathMessageType;
+import net.minecraft.world.entity.LivingEntity;
+
+/**
+ * An {@link IDeathMessageProvider} is used by custom {@link DeathMessageType} instances.<br>
+ * This allows providing custom death messages based on the available parameters, instead of the hard-coded vanilla defaults.
+ */
+public interface IDeathMessageProvider
+{
+    /**
+     * Default death message provider used by the vanilla {@link DeathMessageType}s.
+     * 
+     * @implNote Based off of the implementation in {@link CombatTracker#getDeathMessage()}.
+     */
+    IDeathMessageProvider DEFAULT = (entity, lastEntry, sigFall) -> {
+        DamageSource dmgSrc = lastEntry.source();
+        DeathMessageType msgType = dmgSrc.type().deathMessageType();
+        if (msgType == DeathMessageType.FALL_VARIANTS && sigFall != null)
+        {
+            return entity.getCombatTracker().getFallMessage(sigFall, dmgSrc.getEntity());
+        }
+        else if (msgType == DeathMessageType.INTENTIONAL_GAME_DESIGN)
+        {
+            String s = "death.attack." + dmgSrc.getMsgId();
+            Component component = ComponentUtils.wrapInSquareBrackets(Component.translatable(s + ".link")).withStyle(CombatTracker.INTENTIONAL_GAME_DESIGN_STYLE);
+            return Component.translatable(s + ".message", entity.getDisplayName(), component);
+        }
+        else // DeathMessageType.DEFAULT or DeathMessageType.FALL_VARIANTS and no fall was available.
+        {
+            return dmgSrc.getLocalizedDeathMessage(entity);
+        }
+    };
+
+    /**
+     * Computes the death message from the available context.<br>
+     * This method is not invoked if there are no available combat entries, since the damage source would not be available.
+     * 
+     * @param entity              The entity being killed.
+     * @param lastEntry           The last entry from the entity's {@link CombatTracker}
+     * @param mostSignificantFall The most significant fall inflicted to the entity, from {@link CombatTracker#getMostSignificantFall()}.
+     * @return The death message for the slain entity.
+     * @see {@link LivingEntity#getCombatTracker()} for additional context.
+     */
+    Component getDeathMessage(LivingEntity entity, CombatEntry lastEntry, @Nullable CombatEntry mostSignificantFall);
+}

--- a/src/main/java/net/minecraftforge/common/damagesource/IScalingFunction.java
+++ b/src/main/java/net/minecraftforge/common/damagesource/IScalingFunction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.damagesource;
+
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.damagesource.DamageScaling;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * An {@link IScalingFunction} is used by custom {@link DamageScaling} instances.<br>
+ * This allows finer control over the actual scaling value, instead of the hard-coded vanilla defaults.
+ */
+@FunctionalInterface
+public interface IScalingFunction
+{
+    /**
+     * Default Scaling function used by the vanilla {@link DamageScaling} values.
+     * 
+     * @implNote Values are based on the code found in {@link Player#hurt(DamageSource, float)}.
+     */
+    @SuppressWarnings("deprecation")
+    IScalingFunction DEFAULT = (source, target, amount, difficulty) -> {
+        if (source.scalesWithDifficulty())
+        {
+            return switch (target.level().getDifficulty())
+            {
+                case PEACEFUL -> 0.0F;
+                case EASY -> Math.min(amount / 2.0F + 1.0F, amount);
+                case NORMAL -> amount;
+                case HARD -> amount * 1.5F;
+            };
+        }
+        return 1.0F;
+    };
+
+    /**
+     * Scales the incoming damage amount based on the current difficulty.
+     * 
+     * @param source     The source of the incoming damage.
+     * @param target     The player which is being attacked.
+     * @param amount     The amount of damage being dealt.
+     * @param difficulty The current game difficulty.
+     * @return The scaled damage value.
+     */
+    float scaleDamage(DamageSource source, Player target, float amount, Difficulty difficulty);
+}

--- a/src/main/java/net/minecraftforge/common/damagesource/IScalingFunction.java
+++ b/src/main/java/net/minecraftforge/common/damagesource/IScalingFunction.java
@@ -38,7 +38,8 @@ public interface IScalingFunction
     };
 
     /**
-     * Scales the incoming damage amount based on the current difficulty.
+     * Scales the incoming damage amount based on the current difficulty.<br>
+     * Only damage dealt to players is scaled, other damage is not impacted.
      * 
      * @param source     The source of the incoming damage.
      * @param target     The player which is being attacked.

--- a/src/main/java/net/minecraftforge/common/data/ForgeDamageTypeTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeDamageTypeTagsProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.common.data;
+
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.tags.DamageTypeTagsProvider;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.extensions.IForgeTagAppender;
+
+public final class ForgeDamageTypeTagsProvider extends DamageTypeTagsProvider
+{
+
+    public ForgeDamageTypeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, ExistingFileHelper existingFileHelper)
+    {
+        super(output, lookupProvider, "forge", existingFileHelper);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider lookupProvider)
+    {
+        tag(ForgeMod.POISON_DAMAGE, Tags.DamageTypes.IS_POISON);
+
+        tag(DamageTypes.WITHER, Tags.DamageTypes.IS_WITHER);
+        tag(DamageTypes.WITHER_SKULL, Tags.DamageTypes.IS_WITHER);
+
+        tag(DamageTypes.MAGIC, Tags.DamageTypes.IS_MAGIC);
+        tag(DamageTypes.INDIRECT_MAGIC, Tags.DamageTypes.IS_MAGIC);
+        tag(DamageTypes.THORNS, Tags.DamageTypes.IS_MAGIC);
+        tag(DamageTypes.DRAGON_BREATH, Tags.DamageTypes.IS_MAGIC);
+        IForgeTagAppender.addTags(tag(Tags.DamageTypes.IS_MAGIC), Tags.DamageTypes.IS_POISON, Tags.DamageTypes.IS_WITHER);
+
+        tag(DamageTypes.IN_FIRE, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.ON_FIRE, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.LAVA, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.HOT_FLOOR, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.DROWN, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.STARVE, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.DRY_OUT, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.FREEZE, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.LIGHTNING_BOLT, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.CACTUS, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.STALAGMITE, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.FALLING_STALACTITE, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.FALLING_BLOCK, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.FALLING_ANVIL, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.CRAMMING, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.FLY_INTO_WALL, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.SWEET_BERRY_BUSH, Tags.DamageTypes.IS_ENVIRONMENT);
+        tag(DamageTypes.IN_WALL, Tags.DamageTypes.IS_ENVIRONMENT);
+
+        tag(DamageTypes.CACTUS, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.STALAGMITE, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.FALLING_STALACTITE, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.FALLING_BLOCK, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.FALLING_ANVIL, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.CRAMMING, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.FLY_INTO_WALL, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.SWEET_BERRY_BUSH, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.FALL, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.STING, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.MOB_ATTACK, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.PLAYER_ATTACK, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.MOB_ATTACK_NO_AGGRO, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.ARROW, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.THROWN, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.TRIDENT, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.MOB_PROJECTILE, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.SONIC_BOOM, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.IN_WALL, Tags.DamageTypes.IS_PHYSICAL);
+        tag(DamageTypes.GENERIC, Tags.DamageTypes.IS_PHYSICAL);
+
+        tag(DamageTypes.GENERIC_KILL, Tags.DamageTypes.IS_TECHNICAL);
+        tag(DamageTypes.OUTSIDE_BORDER, Tags.DamageTypes.IS_TECHNICAL);
+        tag(DamageTypes.FELL_OUT_OF_WORLD, Tags.DamageTypes.IS_TECHNICAL);
+    }
+
+    @SafeVarargs
+    private void tag(ResourceKey<DamageType> type, TagKey<DamageType>... tags)
+    {
+        for (TagKey<DamageType> key : tags)
+        {
+            tag(key).add(type);
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return "Forge Damage Type Tags";
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTagAppender.java
@@ -117,4 +117,12 @@ public interface IForgeTagAppender<T>
         }
         return self();
     }
+
+    /**
+     * SafeVarargs version of {@link #addTags(TagKey...)}.
+     */
+    @SafeVarargs
+    static <T> TagsProvider.TagAppender<T> addTags(TagsProvider.TagAppender<T> builder, TagKey<T>... values) {
+        return builder.addTags(values);
+    }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -220,9 +220,15 @@ public net.minecraft.server.packs.resources.FallbackResourceManager f_10599_ # f
 public net.minecraft.util.ExtraCodecs$EitherCodec
 public net.minecraft.util.datafix.fixes.StructuresBecomeConfiguredFix$Conversion
 public net.minecraft.util.thread.BlockableEventLoop m_18689_(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # submitAsync
+public net.minecraft.world.damagesource.CombatTracker f_268553_ # INTENTIONAL_GAME_DESIGN_STYLE
+public net.minecraft.world.damagesource.CombatTracker m_19298_()Lnet/minecraft/world/damagesource/CombatEntry; # getMostSignificantFall
+public net.minecraft.world.damagesource.CombatTracker m_289215_(Lnet/minecraft/world/damagesource/CombatEntry;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/network/chat/Component; # getFallMessage
 #group public net.minecraft.world.damagesource.DamageSource *() #All methods public, most are already
 public net.minecraft.world.damagesource.DamageSource <init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;)V # constructor
 #endgroup
+public net.minecraft.world.damagesource.DamageSources m_269079_(Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/world/damagesource/DamageSource; # source
+public net.minecraft.world.damagesource.DamageSources m_269298_(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/damagesource/DamageSource; # source
+public net.minecraft.world.damagesource.DamageSources m_268998_(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/entity/Entity;)Lnet/minecraft/world/damagesource/DamageSource; # source
 protected net.minecraft.world.entity.Entity f_19843_ # ENTITY_COUNTER
 public net.minecraft.world.entity.Entity m_20078_()Ljava/lang/String; # getEncodeId
 public net.minecraft.world.entity.ExperienceOrb f_20770_ # value

--- a/src/main/resources/data/forge/damage_type/poison.json
+++ b/src/main/resources/data/forge/damage_type/poison.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "magic",
+  "scaling": "when_caused_by_living_non_player"
+}

--- a/src/test/java/net/minecraftforge/debug/CustomDamageTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/CustomDamageTypeTest.java
@@ -1,0 +1,89 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.damagesource.DamageEffects;
+import net.minecraft.world.damagesource.DamageScaling;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.damagesource.DeathMessageType;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.damagesource.IDeathMessageProvider;
+import net.minecraftforge.common.damagesource.IScalingFunction;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegisterEvent;
+
+@Mod("custom_damage_type_test")
+@Mod.EventBusSubscriber(bus = Bus.MOD, modid = "custom_damage_type_test")
+public class CustomDamageTypeTest
+{
+    public static final boolean ENABLE = true;
+
+    public static final IScalingFunction SCALE_FUNC = (source, target, amount, difficulty) -> {
+        return switch (target.level().getDifficulty())
+        {
+            case PEACEFUL -> amount * 0F;
+            case EASY -> amount * 0.75F;
+            case NORMAL -> amount;
+            case HARD -> amount * 5F;
+        };
+    };
+
+    public static final IDeathMessageProvider MSG_PROVIDER = (entity, lastEntry, sigFall) -> {
+        DamageSource dmgSrc = lastEntry.source();
+        return Component.literal(entity.getName().getString() + " was killed via test damage by " + dmgSrc.getDirectEntity().getName().getString());
+    };
+
+    public static final DamageEffects EFFECTS;
+    public static final DamageScaling SCALING;
+    public static final DeathMessageType MSGTYPE;
+
+    public static final ResourceKey<DamageType> TEST_DMG_TYPE = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation("test", "test"));
+
+    static
+    {
+        if (ENABLE)
+        {
+            EFFECTS = DamageEffects.create("TEST_EFFECTS", "test:effects", () -> SoundEvents.DONKEY_ANGRY);
+            SCALING = DamageScaling.create("TEST_SCALING", "test:scaling", SCALE_FUNC);
+            MSGTYPE = DeathMessageType.create("TEST_MSGTYPE", "test:msgtype", MSG_PROVIDER);
+        }
+        else
+        {
+            // Don't create these enums if the test is disabled.
+            EFFECTS = null;
+            SCALING = null;
+            MSGTYPE = null;
+        }
+    }
+
+    @SubscribeEvent
+    public static void register(RegisterEvent e)
+    {
+        if (ENABLE && e.getForgeRegistry() == (Object) ForgeRegistries.ITEMS)
+        {
+            e.getForgeRegistry().register("test", new Item(new Item.Properties())
+            {
+                @Override
+                public boolean onLeftClickEntity(ItemStack stack, Player player, Entity entity)
+                {
+                    if (entity instanceof LivingEntity living)
+                    {
+                        living.hurt(player.level().damageSources().source(TEST_DMG_TYPE, player), 2);
+                    }
+                    return true;
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/CustomDamageTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/CustomDamageTypeTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.debug;
 
 import net.minecraft.core.registries.Registries;

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -301,5 +301,7 @@ modId="alter_ground_event_test"
 modId="keymapping_test"
 [[mods]]
 modId="player_spawn_phantoms_event_test"
+[[mods]]
+modId="custom_damage_type_test"
 
 # ADD ABOVE THIS LINE

--- a/src/test/resources/data/test/damage_type/test.json
+++ b/src/test/resources/data/test/damage_type/test.json
@@ -1,0 +1,7 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "test_mod",
+  "scaling": "test:scaling",
+  "effects": "test:effects",
+  "death_message_type": "test:msgtype"
+}


### PR DESCRIPTION
This PR makes most of the enums that back the `DamageType` record extensible, and is an implementation of https://github.com/MinecraftForge/MinecraftForge/issues/9434 with some changes.

This PR does the following:
1. Makes the enums `DamageEffects`, `DamageScaling`, and `DeathMessageType` extensible.
2. Adds the `IScalingFunction` interface to allow custom `DamageScaling` objects to scale damage.
3. Adds the `IDeathMessageProvider` interface to allow custom `DeathMessageType` objects to provide death messages.
4. Adds the following damage type tags:
  a. `is_environment`
  b. `is_magic`
  c. `is_physical`
  d. `is_poison`
  e. `is_technical`
  f. `is_wither`
  g. `no_flinch`
5. Replaces the damage dealt by `MobEffects.POISON` with the custom damage type `forge:poison` to allow identifying poison damage.
6. Adds AT entries for the methods in `DamageSources` and `CombatTracker` needed to support custom damage types.