### PR TITLE
Fix switched armor points icons in HUD

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
@@ -171,11 +171,11 @@ public class ExtendedGui extends Gui {
         int level = minecraft.player.getArmorValue();
         for (int i = 1; level > 0 && i < 20; i += 2) {
             if (i < level) {
-                guiGraphics.blitSprite(ARMOR_EMPTY_SPRITE, left, top, 9, 9);
+                guiGraphics.blitSprite(ARMOR_FULL_SPRITE, left, top, 9, 9);
             } else if (i == level) {
                 guiGraphics.blitSprite(ARMOR_HALF_SPRITE, left, top, 9, 9);
-            } else if (i > level) {
-                guiGraphics.blitSprite(ARMOR_FULL_SPRITE, left, top, 9, 9);
+            } else {
+                guiGraphics.blitSprite(ARMOR_EMPTY_SPRITE, left, top, 9, 9);
             }
             left += 8;
         }


### PR DESCRIPTION
This PR fixes #224 by switching around the two icons used for rendering the full and empty armor point icon in the HUD. This also includes a small cleanup, removing a useless (always `true`) conditional check.