### PR TITLE
Fix world creation screen being suppressed after world deletion

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
@@ -16,6 +16,14 @@
           if (this.f_101693_.f_91066_.m_231828_().m_231551_() || p_283396_) {
              p_281612_.m_280509_(p_282820_, p_283181_, p_282820_ + 32, p_283181_ + 32, -1601138544);
              int j = p_283204_ - p_282820_;
+@@ -483,6 +_,7 @@
+                this.m_170323_();
+             }
+ 
++            if (this.f_101693_.f_91080_ instanceof ProgressScreen) // Neo - fix MC-251068
+             this.f_101693_.m_91152_(this.f_101694_);
+          }, Component.m_237115_("selectWorld.deleteQuestion"), Component.m_237110_("selectWorld.deleteWarning", this.f_101695_.m_78361_()), Component.m_237115_("selectWorld.deleteButton"), CommonComponents.f_130656_));
+       }
 @@ -604,6 +_,19 @@
  
        public boolean m_214209_() {


### PR DESCRIPTION
Deleting a world is triggered by `WorldSelectionList.WorldListEntry.deleteWorld`. More specifically, it displays a confirm screen, and if the user confirms the handler lambda  invokes `doDeleteWorld` and then returns to the previous screen (the selection screen).

The issue is that `doDeleteWorld` reloads the list of worlds upon deletion. When the list of worlds is reloaded, it is checked for being empty and if so the `CreateWorldScreen` is constructed and displayed. This is then immediately blown away by the `setScreen` call in the lambda mentioned above.

This PR solves the issue by checking whether the current screen is still an instance of `ProgressScreen` before calling `setScreen` again. In the case that the world creation screen is displayed, the screen will now be a `CreateWorldScreen` and thus the call will be skipped. I picked this solution as it's a one-line change.

This is tracked as [MC-251068](https://bugs.mojang.com/browse/MC-251068) on the bug tracker.