### PR TITLE
Deprecate uses of `ModLoadingContext.get()`

### DIFF
--- a/src/main/java/net/minecraftforge/client/ClientForgeMod.java
+++ b/src/main/java/net/minecraftforge/client/ClientForgeMod.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.client;
 
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
@@ -17,6 +18,7 @@ import net.minecraftforge.client.model.EmptyModel;
 import net.minecraftforge.client.model.ItemLayerModel;
 import net.minecraftforge.client.model.SeparateTransformsModel;
 import net.minecraftforge.client.model.obj.ObjLoader;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -26,13 +28,13 @@ public class ClientForgeMod
     @SubscribeEvent
     public static void onRegisterGeometryLoaders(ModelEvent.RegisterGeometryLoaders event)
     {
-        event.register("empty", EmptyModel.LOADER);
-        event.register("elements", ElementsModel.Loader.INSTANCE);
-        event.register("obj", ObjLoader.INSTANCE);
-        event.register("fluid_container", DynamicFluidContainerModel.Loader.INSTANCE);
-        event.register("composite", CompositeModel.Loader.INSTANCE);
-        event.register("item_layers", ItemLayerModel.Loader.INSTANCE);
-        event.register("separate_transforms", SeparateTransformsModel.Loader.INSTANCE);
+        event.register(forge("empty"), EmptyModel.LOADER);
+        event.register(forge("elements"), ElementsModel.Loader.INSTANCE);
+        event.register(forge("obj"), ObjLoader.INSTANCE);
+        event.register(forge("fluid_container"), DynamicFluidContainerModel.Loader.INSTANCE);
+        event.register(forge("composite"), CompositeModel.Loader.INSTANCE);
+        event.register(forge("item_layers"), ItemLayerModel.Loader.INSTANCE);
+        event.register(forge("separate_transforms"), SeparateTransformsModel.Loader.INSTANCE);
     }
 
     @SubscribeEvent
@@ -44,6 +46,11 @@ public class ClientForgeMod
     @SubscribeEvent
     public static void onRegisterNamedRenderTypes(RegisterNamedRenderTypesEvent event)
     {
-        event.register("item_unlit", RenderType.translucent(), ForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
+        event.register(forge("item_unlit"), RenderType.translucent(), ForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
+    }
+
+    private static ResourceLocation forge(String path)
+    {
+        return new ResourceLocation("forge", path);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ModelEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelEvent.java
@@ -176,11 +176,19 @@ public abstract class ModelEvent extends Event
         /**
          * Registers a new geometry loader.
          */
+        public void register(ResourceLocation name, IGeometryLoader<?> loader)
+        {
+            Preconditions.checkArgument(!loaders.containsKey(name), "Geometry loader already registered: " + name);
+            loaders.put(name, loader);
+        }
+
+        /**
+         * @deprecated Use {@link #register(ResourceLocation, IGeometryLoader)} instead.
+         */
+        @Deprecated(forRemoval = true, since = "1.20.1")
         public void register(String name, IGeometryLoader<?> loader)
         {
-            var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name);
-            Preconditions.checkArgument(!loaders.containsKey(key), "Geometry loader already registered: " + key);
-            loaders.put(key, loader);
+            register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), loader);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterGuiOverlaysEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterGuiOverlaysEvent.java
@@ -48,7 +48,7 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
      */
-    public void registerBelowAll(@NotNull String id, @NotNull IGuiOverlay overlay)
+    public void registerBelowAll(@NotNull ResourceLocation id, @NotNull IGuiOverlay overlay)
     {
         register(Ordering.BEFORE, null, id, overlay);
     }
@@ -61,7 +61,7 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
      */
-    public void registerBelow(@NotNull ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay)
+    public void registerBelow(@NotNull ResourceLocation other, @NotNull ResourceLocation id, @NotNull IGuiOverlay overlay)
     {
         register(Ordering.BEFORE, other, id, overlay);
     }
@@ -74,7 +74,7 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
      */
-    public void registerAbove(@NotNull ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay)
+    public void registerAbove(@NotNull ResourceLocation other, @NotNull ResourceLocation id, @NotNull IGuiOverlay overlay)
     {
         register(Ordering.AFTER, other, id, overlay);
     }
@@ -85,14 +85,55 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
      */
-    public void registerAboveAll(@NotNull String id, @NotNull IGuiOverlay overlay)
+    public void registerAboveAll(@NotNull ResourceLocation id, @NotNull IGuiOverlay overlay)
     {
         register(Ordering.AFTER, null, id, overlay);
     }
 
-    private void register(@NotNull Ordering ordering, @Nullable ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay)
+    /**
+     * @deprecated Use {@link #registerBelowAll(ResourceLocation, IGuiOverlay)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void registerBelowAll(@NotNull String id, @NotNull IGuiOverlay overlay)
     {
-        var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), id);
+        register(Ordering.BEFORE, null, mod(id), overlay);
+    }
+
+    /**
+     * @deprecated Use {@link #registerBelow(ResourceLocation, ResourceLocation, IGuiOverlay)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void registerBelow(@NotNull ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay)
+    {
+        register(Ordering.BEFORE, other, mod(id), overlay);
+    }
+
+    /**
+     * @deprecated Use {@link #registerAbove(ResourceLocation, ResourceLocation, IGuiOverlay)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void registerAbove(@NotNull ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay)
+    {
+        register(Ordering.AFTER, other, mod(id), overlay);
+    }
+
+    /**
+     * @deprecated Use {@link #registerAboveAll(ResourceLocation, IGuiOverlay)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void registerAboveAll(@NotNull String id, @NotNull IGuiOverlay overlay)
+    {
+        register(Ordering.AFTER, null, mod(id), overlay);
+    }
+
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    private static ResourceLocation mod(String namespace)
+    {
+        return new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), namespace);
+    }
+
+    private void register(@NotNull Ordering ordering, @Nullable ResourceLocation other, @NotNull ResourceLocation key, @NotNull IGuiOverlay overlay)
+    {
         Preconditions.checkArgument(!overlays.containsKey(key), "Overlay already registered: " + key);
 
         int insertPosition;

--- a/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -45,7 +45,7 @@ public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
      * @param blockRenderType  One of the values returned by {@link RenderType#chunkBufferLayers()}
      * @param entityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
      */
-    public void register(String name, RenderType blockRenderType, RenderType entityRenderType)
+    public void register(ResourceLocation name, RenderType blockRenderType, RenderType entityRenderType)
     {
         register(name, blockRenderType, entityRenderType, entityRenderType);
     }
@@ -59,14 +59,25 @@ public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
      * @param fabulousEntityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY} for use when
      *                                 "fabulous" rendering is enabled
      */
-    public void register(String name, RenderType blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType)
+    public void register(ResourceLocation name, RenderType blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType)
     {
-        var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name);
-        Preconditions.checkArgument(!renderTypes.containsKey(key), "Render type already registered: " + key);
+        Preconditions.checkArgument(!renderTypes.containsKey(name), "Render type already registered: " + name);
         Preconditions.checkArgument(blockRenderType.format() == DefaultVertexFormat.BLOCK, "The block render type must use the BLOCK vertex format.");
         Preconditions.checkArgument(blockRenderType.getChunkLayerId() >= 0, "Only chunk render types can be used for block rendering. Query RenderType#chunkBufferLayers() for a list.");
         Preconditions.checkArgument(entityRenderType.format() == DefaultVertexFormat.NEW_ENTITY, "The entity render type must use the NEW_ENTITY vertex format.");
         Preconditions.checkArgument(fabulousEntityRenderType.format() == DefaultVertexFormat.NEW_ENTITY, "The fabulous entity render type must use the NEW_ENTITY vertex format.");
-        renderTypes.put(key, new RenderTypeGroup(blockRenderType, entityRenderType, fabulousEntityRenderType));
+        renderTypes.put(name, new RenderTypeGroup(blockRenderType, entityRenderType, fabulousEntityRenderType));
+    }
+
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void register(String name, RenderType blockRenderType, RenderType entityRenderType)
+    {
+        register(name, blockRenderType, entityRenderType, entityRenderType);
+    }
+
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public void register(String name, RenderType blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType)
+    {
+        register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), blockRenderType, entityRenderType, fabulousEntityRenderType);
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterPresetEditorsEvent.java
@@ -17,7 +17,6 @@ import net.minecraft.world.level.levelgen.presets.WorldPreset;
 import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.LogicalSide;
-import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
@@ -49,7 +48,7 @@ public class RegisterPresetEditorsEvent extends Event implements IModBusEvent
         PresetEditor old = this.editors.put(key, editor);
         if (old != null)
         {
-            LOGGER.debug("PresetEditor {} overridden by mod {}", key.location(), ModLoadingContext.get().getActiveNamespace());
+            LOGGER.debug("PresetEditor {} with id {} overridden by {}", old, key.location(), editor);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RegisterTextureAtlasSpriteLoadersEvent.java
@@ -39,10 +39,18 @@ public class RegisterTextureAtlasSpriteLoadersEvent extends Event implements IMo
     /**
      * Registers a custom {@link ITextureAtlasSpriteLoader sprite loader}.
      */
+    public void register(ResourceLocation name, ITextureAtlasSpriteLoader loader)
+    {
+        Preconditions.checkArgument(!loaders.containsKey(name), "Sprite loader already registered: " + name);
+        loaders.put(name, loader);
+    }
+
+    /**
+     * @deprecated Use {@link #register(ResourceLocation, ITextureAtlasSpriteLoader)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
     public void register(String name, ITextureAtlasSpriteLoader loader)
     {
-        var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name);
-        Preconditions.checkArgument(!loaders.containsKey(key), "Sprite loader already registered: " + key);
-        loaders.put(key, loader);
+        register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), loader);
     }
 }

--- a/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/ModMismatchEvent.java
@@ -105,12 +105,20 @@ public class ModMismatchEvent extends Event implements IModBusEvent
     }
 
     /**
-     * Marks the mod version mismatch as having been resolved safely by the current mod.
+     * Marks the mod version mismatch as having been resolved safely by a mod.
      */
+    public void markResolved(String modId, ModContainer resolvedBy)
+    {
+        resolved.putIfAbsent(modId, resolvedBy);
+    }
+
+    /**
+     * @deprecated Use {@link #markResolved(String, ModContainer)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
     public void markResolved(String modId)
     {
-        final var resolvedBy = ModLoadingContext.get().getActiveContainer();
-        resolved.putIfAbsent(modId, resolvedBy);
+        markResolved(modId, ModLoadingContext.get().getActiveContainer());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/registries/RegisterEvent.java
+++ b/src/main/java/net/minecraftforge/registries/RegisterEvent.java
@@ -122,7 +122,9 @@ public class RegisterEvent extends Event implements IModBusEvent
          *
          * @param name the name of the object to register as its key with the namespaced inferred from the active mod container
          * @param value the object value
+         * @deprecated Use {@link ResourceLocation}-based overload instead.
          */
+        @Deprecated(forRemoval = true, since = "1.20.1")
         default void register(String name, T value)
         {
             register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), value);

--- a/src/test/java/net/minecraftforge/debug/block/FullPotsAccessorDemo.java
+++ b/src/test/java/net/minecraftforge/debug/block/FullPotsAccessorDemo.java
@@ -247,7 +247,7 @@ public class FullPotsAccessorDemo
         @SubscribeEvent
         public static void registerLoader(final ModelEvent.RegisterGeometryLoaders event)
         {
-            event.register("diorite_pot", new DioritePotGeometryLoader());
+            event.register(new ResourceLocation(MOD_ID, "diorite_pot"), new DioritePotGeometryLoader());
         }
 
         private static class DioritePotGeometryLoader implements IGeometryLoader<DioritePotModelGeometry>

--- a/src/test/java/net/minecraftforge/debug/client/CustomTASTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/CustomTASTest.java
@@ -49,7 +49,7 @@ public class CustomTASTest
 
     private void registerTextureAtlasSpriteLoaders(RegisterTextureAtlasSpriteLoadersEvent event)
     {
-        event.register("tas_loader", new TasLoader());
+        event.register(new ResourceLocation(MOD_ID, "tas_loader"), new TasLoader());
     }
 
     private static class TasLoader implements ITextureAtlasSpriteLoader

--- a/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/NewModelLoaderTest.java
@@ -146,7 +146,7 @@ public class NewModelLoaderTest
 
     public void modelRegistry(ModelEvent.RegisterGeometryLoaders event)
     {
-        event.register("custom_loader", new TestLoader());
+        event.register(new ResourceLocation(MODID, "custom_loader"), new TestLoader());
     }
 
     static class TestLoader implements IGeometryLoader<TestModel>


### PR DESCRIPTION
To move Forge-added events away from the mod event bus, we need to get rid of `ModLoadingContext.get()` calls inside of events. So this PR deprecates all the mod-facing uses in `Forge` (except for two usages in registries - but according to @SizableShrimp that will be addressed by the registry overhaul).

The only real question is whether we want to keep `ModMismatchEvent` on the mod event bus or if we want users to pass their mod container.