### PR TITLE
Restart Versioning with new ModID (Proof of concept WIP, doesn't work yet)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -317,6 +317,7 @@ project(':forge') {
     eclipse.classpath.file.whenMerged { cls -> cls.entries.removeIf { e -> e instanceof SourceFolder && e.path.startsWith('src/') && !e.path.startsWith('src/main/') } }
 
     ext {
+        FORGE_SPEC_VERSION = "47.1.3"
         SPEC_VERSION = gradleutils.gitInfo.tag
         // The new versioning sceme is <MCVersion>-<ForgeMC>.<RB>.<CommitsSinceRB>
         // ForgeMC is a unique identifier for every MC version we have supported.
@@ -482,7 +483,7 @@ project(':forge') {
             }
 
             def forgeDataArgs = [
-                    '--mod', 'forge',
+                    '--mod', 'neoforge',
                     '--all',
                     '--output', rootProject.file('src/generated/resources/'),
                     '--validate',
@@ -546,15 +547,23 @@ project(':forge') {
                 'Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
                 'GitCommit': gradleutils.gitInfo.abbreviatedId,
                 'Git-Branch': gradleutils.gitInfo.branch,
-                'FML-System-Mods': 'forge'
+                'FML-System-Mods': 'neoforge'
+            ] as LinkedHashMap,
+            'net/neoforged/versions/forge/': [
+                    'Specification-Title':      'NeoForge',
+                    'Specification-Vendor':     'NeoForged Project',
+                    'Specification-Version':    SPEC_VERSION,
+                    'Implementation-Title':     project.group,
+                    'Implementation-Version':   project.version.substring(MC_VERSION.length() + 1),
+                    'Implementation-Vendor':    'NeoForged Project'
             ] as LinkedHashMap,
             'net/minecraftforge/versions/forge/': [
                 'Specification-Title':      'Forge',
                 'Specification-Vendor':     'Forge Development LLC',
-                'Specification-Version':    SPEC_VERSION,
+                'Specification-Version':    FORGE_SPEC_VERSION,
                 'Implementation-Title':     project.group,
                 'Implementation-Version':   project.version.substring(MC_VERSION.length() + 1),
-                'Implementation-Vendor':    'Forge Development LLC'
+                'Implementation-Vendor':    'NeoForged Project'
             ] as LinkedHashMap,
             'net/minecraftforge/versions/mcp/': [
                 'Specification-Title':      'Minecraft',
@@ -1023,7 +1032,7 @@ project(':forge') {
             def libs = libraries
             json = [
                 spec: 1,
-                profile: project.name,
+                profile: 'neoforge',
                 version: launcherJson.id,
                 path: null,
                 minecraft: MC_VERSION,

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -128,6 +128,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+@Deprecated(forRemoval = true) // After moving the stuff in this class over to NeoForgeMod
 @Mod("forge")
 public class ForgeMod
 {

--- a/src/main/java/net/neoforged/forge/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/forge/NeoForgeMod.java
@@ -1,0 +1,9 @@
+package net.neoforged.forge;
+
+import net.minecraftforge.fml.common.Mod;
+
+@Mod("neoforge")
+public class NeoForgeMod
+{
+    // TODO: Move relevant stuff from ForgeMod here once backward compatibility is no longer needed
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ logoFile="neoforged_logo.png"
 license="LGPL v2.1"
 
 [[mods]]
-    modId="forge"
+    modId="neoforge"
     # We use the global forge version
     version="${global.forgeVersion}"
     updateJSONURL="https://maven.neoforged.net/releases/net/neoforged/forge/promotions_slim.json"
@@ -14,4 +14,14 @@ license="LGPL v2.1"
     authors="The NeoForged Team"
     description='''
     NeoForge, a NEW broad compatibility API.
+    '''
+
+
+[[mods]]
+modId="forge"
+# We use the global forge version
+version="47.1.3"
+displayName="Forge Compatibility"
+description='''
+    Required for compatibility with existing Forge versions
     '''


### PR DESCRIPTION
(Made it into a draft PR for collaboration purposes.)

Currently NeoForge uses forge artifact name, forge modid, and continues forge versioning. This is terrible because the same version and modid does **not** imply cross-compatibility (e.g. neoforge 47.1.50 and forge 47.1.50 are not equivalent, despite both having forge modid and 47.1.50 version string). This needs to change.

This PR prepares for a version restart (via tag), and updates the neoforge modid and version, while maintaining a backward compatibility forge mod entry.

The choice of versioning is guided by this Discord discussion: https://discord.com/channels/313125603924639766/1137179119713529876

TODO:

- [ ] Fix dev run failing to find system mods
- [ ] Fix runtime failing to launch
- [ ] Change launcher version to say "neoforge" (currently says "forge")
- [ ] Change filename (maven artifact?) to neoforge
- [ ] Figure out what is the highest forge version we are compatible with
