### PR TITLE
Fix signed chat state de-sync caused by `execute run say`

### DIFF
--- a/patches/net/minecraft/network/chat/SignableCommand.java.patch
+++ b/patches/net/minecraft/network/chat/SignableCommand.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/network/chat/SignableCommand.java
++++ b/net/minecraft/network/chat/SignableCommand.java
+@@ -22,7 +22,8 @@
+          (commandcontextbuilder2 = commandcontextbuilder1.getChild()) != null;
+          commandcontextbuilder1 = commandcontextbuilder2
+       ) {
+-         boolean flag = commandcontextbuilder2.getRootNode() != commandcontextbuilder.getRootNode();
++         // NEO: Check if the command node is a RootCommandNode, instead of simply being the original root node; fixes #186
++         boolean flag = !(commandcontextbuilder2.getRootNode() instanceof com.mojang.brigadier.tree.RootCommandNode);
+          if (!flag) {
+             break;
+          }


### PR DESCRIPTION
This PR fixes #186 by generalizing the check in `SignableCommand#of` to account for any root command node, rather than only the original/dispatcher's root command node.

`SignableCommand#of` goes down the command parse results to find signed arguments which will form part of the signed chat state. This allows commands like `/say` to have their messages be signed by the client.

When running through `/execute` (or any other similar command) however, the message shouldn't be signed, as the command may be run by another player, making the signature on the message meaningless.

To prevent this, `SignableCommand` stops searching when a command node redirection loops back to the root command node (where it might go to a command like `/say`). This allows other commands which use redirection to still retain signed arguments, while disallowing `/execute` and similar commands.

However, because of NeoForge's client commands system, the root command node of the dispatcher and the root command node pointed by `/execute run` for redirection are different, causing the stop check above to never trigger, thus causing the client to sign the arguments.

As the server disregards the signatures, this now causes a de-sync between the signed chat state of the client and the server; thus, the client will be kicked by the server upon the next chat message, when it realizes a de-sync happened.

To fix this, we generalize the check from being the original root command node, to being *any* RootCommandNode. This retains compatibility with the original vanilla check, while allowing for our custom root command nodes to also count for the check.