### PR TITLE
Fix KeyMapping modifiers not being respected in conflicting bindings

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -73,8 +73,8 @@ public class KeyMappingLookup {
         Collection<KeyMapping> modifierBindings = map.get(modifier).get(keyCode);
         if (modifierBindings != null) {
             return modifierBindings.stream()
-                .filter(binding -> binding.isActiveAndMatches(keyCode))
-                .toList();
+                    .filter(binding -> binding.isActiveAndMatches(keyCode))
+                    .toList();
         }
         return List.of();
     }

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -60,13 +60,27 @@ public class KeyMappingLookup {
      */
     public List<KeyMapping> getAll(InputConstants.Key keyCode) {
         List<KeyMapping> matchingBindings = new ArrayList<KeyMapping>();
-        for (Map<InputConstants.Key, Collection<KeyMapping>> bindingsMap : map.values()) {
-            Collection<KeyMapping> bindings = bindingsMap.get(keyCode);
-            if (bindings != null) {
-                matchingBindings.addAll(bindings);
-            }
+        KeyModifier activeModifier = KeyModifier.getActiveModifier();
+        // Apply active modifier only if the pressed key is not the modifier itself
+        // Otherwise, look for key bindings without modifiers
+        if (activeModifier == KeyModifier.NONE || activeModifier.matches(keyCode) || !findKeybinds(matchingBindings, keyCode, activeModifier)) {
+            findKeybinds(matchingBindings, keyCode, KeyModifier.NONE);
         }
         return matchingBindings;
+    }
+
+    private boolean findKeybinds(List<KeyMapping> matchingBindings, InputConstants.Key keyCode, KeyModifier modifier) {
+        boolean found = false;
+        Collection<KeyMapping> modifierBindings = map.get(modifier).get(keyCode);
+        if (modifierBindings != null) {
+            for (KeyMapping binding : modifierBindings) {
+                if (binding.isActiveAndMatches(keyCode)) {
+                    matchingBindings.add(binding);
+                    found = true;
+                }
+            }
+        }
+        return found;
     }
 
     public void put(InputConstants.Key keyCode, KeyMapping keyBinding) {

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -63,24 +63,20 @@ public class KeyMappingLookup {
         KeyModifier activeModifier = KeyModifier.getActiveModifier();
         // Apply active modifier only if the pressed key is not the modifier itself
         // Otherwise, look for key bindings without modifiers
-        if (activeModifier == KeyModifier.NONE || activeModifier.matches(keyCode) || !findKeybinds(matchingBindings, keyCode, activeModifier)) {
-            findKeybinds(matchingBindings, keyCode, KeyModifier.NONE);
+        if (activeModifier == KeyModifier.NONE || activeModifier.matches(keyCode) || !matchingBindings.addAll(findKeybinds(keyCode, activeModifier))) {
+            matchingBindings.addAll(findKeybinds(keyCode, KeyModifier.NONE));
         }
         return matchingBindings;
     }
 
-    private boolean findKeybinds(List<KeyMapping> matchingBindings, InputConstants.Key keyCode, KeyModifier modifier) {
-        boolean found = false;
+    private List<KeyMapping> findKeybinds(InputConstants.Key keyCode, KeyModifier modifier) {
         Collection<KeyMapping> modifierBindings = map.get(modifier).get(keyCode);
         if (modifierBindings != null) {
-            for (KeyMapping binding : modifierBindings) {
-                if (binding.isActiveAndMatches(keyCode)) {
-                    matchingBindings.add(binding);
-                    found = true;
-                }
-            }
+            return modifierBindings.stream()
+                .filter(binding -> binding.isActiveAndMatches(keyCode))
+                .toList();
         }
-        return found;
+        return List.of();
     }
 
     public void put(InputConstants.Key keyCode, KeyMapping keyBinding) {


### PR DESCRIPTION
### The issue

Following the merge of MinecraftForge/MinecraftForge#9360, which allowed multiple conflicting key bindings to be clicked at once, a new issue arose in relation to key modifiers. By binding two options to the same key, one of which has a modifier, both will be triggered when the modifier is active.

#### Expected behavior

If i understand this correctly, we should prioritize bindings of keys that have a modifier. Bindings without modifiers should only be checked second.   
For example, assume bindings for Q and ALT+Q exist. When Q is pressed while holding ALT, only the latter binding should be triggered. However, we're still able to use other keys regardless of their modifiers (such as movement keys) while holding ALT+Q or just ALT.

See also:
- #140

### The solution

We prioritize keys with modifiers and once those are pressed, we will look for bindings for the same key without a modifier.  
The `getAll` method will collect bindings in the following order upon key press:
1. Get the active key modifier
2. Check if the pressed key is a modifier (ALT, CTRL, SHIFT). If true, continue to step 4
3. Query key bindings for the active modifier and return them, skipping step 4
4. Query key bindings that do not have a modifier

The `KeyMappingTest` test passes this change successfully.

Fixes #140