### PR TITLE
Use correct parameter and nicer separation in "Couldn't load tag" patch

### DIFF
--- a/patches/minecraft/net/minecraft/tags/TagLoader.java.patch
+++ b/patches/minecraft/net/minecraft/tags/TagLoader.java.patch
@@ -29,6 +29,15 @@
     }
  
     public Map<ResourceLocation, Collection<T>> m_203898_(Map<ResourceLocation, List<TagLoader.EntryWithSource>> p_203899_) {
+@@ -100,7 +_,7 @@
+       });
+       dependencysorter.m_284430_((p_284682_, p_284683_) -> {
+          this.m_215978_(lookup, p_284683_.f_283922_).ifLeft((p_215977_) -> {
+-            f_13445_.error("Couldn't load tag {} as it is missing following references: {}", p_284682_, p_215977_.stream().map(Objects::toString).collect(Collectors.joining(", ")));
++            f_13445_.error("Couldn't load tag {} as it is missing following references: {}", p_284682_, p_215977_.stream().map(Objects::toString).collect(Collectors.joining("\n\t", "\n\t", "")));
+          }).ifRight((p_216001_) -> {
+             map.put(p_284682_, p_216001_);
+          });
 @@ -112,7 +_,8 @@
        return this.m_203898_(this.m_144495_(p_203901_));
     }

--- a/patches/minecraft/net/minecraft/tags/TagLoader.java.patch
+++ b/patches/minecraft/net/minecraft/tags/TagLoader.java.patch
@@ -29,15 +29,6 @@
     }
  
     public Map<ResourceLocation, Collection<T>> m_203898_(Map<ResourceLocation, List<TagLoader.EntryWithSource>> p_203899_) {
-@@ -100,7 +_,7 @@
-       });
-       dependencysorter.m_284430_((p_284682_, p_284683_) -> {
-          this.m_215978_(lookup, p_284683_.f_283922_).ifLeft((p_215977_) -> {
--            f_13445_.error("Couldn't load tag {} as it is missing following references: {}", p_284682_, p_215977_.stream().map(Objects::toString).collect(Collectors.joining(", ")));
-+               f_13445_.error("Couldn't load tag {} as it is missing following references: {}", p_215977_, p_215977_.stream().map(Objects::toString).collect(Collectors.joining(", \n\t")));
-          }).ifRight((p_216001_) -> {
-             map.put(p_284682_, p_216001_);
-          });
 @@ -112,7 +_,8 @@
        return this.m_203898_(this.m_144495_(p_203901_));
     }


### PR DESCRIPTION
Fixes #106.

This patch was added in https://github.com/neoforged/NeoForge/commit/735382be0309e3d118f0243c06d4030bb58efd99#diff-25fbb9cdc0f246b5c8f16799b4cbb56a374f5c14edaecc7decc6d959d8dc5766, and it looks like this was an error rather than an intended change...