### PR TITLE
Call IForgeBakedModel::getModelData when rendering block breaking texture

### DIFF
--- a/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -9,7 +9,7 @@
        this.liquidBlockRenderer = new LiquidBlockRenderer();
     }
  
-@@ -45,11 +_,15 @@
+@@ -45,11 +_,16 @@
        return this.blockModelShaper;
     }
  
@@ -22,6 +22,7 @@
           BakedModel bakedmodel = this.blockModelShaper.getBlockModel(p_110919_);
           long i = p_110919_.getSeed(p_110920_);
 -         this.modelRenderer.tesselateBlock(p_110921_, bakedmodel, p_110919_, p_110920_, p_110922_, p_110923_, true, this.random, i, OverlayTexture.NO_OVERLAY);
++         modelData = bakedmodel.getModelData(p_110921_, p_110920_, p_110919_, modelData);
 +         this.modelRenderer.tesselateBlock(p_110921_, bakedmodel, p_110919_, p_110920_, p_110922_, p_110923_, true, this.random, i, OverlayTexture.NO_OVERLAY, modelData, null);
        }
     }


### PR DESCRIPTION
Adds a call to ``IForgeBakedModel::getModelData`` to get the appropriate model data for rendering the block breaking texture in ``BlockRenderDispatcher::renderBreakingTexture`` to fix issue #136

Before the update to minecraft 1.20, getModelData was called directly in ``ModelBlockRenderer::tesselateBlock``
Since the 1.20 update, the call has been removed and placed in ``ChunkRenderDispatcher::RenderChunkRebuildTask::compile`` instead but renderBreakingTexture (that also calls tesselateBlock) has not been modified. So the block breaking model uses the model data from the blockentity (if any) but not from the bakedmodel
So i added a call to getModelData in renderBreakingTexture to revert to the same functionality as before 1.20