### PR TITLE
Fix extra appearance of experimental warning dialog

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/worldselection/CreateWorldScreen.java.patch
@@ -8,6 +8,17 @@
        WorldLoader.InitConfig worldloader$initconfig = m_245574_(packrepository, WorldDataConfiguration.f_244649_);
        CompletableFuture<WorldCreationContext> completablefuture = WorldLoader.m_214362_(worldloader$initconfig, (p_247792_) -> {
           return new WorldLoader.DataLoadOutput<>(new CreateWorldScreen.DataPackReloadCookie(new WorldGenSettings(WorldOptions.m_247394_(), WorldPresets.m_246552_(p_247792_.f_244104_())), p_247792_.f_244127_()), p_247792_.f_243759_());
+@@ -222,6 +_,10 @@
+          WorldCreationContext worldcreationcontext = this.f_267389_.m_267573_();
+          LevelSettings levelsettings = this.m_205447_(flag);
+          WorldData worlddata = new PrimaryLevelData(levelsettings, worldcreationcontext.f_244272_(), p_250577_, p_249994_);
++         if(worlddata.m_5754_() != Lifecycle.stable()) {
++            // Neo: set experimental settings confirmation flag so user is not shown warning on next open
++            ((PrimaryLevelData)worlddata).withConfirmedWarning(true);
++         }
+          this.f_96541_.m_231466_().m_245064_(optional.get(), worldcreationcontext.f_232990_(), p_249152_, worlddata);
+       }
+    }
 @@ -367,7 +_,7 @@
                 if (p_269627_) {
                    p_270552_.accept(this.f_267389_.m_267573_().f_243842_());


### PR DESCRIPTION
This PR fixes an issue where an unnecessary experimental settings dialog is shown to the user the first time they reopen a world they created with experimental datapacks/mods. The issue is that Forge does not set its confirmation flag when creating a world, only when acknowledging the dialog shown upon loading an existing world.

I have outlined the original and new behaviors below; the assumption here is that at least one mod causing the lifecycle to become experimental is installed.

**Original behavior**

1. User attempts to create world.
2. Experimental warning dialog is shown.
3. User acknowledges dialog, joins world, and later leaves.
4. User attempts to open the world (1st time since creation).
5. Experimental warning dialog is shown (stating that it will not appear again).
6. User acknowledges dialog, setting the confirmation flag added by Forge, and joins the world. They then leave.
7. User opens the world (2nd time since creation).
8. No dialog is shown, as expected.

**New behavior (this PR)**

1. User attempts to create world.
2. Experimental warning dialog is shown.
3. User acknowledges dialog, setting the confirmation flag added by Forge, joins the world, and later leaves.
4. User attempts to open the world (1st time since creation).
5. No dialog is shown.

We can safely set the confirmation flag in advance when a world is created by Forge, as the user has already acknowledged the use of experimental settings at this point.

I tested this PR by writing an equivalent mixin in ModernFix and confirmed that the behavior matches that described above.