### PR TITLE
Fix some hyperlinks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ For support and questions, visit [the NeoForged Discord server][Discord].
 
 [See the "Getting Started" section in the NeoForged Documentation][Getting-Started].
 
-### Contribute to NeoForge
+# Contribute to NeoForge
 
 If you wish to actually inspect NeoForge, submit PRs or otherwise work
 with NeoForge itself, you're in the right place!
@@ -51,7 +51,7 @@ free to use and modify. However, it costs money to run such a large project as t
 our open collective.*
 
 [Contributing]: ./CONTRIBUTING.md
-[CLA]: https://cla-assistant.io/MinecraftForge/MinecraftForge
+[CLA]: https://cla-assistant.io/neoforged/NeoForge
 [Download]: https://maven.neoforged.net/#/releases/net/neoforged/forge/
 [Discord]: https://discord.neoforged.net/
 [Documentation]: https://docs.neoforged.net/

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,9 @@ NeoForge
 
 Forge is a free, open-source modding API all of your favourite mods use!
 
-| Version |    Support    |
-|---------| ------------- |
-| 1.20.x  |    Active     |
+| Version | Support |
+|---------|---------|
+| 1.20.x  | Active  |
 
 * [Download]
 * [Discord]
@@ -31,12 +31,17 @@ For support and questions, visit [the NeoForged Discord server][Discord].
 
 [See the "Getting Started" section in the NeoForged Documentation][Getting-Started].
 
+### Contribute to NeoForge
+
+If you wish to actually inspect NeoForge, submit PRs or otherwise work
+with NeoForge itself, you're in the right place!
+
 ### Pull requests
 
 Please read the contributing guidelines found [here][Contributing] before making a pull request.
 
 ### Contributor License Agreement
-We require all contributors to acknowledge the [Neoforged Contributor License Agreement][CLA]. 
+We require all contributors to acknowledge the [NeoForged Contributor License Agreement][CLA]. 
 Please ensure you have a valid email address associated with your GitHub account to do this. If you have previously 
  signed it, you should be OK.
 
@@ -47,11 +52,8 @@ our open collective.*
 
 [Contributing]: ./CONTRIBUTING.md
 [CLA]: https://cla-assistant.io/MinecraftForge/MinecraftForge
-
 [Download]: https://maven.neoforged.net/#/releases/net/neoforged/forge/
-
 [Discord]: https://discord.neoforged.net/
-
 [Documentation]: https://docs.neoforged.net/
 [Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
 [CurseForge]: https://curseforge.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,6 @@ our opencollective.*
 
 [Documentation]: https://docs.neoforged.net/
 [Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
-[ForgeDev]: https://docs.neoforged.net/en/latest/forgedev/
-[Pull-Requests]: https://docs.neoforged.net/en/latest/forgedev/#making-changes-and-pull-requests
+[ForgeDev]: https://docs.minecraftforge.net/en/latest/forgedev/
+[Pull-Requests]: https://docs.minecraftforge.net/en/latest/forgedev/#making-changes-and-pull-requests
 [CurseForge]: https://curseforge.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Forge is a free, open-source modding API all of your favourite mods use!
 * [Discord]
 * [Documentation]
 
-# Installing NeoForged
+## Installing NeoForged
 
 Go to [CurseForge][CurseForge] project, select the minecraft version and installer, and run it.
 
@@ -27,11 +27,11 @@ You can download the installer for the *Recommended Build* or the
  
 For support and questions, visit [the NeoForged Discord server][Discord].
 
-# Creating Mods
+## Creating Mods
 
 [See the "Getting Started" section in the NeoForged Documentation][Getting-Started].
 
-# Contribute to NeoForge
+## Contribute to NeoForge
 
 If you wish to actually inspect NeoForge, submit PRs or otherwise work
 with NeoForge itself, you're in the right place!

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ our opencollective.*
 [Discord]: https://discord.neoforged.net/
 
 [Documentation]: https://docs.neoforged.net/
-[Getting-Started]: https://docs.neoforged.net/en/latest/gettingstarted/
+[Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
 [ForgeDev]: https://docs.neoforged.net/en/latest/forgedev/
 [Pull-Requests]: https://docs.neoforged.net/en/latest/forgedev/#making-changes-and-pull-requests
-[CurseForge]: https://curseforge.com/placeholder
+[CurseForge]: https://curseforge.com

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,16 +31,7 @@ For support and questions, visit [the NeoForged Discord server][Discord].
 
 [See the "Getting Started" section in the NeoForged Documentation][Getting-Started].
 
-# Contribute to Forge
-
-If you wish to actually inspect Forge, submit PRs or otherwise work
- with Forge itself, you're in the right place!
-
- [See the guide to setting up a Forge workspace][ForgeDev].
-
 ### Pull requests
-
-[See the "Making Changes and Pull Requests" section in the Forge documentation][Pull-Requests].
 
 Please read the contributing guidelines found [here][Contributing] before making a pull request.
 
@@ -52,7 +43,7 @@ Please ensure you have a valid email address associated with your GitHub account
 #### Donate
 *NeoForged is a large project with many collaborators working on it around the clock. It will always remain 
 free to use and modify. However, it costs money to run such a large project as this, so please consider visiting
-our opencollective.*
+our open collective.*
 
 [Contributing]: ./CONTRIBUTING.md
 [CLA]: https://cla-assistant.io/MinecraftForge/MinecraftForge
@@ -63,6 +54,4 @@ our opencollective.*
 
 [Documentation]: https://docs.neoforged.net/
 [Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
-[ForgeDev]: https://docs.minecraftforge.net/en/latest/forgedev/
-[Pull-Requests]: https://docs.minecraftforge.net/en/latest/forgedev/#making-changes-and-pull-requests
 [CurseForge]: https://curseforge.com


### PR DESCRIPTION
Description: This PR fixes hyperlinks in the README file. I have also found other hyperlinks that are broken but I am not sure where they could be redirected to. One more thing, I have also changed the CurseForge link to remove the '/placeholder' since it was an invalid link. Let me know if you want me to revert that change back since I would be happy to.

The ones that are broken are:

- ForgeDev
- Pull-Requests

I found that these two links did not have a page to redirect to or I could not find a page to redirect them to on the current wiki, so I left those hyperlinks alone.