### PR TITLE
Suffix branch in version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,14 @@ plugins {
 apply plugin: 'net.neoforged.gradleutils'
 
 gradleutils.version {
+    minecraftVersion project.minecraft_version
+    versionPrefix = null // Reset version prefix, which is set by prev. line
     tags {
         label = "beta"
         cleanMarkerLabel = "stable"
+    }
+    branches {
+        suffixBranch = true
     }
 }
 


### PR DESCRIPTION
This PR enables the branch suffixing feature in GradleUtils 3.x, which suffixes the branch to the version when it does not match a set of exempted branches. This makes installer and other artifacts from non-main branches distinguishable from artifacts of the main branches (e.g., `1.20.x`), which is particularly useful for local development (or sharing installer JARs for testing changes).

The `branches.suffixBranch` property controls the actual branch suffixing. The call to `minecraftVersion` configures the set of exempted branches and the version prefix; as our versioning does not call for it, the version prefix is unset immediately afterwards.

The changelog does not include the branch suffix in all the listed versions; this is semi-intended behavior, as the changelog originally had the branch name at the very top. This will be rectified soon:tm: in GradleUtils.