### PR TITLE
[1.20.1] Step Height Cleanup

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -517,13 +517,33 @@
  
     }
  
-@@ -3264,6 +_,7 @@
+@@ -3264,10 +_,27 @@
        return false;
     }
  
-+   @Deprecated /** Forge: Use {@link net.minecraftforge.common.extensions.IForgeEntity#getStepHeight()} */
++   /**
++    * Gets the value of the legacy {@link #maxUpStep} field. Only used by players when the modified value causes issues.
++    * @deprecated Use {@link net.minecraftforge.common.extensions.IForgeEntity#getStepHeight()} to get the real step height value.
++    */
++   @Deprecated
     public float m_274421_() {
        return this.f_19793_;
+    }
+ 
++   /**
++    * Changes the legacy {@link #maxUpStep} field. Only used by vanilla entities to improve maintainability.
++    * <p>
++    * For your own entities, you should change the default value of {@linkplain net.minecraftforge.common.ForgeMod#STEP_HEIGHT ForgeMod#STEP_HEIGHT}
++    * during attribute creation.
++    * <p>
++    * For modifying the step height of other entities, you should use {@link net.minecraft.world.entity.ai.attributes.AttributeModifier AttributeModifiers} for
++    * {@link net.minecraftforge.common.ForgeMod#STEP_HEIGHT ForgeMod#STEP_HEIGHT}.
++    * 
++    * @deprecated Use attribute modifiers for the {@link net.minecraftforge.common.ForgeMod#STEP_HEIGHT ForgeMod#STEP_HEIGHT} attribute.
++    */
++   @Deprecated
+    public void m_274367_(float p_275672_) {
+       this.f_19793_ = p_275672_;
     }
 @@ -3319,6 +_,103 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -21,7 +21,7 @@
  
     public static AttributeSupplier.Builder m_21183_() {
 -      return AttributeSupplier.m_22244_().m_22266_(Attributes.f_22276_).m_22266_(Attributes.f_22278_).m_22266_(Attributes.f_22279_).m_22266_(Attributes.f_22284_).m_22266_(Attributes.f_22285_);
-+      return AttributeSupplier.m_22244_().m_22266_(Attributes.f_22276_).m_22266_(Attributes.f_22278_).m_22266_(Attributes.f_22279_).m_22266_(Attributes.f_22284_).m_22266_(Attributes.f_22285_).m_22266_(net.minecraftforge.common.ForgeMod.SWIM_SPEED.get()).m_22266_(net.minecraftforge.common.ForgeMod.NAMETAG_DISTANCE.get()).m_22266_(net.minecraftforge.common.ForgeMod.ENTITY_GRAVITY.get()).m_22266_(net.minecraftforge.common.ForgeMod.STEP_HEIGHT_ADDITION.get());
++      return AttributeSupplier.m_22244_().m_22266_(Attributes.f_22276_).m_22266_(Attributes.f_22278_).m_22266_(Attributes.f_22279_).m_22266_(Attributes.f_22284_).m_22266_(Attributes.f_22285_).m_22266_(net.minecraftforge.common.ForgeMod.SWIM_SPEED.get()).m_22266_(net.minecraftforge.common.ForgeMod.NAMETAG_DISTANCE.get()).m_22266_(net.minecraftforge.common.ForgeMod.ENTITY_GRAVITY.get()).m_22266_(net.minecraftforge.common.ForgeMod.STEP_HEIGHT.get());
     }
  
     protected void m_7840_(double p_20990_, boolean p_20991_, BlockState p_20992_, BlockPos p_20993_) {
@@ -749,3 +749,15 @@
        Equipable equipable = Equipable.m_269088_(p_147234_);
        return equipable != null ? equipable.m_40402_() : EquipmentSlot.MAINHAND;
     }
+@@ -3327,6 +_,11 @@
+       return this.m_21205_().m_41720_() instanceof AxeItem;
+    }
+ 
++   /**
++    * Gets the value of the legacy {@link #maxUpStep} field.
++    * @deprecated Use {@link net.minecraftforge.common.extensions.IForgeEntity#getStepHeight()} to get the real step height value.
++    */
++   @Deprecated
+    public float m_274421_() {
+       float f = super.m_274421_();
+       return this.m_6688_() instanceof Player ? Math.max(f, 1.0F) : f;

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.common;
 
 import net.minecraft.DetectedVersion;
+import net.minecraft.SharedConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BiomeColors;
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
@@ -474,7 +475,13 @@ public class ForgeMod
 
         ForgeRegistries.ITEMS.tags().addOptionalTagDefaults(Tags.Items.ENCHANTING_FUELS, Set.of(ForgeRegistries.ITEMS.getDelegateOrThrow(Items.LAPIS_LAZULI)));
 
-        addAlias(ForgeRegistries.ATTRIBUTES, new ResourceLocation("forge", "step_height_addition"), new ResourceLocation("forge", "step_height"));
+        // TODO: Remove 1.20.2.
+        if ("1.20.1".equals(SharedConstants.getCurrentVersion().getName()))
+        {
+            ForgeRegistries.ATTRIBUTES.addAlias(new ResourceLocation("forge", "reach_distance"), new ResourceLocation("forge", "block_reach"));
+            ForgeRegistries.ATTRIBUTES.addAlias(new ResourceLocation("forge", "attack_range"), new ResourceLocation("forge", "entity_reach"));
+            ForgeRegistries.ATTRIBUTES.addAlias(new ResourceLocation("forge", "step_height_addition"), new ResourceLocation("forge", "step_height"));
+        }
     }
 
     public void preInit(FMLCommonSetupEvent evt)
@@ -651,15 +658,5 @@ public class ForgeMod
     public void registerPermissionNodes(PermissionGatherEvent.Nodes event)
     {
         event.addNodes(USE_SELECTORS_PERMISSION);
-    }
-
-    /**
-     * TODO: Remove when {@link ForgeRegistry#addAlias(ResourceLocation, ResourceLocation)} is elevated to {@link IForgeRegistry}.
-     */
-    @Deprecated(forRemoval = true, since = "1.20")
-    private static <T> void addAlias(IForgeRegistry<T> registry, ResourceLocation from, ResourceLocation to)
-    {
-        ForgeRegistry<T> fReg = (ForgeRegistry<T>) registry;
-        fReg.addAlias(from, to);
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -172,8 +172,14 @@ public class ForgeMod
      * Step Height Addition modifies the amount of blocks an entity may walk up without jumping.
      * @see IForgeEntity#getStepHeight()
      */
-    public static final RegistryObject<Attribute> STEP_HEIGHT_ADDITION = ATTRIBUTES.register("step_height_addition", () -> new RangedAttribute("forge.step_height", 0.0D, -512.0D, 512.0D).setSyncable(true));
+    public static final RegistryObject<Attribute> STEP_HEIGHT = ATTRIBUTES.register("step_height", () -> new RangedAttribute("forge.step_height", 0.0D, -512.0D, 512.0D).setSyncable(true));
 
+    /**
+     * @deprecated Use {@link #STEP_HEIGHT}
+     */
+    @Deprecated(forRemoval = true, since = "1.20.1")
+    public static final RegistryObject<Attribute> STEP_HEIGHT_ADDITION = STEP_HEIGHT;
+    
     /**
      * Noop biome modifier. Can be used in a biome modifier json with "type": "forge:none".
      */
@@ -468,9 +474,7 @@ public class ForgeMod
 
         ForgeRegistries.ITEMS.tags().addOptionalTagDefaults(Tags.Items.ENCHANTING_FUELS, Set.of(ForgeRegistries.ITEMS.getDelegateOrThrow(Items.LAPIS_LAZULI)));
 
-        // TODO: Remove when addAlias becomes proper API, as this should be done in the DR's above.
-        addAlias(ForgeRegistries.ATTRIBUTES, new ResourceLocation("forge", "reach_distance"), new ResourceLocation("forge", "block_reach"));
-        addAlias(ForgeRegistries.ATTRIBUTES, new ResourceLocation("forge", "attack_range"), new ResourceLocation("forge", "entity_reach"));
+        addAlias(ForgeRegistries.ATTRIBUTES, new ResourceLocation("forge", "step_height_addition"), new ResourceLocation("forge", "step_height"));
     }
 
     public void preInit(FMLCommonSetupEvent evt)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -212,7 +212,7 @@ public interface IForgeEntity extends ICapabilitySerializable<CompoundTag>
         float vanillaStep = self().maxUpStep();
         if (self() instanceof LivingEntity living)
         {
-            AttributeInstance stepHeightAttribute = living.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get());
+            AttributeInstance stepHeightAttribute = living.getAttribute(ForgeMod.STEP_HEIGHT.get());
             if (stepHeightAttribute != null)
             {
                 return (float) Math.max(0, vanillaStep + stepHeightAttribute.getValue());

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -477,14 +477,7 @@ public class ForgeRegistry<V> implements IForgeRegistryInternal<V>, IForgeRegist
         return ret;
     }
 
-    /**
-     * Adds an alias that maps from the name specified by <code>src</code> to the name specified by <code>dst</code>.<p>
-     * Any registry lookups that target the first name will resolve as the second name, if the first name is not present.
-     * @param src The source registry name to alias from.
-     * @param dst The target registry name to alias to.
-     *
-     * TODO: Add as public API in IForgeRegistry and DeferredRegister.
-     */
+    @Override
     public void addAlias(ResourceLocation src, ResourceLocation dst)
     {
         if (this.isLocked())

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -95,6 +95,16 @@ public interface IForgeRegistry<V> extends Iterable<V>
     <T> T getSlaveMap(ResourceLocation slaveMapName, Class<T> type);
 
     /**
+     * Adds an alias that maps from the name specified by <code>src</code> to the name specified by <code>dst</code>.
+     * <p>
+     * Any registry lookups that target the first name will resolve as the second name, if the first name is not present.
+     * 
+     * @param src The source registry name to alias from.
+     * @param dst The target registry name to alias to.
+     */
+    public void addAlias(ResourceLocation src, ResourceLocation dst);
+
+    /**
      * Callback fired when objects are added to the registry. This will fire when the registry is rebuilt
      * on the client side from a server side synchronization, or when a world is loaded.
      */

--- a/src/test/java/net/minecraftforge/debug/item/ForgeSpawnEggItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ForgeSpawnEggItemTest.java
@@ -70,7 +70,7 @@ public class ForgeSpawnEggItemTest
         //Remove step height attribute to validate that things are handled properly when an entity doesn't have it
         Map<Attribute, AttributeInstance> builder = ObfuscationReflectionHelper.getPrivateValue(AttributeSupplier.Builder.class, attributes, "f_2226" + "2_");
         if (builder != null) {
-            builder.remove(ForgeMod.STEP_HEIGHT_ADDITION.get());
+            builder.remove(ForgeMod.STEP_HEIGHT.get());
         }
         event.put(ENTITY.get(), attributes.build());
     }


### PR DESCRIPTION
This is a partial implementatioin of #121 that completes the first three tasks. The remaining two tasks are breaking changes, so this is as far as we can go until 1.20.2 hits.

This PR performs the following changes:
1. Deprecates `LivingEntity#maxUpStep()` and `Entity#setMaxUpStep(float)`.
2. Renames `ForgeMod#STEP_HEIGHT_ADDITION` to `ForgeMod#STEP_HEIGHT`
  a. The registry name was updated to `step_height` to match. An alias from `step_height_addition` to `step_height` was added.
4. Exposes `addAlias` in `IForgeRegistry` instead of keeping it as internal.