### PR TITLE
Fix worlds becoming unusable after custom dimension is removed

### DIFF
--- a/patches/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/patches/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
-@@ -288,7 +_,7 @@
-          compoundtag1.remove("Player");
-          int i = NbtUtils.getDataVersion(compoundtag1, -1);
-          Dynamic<?> dynamic = DataFixTypes.LEVEL.updateToCurrentVersion(p_265021_, new Dynamic<>(p_250592_, compoundtag1), i);
--         WorldGenSettings worldgensettings = readWorldGenSettings(dynamic, p_265021_, i).getOrThrow(false, Util.prefix("WorldGenSettings: ", LOGGER::error));
-+         WorldGenSettings worldgensettings = readWorldGenSettings(dynamic, p_265021_, i).getOrThrow(true, Util.prefix("WorldGenSettings: ", LOGGER::error));
-          LevelVersion levelversion = LevelVersion.parse(dynamic);
-          LevelSettings levelsettings = LevelSettings.parse(dynamic, p_249054_);
-          WorldDimensions.Complete worlddimensions$complete = worldgensettings.dimensions().bake(p_249363_);
 @@ -505,13 +_,26 @@
        public Pair<WorldData, WorldDimensions.Complete> getDataTag(
           DynamicOps<Tag> p_248747_, WorldDataConfiguration p_251873_, Registry<LevelStem> p_249187_, Lifecycle p_249736_

--- a/patches/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/patches/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
+@@ -288,7 +_,7 @@
+          compoundtag1.remove("Player");
+          int i = NbtUtils.getDataVersion(compoundtag1, -1);
+          Dynamic<?> dynamic = DataFixTypes.LEVEL.updateToCurrentVersion(p_265021_, new Dynamic<>(p_250592_, compoundtag1), i);
+-         WorldGenSettings worldgensettings = readWorldGenSettings(dynamic, p_265021_, i).getOrThrow(false, Util.prefix("WorldGenSettings: ", LOGGER::error));
++         WorldGenSettings worldgensettings = readWorldGenSettings(dynamic, p_265021_, i).getOrThrow(true, Util.prefix("WorldGenSettings: ", LOGGER::error));
+          LevelVersion levelversion = LevelVersion.parse(dynamic);
+          LevelSettings levelsettings = LevelSettings.parse(dynamic, p_249054_);
+          WorldDimensions.Complete worlddimensions$complete = worldgensettings.dimensions().bake(p_249363_);
 @@ -505,13 +_,26 @@
        public Pair<WorldData, WorldDimensions.Complete> getDataTag(
           DynamicOps<Tag> p_248747_, WorldDataConfiguration p_251873_, Registry<LevelStem> p_249187_, Lifecycle p_249736_

--- a/src/main/java/net/neoforged/neoforge/common/LenientUnboundedMapCodec.java
+++ b/src/main/java/net/neoforged/neoforge/common/LenientUnboundedMapCodec.java
@@ -14,10 +14,9 @@ import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.Lifecycle;
 import com.mojang.serialization.MapLike;
 import com.mojang.serialization.codecs.BaseMapCodec;
-import org.slf4j.Logger;
-
 import java.util.Map;
 import java.util.Objects;
+import org.slf4j.Logger;
 
 /**
  * Key and value decoded independently, unknown set of keys


### PR DESCRIPTION
### The issue

Removing a dimension that was previously added by a mod/datapack will lead to deserialization errors when trying to open the world again. This has been previously fixed by MinecraftForge/MinecraftForge#7527. However, the issue has resurfaced in 1.20.1.

After a bit of investigation, I found out this is caused by `LevelStorageSource#getLevelData` calling `getOrThrow` on the deserialized data result with `allowPartial` set to `false`, while previous minecraft versions did allow partial results. This prevents the data from loading, as `LenientUnboundedMapCodec` returns a partial result if it fails to deserialize certain elements.
### The solution

I can see 2 possible solutions here:
1. Modify `LenientUnboundedMapCodec` to always return a successful `DataResult` regardless of the encountered errors. In addition, all errors are logged during deserialization.
   - **Pros** Doesn't require changes to vanilla code, might be safer
   - **Cons** Using DFU correctly, we shouldn't be discarding errors, but instead we should provide partial results instead
2. Allow partial results in `getLevelData`'s call to ``getOrThrow``
   - **Pros** Partial results are preserved
   - **Cons** Requires changes to vanilla code, might negatively affect other codecs that are deserialized in the process

I decided to go with option 2, as I consider it to more "idiomatic" to DFU. As it had worked in old mc versions, it should not cause any problems with other codes. Feedback is welcome.

Fixes #102