### PR TITLE
[1.20.x] Provide a default atlas json for /blocks and /items

### DIFF
--- a/src/main/resources/assets/minecraft/atlases/blocks.json
+++ b/src/main/resources/assets/minecraft/atlases/blocks.json
@@ -1,0 +1,14 @@
+{
+    "sources": [
+        {
+            "type": "directory",
+            "source": "blocks",
+            "prefix": "blocks/"
+        },
+        {
+            "type": "directory",
+            "source": "items",
+            "prefix": "items/"
+        }
+    ]
+}


### PR DESCRIPTION
This provides a default `atlases` json which triggers a load of sprites in `/blocks` and `/items` to the block atlas. It is preferrable that we add it, rather than telling mods to add it, because each mod that adds a copy of this file will cause a re-scan of the `/blocks` and `/items` directories due to how atlases are implemented.

`SpriteResourceLoader` picks up a copy of each `SpriteSource` from every json file in all resource packs, performs no de-duplication, and runs all of them in sequence.