### PR TITLE
Call onLoad when loading from a blockItem

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BlockItem.java.patch
@@ -28,6 +28,14 @@
     @Nullable
     public BlockPlaceContext m_7732_(BlockPlaceContext p_40609_) {
        return p_40609_;
+@@ -175,6 +_,7 @@
+                compoundtag1.m_128391_(compoundtag);
+                if (!compoundtag1.equals(compoundtag2)) {
+                   blockentity.m_142466_(compoundtag1);
++                  blockentity.onLoad();
+                   blockentity.m_6596_();
+                   return true;
+                }
 @@ -195,11 +_,19 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/BlockItem.java.patch
@@ -28,14 +28,6 @@
     @Nullable
     public BlockPlaceContext m_7732_(BlockPlaceContext p_40609_) {
        return p_40609_;
-@@ -175,6 +_,7 @@
-                compoundtag1.m_128391_(compoundtag);
-                if (!compoundtag1.equals(compoundtag2)) {
-                   blockentity.m_142466_(compoundtag1);
-+                  blockentity.onLoad();
-                   blockentity.m_6596_();
-                   return true;
-                }
 @@ -195,11 +_,19 @@
     }
  

--- a/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -59,7 +59,7 @@
           }
  
           this.m_156406_(p_156391_);
-+         p_156391_.onLoad();
++         this.f_62776_.addFreshBlockEntities(java.util.List.of(p_156391_));
        }
  
     }


### PR DESCRIPTION
Currently, when placing a block entity, onLoad is called when the data isn't yet updated by the block item. This change makes it call onLoad after setting the data from the block item. This means that onLoad is called 2 times, once while placing the block and once after updating the data. This change is needed, as otherwise onLoad can't be used in combination with placing the block with nbt data.