### PR TITLE
[1.20.2] Fix FallingBlockRenderer not using RenderTypes given by the BakedModel

### DIFF
--- a/patches/net/minecraft/client/renderer/entity/FallingBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/FallingBlockRenderer.java.patch
@@ -9,7 +9,12 @@
              this.dispatcher
                 .getModelRenderer()
                 .tesselateBlock(
-@@ -46,7 +48,9 @@
+@@ -42,11 +44,13 @@
+                   blockstate,
+                   blockpos,
+                   p_114637_,
+-                  p_114638_.getBuffer(ItemBlockRenderTypes.getMovingBlockRenderType(blockstate)),
++                  p_114638_.getBuffer(net.neoforged.neoforge.client.RenderTypeHelper.getMovingBlockRenderType(renderType)),
                    false,
                    RandomSource.create(),
                    blockstate.getSeed(p_114634_.getStartPos()),


### PR DESCRIPTION
This PR fixes the `FallingBlockRenderer` ignoring the `RenderType`s given by the `BakedModel` and instead falling back to the "moving block" `RenderType` given by `ItemBlockRenderTypes` for the `BlockState` being rendered. The fallback to `ItemBlockRenderTypes` was added in the 1.20.2 port to fix #154, which this PR fixes properly.

The change can be tested with the command `/summon minecraft:falling_block ~ ~ ~ {BlockState:{Name:"minecraft:red_stained_glass"}, NoGravity:1b}`. It's worth noting though that testing with this would also show correct behaviour with the existing fix. The difference would only become visible with a custom model that uses a different `RenderType` than the one `ItemBlockRenderTypes` is aware of. I can add a test mod for this if desired.