### PR TITLE
Fix milk bucket curing effects before advancement trigger

### DIFF
--- a/patches/net/minecraft/world/item/MilkBucketItem.java.patch
+++ b/patches/net/minecraft/world/item/MilkBucketItem.java.patch
@@ -1,14 +1,12 @@
 --- a/net/minecraft/world/item/MilkBucketItem.java
 +++ b/net/minecraft/world/item/MilkBucketItem.java
-@@ -18,6 +_,7 @@
- 
-    @Override
-    public ItemStack finishUsingItem(ItemStack p_42923_, Level p_42924_, LivingEntity p_42925_) {
-+      if (!p_42924_.isClientSide) p_42925_.curePotionEffects(p_42923_); // FORGE - move up so stack.shrink does not turn stack into air
-       if (p_42925_ instanceof ServerPlayer serverplayer) {
+@@ -22,15 +_,12 @@
           CriteriaTriggers.CONSUME_ITEM.trigger(serverplayer, p_42923_);
           serverplayer.awardStat(Stats.ITEM_USED.get(this));
-@@ -27,10 +_,6 @@
+       }
++      if (!p_42924_.isClientSide) p_42925_.curePotionEffects(p_42923_); // FORGE - move up so stack.shrink does not turn stack into air
+ 
+       if (p_42925_ instanceof Player && !((Player)p_42925_).getAbilities().instabuild) {
           p_42923_.shrink(1);
        }
  


### PR DESCRIPTION
### The issue

Forge moves the effect curing call in `MilkBucketItem#finishUsingItem` to the method's head, in order to use the stack's properties before it is emptied. However, the method call also comes before the item use advancement trigger, which prevents it from being used in combination with advancement criterions that check for the user's active effects.

[Here's](https://gist.github.com/Su5eD/c87ba0b5c8668204de168e1033e32109) the advancement I used to test this behavior. It is supposed to trigger when the player consumes milk with the nausea effect active.

### The solution

We move the method call to `curePotionEffects` after the advancement trigger so that it meets both of our criteria - allowing the advancement to run and still being able to access the stack in the effect curing method.

Fixes #151