### PR TITLE
Add hook for `onDestroyedByPushReaction`

### DIFF
--- a/patches/minecraft/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -24,6 +24,16 @@
        return true;
     }
  
+@@ -288,8 +_,7 @@
+             BlockState blockstate1 = p_60182_.m_8055_(blockpos2);
+             BlockEntity blockentity = blockstate1.m_155947_() ? p_60182_.m_7702_(blockpos2) : null;
+             m_49892_(blockstate1, p_60182_, blockpos2, blockentity);
+-            p_60182_.m_7731_(blockpos2, Blocks.f_50016_.m_49966_(), 18);
+-            p_60182_.m_220407_(GameEvent.f_157794_, blockpos2, GameEvent.Context.m_223722_(blockstate1));
++            blockstate1.onDestroyedByPushReaction(blockstate1, p_60182_, blockpos2, direction, p_60182_.m_6425_(blockpos2));
+             if (!blockstate1.m_204336_(BlockTags.f_13076_)) {
+                p_60182_.m_142052_(blockpos2, blockstate1);
+             }
 @@ -354,6 +_,10 @@
  
     public BlockState m_6843_(BlockState p_60215_, Rotation p_60216_) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.world.level.SignalGetter;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MapColor;
@@ -56,6 +57,7 @@ import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.jetbrains.annotations.Nullable;
+import org.jline.utils.Log;
 
 @SuppressWarnings("deprecation")
 public interface IForgeBlock
@@ -193,6 +195,28 @@ public interface IForgeBlock
     {
         self().playerWillDestroy(level, pos, state, player);
         return level.setBlock(pos, fluid.createLegacyBlock(), level.isClientSide ? 11 : 3);
+    }
+
+    /**
+     * Called when a block is removed by {@link PushReaction#DESTROY}.  This is responsible for
+     * actually destroying the block, and the block is intact at time of call.
+     *
+     * Will only be called if {@link BlockState#getPistonPushReaction} returns {@link PushReaction#DESTROY}.
+     *
+     * Note: When used in multiplayer, this is called on both client and
+     * server sides!
+     *
+     * @param state The current state.
+     * @param level The current level
+     * @param pos Block position in level
+     * @param pushDirection The direction of block movement
+     * @param fluid The current fluid state at current position
+     */
+    default void onDestroyedByPushReaction(BlockState state, Level level, BlockPos pos, Direction pushDirection, FluidState fluid)
+    {
+        Log.debug("wow, this is overridable!");
+        level.setBlock(pos, Blocks.AIR.defaultBlockState(), level.isClientSide ? 11 : 3);
+        level.gameEvent(GameEvent.BLOCK_DESTROY, pos, GameEvent.Context.of(state));
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -57,7 +57,6 @@ import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import org.jetbrains.annotations.Nullable;
-import org.jline.utils.Log;
 
 @SuppressWarnings("deprecation")
 public interface IForgeBlock
@@ -214,7 +213,6 @@ public interface IForgeBlock
      */
     default void onDestroyedByPushReaction(BlockState state, Level level, BlockPos pos, Direction pushDirection, FluidState fluid)
     {
-        Log.debug("wow, this is overridable!");
         level.setBlock(pos, Blocks.AIR.defaultBlockState(), level.isClientSide ? 11 : 3);
         level.gameEvent(GameEvent.BLOCK_DESTROY, pos, GameEvent.Context.of(state));
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -23,6 +23,7 @@ import net.minecraft.world.level.SignalGetter;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.level.pathfinder.BlockPathTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.HitResult;
@@ -127,6 +128,26 @@ public interface IForgeBlockState
     default boolean onDestroyedByPlayer(Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
     {
         return self().getBlock().onDestroyedByPlayer(self(), level, pos, player, willHarvest, fluid);
+    }
+
+    /**
+     * Called when a block is removed by {@link PushReaction#DESTROY}.  This is responsible for
+     * actually destroying the block, and the block is intact at time of call.
+     *
+     * Will only be called if {@link BlockState#getPistonPushReaction} returns {@link PushReaction#DESTROY}.
+     *
+     * Note: When used in multiplayer, this is called on both client and
+     * server sides!
+     *
+     * @param state The current state.
+     * @param level The current level
+     * @param pos Block position in level
+     * @param pushDirection The direction of block movement
+     * @param fluid The current fluid state at current position
+     */
+    default void onDestroyedByPushReaction(BlockState state, Level level, BlockPos pos, Direction pushDirection, FluidState fluid)
+    {
+        self().getBlock().onDestroyedByPushReaction(self(), level, pos, pushDirection, fluid);
     }
 
     /**


### PR DESCRIPTION
# What problem does this solve?
`BlockBehaviour#onRemove` is not suitable for use cases that are sensitive to what action or entity destroyed the block, e.g. 
- non-player entities (such as an Enderman)
- players (for which there exists `onDestroyedByPlayer`)
- explosions (for which there exists `onBlockExploded`)
- pistons' `PushReaction#DESTROY`

This PR aims to solve this issue for `PushReaction#DESTROY` by adding a hook `onDestroyedByPushReaction` that can be overridden by any block. 

# What have you tried instead?
A proprosed solution to this issue using the current API was to use the `PistonEvent.Pre` event, and consider which blocks were going to be destroyed that way. Here is an example of that approach:
```java
@SubscribeEvent
public static void doSomethingOnPistonAction(final PistonEvent.Pre event) {
    if (!(event.getLevel() instanceof Level level)) return;
    if (level.isClientSide) return;

    PistonStructureResolver structureResolver = event.getStructureHelper();
    if (structureResolver == null) return;
    if (!structureResolver.resolve()) return;

    structureResolver.getToDestroy().forEach((BlockPos pos) -> {
        doSomething();
    });
}
```

## Why didn't that work?
This approach handles piston *extension* perfectly, but on piston *retraction* the resolver will always fail, as at the time the `Pre` event fires, the piston head has not yet been removed, and so the resolver finds the unpushable piston head and returns `false` (which in the context of `PistonBaseBlock#moveBlocks` would cancel the operation). 

As a result, this approach cannot reliably resolve the blocks that will be destroyed. 

# Considerations
- The `pushDirection` parameter of the hook allows granular control over a block's behaviour when being destroyed by a `PushReaction#DESTROY`
