### PR TITLE
1.20.x More builtin json types

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/NaturalSpawner.java.patch
@@ -35,13 +35,19 @@
        }
     }
  
-@@ -258,7 +_,8 @@
+@@ -258,7 +_,14 @@
     }
  
     private static WeightedRandomList<MobSpawnSettings.SpawnerData> m_220443_(ServerLevel p_220444_, StructureManager p_220445_, ChunkGenerator p_220446_, MobCategory p_220447_, BlockPos p_220448_, @Nullable Holder<Biome> p_220449_) {
 -      return m_220455_(p_220448_, p_220444_, p_220447_, p_220445_) ? NetherFortressStructure.f_228517_ : p_220446_.m_223133_(p_220449_ != null ? p_220449_ : p_220444_.m_204166_(p_220448_), p_220445_, p_220447_, p_220448_);
 +      // Forge: Add in potential spawns, and replace hardcoded nether fortress mob list
-+      return net.minecraftforge.event.ForgeEventFactory.getPotentialSpawns(p_220444_, p_220447_, p_220448_, m_220455_(p_220448_, p_220444_, p_220447_, p_220445_) ? p_220445_.m_220521_().m_175515_(Registries.f_256944_).m_123013_(BuiltinStructures.f_209859_).m_226612_().get(MobCategory.MONSTER).f_210044_() : p_220446_.m_223133_(p_220449_ != null ? p_220449_ : p_220444_.m_204166_(p_220448_), p_220445_, p_220447_, p_220448_));
++      if (m_220455_(p_220448_, p_220444_, p_220447_, p_220445_)) {
++          var monsterSpawns = p_220445_.m_220521_().m_175515_(Registries.f_256944_).m_123013_(BuiltinStructures.f_209859_).m_226612_().get(MobCategory.MONSTER);
++          if (monsterSpawns != null) { // structure modifiers can clear the spawn overrides
++              return net.minecraftforge.event.ForgeEventFactory.getPotentialSpawns(p_220444_, p_220447_, p_220448_, monsterSpawns.f_210044_());
++          }
++      }
++      return net.minecraftforge.event.ForgeEventFactory.getPotentialSpawns(p_220444_, p_220447_, p_220448_, p_220446_.m_223133_(p_220449_ != null ? p_220449_ : p_220444_.m_204166_(p_220448_), p_220445_, p_220447_, p_220448_));
     }
  
     public static boolean m_220455_(BlockPos p_220456_, ServerLevel p_220457_, MobCategory p_220458_, StructureManager p_220459_) {

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -69,6 +69,7 @@ import net.minecraftforge.common.world.ForgeBiomeModifiers.AddSpawnCostsBiomeMod
 import net.minecraftforge.common.world.ForgeBiomeModifiers.AddSpawnsBiomeModifier;
 import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveCarversBiomeModifier;
 import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveFeaturesBiomeModifier;
+import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveSpawnCostsBiomeModifier;
 import net.minecraftforge.common.world.ForgeBiomeModifiers.RemoveSpawnsBiomeModifier;
 import net.minecraftforge.common.world.ForgeStructureModifiers.AddSpawnsStructureModifier;
 import net.minecraftforge.common.world.ForgeStructureModifiers.ClearSpawnsStructureModifier;
@@ -225,7 +226,7 @@ public class ForgeMod
     /**
      * Stock biome modifier for adding carvers to biomes.
      */
-    public static final RegistryObject<Codec<AddCarversBiomeModifier>> ADD_CARVERS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("add_features", () ->
+    public static final RegistryObject<Codec<AddCarversBiomeModifier>> ADD_CARVERS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("add_carvers", () ->
         RecordCodecBuilder.create(builder -> builder.group(
                 Biome.LIST_CODEC.fieldOf("biomes").forGetter(AddCarversBiomeModifier::biomes),
                 ConfiguredWorldCarver.LIST_CODEC.fieldOf("carvers").forGetter(AddCarversBiomeModifier::carvers),
@@ -236,7 +237,7 @@ public class ForgeMod
     /**
      * Stock biome modifier for removing carvers from biomes.
      */
-    public static final RegistryObject<Codec<RemoveCarversBiomeModifier>> REMOVE_CARVERS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("remove_features", () ->
+    public static final RegistryObject<Codec<RemoveCarversBiomeModifier>> REMOVE_CARVERS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("remove_carvers", () ->
         RecordCodecBuilder.create(builder -> builder.group(
                 Biome.LIST_CODEC.fieldOf("biomes").forGetter(RemoveCarversBiomeModifier::biomes),
                 ConfiguredWorldCarver.LIST_CODEC.fieldOf("carvers").forGetter(RemoveCarversBiomeModifier::carvers),
@@ -275,7 +276,7 @@ public class ForgeMod
     /**
      * Stock biome modifier for adding mob spawn costs to biomes.
      */
-    public static final RegistryObject<Codec<AddSpawnCostsBiomeModifier>> ADD_SPAWN_COSTS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("add_spawns", () ->
+    public static final RegistryObject<Codec<AddSpawnCostsBiomeModifier>> ADD_SPAWN_COSTS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("add_spawn_costs", () ->
         RecordCodecBuilder.create(builder -> builder.group(
                 Biome.LIST_CODEC.fieldOf("biomes").forGetter(AddSpawnCostsBiomeModifier::biomes),
                 RegistryCodecs.homogeneousList(Registries.ENTITY_TYPE).fieldOf("entity_types").forGetter(AddSpawnCostsBiomeModifier::entityTypes),
@@ -286,11 +287,11 @@ public class ForgeMod
     /**
      * Stock biome modifier for removing mob spawn costs from biomes.
      */
-    public static final RegistryObject<Codec<RemoveSpawnsBiomeModifier>> REMOVE_SPAWN_COSTS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("remove_spawns", () ->
+    public static final RegistryObject<Codec<RemoveSpawnCostsBiomeModifier>> REMOVE_SPAWN_COSTS_BIOME_MODIFIER_TYPE = BIOME_MODIFIER_SERIALIZERS.register("remove_spawn_costs", () ->
         RecordCodecBuilder.create(builder -> builder.group(
-                Biome.LIST_CODEC.fieldOf("biomes").forGetter(RemoveSpawnsBiomeModifier::biomes),
-                RegistryCodecs.homogeneousList(ForgeRegistries.Keys.ENTITY_TYPES).fieldOf("entity_types").forGetter(RemoveSpawnsBiomeModifier::entityTypes)
-            ).apply(builder, RemoveSpawnsBiomeModifier::new))
+                Biome.LIST_CODEC.fieldOf("biomes").forGetter(RemoveSpawnCostsBiomeModifier::biomes),
+                RegistryCodecs.homogeneousList(ForgeRegistries.Keys.ENTITY_TYPES).fieldOf("entity_types").forGetter(RemoveSpawnCostsBiomeModifier::entityTypes)
+            ).apply(builder, RemoveSpawnCostsBiomeModifier::new))
         );
     
     /**
@@ -318,7 +319,7 @@ public class ForgeMod
      */
     public static final RegistryObject<Codec<RemoveSpawnsStructureModifier>> REMOVE_SPAWNS_STRUCTURE_MODIFIER_TYPE = STRUCTURE_MODIFIER_SERIALIZERS.register("remove_spawns", () ->
         RecordCodecBuilder.create(builder -> builder.group(
-                RegistryCodecs.homogeneousList(Registries.STRUCTURE, Structure.DIRECT_CODEC).fieldOf("biomes").forGetter(RemoveSpawnsStructureModifier::structures),
+                RegistryCodecs.homogeneousList(Registries.STRUCTURE, Structure.DIRECT_CODEC).fieldOf("structures").forGetter(RemoveSpawnsStructureModifier::structures),
                 RegistryCodecs.homogeneousList(ForgeRegistries.Keys.ENTITY_TYPES).fieldOf("entity_types").forGetter(RemoveSpawnsStructureModifier::entityTypes)
             ).apply(builder, RemoveSpawnsStructureModifier::new))
         );
@@ -549,6 +550,7 @@ public class ForgeMod
         modEventBus.register(this);
         ATTRIBUTES.register(modEventBus);
         COMMAND_ARGUMENT_TYPES.register(modEventBus);
+        GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
         BIOME_MODIFIER_SERIALIZERS.register(modEventBus);
         STRUCTURE_MODIFIER_SERIALIZERS.register(modEventBus);
         HOLDER_SET_TYPES.register(modEventBus);

--- a/src/main/java/net/minecraftforge/common/loot/AddTableModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/AddTableModifier.java
@@ -27,7 +27,7 @@ import net.minecraftforge.common.ForgeMod;
  * <p> Json format:
  * <pre>
  * {
- *   "type": "forge": "add_table",
+ *   "type": "forge:add_table",
  *   "conditions": [], // conditions block to predicate target tables by
  *   "table": "namespace:loot_table_id" // subtable to roll loot for to add to the target table(s)
  * }

--- a/src/main/java/net/minecraftforge/common/loot/AddTableModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/AddTableModifier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.loot;
 
 import org.jetbrains.annotations.ApiStatus;

--- a/src/main/java/net/minecraftforge/common/loot/AddTableModifier.java
+++ b/src/main/java/net/minecraftforge/common/loot/AddTableModifier.java
@@ -1,0 +1,73 @@
+package net.minecraftforge.common.loot;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraftforge.common.ForgeMod;
+
+/**
+ * <p>Loot modifier that rolls one loot table (the "subtable" and adds the results to the loot being modified (the "target table").
+ * Loot modifiers are not rolled for the subtable, as that could result in the subtables'
+ * items being modified twice (by downstream loot modifiers modifying the target table).</p>
+ * 
+ * <p> Json format:
+ * <pre>
+ * {
+ *   "type": "forge": "add_table",
+ *   "conditions": [], // conditions block to predicate target tables by
+ *   "table": "namespace:loot_table_id" // subtable to roll loot for to add to the target table(s)
+ * }
+ * </pre>
+ * </p>
+ */
+public class AddTableModifier extends LootModifier
+{
+    /**
+     * @see {@link ForgeMod#ADD_TABLE_LOOT_MODIFIER_TYPE}
+     */
+    @ApiStatus.Internal
+    public static final Codec<AddTableModifier> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+                    IGlobalLootModifier.LOOT_CONDITIONS_CODEC.fieldOf("conditions").forGetter(glm -> glm.conditions),
+                    ResourceLocation.CODEC.fieldOf("table").forGetter(AddTableModifier::table)
+                ).apply(instance, AddTableModifier::new));
+    
+    private final ResourceLocation table;
+
+    protected AddTableModifier(LootItemCondition[] conditionsIn, ResourceLocation table)
+    {
+        super(conditionsIn);
+        this.table = table;
+    }
+    
+    public ResourceLocation table()
+    {
+        return this.table;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected @NotNull ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context)
+    {
+        LootTable extraTable = context.getResolver().getLootTable(this.table);
+        // Don't run loot modifiers for subtables;
+        // the added loot will be modifiable by downstream loot modifiers modifying the target table,
+        // so if we modify it here then it could get modified twice.
+        extraTable.getRandomItemsRaw(context, LootTable.createStackSplitter(context.getLevel(), generatedLoot::add));
+        return generatedLoot;
+    }
+
+    @Override
+    public Codec<? extends IGlobalLootModifier> codec()
+    {
+        return ForgeMod.ADD_TABLE_LOOT_MODIFIER_TYPE.get();
+    }
+}

--- a/src/main/java/net/minecraftforge/common/world/ForgeBiomeModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeBiomeModifiers.java
@@ -116,7 +116,7 @@ public final class ForgeBiomeModifiers
      * <p>Stock biome modifier that adds carvers to biomes (from the configured_carver json registry). Has the following json format:</p>
      * <pre>
      * {
-     *   "type": "forge:add_features", // required
+     *   "type": "forge:add_carvers", // required
      *   "biomes": "#namespace:your_biome_tag" // accepts a biome id, [list of biome ids], or #namespace:biome_tag
      *   "carvers": "namespace:your_carver", // accepts a configured carver id, [list of configured carver ids], or #namespace:carver_tag
      *   "step": "air" // Carving step, can be "air" or "liquid"
@@ -157,7 +157,7 @@ public final class ForgeBiomeModifiers
      * }
      * </pre>
      *
-     * @param biomes Biomes to remove features from.
+     * @param biomes Biomes to remove carvers from.
      * @param features ConfiguredWorldCarvers to remove from biomes.
      * @param steps Carving steps to remove carvers from. Can be 
      */

--- a/src/main/java/net/minecraftforge/common/world/ForgeBiomeModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeBiomeModifiers.java
@@ -16,8 +16,11 @@ import net.minecraft.core.HolderSet;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.MobSpawnSettings.MobSpawnCost;
 import net.minecraft.world.level.biome.MobSpawnSettings.SpawnerData;
+import net.minecraft.world.level.levelgen.GenerationStep.Carving;
 import net.minecraft.world.level.levelgen.GenerationStep.Decoration;
+import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.world.ModifiableBiomeInfo.BiomeInfo.Builder;
@@ -66,7 +69,7 @@ public final class ForgeBiomeModifiers
      * <p>Stock biome modifier that removes features from biomes. Has the following json format:</p>
      * <pre>
      * {
-     *   "type": "forge:removefeatures", // required
+     *   "type": "forge:remove_features", // required
      *   "biomes": "#namespace:your_biome_tag", // accepts a biome id, [list of biome ids], or #namespace:biome_tag
      *   "features": "namespace:your_feature", // accepts a placed feature id, [list of placed feature ids], or #namespace:feature_tag
      *   "steps": "underground_ores" OR ["underground_ores", "vegetal_decoration"] // one or more decoration steps; optional field, defaults to all steps if not specified
@@ -106,6 +109,87 @@ public final class ForgeBiomeModifiers
         public Codec<? extends BiomeModifier> codec()
         {
             return ForgeMod.REMOVE_FEATURES_BIOME_MODIFIER_TYPE.get();
+        }
+    }
+
+    /**
+     * <p>Stock biome modifier that adds carvers to biomes (from the configured_carver json registry). Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:add_features", // required
+     *   "biomes": "#namespace:your_biome_tag" // accepts a biome id, [list of biome ids], or #namespace:biome_tag
+     *   "carvers": "namespace:your_carver", // accepts a configured carver id, [list of configured carver ids], or #namespace:carver_tag
+     *   "step": "air" // Carving step, can be "air" or "liquid"
+     * }
+     * </pre>
+     *
+     * @param biomes Biomes to add features to.
+     * @param carvers ConfiguredWorldCarvers to add to biomes.
+     * @param steps Carving step to run features in.
+     */
+    public static record AddCarversBiomeModifier(HolderSet<Biome> biomes, HolderSet<ConfiguredWorldCarver<?>> carvers, Carving step) implements BiomeModifier
+    {
+        @Override
+        public void modify(Holder<Biome> biome, Phase phase, Builder builder)
+        {
+            if (phase == Phase.ADD && this.biomes.contains(biome))
+            {
+                BiomeGenerationSettingsBuilder generationSettings = builder.getGenerationSettings();
+                this.carvers.forEach(holder -> generationSettings.addCarver(this.step, holder));
+            }
+        }
+
+        @Override
+        public Codec<? extends BiomeModifier> codec()
+        {
+            return ForgeMod.ADD_CARVERS_BIOME_MODIFIER_TYPE.get();
+        }
+    }
+
+    /**
+     * <p>Stock biome modifier that removes carvers from biomes. Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:remove_carvers", // required
+     *   "biomes": "#namespace:your_biome_tag", // accepts a biome id, [list of biome ids], or #namespace:biome_tag
+     *   "carvers": "namespace:your_carver", // accepts a configured carver id, [list of configured carver ids], or #namespace:carver_tag
+     *   "steps": "air" OR "liquid" OR ["air", "liquid"] // one or more carving steps; optional field, defaults to all steps if not specified
+     * }
+     * </pre>
+     *
+     * @param biomes Biomes to remove features from.
+     * @param features ConfiguredWorldCarvers to remove from biomes.
+     * @param steps Carving steps to remove carvers from. Can be 
+     */
+    public static record RemoveCarversBiomeModifier(HolderSet<Biome> biomes, HolderSet<ConfiguredWorldCarver<?>> carvers, Set<Carving> steps) implements BiomeModifier
+    {
+        /**
+         * Creates a modifier that removes the given features from all decoration steps in the given biomes.
+         * @param biomes Biomes to remove features from.
+         * @param features PlacedFeatures to remove from biomes.
+         */
+        public static RemoveFeaturesBiomeModifier allSteps(HolderSet<Biome> biomes, HolderSet<PlacedFeature> features)
+        {
+            return new RemoveFeaturesBiomeModifier(biomes, features, EnumSet.allOf(Decoration.class));
+        }
+
+        @Override
+        public void modify(Holder<Biome> biome, Phase phase, Builder builder)
+        {
+            if (phase == Phase.REMOVE && this.biomes.contains(biome))
+            {
+                BiomeGenerationSettingsBuilder generationSettings = builder.getGenerationSettings();
+                for (Carving step : this.steps)
+                {
+                    generationSettings.getCarvers(step).removeIf(this.carvers::contains);
+                }
+            }
+        }
+
+        @Override
+        public Codec<? extends BiomeModifier> codec()
+        {
+            return ForgeMod.REMOVE_CARVERS_BIOME_MODIFIER_TYPE.get();
         }
     }
 
@@ -185,13 +269,13 @@ public final class ForgeBiomeModifiers
      * <p>Stock biome modifier that removes mob spawns from a biome. Has the following json format:</p>
      * <pre>
      * {
-     *   "type": "forge:add_spawns", // Required
+     *   "type": "forge:remove_spawns", // Required
      *   "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
      *   "entity_types": #namespace:entitytype_tag // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
      * }
      * </pre>
      *
-     * @param biomes Biomes to add mob spawns to.
+     * @param biomes Biomes to remove mob spawns from.
      * @param entityTypes EntityTypes to remove from spawn lists.
      */
     public record RemoveSpawnsBiomeModifier(HolderSet<Biome> biomes, HolderSet<EntityType<?>> entityTypes) implements BiomeModifier
@@ -214,6 +298,82 @@ public final class ForgeBiomeModifiers
         public Codec<? extends BiomeModifier> codec()
         {
             return ForgeMod.REMOVE_SPAWNS_BIOME_MODIFIER_TYPE.get();
+        }
+    }
+    
+    /**
+     * <p>Stock biome modifier at adds spawn costs to a biome. Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:add_spawn_costs", // Required
+     *   "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
+     *   "entity_types": #namespace:entitytype_tag, // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
+     *   "spawn_cost": {
+     *     "energy_budget": 1.0, // double
+     *     "charge": 1.0 // double
+     *   }
+     * }
+     * </pre>
+     * 
+     * @param biomes Biomes to add spawn costs to.
+     * @param entityTypes EntityTypes to add spawn costs for.
+     * @param spawnCost MobSpawnCost to add for those entity types.
+     */
+    public record AddSpawnCostsBiomeModifier(HolderSet<Biome> biomes, HolderSet<EntityType<?>> entityTypes, MobSpawnCost spawnCost) implements BiomeModifier
+    {
+        @Override
+        public void modify(Holder<Biome> biome, Phase phase, Builder builder)
+        {
+            if (phase == Phase.ADD)
+            {
+                MobSpawnSettingsBuilder spawnBuilder = builder.getMobSpawnSettings();
+                for (var entityType : entityTypes)
+                {
+                    spawnBuilder.addMobCharge(entityType.get(), spawnCost.charge(), spawnCost.energyBudget());
+                }
+            }
+        }
+
+        @Override
+        public Codec<? extends BiomeModifier> codec()
+        {
+            return ForgeMod.ADD_SPAWN_COSTS_BIOME_MODIFIER_TYPE.get();
+        }
+    }
+
+
+    /**
+     * <p>Stock biome modifier that removes mob spawn costs from a biome. Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:remove_spawn_costs", // Required
+     *   "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
+     *   "entity_types": #namespace:entitytype_tag // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
+     * }
+     * </pre>
+     *
+     * @param biomes Biomes to remove mob spawns from.
+     * @param entityTypes EntityTypes to remove from spawn lists.
+     */
+    public record RemoveSpawnCostsBiomeModifier(HolderSet<Biome> biomes, HolderSet<EntityType<?>> entityTypes) implements BiomeModifier
+    {
+        @Override
+        public void modify(Holder<Biome> biome, Phase phase, Builder builder)
+        {
+            if (phase == Phase.REMOVE)
+            {
+                MobSpawnSettingsBuilder spawnBuilder = builder.getMobSpawnSettings();
+                for (var entityType : entityTypes)
+                {
+                    spawnBuilder.removeSpawnCost(entityType.get());
+                }
+            }
+        }
+
+        @Override
+        public Codec<? extends BiomeModifier> codec()
+        {
+            return ForgeMod.REMOVE_SPAWN_COSTS_BIOME_MODIFIER_TYPE.get();
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.common.world;
 
 import java.util.List;

--- a/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
@@ -104,7 +104,7 @@ public final class ForgeStructureModifiers
      * <pre>
      * {
      *   "type": "forge:remove_spawns", // Required
-     *   "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
+     *   "structures": "#namespace:structure_tag", // Accepts a structure id, [list of structure ids], or #namespace:structure_tag
      *   "entity_types": #namespace:entitytype_tag // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
      * }
      * </pre>
@@ -147,6 +147,7 @@ public final class ForgeStructureModifiers
      * <pre>
      * {
      *   "type": "forge:clear_spawns", // Required
+     *   "structures": "#namespace:structure_tag", // Accepts a structure id, [list of structure ids], or #namespace:structure_tag
      *   "categories": "monster" OR ["monster", "creature"] // Optional, one or more {@link MobCategory}s; defaults to all categories if not specified.
      * }
      * </pre>

--- a/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
@@ -58,20 +58,20 @@ public final class ForgeStructureModifiers
      * }
      * </pre>
      *
-     * @param structures Biomes to add mob spawns to.
+     * @param structures Structures to add mob spawns to.
      * @param spawners List of SpawnerDatas specifying EntityType, weight, and pack size.
      */
     public record AddSpawnsStructureModifier(HolderSet<Structure> structures, List<SpawnerData> spawners) implements StructureModifier
     {
         /**
          * Convenience method for using a single spawn data.
-         * @param biomes Biomes to add mob spawns to.
+         * @param structures Structures to add mob spawns to.
          * @param spawner SpawnerData specifying EntityTYpe, weight, and pack size.
-         * @return AddSpawnsBiomeModifier that adds a single spawn entry to the specified biomes.
+         * @return AddSpawnsStructureModifier that adds a single spawn entry to the specified biomes.
          */
-        public static AddSpawnsBiomeModifier singleSpawn(HolderSet<Biome> biomes, SpawnerData spawner)
+        public static AddSpawnsStructureModifier singleSpawn(HolderSet<Structure> biomes, SpawnerData spawner)
         {
-            return new AddSpawnsBiomeModifier(biomes, List.of(spawner));
+            return new AddSpawnsStructureModifier(biomes, List.of(spawner));
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
@@ -126,8 +126,7 @@ public final class ForgeStructureModifiers
                     if (overrides == null || overrides.getSpawns().isEmpty())
                         continue;
                     
-                    List<SpawnerData> spawns = overrides.getSpawns();
-                    spawns.removeIf(spawnerData -> this.entityTypes.contains(ForgeRegistries.ENTITY_TYPES.getHolder(spawnerData.type).get()));
+                    overrides.removeSpawns(spawnerData -> this.entityTypes.contains(ForgeRegistries.ENTITY_TYPES.getHolder(spawnerData.type).get()));
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
+++ b/src/main/java/net/minecraftforge/common/world/ForgeStructureModifiers.java
@@ -1,0 +1,180 @@
+package net.minecraftforge.common.world;
+
+import java.util.List;
+import java.util.Set;
+
+import com.mojang.serialization.Codec;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.MobSpawnSettings.SpawnerData;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.common.world.ForgeBiomeModifiers.AddSpawnsBiomeModifier;
+import net.minecraftforge.common.world.ModifiableStructureInfo.StructureInfo.Builder;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public final class ForgeStructureModifiers
+{
+    private ForgeStructureModifiers() {} // Utility class.
+
+    /**
+     * <p>Stock structure modifier that adds a mob spawn override to a structure.
+     * If a structure has mob spawn overrides, random mob spawning will use the structure's spawns instead of the local biome's spawns.
+     * Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:add_spawns", // Required
+     *   "structures": "#namespace:structure_tag", // Accepts a structure id, [list of structure ids], or #namespace:structure_tag
+     *   "spawners":
+     *   {
+     *     "type": "namespace:entity_type", // Type of mob to spawn
+     *     "weight": 100, // int, spawn weighting
+     *     "minCount": 1, // int, minimum pack size
+     *     "maxCount": 4, // int, maximum pack size
+     *   }
+     * }
+     * </pre>
+     * <p>Optionally accepts a list of spawner objects instead of a single spawner:</p>
+     * <pre>
+     * {
+     *   "type": "forge:add_spawns", // Required
+     *   "structure": "#namespace:structure_tag", // Accepts a structure id, [list of structure ids], or #namespace:structure_tag
+     *   "spawners":
+     *   [
+     *     {
+     *       "type": "namespace:entity_type", // Type of mob to spawn
+     *       "weight": 100, // int, spawn weighting
+     *       "minCount": 1, // int, minimum pack size
+     *       "maxCount": 4, // int, maximum pack size
+     *     },
+     *     {
+     *       // additional spawner object
+     *     }
+     *   ]
+     * }
+     * </pre>
+     *
+     * @param structures Biomes to add mob spawns to.
+     * @param spawners List of SpawnerDatas specifying EntityType, weight, and pack size.
+     */
+    public record AddSpawnsStructureModifier(HolderSet<Structure> structures, List<SpawnerData> spawners) implements StructureModifier
+    {
+        /**
+         * Convenience method for using a single spawn data.
+         * @param biomes Biomes to add mob spawns to.
+         * @param spawner SpawnerData specifying EntityTYpe, weight, and pack size.
+         * @return AddSpawnsBiomeModifier that adds a single spawn entry to the specified biomes.
+         */
+        public static AddSpawnsBiomeModifier singleSpawn(HolderSet<Biome> biomes, SpawnerData spawner)
+        {
+            return new AddSpawnsBiomeModifier(biomes, List.of(spawner));
+        }
+
+        @Override
+        public void modify(Holder<Structure> structure, Phase phase, Builder builder)
+        {
+            if (phase == Phase.ADD && this.structures.contains(structure))
+            {
+                StructureSettingsBuilder settingsBuilder = builder.getStructureSettings();
+                for (SpawnerData spawner : this.spawners)
+                {
+                    EntityType<?> type = spawner.type;
+                    settingsBuilder.getOrAddSpawnOverrides(type.getCategory()).addSpawn(spawner);
+                }
+            }
+        }
+
+        @Override
+        public Codec<? extends StructureModifier> codec()
+        {
+            return ForgeMod.ADD_SPAWNS_STRUCTURE_MODIFIER_TYPE.get();
+        }
+    }
+
+    /**
+     * <p>Stock structure modifier that removes mob spawns from a structure.
+     * Does not remove the override list itself;
+     * see {@link ClearSpawnsStructureModifier} to remove override lists completely.
+     * </p>
+     * Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:remove_spawns", // Required
+     *   "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
+     *   "entity_types": #namespace:entitytype_tag // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
+     * }
+     * </pre>
+     *
+     * @param structures Biomes to remove mob spawns from.
+     * @param entityTypes EntityTypes to remove from spawn lists.
+     */
+    public record RemoveSpawnsStructureModifier(HolderSet<Structure> structures, HolderSet<EntityType<?>> entityTypes) implements StructureModifier
+    {
+        @Override
+        public void modify(Holder<Structure> structure, Phase phase, Builder builder)
+        {
+            if (phase == Phase.REMOVE && this.structures.contains(structure))
+            {
+                StructureSettingsBuilder settingsBuilder = builder.getStructureSettings();
+                for (MobCategory category : MobCategory.values())
+                {
+                    var overrides = settingsBuilder.getSpawnOverrides(category);
+                    if (overrides == null || overrides.getSpawns().isEmpty())
+                        continue;
+                    
+                    List<SpawnerData> spawns = overrides.getSpawns();
+                    spawns.removeIf(spawnerData -> this.entityTypes.contains(ForgeRegistries.ENTITY_TYPES.getHolder(spawnerData.type).get()));
+                }
+            }
+        }
+
+        @Override
+        public Codec<? extends StructureModifier> codec()
+        {
+            return ForgeMod.REMOVE_SPAWNS_STRUCTURE_MODIFIER_TYPE.get();
+        }
+    }
+    
+    /**
+     * <p>Stock biome modifier that removes mob spawns from a structure modifier.
+     * Does not remove the override list itself;
+     * see {@link ClearSpawnsStructureModifier} to remove override lists completely.
+     * </p>
+     * Has the following json format:</p>
+     * <pre>
+     * {
+     *   "type": "forge:clear_spawns", // Required
+     *   "categories": "monster" OR ["monster", "creature"] // Optional, one or more {@link MobCategory}s; defaults to all categories if not specified.
+     * }
+     * </pre>
+     *
+     * @param structures Structures to remove mob spawn overrides from.
+     * @param categories Set of mob categories to remove spawn overrides for.
+     */
+    public record ClearSpawnsStructureModifier(HolderSet<Structure> structures, Set<MobCategory> categories) implements StructureModifier
+    {
+        @Override
+        public void modify(Holder<Structure> structure, Phase phase, Builder builder)
+        {
+            if (phase == Phase.REMOVE && this.structures.contains(structure))
+            {
+                StructureSettingsBuilder settingsBuilder = builder.getStructureSettings();
+                for (MobCategory category : this.categories)
+                {
+                    settingsBuilder.removeSpawnOverrides(category);
+                }
+            }
+        }
+
+        @Override
+        public Codec<? extends StructureModifier> codec()
+        {
+            return ForgeMod.CLEAR_SPAWNS_STRUCTURE_MODIFIER_TYPE.get();
+        }
+        
+    }
+}

--- a/src/main/java/net/minecraftforge/common/world/MobSpawnSettingsBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/MobSpawnSettingsBuilder.java
@@ -59,4 +59,10 @@ public class MobSpawnSettingsBuilder extends MobSpawnSettings.Builder
     {
         return this;
     }
+    
+    public MobSpawnSettingsBuilder removeSpawnCost(EntityType<?> entityType)
+    {
+        this.mobSpawnCosts.remove(entityType);
+        return this;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/world/StructureSettingsBuilder.java
+++ b/src/main/java/net/minecraftforge/common/world/StructureSettingsBuilder.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import net.minecraft.core.HolderSet;
 import net.minecraft.util.random.WeightedRandomList;
@@ -187,6 +188,11 @@ public class StructureSettingsBuilder
         public void removeSpawn(MobSpawnSettings.SpawnerData spawn)
         {
             this.spawns.remove(spawn);
+        }
+        
+        public void removeSpawns(Predicate<MobSpawnSettings.SpawnerData> spawnPredicate)
+        {
+            this.spawns.removeIf(spawnPredicate);
         }
 
         /**


### PR DESCRIPTION
This adds builtin codecs for the things mentioned below.

A datapack is provided that uses all of them for testing:
[more_builtins_test.zip](https://github.com/neoforged/NeoForge/files/12209394/more_builtins_test.zip)


## Biome Modifiers

### Add Carvers
* Adds carvers to biomes
```json5
{
  "type": "forge:add_carvers", // required
  "biomes": "#namespace:your_biome_tag" // accepts a biome id, [list of biome ids], or #namespace:biome_tag
  "carvers": "namespace:your_carver", // accepts a configured carver id, [list of configured carver ids], or #namespace:carver_tag
  "step": "air" // Carving step, can be "air" or "liquid"
}
```

### Remove Carvers
* Removes carvers from biomes
```json5
{
  "type": "forge:remove_carvers", // required
  "biomes": "#namespace:your_biome_tag", // accepts a biome id, [list of biome ids], or #namespace:biome_tag
  "carvers": "namespace:your_carver", // accepts a configured carver id, [list of configured carver ids], or #namespace:carver_tag
  "steps": "air" OR "liquid" OR ["air", "liquid"] // one or more carving steps; optional field, defaults to all steps if not specified
}
```

### Add Spawn Costs
* Adds spawn costs for specified entitytypes to biomes. Each entitytype can have at most one spawn cost entry per biome, so this is an overwriting behavior.
```json5
{
  "type": "forge:add_spawn_costs", // Required
  "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
  "entity_types": #namespace:entitytype_tag, // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
  "spawn_cost": {
    "energy_budget": 1.0, // double
    "charge": 1.0 // double
  }
}
```

### Remove Spawn Costs
* Removes spawn costs for specified entitytypes from biomes.
```json5
{
  "type": "forge:remove_spawn_costs", // Required
  "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
  "entity_types": #namespace:entitytype_tag // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
}
```

## Structure Modifiers

### Add Spawns
* Adds spawn overrides to structures, causing that structure to override biome spawns in its presence.
```json5
{
  "type": "forge:add_spawns", // Required
  "structure": "#namespace:structure_tag", // Accepts a structure id, [list of structure ids], or #namespace:structure_tag
  "spawners": // spawner object or list of spawner objects
  [
    {
      "type": "namespace:entity_type", // Type of mob to spawn
      "weight": 100, // int, spawn weighting
      "minCount": 1, // int, minimum pack size
      "maxCount": 4, // int, maximum pack size
    },
    {
      // additional spawner object
    }
  ]
}
```

### Remove Spawns
* Removes spawns from the structure's override lists. Does not remove the override list itself, as an empty override list (which prevents spawns completely within the structure for that mob category) is semantically different than an absent override list (which allows natural biome spawns within the structure).
```json5
{
  "type": "forge:remove_spawns", // Required
  "biomes": "#namespace:biome_tag", // Accepts a biome id, [list of biome ids], or #namespace:biome_tag
  "entity_types": #namespace:entitytype_tag // Accepts an entity type, [list of entity types], or #namespace:entitytype_tag
}
```

### Clear Spawns
* Removes structure override lists for specified mob categories, allowing natural biome spawns within the structure.
```json5
{
  "type": "forge:clear_spawns", // Required
  "structures": "#namespace:structure_tag", // Accepts a structure id, [list of structure ids], or #namespace:structure_tag
  "categories": "monster" OR ["monster", "creature"] // Optional, one or more {@link MobCategory}s; defaults to all categories if not specified.
}
```

## Loot Modifiers

### Add Table
* Rolls a specified loot table (the subtable) and adds the results to the loot being modified (the target table). Does not apply loot modifiers to the subtable, as this could result in loot modifiers applying to the subtable's loot twice, when downstream modifiers apply to the target table.
```json5
{
  "type": "forge:add_table",
  "conditions": [], // conditions block to predicate target tables by
  "table": "namespace:loot_table_id" // subtable to roll loot for to add to the target table(s)
}
```