### PR TITLE
Fix another misapplied component of the chunk future patch

### DIFF
--- a/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
+@@ -126,6 +_,10 @@
+             }
+          }
+ 
++         ChunkHolder chunkholder = this.m_8364_(i);
++         if (chunkholder != null && chunkholder.currentlyLoading != null)
++            return chunkholder.currentlyLoading; // Neo: If the requested chunk is loading, bypass the future chain to prevent a deadlock.
++
+          profilerfiller.m_6174_("getChunkCacheMiss");
+          CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = this.m_8456_(p_8360_, p_8361_, p_8362_, p_8363_);
+          this.f_8332_.m_18701_(completablefuture::isDone);
 @@ -162,6 +_,7 @@
           if (chunkholder == null) {
              return null;


### PR DESCRIPTION
This PR fixes the `currentlyLoading` chunk future bypass only applying to `ServerChunkCache#getChunkNow` calls as of 1.17+, and not to `ServerChunkCache#getChunk` calls as it did in 1.16. This appears to have been changed during the 1.17 update process.

Here is a thread dump excerpt from Forge 1.19.2 without this change, but with #99 backported:

<details>
<summary>Thread dump</summary>

```
"Server thread" #160 prio=4 os_prio=-1 cpu=3812.50ms elapsed=429.15s tid=0x000001e9c363f7b0 nid=0x92a4 runnable  [0x00000037170fd000]
   java.lang.Thread.State: TIMED_WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@17.0.3/Native Method)
        - parking to wait for  <0x0000000532ae7b70> (a java.lang.String)
        at java.util.concurrent.locks.LockSupport.parkNanos(java.base@17.0.3/LockSupport.java:252)
        at net.minecraft.util.thread.BlockableEventLoop.m_5667_(minecraft@1.19.2/BlockableEventLoop.java:152)
        at net.minecraft.util.thread.BlockableEventLoop.m_18701_(minecraft@1.19.2/BlockableEventLoop.java:142)
        at net.minecraft.server.level.ServerChunkCache.m_7587_(minecraft@1.19.2/ServerChunkCache.java:130)
        at net.minecraft.world.level.Level.m_6522_(minecraft@1.19.2/Level.java:179)
        at net.minecraft.world.level.LevelReader.m_46819_(minecraft@1.19.2/LevelReader.java:129)
        at net.minecraft.world.level.Level.m_6325_(minecraft@1.19.2/Level.java:174)
        at net.minecraft.world.level.Level.m_46745_(minecraft@1.19.2/Level.java:170)
        at net.minecraft.world.level.Level.m_6436_(minecraft@1.19.2/Level.java:868)
        at com.infamous.dungeons_libraries.entities.elite.EliteMobEvents.makeEliteChance(dungeons_libraries@1.19.2-3.0.10-beta/EliteMobEvents.java:56)
        at com.infamous.dungeons_libraries.entities.elite.EliteMobEvents.onEntityJoin(dungeons_libraries@1.19.2-3.0.10-beta/EliteMobEvents.java:46)
        at com.infamous.dungeons_libraries.entities.elite.__EliteMobEvents_onEntityJoin_EntityJoinLevelEvent.invoke(dungeons_libraries@1.19.2-3.0.10-beta/.dynamic)
        at net.minecraftforge.eventbus.ASMEventHandler.invoke(net.minecraftforge.eventbus/ASMEventHandler.java:73)
        at net.minecraftforge.eventbus.EventBus$$Lambda$4620/0x0000000800e0c000.invoke(net.minecraftforge.eventbus/Unknown Source)
        at net.minecraftforge.eventbus.EventBus.post(net.minecraftforge.eventbus/EventBus.java:315)
        at net.minecraftforge.eventbus.EventBus.post(net.minecraftforge.eventbus/EventBus.java:296)
        at net.minecraft.world.level.entity.PersistentEntitySectionManager.m_157538_(minecraft@1.19.2/PersistentEntitySectionManager.java:79)
        at net.minecraft.world.level.entity.PersistentEntitySectionManager.m_157604_(minecraft@1.19.2/PersistentEntitySectionManager.java:121)
        at net.minecraft.world.level.entity.PersistentEntitySectionManager$$Lambda$51173/0x0000000804f626d8.accept(minecraft@1.19.2/Unknown Source)
        at net.minecraft.world.entity.EntityType$1.m_147060_(minecraft@1.19.2/EntityType.java:529)
        at net.minecraft.world.entity.EntityType$1$$Lambda$51175/0x0000000804f62b38.apply(minecraft@1.19.2/Unknown Source)
        at java.util.Optional.map(java.base@17.0.3/Optional.java:260)
        at net.minecraft.world.entity.EntityType.m_20645_(minecraft@1.19.2/EntityType.java:507)
        at net.minecraft.world.entity.EntityType$1.m_147056_(minecraft@1.19.2/EntityType.java:528)
        at net.minecraft.world.entity.EntityType$1$$Lambda$51174/0x0000000804f62908.accept(minecraft@1.19.2/Unknown Source)
        at java.util.ArrayList$ArrayListSpliterator.tryAdvance(java.base@17.0.3/ArrayList.java:1602)
        at net.minecraft.world.entity.EntityType$1.tryAdvance(minecraft@1.19.2/EntityType.java:527)
        at java.util.Spliterator.forEachRemaining(java.base@17.0.3/Spliterator.java:332)
        at java.util.stream.ReferencePipeline$Head.forEach(java.base@17.0.3/ReferencePipeline.java:762)
        at net.minecraft.world.level.entity.PersistentEntitySectionManager.m_157559_(minecraft@1.19.2/PersistentEntitySectionManager.java:120)
        at net.minecraft.server.level.ServerLevel.m_143327_(minecraft@1.19.2/ServerLevel.java:1517)
        at net.minecraft.server.level.ChunkMap.m_143064_(minecraft@1.19.2/ChunkMap.java:666)
        at net.minecraft.server.level.ChunkMap.m_214898_(minecraft@1.19.2/ChunkMap.java:683)
        at net.minecraft.server.level.ChunkMap$$Lambda$50805/0x0000000804f06188.m_196866_(minecraft@1.19.2/Unknown Source)
        at net.minecraft.world.level.chunk.LevelChunk.m_62952_(minecraft@1.19.2/LevelChunk.java:429)
        at net.minecraft.server.level.ChunkMap.mixinextras$bridge$0$m_62952_(minecraft@1.19.2/ChunkMap.java)
        at net.minecraft.server.level.ChunkMap$$Lambda$50808/0x0000000804f071a8.call(minecraft@1.19.2/Unknown Source)
        at net.minecraft.server.level.ChunkMap.wrapOperation$zlb000$setCurrentLoadingThenPostLoad(minecraft@1.19.2/ChunkMap.java:1854)
        at net.minecraft.server.level.ChunkMap.m_214854_(minecraft@1.19.2/ChunkMap.java:691)
```
</details>

`setCurrentLoadingThenPostLoad` is the ModernFix mixin backport of #99, and functions identically to that PR. The event handler in question can be found [here](https://github.com/Infamous-Misadventures/Dungeons-Libraries/blob/1.19/src/main/java/com/infamous/dungeons_libraries/entities/elite/EliteMobEvents.java#L56), where we see it invokes `Level#getCurrentDifficultyAt`, which ends up in a call to `ServerChunkCache#getChunk`, where the deadlock occurs.

After applying the mixin equivalent of this PR in ModernFix, the player confirmed that the deadlock has stopped. I believe this change is correct as it was what was already being done in 1.16.