### PR TITLE
Call `getModelData` on multipart submodels

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
@@ -65,7 +65,7 @@
        }
     }
  
-@@ -77,6 +_,14 @@
+@@ -77,6 +_,19 @@
        return this.f_119453_;
     }
  
@@ -75,6 +75,11 @@
 +
 +   public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
 +      return this.defaultModel.useAmbientOcclusion(state, renderType);
++   }
++
++   @Override
++   public net.minecraftforge.client.model.data.ModelData getModelData(net.minecraft.world.level.BlockAndTintGetter level, net.minecraft.core.BlockPos pos, BlockState state, net.minecraftforge.client.model.data.ModelData modelData) {
++      return net.minecraftforge.client.model.data.MultipartModelData.create(f_119459_, getSelectors(state), level, pos, state, modelData);
 +   }
 +
     public boolean m_7539_() {

--- a/src/main/java/net/minecraftforge/client/model/data/MultipartModelData.java
+++ b/src/main/java/net/minecraftforge/client/model/data/MultipartModelData.java
@@ -6,13 +6,25 @@
 package net.minecraftforge.client.model.data;
 
 import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.BitSet;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
+@ApiStatus.Internal
 public class MultipartModelData
 {
+    // Next BC window: don't remove but make private and change the type to ModelProperty<Map<BakedModel, ModelData>>.
+    @Deprecated(forRemoval = true)
     public static final ModelProperty<MultipartModelData> PROPERTY = new ModelProperty<>();
 
     private final Map<BakedModel, ModelData> partData;
@@ -22,6 +34,7 @@ public class MultipartModelData
         this.partData = partData;
     }
 
+    @Deprecated(forRemoval = true)
     @Nullable
     public ModelData get(BakedModel model)
     {
@@ -44,11 +57,38 @@ public class MultipartModelData
         return partData != null ? partData : modelData;
     }
 
+    public static ModelData create(List<Pair<Predicate<BlockState>, BakedModel>> selectors, BitSet bitset, BlockAndTintGetter level, BlockPos pos, BlockState state, ModelData tileModelData)
+    {
+        // Don't allocate memory if no submodel changes the model data
+        Map<BakedModel, ModelData> dataMap = null;
+
+        for (int i = 0; i < bitset.length(); ++i)
+        {
+            if (bitset.get(i))
+            {
+                var model = selectors.get(i).getRight();
+                var data = model.getModelData(level, pos, state, tileModelData);
+
+                if (data != tileModelData)
+                {
+                    if (dataMap == null)
+                        dataMap = new IdentityHashMap<>();
+
+                    dataMap.put(model, data);
+                }
+            }
+        }
+
+        return dataMap == null ? tileModelData : tileModelData.derive().with(PROPERTY, new MultipartModelData(dataMap)).build();
+    }
+
+    @Deprecated(forRemoval = true)
     public static Builder builder()
     {
         return new Builder();
     }
 
+    @Deprecated(forRemoval = true)
     public static final class Builder
     {
         private final Map<BakedModel, ModelData> partData = new IdentityHashMap<>();


### PR DESCRIPTION
`MultipartModelData` was introduced in https://github.com/MinecraftForge/MinecraftForge/pull/7595 to properly call `getModelData` on the parts of a multipart model.

A regression was introduced by the 1.19 rendering reworks, effectively undoing https://github.com/MinecraftForge/MinecraftForge/pull/7595. I restored the intended behavior of `MultipartModelData`, and marked it as internal. I deprecated some methods because the wrapping around a map is useless and just leads to double the allocation.

Did some testing by playing around with one of the test mods (the diorite flower pot thing).

(thanks to @Commoble for noticing this)