### PR TITLE
[1.20.1] Add GetEnchantmentLevelEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -10,11 +10,19 @@
 +      return p_44845_.getEnchantmentLevel(p_44844_);
 +   }
 +
-+   /** Gets the enchantment level from NBT. Generally should use {@link ItemStack#getEnchantmentLevel(Enchantment)} for gameplay logic */
++   /** Gets the enchantment level from NBT. Use {@link ItemStack#getEnchantmentLevel(Enchantment)} for gameplay logic */
 +   public static int getTagEnchantmentLevel(Enchantment p_44844_, ItemStack p_44845_) {
        if (p_44845_.m_41619_()) {
           return 0;
        } else {
+@@ -78,6 +_,7 @@
+       }
+    }
+ 
++   /** Gets all enchantment levels from NBT. Use {@link ItemStack#getAllEnchantments()} for gameplay logic */
+    public static Map<Enchantment, Integer> m_44831_(ItemStack p_44832_) {
+       ListTag listtag = p_44832_.m_150930_(Items.f_42690_) ? EnchantedBookItem.m_41163_(p_44832_) : p_44832_.m_41785_();
+       return m_44882_(listtag);
 @@ -120,6 +_,13 @@
  
     private static void m_44850_(EnchantmentHelper.EnchantmentVisitor p_44851_, ItemStack p_44852_) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -43,6 +43,7 @@ import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.items.wrapper.ShulkerItemStackInvWrapper;
 import net.minecraftforge.registries.IForgeRegistry;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -524,13 +525,15 @@ public interface IForgeItem
     /**
      * Gets the level of the enchantment currently present on the stack. By default, returns the enchantment level present in NBT.
      * Most enchantment implementations rely upon this method.
-     * For consistency, results of this method should be the same as getting the enchantment from {@link #getAllEnchantments(ItemStack)}
+     * The returned value must be the same as getting the enchantment from {@link #getAllEnchantments(ItemStack)}
      *
-     * @param stack        the item stack being checked
-     * @param enchantment  the enchantment being checked for
-     * @return  Level of the enchantment, or 0 if not present
+     * @param stack       The item stack being checked
+     * @param enchantment The enchantment being checked for
+     * @return Level of the enchantment, or 0 if not present
      * @see #getAllEnchantments(ItemStack)
+     * @apiNote Call via {@link IForgeItemStack#getEnchantmentLevel(Enchantment)}.
      */
+    @ApiStatus.OverrideOnly
     default int getEnchantmentLevel(ItemStack stack, Enchantment enchantment)
     {
         return EnchantmentHelper.getTagEnchantmentLevel(enchantment, stack);
@@ -541,10 +544,12 @@ public interface IForgeItem
      * Used in several places in code including armor enchantment hooks.
      * For consistency, any enchantments in the returned map should include the same level in {@link #getEnchantmentLevel(ItemStack, Enchantment)}
      *
-     * @param stack        the item stack being checked
-     * @return  Map of all enchantments on the stack, empty if no enchantments are present
+     * @param stack The item stack being checked
+     * @return Map of all enchantments on the stack, empty if no enchantments are present
      * @see #getEnchantmentLevel(ItemStack, Enchantment)
+     * @apiNote Call via {@link IForgeItemStack#getAllEnchantments()}.
      */
+    @ApiStatus.OverrideOnly
     default Map<Enchantment, Integer> getAllEnchantments(ItemStack stack)
     {
         return EnchantmentHelper.deserializeEnchantments(stack.getEnchantmentTags());

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -542,7 +542,7 @@ public interface IForgeItem
     /**
      * Gets a map of all enchantments present on the stack. By default, returns the enchantments present in NBT.
      * Used in several places in code including armor enchantment hooks.
-     * For consistency, any enchantments in the returned map should include the same level in {@link #getEnchantmentLevel(ItemStack, Enchantment)}
+     * The returned value(s) must have the same level as {@link #getEnchantmentLevel(ItemStack, Enchantment)}.
      *
      * @param stack The item stack being checked
      * @return Map of all enchantments on the stack, empty if no enchantments are present

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -167,11 +167,13 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Gets the level of the enchantment currently present on the stack. By default, returns the enchantment level present in NBT.
+     * Gets the gameplay level of the target enchantment on this stack.
      * <p>
-     * Equivalent to calling {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}
-     * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} for checking presence of an enchantment in logic implementing the enchantment behavior.
-     * Use {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} instead when modifying an item's enchantments.
+     * Equivalent to calling {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}.
+     * <p>
+     * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} for gameplay logic.
+     * <p>
+     * Use {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} instead when modifying the item's enchantments.
      *
      * @param enchantment The enchantment being checked for
      * @return The level of the enchantment, or 0 if not present.
@@ -185,12 +187,13 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
     }
 
     /**
-     * Gets a map of all enchantments present on the stack. By default, returns the enchantments present in NBT, ignoring book enchantments.
+     * Gets the gameplay level of all enchantments on this stack.
      * <p>
-     * Use in place of {@link EnchantmentHelper#getEnchantments(ItemStack)} for checking presence of an enchantment in logic implementing the enchantment behavior.
-     * Use {@link EnchantmentHelper#getEnchantments(ItemStack)} instead when modifying an item's enchantments.
+     * Use in place of {@link EnchantmentHelper#getEnchantments(ItemStack)} for gameplay logic.
+     * <p>
+     * Use {@link EnchantmentHelper#getEnchantments(ItemStack)} instead when modifying the item's enchantments.
      *
-     * @return  Map of all enchantments on the stack, empty if no enchantments are present
+     * @return  Map of all enchantments on the stack, or an empty map if no enchantments are present
      * @see #getEnchantmentLevel(Enchantment)
      * @see EnchantmentHelper#getEnchantments(ItemStack)
      */

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItemStack.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.LivingEntity;
@@ -34,6 +35,8 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.event.ForgeEventFactory;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -165,34 +168,36 @@ public interface IForgeItemStack extends ICapabilitySerializable<CompoundTag>
 
     /**
      * Gets the level of the enchantment currently present on the stack. By default, returns the enchantment level present in NBT.
+     * <p>
+     * Equivalent to calling {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}
+     * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} for checking presence of an enchantment in logic implementing the enchantment behavior.
+     * Use {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} instead when modifying an item's enchantments.
      *
-     * Equivalent to calling {@link net.minecraft.world.item.enchantment.EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}
-     * Use in place of {@link net.minecraft.world.item.enchantment.EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} for checking presence of an enchantment in logic implementing the enchantment behavior.
-     * Use {@link net.minecraft.world.item.enchantment.EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} instead when modifying an item's enchantments.
-     *
-     * @param enchantment  the enchantment being checked for
-     * @return  Level of the enchantment, or 0 if not present
+     * @param enchantment The enchantment being checked for
+     * @return The level of the enchantment, or 0 if not present.
      * @see #getAllEnchantments()
-     * @see net.minecraft.world.item.enchantment.EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)
+     * @see EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)
      */
     default int getEnchantmentLevel(Enchantment enchantment)
     {
-        return self().getItem().getEnchantmentLevel(self(), enchantment);
+        int level = self().getItem().getEnchantmentLevel(self(), enchantment);
+        return ForgeEventFactory.getEnchantmentLevelSpecific(level, self(), enchantment);
     }
 
     /**
      * Gets a map of all enchantments present on the stack. By default, returns the enchantments present in NBT, ignoring book enchantments.
-     *
-     * Use in place of {@link net.minecraft.world.item.enchantment.EnchantmentHelper#getEnchantments(ItemStack)} for checking presence of an enchantment in logic implementing the enchantment behavior.
-     * Use {@link net.minecraft.world.item.enchantment.EnchantmentHelper#getEnchantments(ItemStack)} instead when modifying an item's enchantments.
+     * <p>
+     * Use in place of {@link EnchantmentHelper#getEnchantments(ItemStack)} for checking presence of an enchantment in logic implementing the enchantment behavior.
+     * Use {@link EnchantmentHelper#getEnchantments(ItemStack)} instead when modifying an item's enchantments.
      *
      * @return  Map of all enchantments on the stack, empty if no enchantments are present
      * @see #getEnchantmentLevel(Enchantment)
-     * @see net.minecraft.world.item.enchantment.EnchantmentHelper#getEnchantments(ItemStack)
+     * @see EnchantmentHelper#getEnchantments(ItemStack)
      */
     default Map<Enchantment, Integer> getAllEnchantments()
     {
-        return self().getItem().getAllEnchantments(self());
+        Map<Enchantment, Integer> map = self().getItem().getAllEnchantments(self());
+        return ForgeEventFactory.getEnchantmentLevel(map, self());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -59,6 +59,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.world.level.BaseSpawner;
@@ -90,6 +91,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.extensions.IForgeItemStack;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
@@ -975,5 +977,35 @@ public class ForgeEventFactory
     public static void onAdvancementProgressedEvent(Player player, Advancement progressed, AdvancementProgress advancementProgress, String criterion, ProgressType progressType)
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementProgressEvent(player, progressed, advancementProgress, criterion, progressType));
+    }
+
+    /**
+     * Fires {@link GetEnchantmentLevelEvent} and for a single enchantment, returning the (possibly event-modified) level.
+     * 
+     * @param level The original level of the enchantment as provided by the Item.
+     * @param stack The stack being queried against.
+     * @param ench  The enchantment being queried for.
+     * @return The new level of the enchantment.
+     */
+    public static int getEnchantmentLevelSpecific(int level, ItemStack stack, Enchantment ench) {
+        Map<Enchantment, Integer> map = new HashMap<>();
+        map.put(ench, level);
+        var event = new GetEnchantmentLevelEvent(stack, map);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getEnchantments().get(ench);
+    }
+
+    /**
+     * Fires {@link GetEnchantmentLevelEvent} and for all enchantments, returning the (possibly event-modified) enchantment map.
+     * 
+     * @param enchantments The original enchantment map as provided by the Item.
+     * @param stack        The stack being queried against.
+     * @return The new enchantment map.
+     */
+    public static Map<Enchantment, Integer> getEnchantmentLevel(Map<Enchantment, Integer> enchantments, ItemStack stack) {
+        enchantments = new HashMap<>(enchantments);
+        var event = new GetEnchantmentLevelEvent(stack, enchantments);
+        MinecraftForge.EVENT_BUS.post(event);
+        return enchantments;
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -990,9 +990,9 @@ public class ForgeEventFactory
     public static int getEnchantmentLevelSpecific(int level, ItemStack stack, Enchantment ench) {
         Map<Enchantment, Integer> map = new HashMap<>();
         map.put(ench, level);
-        var event = new GetEnchantmentLevelEvent(stack, map);
+        var event = new GetEnchantmentLevelEvent(stack, map, ench);
         MinecraftForge.EVENT_BUS.post(event);
-        return event.getEnchantments().get(ench);
+        return event.getEnchantments().getOrDefault(ench, 0);
     }
 
     /**
@@ -1004,7 +1004,7 @@ public class ForgeEventFactory
      */
     public static Map<Enchantment, Integer> getEnchantmentLevel(Map<Enchantment, Integer> enchantments, ItemStack stack) {
         enchantments = new HashMap<>(enchantments);
-        var event = new GetEnchantmentLevelEvent(stack, enchantments);
+        var event = new GetEnchantmentLevelEvent(stack, enchantments, null);
         MinecraftForge.EVENT_BUS.post(event);
         return enchantments;
     }

--- a/src/main/java/net/minecraftforge/event/GetEnchantmentLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/GetEnchantmentLevelEvent.java
@@ -7,9 +7,10 @@ package net.minecraftforge.event;
 
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.extensions.IForgeItemStack;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -18,35 +19,56 @@ import net.minecraftforge.eventbus.api.Event;
  * It is called from {@link IForgeItemStack#getEnchantmentLevel(Enchantment)} and {@link IForgeItemStack#getAllEnchantments()}.
  * <p>
  * It is not fired for interactions with NBT, which means these changes will not reflect in the item tooltip.
- * <p>
- * This event is fired on {@link MinecraftForge#EVENT_BUS}.<br>
- * This event is not cancellable.<br>
- * This event does not have a result.
  */
-public class GetEnchantmentLevelEvent extends Event
-{
+public class GetEnchantmentLevelEvent extends Event {
+
     protected final ItemStack stack;
     protected final Map<Enchantment, Integer> enchantments;
+    @Nullable
+    protected final Enchantment targetEnchant;
 
-    public GetEnchantmentLevelEvent(ItemStack stack, Map<Enchantment, Integer> enchantments)
-    {
+    public GetEnchantmentLevelEvent(ItemStack stack, Map<Enchantment, Integer> enchantments, @Nullable Enchantment targetEnchant) {
         this.stack = stack;
         this.enchantments = enchantments;
+        this.targetEnchant = targetEnchant;
     }
 
     /**
-     * Returns the item stack that is being queried.
+     * Returns the item stack that is being queried against.
      */
-    public ItemStack getStack()
-    {
+    public ItemStack getStack() {
         return this.stack;
     }
 
     /**
      * Returns the mutable enchantment->level map.
      */
-    public Map<Enchantment, Integer> getEnchantments()
-    {
+    public Map<Enchantment, Integer> getEnchantments() {
         return this.enchantments;
+    }
+
+    /**
+     * This method returns the specific enchantment being queried from {@link IForgeItemStack#getEnchantmentLevel(Enchantment)}.
+     * <p>
+     * If this is value is present, you only need to adjust the level of that enchantment.
+     * <p>
+     * If this value is null, then the event was fired from {@link IForgeItemStack#getAllEnchantments()} and all enchantments should be populated.
+     * 
+     * @return The specific enchantment being queried, or null, if all enchantments are being requested.
+     */
+    @Nullable
+    public Enchantment getTargetEnchant() {
+        return this.targetEnchant;
+    }
+
+    /**
+     * Helper method around {@link #getTargetEnchant()} that checks if the target is the specified enchantment, or if the target is null.
+     * 
+     * @param ench The enchantment to check.
+     * @return If modifications to the passed enchantment are relevant for this event.
+     * @see {@link #getTargetEnchant()} for more information about the target enchantment.
+     */
+    public boolean isTargetting(Enchantment ench) {
+        return this.targetEnchant == null || this.targetEnchant == ench;
     }
 }

--- a/src/main/java/net/minecraftforge/event/GetEnchantmentLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/GetEnchantmentLevelEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.minecraftforge.event;
 
 import java.util.Map;

--- a/src/main/java/net/minecraftforge/event/GetEnchantmentLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/GetEnchantmentLevelEvent.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.event;
+
+import java.util.Map;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.extensions.IForgeItemStack;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * This event is fired whenever the enchantment level of a particular item is requested for gameplay purposes.<br>
+ * It is called from {@link IForgeItemStack#getEnchantmentLevel(Enchantment)} and {@link IForgeItemStack#getAllEnchantments()}.
+ * <p>
+ * It is not fired for interactions with NBT, which means these changes will not reflect in the item tooltip.
+ * <p>
+ * This event is fired on {@link MinecraftForge#EVENT_BUS}.<br>
+ * This event is not cancellable.<br>
+ * This event does not have a result.
+ */
+public class GetEnchantmentLevelEvent extends Event
+{
+    protected final ItemStack stack;
+    protected final Map<Enchantment, Integer> enchantments;
+
+    public GetEnchantmentLevelEvent(ItemStack stack, Map<Enchantment, Integer> enchantments)
+    {
+        this.stack = stack;
+        this.enchantments = enchantments;
+    }
+
+    /**
+     * Returns the item stack that is being queried.
+     */
+    public ItemStack getStack()
+    {
+        return this.stack;
+    }
+
+    /**
+     * Returns the mutable enchantment->level map.
+     */
+    public Map<Enchantment, Integer> getEnchantments()
+    {
+        return this.enchantments;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/misc/GetEnchantmentLevelEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/GetEnchantmentLevelEventTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.debug.misc;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.GetEnchantmentLevelEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Tests {@link GetEnchantmentLevelEvent} by changing the level of fortune to 100 when holding an iron pickaxe named "Fortuna"
+ */
+@Mod(GetEnchantmentLevelEventTest.MOD_ID)
+public class GetEnchantmentLevelEventTest
+{
+    private static final boolean ENABLED = true;
+    static final String MOD_ID = "get_ench_level_test";
+
+    public GetEnchantmentLevelEventTest()
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.addListener(this::enchLevels);
+        }
+    }
+
+    private void enchLevels(GetEnchantmentLevelEvent e)
+    {
+        ItemStack s = e.getStack();
+        if (s.getItem() == Items.IRON_PICKAXE && s.hasCustomHoverName() && s.getHoverName().getString().equalsIgnoreCase("fortuna"))
+        {
+            e.getEnchantments().put(Enchantments.BLOCK_FORTUNE, 100);
+        }
+    }
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -31,9 +31,10 @@ license="LGPL v2.1"
     modId="custom_preset_editor_test"
 [[mods]]
     modId="level_sensitive_light_block_test"
-
 [[mods]]
     modId="living_swap_items_event_test"
+[[mods]]
+    modId="get_ench_level_test"
 
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.


### PR DESCRIPTION
This PR adds the `GetEnchantmentLevelEvent`, which allows for modifying the gameplay levels of enchantments on arbitrary items.

This event has been tested fairly thoroughly via Placebo and Apotheosis since 1.19.2 - Placebo's implementation is the same implementation used here (though without needing a coremod to inject the hook into the interface).

My personal usecase is for the gems added by Apotheosis, which can provide enchantment level bonuses: ![](https://i.imgur.com/2D8ssiD.png)

Other mods have previously tried to use this functionality, like Astral Sorcery's Resplendant Prism.