### PR TITLE
Update documentation links in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ our opencollective.*
 [Discord]: https://discord.neoforged.net/
 
 [Documentation]: https://docs.neoforged.net/
-[Getting-Started]: https://docs.neoforged.net/en/latest/gettingstarted/
-[ForgeDev]: https://docs.neoforged.net/en/latest/forgedev/
-[Pull-Requests]: https://docs.neoforged.net/en/latest/forgedev/#making-changes-and-pull-requests
+[Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
+[ForgeDev]: https://docs.neoforged.net/docs/forgedev/
+[Pull-Requests]: https://docs.neoforged.net/docs/forgedev/#making-changes-and-pull-requests
 [CurseForge]: https://curseforge.com/placeholder


### PR DESCRIPTION
The link format changed with the move to docusaurus.  Thanks to Raoul for pointing this out.