### PR TITLE
Fix ForgeFaceData not being datagenned for elements

### DIFF
--- a/src/generated_test/resources/assets/minecraft/models/item/stick.json
+++ b/src/generated_test/resources/assets/minecraft/models/item/stick.json
@@ -3,19 +3,19 @@
   "display": {
     "custom_transformtype_test:hanging": {
       "rotation": [
-        180,
+        62,
         147,
         40
       ],
       "scale": [
-        1,
+        0.48,
         0.48,
         0.48
       ],
       "translation": [
         -2.25,
         1.5,
-        -3
+        -0.25
       ]
     }
   },

--- a/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/generators/ModelBuilder.java
@@ -311,6 +311,10 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
                     partObj.addProperty("shade", part.shade);
                 }
 
+                if (!part.getFaceData().equals(ForgeFaceData.DEFAULT)) {
+                    partObj.add("forge_data", ForgeFaceData.CODEC.encodeStart(JsonOps.INSTANCE, part.getFaceData()).result().get());
+                }
+
                 JsonObject faces = new JsonObject();
                 for (Direction dir : Direction.values()) {
                     BlockElementFace face = part.faces.get(dir);


### PR DESCRIPTION
Fixes #74.

Tested manually by adjusting the datagen a bit and observing the output. This confirmed both the issue and the fix.

The `stick.json` change is included because that is what the datagen actually produces; not sure how exactly they ended up diverging.