### PR TITLE
Tweak actions for PRs

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -9,16 +9,20 @@ on:
       - reopened
 
 jobs:
-  jdk17:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1000
           fetch-tags: true
+
+      # GradleUtils will append the branch name to the version,
+      # but for that we need a properly checked out branch
+      - name: Create branch for commit
+        run:
+          git switch -C ${{ github.event.pull_request.head.ref }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v2

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -22,7 +22,7 @@ jobs:
       # but for that we need a properly checked out branch
       - name: Create branch for commit
         run:
-          git switch -C ${{ github.event.pull_request.head.ref }}
+          git switch -C pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.ref }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v2

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ changelog {
     disableAutomaticPublicationRegistration()
 }
 
+// Print version, generally useful to know - also appears on CI
+System.out.println("NeoForge version ${gradleutils.version.toString()}")
+
 allprojects {
     version gradleutils.version.toString()
     group 'net.neoforged'


### PR DESCRIPTION
- Change job name from `jdk17` to `build` (it shows in the GH UI and is also used to configure required workflows).
- Add a print for the current NeoForge version in the buildscript - this is generally nice to have to debug version-related issues.
- Make sure we checkout the merged commit in the action.
- Since we are in detached HEAD after the checkout, add a step to switch to a proper branch. This makes GradleUtils branch suffixing work.