### PR TITLE
Add Pointed Dripstone drip support to FluidTypes

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/CauldronBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/CauldronBlock.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/world/level/block/CauldronBlock.java
++++ b/net/minecraft/world/level/block/CauldronBlock.java
+@@ -51,16 +_,13 @@
+    }
+ 
+    protected void m_142310_(BlockState p_152940_, Level p_152941_, BlockPos p_152942_, Fluid p_152943_) {
+-      if (p_152943_ == Fluids.f_76193_) {
+-         BlockState blockstate = Blocks.f_152476_.m_49966_();
++      if (p_152943_.getFluidType().getDripInfo() != null) {
++         BlockState blockstate = p_152943_.getFluidType().getDripInfo().cauldron().m_49966_();
+          p_152941_.m_46597_(p_152942_, blockstate);
+          p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate));
+-         p_152941_.m_46796_(1047, p_152942_, 0);
+-      } else if (p_152943_ == Fluids.f_76195_) {
+-         BlockState blockstate1 = Blocks.f_152477_.m_49966_();
+-         p_152941_.m_46597_(p_152942_, blockstate1);
+-         p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate1));
+-         p_152941_.m_46796_(1046, p_152942_, 0);
++         if (p_152943_.getFluidType().getDripInfo().fillSound() != null) {
++            p_152941_.m_5594_(null, p_152942_, p_152943_.getFluidType().getDripInfo().fillSound(), net.minecraft.sounds.SoundSource.BLOCKS, 2.0F, p_152941_.f_46441_.m_188501_() * 0.1F + 0.9F);
++         }
+       }
+ 
+    }

--- a/patches/minecraft/net/minecraft/world/level/block/CauldronBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/CauldronBlock.java.patch
@@ -1,24 +1,18 @@
 --- a/net/minecraft/world/level/block/CauldronBlock.java
 +++ b/net/minecraft/world/level/block/CauldronBlock.java
-@@ -51,16 +_,13 @@
+@@ -51,7 +_,14 @@
     }
  
     protected void m_142310_(BlockState p_152940_, Level p_152941_, BlockPos p_152942_, Fluid p_152943_) {
 -      if (p_152943_ == Fluids.f_76193_) {
--         BlockState blockstate = Blocks.f_152476_.m_49966_();
 +      if (p_152943_.getFluidType().getDripInfo() != null) {
 +         BlockState blockstate = p_152943_.getFluidType().getDripInfo().cauldron().m_49966_();
++         p_152941_.m_46597_(p_152942_, blockstate);
++         p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate));
++         if (p_152943_.getFluidType().getSound(net.minecraftforge.common.SoundActions.CAULDRON_DRIP) != null) {
++            p_152941_.m_5594_(null, p_152942_, p_152943_.getFluidType().getSound(net.minecraftforge.common.SoundActions.CAULDRON_DRIP), net.minecraft.sounds.SoundSource.BLOCKS, 2.0F, p_152941_.f_46441_.m_188501_() * 0.1F + 0.9F);
++         }
++      } else if (p_152943_ == Fluids.f_76193_) {
+          BlockState blockstate = Blocks.f_152476_.m_49966_();
           p_152941_.m_46597_(p_152942_, blockstate);
           p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate));
--         p_152941_.m_46796_(1047, p_152942_, 0);
--      } else if (p_152943_ == Fluids.f_76195_) {
--         BlockState blockstate1 = Blocks.f_152477_.m_49966_();
--         p_152941_.m_46597_(p_152942_, blockstate1);
--         p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate1));
--         p_152941_.m_46796_(1046, p_152942_, 0);
-+         if (p_152943_.getFluidType().getDripInfo().fillSound() != null) {
-+            p_152941_.m_5594_(null, p_152942_, p_152943_.getFluidType().getDripInfo().fillSound(), net.minecraft.sounds.SoundSource.BLOCKS, 2.0F, p_152941_.f_46441_.m_188501_() * 0.1F + 0.9F);
-+         }
-       }
- 
-    }

--- a/patches/minecraft/net/minecraft/world/level/block/CauldronBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/CauldronBlock.java.patch
@@ -1,18 +1,10 @@
 --- a/net/minecraft/world/level/block/CauldronBlock.java
 +++ b/net/minecraft/world/level/block/CauldronBlock.java
-@@ -51,7 +_,14 @@
+@@ -51,6 +_,7 @@
     }
  
     protected void m_142310_(BlockState p_152940_, Level p_152941_, BlockPos p_152942_, Fluid p_152943_) {
--      if (p_152943_ == Fluids.f_76193_) {
-+      if (p_152943_.getFluidType().getDripInfo() != null) {
-+         BlockState blockstate = p_152943_.getFluidType().getDripInfo().cauldron().m_49966_();
-+         p_152941_.m_46597_(p_152942_, blockstate);
-+         p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate));
-+         if (p_152943_.getFluidType().getSound(net.minecraftforge.common.SoundActions.CAULDRON_DRIP) != null) {
-+            p_152941_.m_5594_(null, p_152942_, p_152943_.getFluidType().getSound(net.minecraftforge.common.SoundActions.CAULDRON_DRIP), net.minecraft.sounds.SoundSource.BLOCKS, 2.0F, p_152941_.f_46441_.m_188501_() * 0.1F + 0.9F);
-+         }
-+      } else if (p_152943_ == Fluids.f_76193_) {
++      if (!net.minecraftforge.common.ForgeHooks.handleDripInfo(p_152943_, p_152941_, p_152942_))
+       if (p_152943_ == Fluids.f_76193_) {
           BlockState blockstate = Blocks.f_152476_.m_49966_();
           p_152941_.m_46597_(p_152942_, blockstate);
-          p_152941_.m_220407_(GameEvent.f_157792_, p_152942_, GameEvent.Context.m_223722_(blockstate));

--- a/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
@@ -1,0 +1,54 @@
+--- a/net/minecraft/world/level/block/PointedDripstoneBlock.java
++++ b/net/minecraft/world/level/block/PointedDripstoneBlock.java
+@@ -162,23 +_,12 @@
+ 
+    @VisibleForTesting
+    public static void m_221859_(BlockState p_221860_, ServerLevel p_221861_, BlockPos p_221862_, float p_221863_) {
+-      if (!(p_221863_ > 0.17578125F) || !(p_221863_ > 0.05859375F)) {
+          if (m_154203_(p_221860_, p_221861_, p_221862_)) {
+             Optional<PointedDripstoneBlock.FluidInfo> optional = m_154181_(p_221861_, p_221862_, p_221860_);
+             if (!optional.isEmpty()) {
+                Fluid fluid = (optional.get()).f_221893_;
+-               float f;
+-               if (fluid == Fluids.f_76193_) {
+-                  f = 0.17578125F;
+-               } else {
+-                  if (fluid != Fluids.f_76195_) {
+-                     return;
+-                  }
+-
+-                  f = 0.05859375F;
+-               }
+-
+-               if (!(p_221863_ >= f)) {
++               net.minecraftforge.fluids.FluidType.DripstoneDripInfo dripInfo = fluid.getFluidType().getDripInfo();
++               if (dripInfo != null && !(p_221863_ >= dripInfo.chance())) {
+                   BlockPos blockpos = m_154130_(p_221860_, p_221861_, p_221862_, 11, false);
+                   if (blockpos != null) {
+                      if ((optional.get()).f_221894_.m_60713_(Blocks.f_220864_) && fluid == Fluids.f_76193_) {
+@@ -201,7 +_,6 @@
+                }
+             }
+          }
+-      }
+    }
+ 
+    @Nullable
+@@ -377,7 +_,7 @@
+       double d2 = (double)((float)(p_154073_.m_123342_() + 1) - 0.6875F) - 0.0625D;
+       double d3 = (double)p_154073_.m_123343_() + 0.5D + vec3.f_82481_;
+       Fluid fluid = m_154052_(p_154072_, p_154075_);
+-      ParticleOptions particleoptions = fluid.m_205067_(FluidTags.f_13132_) ? ParticleTypes.f_175822_ : ParticleTypes.f_175824_;
++      ParticleOptions particleoptions = fluid.getFluidType().getDripInfo() != null ? fluid.getFluidType().getDripInfo().dripParticle() : ParticleTypes.f_175824_;
+       p_154072_.m_7106_(particleoptions, d1, d2, d3, 0.0D, 0.0D, 0.0D);
+    }
+ 
+@@ -535,7 +_,7 @@
+    }
+ 
+    private static boolean m_154158_(Fluid p_154159_) {
+-      return p_154159_ == Fluids.f_76195_ || p_154159_ == Fluids.f_76193_;
++      return p_154159_.getFluidType().getDripInfo() != null;
+    }
+ 
+    private static boolean m_154140_(BlockState p_154141_, BlockState p_154142_) {

--- a/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
@@ -33,12 +33,13 @@
     }
  
     @Nullable
-@@ -377,7 +_,7 @@
+@@ -377,7 +_,8 @@
        double d2 = (double)((float)(p_154073_.m_123342_() + 1) - 0.6875F) - 0.0625D;
        double d3 = (double)p_154073_.m_123343_() + 0.5D + vec3.f_82481_;
        Fluid fluid = m_154052_(p_154072_, p_154075_);
 -      ParticleOptions particleoptions = fluid.m_205067_(FluidTags.f_13132_) ? ParticleTypes.f_175822_ : ParticleTypes.f_175824_;
-+      ParticleOptions particleoptions = fluid.getFluidType().getDripInfo() != null && fluid.getFluidType().getDripInfo().dripParticle() != null ? fluid.getFluidType().getDripInfo().dripParticle() : ParticleTypes.f_175824_;
++      ParticleOptions particleoptions = fluid.getFluidType().getDripInfo() != null ? fluid.getFluidType().getDripInfo().dripParticle() : ParticleTypes.f_175824_;
++      if (particleoptions != null)
        p_154072_.m_7106_(particleoptions, d1, d2, d3, 0.0D, 0.0D, 0.0D);
     }
  

--- a/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
@@ -39,7 +39,7 @@
        double d3 = (double)p_154073_.m_123343_() + 0.5D + vec3.f_82481_;
        Fluid fluid = m_154052_(p_154072_, p_154075_);
 -      ParticleOptions particleoptions = fluid.m_205067_(FluidTags.f_13132_) ? ParticleTypes.f_175822_ : ParticleTypes.f_175824_;
-+      ParticleOptions particleoptions = fluid.getFluidType().getDripInfo() != null ? fluid.getFluidType().getDripInfo().dripParticle() : ParticleTypes.f_175824_;
++      ParticleOptions particleoptions = fluid.getFluidType().getDripInfo() != null && fluid.getFluidType().getDripInfo().dripParticle() != null ? fluid.getFluidType().getDripInfo().dripParticle() : ParticleTypes.f_175824_;
        p_154072_.m_7106_(particleoptions, d1, d2, d3, 0.0D, 0.0D, 0.0D);
     }
  

--- a/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/PointedDripstoneBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/PointedDripstoneBlock.java
 +++ b/net/minecraft/world/level/block/PointedDripstoneBlock.java
-@@ -162,23 +_,12 @@
+@@ -162,7 +_,6 @@
  
     @VisibleForTesting
     public static void m_221859_(BlockState p_221860_, ServerLevel p_221861_, BlockPos p_221862_, float p_221863_) {
@@ -8,17 +8,16 @@
           if (m_154203_(p_221860_, p_221861_, p_221862_)) {
              Optional<PointedDripstoneBlock.FluidInfo> optional = m_154181_(p_221861_, p_221862_, p_221860_);
              if (!optional.isEmpty()) {
-                Fluid fluid = (optional.get()).f_221893_;
--               float f;
--               if (fluid == Fluids.f_76193_) {
--                  f = 0.17578125F;
--               } else {
+@@ -171,14 +_,10 @@
+                if (fluid == Fluids.f_76193_) {
+                   f = 0.17578125F;
+                } else {
 -                  if (fluid != Fluids.f_76195_) {
 -                     return;
 -                  }
 -
--                  f = 0.05859375F;
--               }
+                   f = 0.05859375F;
+                }
 -
 -               if (!(p_221863_ >= f)) {
 +               net.minecraftforge.fluids.FluidType.DripstoneDripInfo dripInfo = fluid.getFluidType().getDripInfo();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -60,6 +60,7 @@ import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagEntry;
 import net.minecraft.tags.TagKey;
@@ -939,6 +940,19 @@ public class ForgeHooks
         if (ForgeMod.MILK.filter(milk -> milk == fluid).isPresent() || ForgeMod.FLOWING_MILK.filter(milk -> milk == fluid).isPresent())
             return ForgeMod.MILK_TYPE.get();
         throw new RuntimeException("Mod fluids must override getFluidType.");
+    }
+
+    public static boolean handleDripInfo(Fluid fluid, Level level, BlockPos pos) {
+        if (fluid.isSource(fluid.defaultFluidState()) && fluid.getFluidType().getDripInfo() != null) {
+            BlockState cauldronBlock = fluid.getFluidType().getDripInfo().cauldron().defaultBlockState();
+            level.setBlockAndUpdate(pos, cauldronBlock);
+            level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(cauldronBlock));
+            if (fluid.getFluidType().getSound(SoundActions.CAULDRON_DRIP) != null) {
+                level.playSound(null, pos, fluid.getFluidType().getSound(SoundActions.CAULDRON_DRIP), SoundSource.BLOCKS, 2.0F, level.getRandom().nextFloat() * 0.1F + 0.9F);
+            }
+            return true;
+        }
+        return false;
     }
 
     public static TagKey<Block> getTagFromVanillaTier(Tiers tier)

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -288,8 +288,9 @@ public class ForgeMod
                     .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)
                     .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY)
                     .sound(SoundActions.FLUID_VAPORIZE, SoundEvents.FIRE_EXTINGUISH)
+                    .sound(SoundActions.CAULDRON_DRIP, SoundEvents.POINTED_DRIPSTONE_DRIP_WATER_INTO_CAULDRON)
                     .canHydrate(true)
-                    .addDripstoneDripping(0.17578125F, ParticleTypes.DRIPPING_DRIPSTONE_WATER, Blocks.WATER_CAULDRON, SoundEvents.POINTED_DRIPSTONE_DRIP_WATER_INTO_CAULDRON))
+                    .addDripstoneDripping(0.17578125F, ParticleTypes.DRIPPING_DRIPSTONE_WATER, Blocks.WATER_CAULDRON))
             {
                 @Override
                 public @Nullable BlockPathTypes getBlockPathType(FluidState state, BlockGetter level, BlockPos pos, @Nullable Mob mob, boolean canFluidLog)
@@ -355,11 +356,12 @@ public class ForgeMod
                     .adjacentPathType(null)
                     .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL_LAVA)
                     .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY_LAVA)
+                    .sound(SoundActions.CAULDRON_DRIP, SoundEvents.POINTED_DRIPSTONE_DRIP_LAVA_INTO_CAULDRON)
                     .lightLevel(15)
                     .density(3000)
                     .viscosity(6000)
                     .temperature(1300)
-                    .addDripstoneDripping(0.05859375F, ParticleTypes.DRIPPING_DRIPSTONE_LAVA, Blocks.LAVA_CAULDRON, SoundEvents.POINTED_DRIPSTONE_DRIP_LAVA_INTO_CAULDRON))
+                    .addDripstoneDripping(0.05859375F, ParticleTypes.DRIPPING_DRIPSTONE_LAVA, Blocks.LAVA_CAULDRON))
             {
                 @Override
                 public double motionScale(Entity entity)

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -288,9 +288,8 @@ public class ForgeMod
                     .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)
                     .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY)
                     .sound(SoundActions.FLUID_VAPORIZE, SoundEvents.FIRE_EXTINGUISH)
-                    .sound(SoundActions.CAULDRON_DRIP, SoundEvents.POINTED_DRIPSTONE_DRIP_WATER_INTO_CAULDRON)
                     .canHydrate(true)
-                    .addDripstoneDripping(0.17578125F, ParticleTypes.DRIPPING_DRIPSTONE_WATER, Blocks.WATER_CAULDRON))
+                    .addDripstoneDripping(0.17578125F, ParticleTypes.DRIPPING_DRIPSTONE_WATER, Blocks.WATER_CAULDRON, SoundEvents.POINTED_DRIPSTONE_DRIP_WATER_INTO_CAULDRON))
             {
                 @Override
                 public @Nullable BlockPathTypes getBlockPathType(FluidState state, BlockGetter level, BlockPos pos, @Nullable Mob mob, boolean canFluidLog)
@@ -356,12 +355,11 @@ public class ForgeMod
                     .adjacentPathType(null)
                     .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL_LAVA)
                     .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY_LAVA)
-                    .sound(SoundActions.CAULDRON_DRIP, SoundEvents.POINTED_DRIPSTONE_DRIP_LAVA_INTO_CAULDRON)
                     .lightLevel(15)
                     .density(3000)
                     .viscosity(6000)
                     .temperature(1300)
-                    .addDripstoneDripping(0.05859375F, ParticleTypes.DRIPPING_DRIPSTONE_LAVA, Blocks.LAVA_CAULDRON))
+                    .addDripstoneDripping(0.05859375F, ParticleTypes.DRIPPING_DRIPSTONE_LAVA, Blocks.LAVA_CAULDRON, SoundEvents.POINTED_DRIPSTONE_DRIP_LAVA_INTO_CAULDRON))
             {
                 @Override
                 public double motionScale(Entity entity)

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -13,6 +13,7 @@ import net.minecraft.commands.synchronization.ArgumentTypeInfos;
 import net.minecraft.commands.synchronization.SingletonArgumentInfo;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.metadata.PackMetadataGenerator;
@@ -32,6 +33,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.MobSpawnSettings.SpawnerData;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.GenerationStep.Decoration;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.material.Fluid;
@@ -286,7 +288,8 @@ public class ForgeMod
                     .sound(SoundActions.BUCKET_FILL, SoundEvents.BUCKET_FILL)
                     .sound(SoundActions.BUCKET_EMPTY, SoundEvents.BUCKET_EMPTY)
                     .sound(SoundActions.FLUID_VAPORIZE, SoundEvents.FIRE_EXTINGUISH)
-                    .canHydrate(true))
+                    .canHydrate(true)
+                    .addDripstoneDripping(0.17578125F, ParticleTypes.DRIPPING_DRIPSTONE_WATER, Blocks.WATER_CAULDRON, SoundEvents.POINTED_DRIPSTONE_DRIP_WATER_INTO_CAULDRON))
             {
                 @Override
                 public @Nullable BlockPathTypes getBlockPathType(FluidState state, BlockGetter level, BlockPos pos, @Nullable Mob mob, boolean canFluidLog)
@@ -355,7 +358,8 @@ public class ForgeMod
                     .lightLevel(15)
                     .density(3000)
                     .viscosity(6000)
-                    .temperature(1300))
+                    .temperature(1300)
+                    .addDripstoneDripping(0.05859375F, ParticleTypes.DRIPPING_DRIPSTONE_LAVA, Blocks.LAVA_CAULDRON, SoundEvents.POINTED_DRIPSTONE_DRIP_LAVA_INTO_CAULDRON))
             {
                 @Override
                 public double motionScale(Entity entity)

--- a/src/main/java/net/minecraftforge/common/SoundActions.java
+++ b/src/main/java/net/minecraftforge/common/SoundActions.java
@@ -29,4 +29,9 @@ public final class SoundActions
      * When the fluid is being vaporized.
      */
     public static final SoundAction FLUID_VAPORIZE = SoundAction.get("fluid_vaporize");
+
+    /**
+     * When a Pointed Dripstone drips this fluid into an empty cauldron.
+     */
+    public static final SoundAction CAULDRON_DRIP = SoundAction.get("cauldron_drip");
 }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -1177,17 +1177,23 @@ public class FluidType
          * @param chance the chance that the cauldron below will be filled every time the Pointed Dripstone is randomly ticked
          * @param dripParticle the particle that spawns randomly from the tip of the Pointed Dripstone when this fluid is above it
          * @param cauldron the block the Pointed Dripstone should replace an empty cauldron with when it successfully tries to fill the cauldron
-         * @param fillSound the sound that plays when the Pointed Dripstone successfully tries to fill an empty cauldron. If null, no sound will play. Note that if your block class does not extend {@link CauldronBlock}, this sound will not play regardless.
          * @return the property holder instance
          */
-        public Properties addDripstoneDripping(float chance, ParticleOptions dripParticle, Block cauldron, @Nullable SoundEvent fillSound)
+        public Properties addDripstoneDripping(float chance, ParticleOptions dripParticle, Block cauldron)
         {
-            this.dripInfo = new DripstoneDripInfo(chance, dripParticle, cauldron, fillSound);
+            this.dripInfo = new DripstoneDripInfo(chance, dripParticle, cauldron);
             return this;
         }
     }
 
-    public record DripstoneDripInfo(float chance, ParticleOptions dripParticle, Block cauldron, @Nullable SoundEvent fillSound)
+    /**
+     * A record that holds some information to let a fluid drip from Pointed Dripstones and fill cauldrons below.
+     *
+     * @param chance the chance that the cauldron below will be filled every time the Pointed Dripstone is randomly ticked
+     * @param dripParticle the particle that spawns randomly from the tip of the Pointed Dripstone when this fluid is above it
+     * @param cauldron the block the Pointed Dripstone should replace an empty cauldron with when it successfully tries to fill the cauldron
+     */
+    public record DripstoneDripInfo(float chance, ParticleOptions dripParticle, Block cauldron)
     {
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -1193,7 +1193,7 @@ public class FluidType
      * @param dripParticle the particle that spawns randomly from the tip of the Pointed Dripstone when this fluid is above it
      * @param cauldron the block the Pointed Dripstone should replace an empty cauldron with when it successfully tries to fill the cauldron
      */
-    public record DripstoneDripInfo(float chance, ParticleOptions dripParticle, Block cauldron)
+    public record DripstoneDripInfo(float chance, @Nullable ParticleOptions dripParticle, Block cauldron)
     {
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -8,6 +8,7 @@ package net.minecraftforge.fluids;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -28,6 +29,8 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CauldronBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
@@ -87,6 +90,8 @@ public class FluidType
     private final int temperature;
     private final int viscosity;
     private final Rarity rarity;
+    @Nullable
+    private final DripstoneDripInfo dripInfo;
 
     /**
      * A map of actions performed to sound that should be played.
@@ -118,6 +123,7 @@ public class FluidType
         this.temperature = properties.temperature;
         this.viscosity = properties.viscosity;
         this.rarity = properties.rarity;
+        this.dripInfo = properties.dripInfo;
 
         this.initClient();
     }
@@ -217,6 +223,17 @@ public class FluidType
     public Rarity getRarity()
     {
         return this.rarity;
+    }
+
+    /**
+     * Returns the Pointed Dripstone drip information of the fluid.
+     * <p> Note that this CAN be null!
+     * @return the Pointed Dripstone drip information of the fluid
+     */
+    @Nullable
+    public DripstoneDripInfo getDripInfo()
+    {
+        return this.dripInfo;
     }
 
     /**
@@ -911,6 +928,8 @@ public class FluidType
                 temperature = 300,
                 viscosity = 1000;
         private Rarity rarity = Rarity.COMMON;
+        @Nullable
+        private DripstoneDripInfo dripInfo;
 
         private Properties() {}
 
@@ -1151,5 +1170,24 @@ public class FluidType
             this.rarity = rarity;
             return this;
         }
+
+        /**
+         * Allows this fluid to drip from Pointed Dripstones and fill cauldrons below.
+         *
+         * @param chance the chance that the cauldron below will be filled every time the Pointed Dripstone is randomly ticked
+         * @param dripParticle the particle that spawns randomly from the tip of the Pointed Dripstone when this fluid is above it
+         * @param cauldron the block the Pointed Dripstone should replace an empty cauldron with when it successfully tries to fill the cauldron
+         * @param fillSound the sound that plays when the Pointed Dripstone successfully tries to fill an empty cauldron. If null, no sound will play. Note that if your block class does not extend {@link CauldronBlock}, this sound will not play regardless.
+         * @return the property holder instance
+         */
+        public Properties addDripstoneDripping(float chance, ParticleOptions dripParticle, Block cauldron, @Nullable SoundEvent fillSound)
+        {
+            this.dripInfo = new DripstoneDripInfo(chance, dripParticle, cauldron, fillSound);
+            return this;
+        }
+    }
+
+    public record DripstoneDripInfo(float chance, ParticleOptions dripParticle, Block cauldron, @Nullable SoundEvent fillSound)
+    {
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -1177,10 +1177,15 @@ public class FluidType
          * @param chance the chance that the cauldron below will be filled every time the Pointed Dripstone is randomly ticked
          * @param dripParticle the particle that spawns randomly from the tip of the Pointed Dripstone when this fluid is above it
          * @param cauldron the block the Pointed Dripstone should replace an empty cauldron with when it successfully tries to fill the cauldron
+         * @param fillSound the sound that plays when the Pointed Dripstone successfully tries to fill an empty cauldron. If null, no sound will play. Note that if your block class does not extend {@link CauldronBlock}, this sound will not play regardless.
          * @return the property holder instance
          */
-        public Properties addDripstoneDripping(float chance, ParticleOptions dripParticle, Block cauldron)
+        public Properties addDripstoneDripping(float chance, ParticleOptions dripParticle, Block cauldron, @Nullable SoundEvent fillSound)
         {
+            if (fillSound != null)
+            {
+                this.sounds.put(SoundActions.CAULDRON_DRIP, fillSound);
+            }
             this.dripInfo = new DripstoneDripInfo(chance, dripParticle, cauldron);
             return this;
         }

--- a/src/main/java/net/minecraftforge/fluids/FluidType.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidType.java
@@ -227,7 +227,7 @@ public class FluidType
 
     /**
      * Returns the Pointed Dripstone drip information of the fluid.
-     * <p> Note that this CAN be null!
+     *
      * @return the Pointed Dripstone drip information of the fluid
      */
     @Nullable

--- a/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
@@ -28,6 +28,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.common.ForgeMod;
+import net.minecraftforge.common.SoundActions;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fluids.FluidInteractionRegistry;
@@ -82,7 +83,7 @@ public class FluidTypeTest
     }
 
     private static final RegistryObject<FluidType> TEST_FLUID_TYPE = FLUID_TYPES.register("test_fluid", () ->
-            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true).addDripstoneDripping(0.25F, ParticleTypes.SCULK_SOUL, Blocks.POWDER_SNOW_CAULDRON, SoundEvents.END_PORTAL_SPAWN))
+            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true).sound(SoundActions.CAULDRON_DRIP, SoundEvents.END_PORTAL_SPAWN).addDripstoneDripping(0.25F, ParticleTypes.SCULK_SOUL, Blocks.POWDER_SNOW_CAULDRON))
             {
                 @Override
                 public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer)

--- a/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
@@ -13,7 +13,9 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -80,7 +82,7 @@ public class FluidTypeTest
     }
 
     private static final RegistryObject<FluidType> TEST_FLUID_TYPE = FLUID_TYPES.register("test_fluid", () ->
-            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true))
+            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true).addDripstoneDripping(0.25F, ParticleTypes.SCULK_SOUL, Blocks.POWDER_SNOW_CAULDRON, SoundEvents.END_PORTAL_SPAWN))
             {
                 @Override
                 public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer)

--- a/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/FluidTypeTest.java
@@ -28,7 +28,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.client.event.RegisterColorHandlersEvent;
 import net.minecraftforge.common.ForgeMod;
-import net.minecraftforge.common.SoundActions;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fluids.FluidInteractionRegistry;
@@ -83,7 +82,7 @@ public class FluidTypeTest
     }
 
     private static final RegistryObject<FluidType> TEST_FLUID_TYPE = FLUID_TYPES.register("test_fluid", () ->
-            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true).sound(SoundActions.CAULDRON_DRIP, SoundEvents.END_PORTAL_SPAWN).addDripstoneDripping(0.25F, ParticleTypes.SCULK_SOUL, Blocks.POWDER_SNOW_CAULDRON))
+            new FluidType(FluidType.Properties.create().supportsBoating(true).canHydrate(true).addDripstoneDripping(0.25F, ParticleTypes.SCULK_SOUL, Blocks.POWDER_SNOW_CAULDRON, SoundEvents.END_PORTAL_SPAWN))
             {
                 @Override
                 public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer)


### PR DESCRIPTION
In 1.17, Mojang added Pointed Dripstone, which has a unique quirk in that it can fill cauldrons below it with fluids if the fluid is sitting above it. However, this system is extremely hardcoded. To get around it, you'll need to add 4 mixins to your project. (3 in `PointedDripstoneBlock` and 1 in `CauldronBlock`). This PR aims to allow modders to easily allow their fluids to drip from pointed dripstones if they so desire. 

This PR adds a new `FluidType` property, `addDripstoneDripping`. You can define the fill chance, the particle that drips from the tip of the pointed dripstone when your fluid is above it, what filled cauldron you want to replace an empty one with when the pointed dripstone successfully drips, and a sound to play when an empty cauldron fills up. Since this has been moved to FluidType properties, the hardcoded vanilla properties have been removed from `PointedDripstoneBlock` and `CauldronBlock` and moved to the fluid type registration for the fluids in `ForgeMod`.

This PR expands on an existing test mod and adds dripstone dripping to it. Placing `TEST_FLUID` from `FluidTypeTest` above a dripstone will spawn soul particles, fill the cauldron with a layer of powdered snow, and play the end portal opening sound when the cauldron is filled.

Please let me know if you guys aren't happy with how anything is named or how the Javadocs are worded. I'm not the best at wording things so I'm happy to change anything as needed. 