### PR TITLE
Fix server installer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
     SLF4J_API_VERSION = '1.8.0-beta4'
     APACHE_MAVEN_ARTIFACT_VERSION = '3.8.5'
     JARJAR_VERSION = '0.3.19'
-    FANCY_MOD_LOADER_VERSION = '47.1.43'
+    FANCY_MOD_LOADER_VERSION = '47.1.41'
 
     // These versions should be kept in sync with the version manifest JSON
     // To use a version newer than the version manifest JSON, the dependency must be added to the installer configuration
@@ -370,11 +370,6 @@ project(':forge') {
         moduleonly "cpw.mods:bootstraplauncher:${BOOTSTRAPLAUNCHER_VERSION}"
         moduleonly "net.minecraftforge:JarJarFileSystems:${JARJAR_VERSION}"
 
-        installer "net.neoforged.fancymodloader:core:${FANCY_MOD_LOADER_VERSION}"
-        installer "net.neoforged.fancymodloader:events:${FANCY_MOD_LOADER_VERSION}"
-        installer "net.neoforged.fancymodloader:language-java:${FANCY_MOD_LOADER_VERSION}"
-        installer "net.neoforged.fancymodloader:language-lowcode:${FANCY_MOD_LOADER_VERSION}"
-        installer "net.neoforged.fancymodloader:language-minecraft:${FANCY_MOD_LOADER_VERSION}"
         installer "cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}"
         installer "org.ow2.asm:asm:${ASM_VERSION}"
         installer "org.ow2.asm:asm-commons:${ASM_VERSION}"
@@ -778,11 +773,13 @@ project(':forge') {
             MC_VERSION:    MC_VERSION,
             MCP_VERSION:   MCP_VERSION,
             FORGE_GROUP:   group,
-            IGNORE_LIST: [
-                configurations.moduleonly, configurations.gameLayerLibrary, configurations.pluginLayerLibrary
-            ].collectMany { Util.getArtifacts(project, it, false).values() }
-                .collect{it.downloads.artifact.path.rsplit('/', 1)[1]}
-                .join(','),
+            IGNORE_LIST:   ['moduleonly', 'gameLayerLibrary', 'pluginLayerLibrary'].collectMany { configurations.getByName(it).files }.collect {
+                if (it.name.startsWith('events') || it.name.startsWith('core')) {
+                    it.name // These names are too generic by themselves, so let's keep the version info
+                } else {
+                    it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '')
+                }
+            }.join(','),
             PLUGIN_LAYER_LIBRARIES: project.patcher.runs.forge_client.properties['fml.pluginLayerLibraries'],
             GAME_LAYER_LIBRARIES: project.patcher.runs.forge_client.properties['fml.gameLayerLibraries'],
             MODULES: 'ALL-MODULE-PATH'
@@ -790,7 +787,8 @@ project(':forge') {
 
     task([dependsOn: rootProject.downloadServerRaw], 'makeClasspathFiles') {
         doLast {
-            def CLASS_PATH = Util.getArtifacts(project, configurations.installer, false).values().collect{"libraries/${it.downloads.artifact.path}"} +
+            def CLASS_PATH = ['installer', 'gameLayerLibrary', 'pluginLayerLibrary'].collectMany { Util.getArtifacts(project, configurations.getByName(it), false).values() }.
+                    collect{"libraries/${it.downloads.artifact.path}"} +
                     [
                             "libraries/net/minecraft/server/${MC_VERSION}-${MCP_VERSION}/server-${MC_VERSION}-${MCP_VERSION}-extra.jar"
                     ]

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
     SLF4J_API_VERSION = '1.8.0-beta4'
     APACHE_MAVEN_ARTIFACT_VERSION = '3.8.5'
     JARJAR_VERSION = '0.3.19'
-    FANCY_MOD_LOADER_VERSION = '47.1.41'
+    FANCY_MOD_LOADER_VERSION = '47.1.43'
 
     // These versions should be kept in sync with the version manifest JSON
     // To use a version newer than the version manifest JSON, the dependency must be added to the installer configuration
@@ -209,7 +209,7 @@ subprojects {
             maven gradleutils.getPublishingForgeMaven()
         }
     }
-    
+
     tasks.withType(JavaCompile).configureEach {
         options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
         options.warnings = false // Shutup deprecated for removal warnings
@@ -268,7 +268,7 @@ project(':clean') {
             }
         }
     }
-    
+
     tasks.named('compileJava') { mustRunAfter 'extractMapped' }
 }
 
@@ -279,8 +279,8 @@ project(':forge') {
     apply plugin: 'org.parchmentmc.librarian.forgegradle'
     apply plugin: 'org.cadixdev.licenser'
 
-    applyPatches { 
-		verbose = true 
+    applyPatches {
+		verbose = true
 		//failOnError = false
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -783,7 +783,6 @@ project(':forge') {
         doLast {
             def CLASS_PATH = Util.getArtifacts(project, configurations.installer, false).values().collect{"libraries/${it.downloads.artifact.path}"} +
                     [
-                            'libraries/' + Util.getMavenPath(project, "net.neoforged.fancymodloader:loader:${FANCY_MOD_LOADER_VERSION}"),
                             "libraries/net/minecraft/server/${MC_VERSION}-${MCP_VERSION}/server-${MC_VERSION}-${MCP_VERSION}-extra.jar"
                     ]
             def claimed = CLASS_PATH.collect{ it.rsplit('/', 2)[0] }.toSet() // Allow us to override versions

--- a/build.gradle
+++ b/build.gradle
@@ -370,6 +370,11 @@ project(':forge') {
         moduleonly "cpw.mods:bootstraplauncher:${BOOTSTRAPLAUNCHER_VERSION}"
         moduleonly "net.minecraftforge:JarJarFileSystems:${JARJAR_VERSION}"
 
+        installer "net.neoforged.fancymodloader:core:${FANCY_MOD_LOADER_VERSION}"
+        installer "net.neoforged.fancymodloader:events:${FANCY_MOD_LOADER_VERSION}"
+        installer "net.neoforged.fancymodloader:language-java:${FANCY_MOD_LOADER_VERSION}"
+        installer "net.neoforged.fancymodloader:language-lowcode:${FANCY_MOD_LOADER_VERSION}"
+        installer "net.neoforged.fancymodloader:language-minecraft:${FANCY_MOD_LOADER_VERSION}"
         installer "cpw.mods:securejarhandler:${SECUREJARHANDLER_VERSION}"
         installer "org.ow2.asm:asm:${ASM_VERSION}"
         installer "org.ow2.asm:asm-commons:${ASM_VERSION}"

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
     SLF4J_API_VERSION = '1.8.0-beta4'
     APACHE_MAVEN_ARTIFACT_VERSION = '3.8.5'
     JARJAR_VERSION = '0.3.19'
-    FANCY_MOD_LOADER_VERSION = '47.1.41'
+    FANCY_MOD_LOADER_VERSION = '47.1.45'
 
     // These versions should be kept in sync with the version manifest JSON
     // To use a version newer than the version manifest JSON, the dependency must be added to the installer configuration
@@ -714,8 +714,8 @@ project(':forge') {
                 it.name.replaceAll(/([-_]([.\d]*\d+)|\.jar$)/, '')
             }
         }.join(',') + ",client-extra,${project.name}-"
-        run.property 'fml.pluginLayerLibraries', configurations.pluginLayerLibrary.files.collect { it.name }.join(';')
-        run.property 'fml.gameLayerLibraries', configurations.gameLayerLibrary.files.collect { it.name }.join(';')
+        run.property 'fml.pluginLayerLibraries', configurations.pluginLayerLibrary.files.collect { it.name }.join(',')
+        run.property 'fml.gameLayerLibraries', configurations.gameLayerLibrary.files.collect { it.name }.join(',')
         // FIXME: Without this jna doesn't work at runtime. Someone figure out why please?
         run.property 'mergeModules', 'jna-5.10.0.jar,jna-platform-5.10.0.jar'
         if (userdevRuns.contains(run)) {

--- a/build.gradle
+++ b/build.gradle
@@ -778,7 +778,11 @@ project(':forge') {
             MC_VERSION:    MC_VERSION,
             MCP_VERSION:   MCP_VERSION,
             FORGE_GROUP:   group,
-            IGNORE_LIST: Util.getArtifacts(project, configurations.moduleonly, false).values().collect{it.downloads.artifact.path.rsplit('/', 1)[1]}.join(','),
+            IGNORE_LIST: [
+                configurations.moduleonly, configurations.gameLayerLibrary, configurations.pluginLayerLibrary
+            ].collectMany { Util.getArtifacts(project, it, false).values() }
+                .collect{it.downloads.artifact.path.rsplit('/', 1)[1]}
+                .join(','),
             PLUGIN_LAYER_LIBRARIES: project.patcher.runs.forge_client.properties['fml.pluginLayerLibraries'],
             GAME_LAYER_LIBRARIES: project.patcher.runs.forge_client.properties['fml.gameLayerLibraries'],
             MODULES: 'ALL-MODULE-PATH'

--- a/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
+++ b/buildSrc/src/main/groovy/net/minecraftforge/forge/tasks/TeamcityRequests.groovy
@@ -32,7 +32,7 @@ class TeamcityRequests {
     @Nullable
     static Map<String, Build> buildsByCommit() throws IOException {
         final Map<String, Build> builds = [:]
-        jsonRequest(new TypeToken<Builds>() {}, 'https://teamcity.neoforged.net/guestAuth/app/rest/builds?fields=build:(revisions,number)&locator=buildType:(id:MinecraftForge_MinecraftForge_MinecraftForge_MinecraftForge__Build),defaultFilter:false,count:300,status:SUCCESS')
+        jsonRequest(new TypeToken<Builds>() {}, 'https://teamcity.neoforged.net/guestAuth/app/rest/builds?fields=build:(revisions,number)&locator=buildType:(id:MinecraftForge_NeoForge_MinecraftForge_MinecraftForge__Build),defaultFilter:false,count:300,status:SUCCESS')
                 ?.build?.forEach {
             it.revisions.revision.each { rev -> builds[rev.version] = it }
         }


### PR DESCRIPTION
- `net.neoforged.fancymodloader:loader` is already an `installer` dependency, so adding it explicitly causes the "duplicate key" error (first commit).
- Once that is fixed, you get errors along the lines of `Missing language javafml version [24,] wanted by forge-1.20.1-47.1.57-universal.jar`. This can be fixed by adding the corresponding JARs to the `legacyClasspath` by making them `installer` dependencies (second commit); I do not understand the NF launch process well enough to say whether this is the "right" fix or just a workaround though. On the client all of these jars are passed in the "real" classpath (`-cp`), which I assume has a similar effect.
- This results in an error `Module fml_language_java reads more than one module named fml_core`, which can be fixed by adding `pluginLayerLibrary` and `gameLayerLibrary` dependencies to the `ignoreList` property (third commit). Again I am not sure whether this is the right solution, but it mirrors what is done in the client installations.

closes #38