### PR TITLE
[1.20.2] Fix duplicate sprite expansion in FaceBakery

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
@@ -16,14 +16,3 @@
     }
  
     public static BlockFaceUV recomputeUVs(BlockFaceUV p_111582_, Direction p_111583_, Transformation p_111584_, ResourceLocation p_111585_) {
-@@ -154,8 +161,8 @@
-       p_111615_[i + 1] = Float.floatToRawIntBits(p_254291_.y());
-       p_111615_[i + 2] = Float.floatToRawIntBits(p_254291_.z());
-       p_111615_[i + 3] = -1;
--      p_111615_[i + 4] = Float.floatToRawIntBits(p_111618_.getU(p_111619_.getU(p_111616_) / 16.0F));
--      p_111615_[i + 4 + 1] = Float.floatToRawIntBits(p_111618_.getV(p_111619_.getV(p_111616_) / 16.0F));
-+      p_111615_[i + 4] = Float.floatToRawIntBits(p_111618_.getU(p_111619_.getU(p_111616_) / 16.0F * .999F + p_111619_.getU((p_111616_ + 2) % 4) / 16.0F * .001F));
-+      p_111615_[i + 4 + 1] = Float.floatToRawIntBits(p_111618_.getV(p_111619_.getV(p_111616_) / 16.0F * .999F + p_111619_.getV((p_111616_ + 2) % 4) / 16.0F * .001F));
-    }
- 
-    private void applyElementRotation(Vector3f p_254412_, @Nullable BlockElementRotation p_254150_) {


### PR DESCRIPTION
This PR removes the Forge patch adding sprite expansion as the same feature is already provided by vanilla (has been for a while to be exact).

The following screenshots show the difference between before (top) and after (bottom) on item models:
![2023-10-31_01 31 33](https://github.com/neoforged/NeoForge/assets/11262040/0f84d5b6-1835-4515-8569-eb3f23468ee8)
![2023-10-31_01 32 01](https://github.com/neoforged/NeoForge/assets/11262040/a4409435-8e64-41b3-a7d0-58c0173aeff4)

This also fixes minor visual differences between vanilla and NeoForge on block models like this one mentioned on the Discord: https://discord.com/channels/313125603924639766/313125603924639766/1155482650543407115