### PR TITLE
Fix installer logo to use NeoForge logo

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -196,6 +196,18 @@ tasks.withType(Javadoc.class).configureEach {
 
 tasks.withType(GenerateModuleMetadata).configureEach { enabled = false }
 
+project.afterEvaluate {
+    // Installer jar task is created after project evaluation
+    // Not using the actual task type, to avoid importing it -- using a likely-permanent ancestor
+    tasks.named('legacyInstallerJar', AbstractArchiveTask) {
+        // Exclude original logo, insert our own
+        exclude 'big_logo.png'
+        from(project.parent.file('src/main/resources/neoforged_logo.png')) {
+            rename { 'big_logo.png' }
+        }
+    }
+}
+
 configurations {
     forValidation {
         canBeConsumed = true


### PR DESCRIPTION
This PR fixes the logo in the installer to use the NeoForge logo, rather than the Minecraft Forge logo (which is packed into the shrunk installer base we currently use).

Future work should be done to create our own version of the installer base with our logo and other enhancements and fixes. See https://github.com/neoforged/LegacyInstaller, which is currently unmodified and unpublished.

Tested by assembling the installer locally (via the `assemble` task, and looking in `projects/neoforge/build/libs`) and running it.