### PR TITLE
Fix `Level` leak in debug HUD

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
+++ b/src/main/java/net/minecraftforge/client/gui/overlay/ForgeGui.java
@@ -474,6 +474,13 @@ public class ForgeGui extends Gui
         }
     }
 
+    @Override
+    public void clearCache()
+    {
+        super.clearCache();
+        this.debugOverlay.clearChunkCache();
+    }
+
     protected void renderRecordOverlay(int width, int height, float partialTick, GuiGraphics guiGraphics)
     {
         if (overlayMessageTime > 0)


### PR DESCRIPTION
Previously opening the debug HUD (F3) caused `Level` instances to remain reachable after closing a world, via the chunk members of `ForgeDebugScreenOverlay`. The members of the vanilla `DebugScreenOverlay` are set to `null` in `Gui#clearCache` to avoid this, this PR does the same for the Forge overlay.