### PR TITLE
Fix DebugLevelSource being off-by-one on grid height

### DIFF
--- a/patches/net/minecraft/world/level/levelgen/DebugLevelSource.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/DebugLevelSource.java.patch
@@ -7,7 +7,7 @@
 +   public static void initValidStates() {
 +      ALL_BLOCKS = StreamSupport.stream(BuiltInRegistries.BLOCK.spliterator(), false).flatMap(block -> block.getStateDefinition().getPossibleStates().stream()).collect(Collectors.toList());
 +      GRID_WIDTH = Mth.ceil(Mth.sqrt(ALL_BLOCKS.size()));
-+      GRID_HEIGHT = Mth.ceil((float) (ALL_BLOCKS.size() / GRID_WIDTH));
++      GRID_HEIGHT = Mth.ceil((float)ALL_BLOCKS.size() / (float)GRID_WIDTH);
 +   }
 +
     @Override


### PR DESCRIPTION
Fix the debug level missing a row compared to vanilla. The cast previously made the `ceil` have no effect as it was done *after* integer division occured - meaning the incoming value would already be a (floored) integer. This meant the height was one less than it should have been.

The new version places the casts in the same location as vanilla, and fixes the issue.