### PR TITLE
Fix chunk future chain not being bypassed for entity loads in 1.17+

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -16,8 +16,16 @@
                 }
  
                 this.m_140258_(p_203002_);
-@@ -713,8 +_,14 @@
+@@ -710,11 +_,22 @@
+             levelchunk.m_62879_(() -> {
+                return ChunkLevel.m_287264_(p_140384_.m_140093_());
+             });
++            try {
++            p_140384_.currentlyLoading = levelchunk; // Forge - bypass the future chain when getChunk is called, this prevents deadlocks.
              levelchunk.m_62952_();
++            } finally {
++            p_140384_.currentlyLoading = null; // Forge - Stop bypassing the future chain.
++            }
              if (this.f_140132_.add(chunkpos.m_45588_())) {
                 levelchunk.m_62913_(true);
 +               try {

--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -21,20 +21,20 @@
                 return ChunkLevel.m_287264_(p_140384_.m_140093_());
              });
 +            try {
-+            p_140384_.currentlyLoading = levelchunk; // Forge - bypass the future chain when getChunk is called, this prevents deadlocks.
++            p_140384_.currentlyLoading = levelchunk; // Neo - bypass the future chain when getChunk is called, this prevents deadlocks.
              levelchunk.m_62952_();
 +            } finally {
-+            p_140384_.currentlyLoading = null; // Forge - Stop bypassing the future chain.
++            p_140384_.currentlyLoading = null; // Neo - Stop bypassing the future chain.
 +            }
              if (this.f_140132_.add(chunkpos.m_45588_())) {
                 levelchunk.m_62913_(true);
 +               try {
-+               p_140384_.currentlyLoading = levelchunk; // Forge - bypass the future chain when getChunk is called, this prevents deadlocks.
++               p_140384_.currentlyLoading = levelchunk; // Neo - bypass the future chain when getChunk is called, this prevents deadlocks.
                 levelchunk.m_156369_();
                 levelchunk.m_187958_(this.f_140133_);
 +               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk, !(protochunk instanceof ImposterProtoChunk)));
 +               } finally {
-+                   p_140384_.currentlyLoading = null; // Forge - Stop bypassing the future chain.
++                   p_140384_.currentlyLoading = null; // Neo - Stop bypassing the future chain.
 +               }
              }
  

--- a/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ChunkMap.java.patch
@@ -21,20 +21,20 @@
                 return ChunkLevel.m_287264_(p_140384_.m_140093_());
              });
 +            try {
-+            p_140384_.currentlyLoading = levelchunk; // Neo - bypass the future chain when getChunk is called, this prevents deadlocks.
++            p_140384_.currentlyLoading = levelchunk; // Neo: bypass the future chain when getChunk is called, this prevents deadlocks.
              levelchunk.m_62952_();
 +            } finally {
-+            p_140384_.currentlyLoading = null; // Neo - Stop bypassing the future chain.
++            p_140384_.currentlyLoading = null; // Neo: Stop bypassing the future chain.
 +            }
              if (this.f_140132_.add(chunkpos.m_45588_())) {
                 levelchunk.m_62913_(true);
 +               try {
-+               p_140384_.currentlyLoading = levelchunk; // Neo - bypass the future chain when getChunk is called, this prevents deadlocks.
++               p_140384_.currentlyLoading = levelchunk; // Neo: bypass the future chain when getChunk is called, this prevents deadlocks.
                 levelchunk.m_156369_();
                 levelchunk.m_187958_(this.f_140133_);
 +               net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.level.ChunkEvent.Load(levelchunk, !(protochunk instanceof ImposterProtoChunk)));
 +               } finally {
-+                   p_140384_.currentlyLoading = null; // Neo - Stop bypassing the future chain.
++                   p_140384_.currentlyLoading = null; // Neo: Stop bypassing the future chain.
 +               }
              }
  


### PR DESCRIPTION
The chunk future bypass added in https://github.com/MinecraftForge/MinecraftForge/pull/7697 no longer functions completely since 1.17. In 1.16 entities were added within the try/finally block, but in 1.18 (and thus presumably 1.17) entity adding is now done inside `levelChunk.runPostLoad`, which runs before that block.

This PR adapts to the vanilla change by adding a second wrapper around `runPostLoad`.

This should hopefully fix some widespread issues with mods using `EntityJoinLevelEvent` causing deadlocks.