### PR TITLE
Don't warn about potentially malformed pack mcmeta files in datagen

### DIFF
--- a/patches/minecraft/net/minecraft/server/packs/resources/MultiPackResourceManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/packs/resources/MultiPackResourceManager.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/packs/resources/MultiPackResourceManager.java
++++ b/net/minecraft/server/packs/resources/MultiPackResourceManager.java
+@@ -64,6 +_,7 @@
+       try {
+          return p_215468_.m_5550_(ResourceFilterSection.f_244163_);
+       } catch (IOException ioexception) {
++         if (!net.minecraftforge.data.loading.DatagenModLoader.isRunningDataGen())// Neo: Only warn about malformed pack filters outside of datagen in case modders are replacing variables with gradle
+          f_215463_.error("Failed to get filter section from pack {}", (Object)p_215468_.m_5542_());
+          return null;
+       }


### PR DESCRIPTION
Datagen does not care whether pack.mcmeta files actually exist or not so if they happen to be malformed is irrelevant. So if the json is malformed due to having variables for replacement, just silence the error logging during datagen. https://github.com/neoforged/MDK/issues/9