### PR TITLE
Use updated translation keys in commands/command arguments

### DIFF
--- a/src/main/java/net/neoforged/neoforge/server/command/EnumArgument.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/EnumArgument.java
@@ -26,7 +26,7 @@ import net.minecraft.network.chat.Component;
 
 public class EnumArgument<T extends Enum<T>> implements ArgumentType<T> {
     private static final Dynamic2CommandExceptionType INVALID_ENUM = new Dynamic2CommandExceptionType(
-            (found, constants) -> Component.translatable("commands.forge.arguments.enum.invalid", constants, found));
+            (found, constants) -> Component.translatable("commands.neoforge.arguments.enum.invalid", constants, found));
     private final Class<T> enumClass;
 
     public static <R extends Enum<R>> EnumArgument<R> enumArgument(Class<R> enumClass) {

--- a/src/main/java/net/neoforged/neoforge/server/command/ModListCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/ModListCommand.java
@@ -18,7 +18,7 @@ class ModListCommand {
         return Commands.literal("mods")
                 .requires(cs -> cs.hasPermission(0)) //permission
                 .executes(ctx -> {
-                    ctx.getSource().sendSuccess(() -> Component.translatable("commands.forge.mods.list",
+                    ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.mods.list",
                             ModList.get().applyForEachModFile(modFile ->
                     // locator - filename : firstmod (version) - numberofmods\n
                     String.format(Locale.ROOT, "%s %s : %s (%s) - %d",

--- a/src/main/java/net/neoforged/neoforge/server/command/TPSCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TPSCommand.java
@@ -33,7 +33,7 @@ class TPSCommand {
                     @SuppressWarnings("resource")
                     double meanTickTime = mean(ctx.getSource().getServer().tickTimes) * 1.0E-6D;
                     double meanTPS = Math.min(1000.0 / meanTickTime, 20);
-                    ctx.getSource().sendSuccess(() -> Component.translatable("commands.forge.tps.summary.all", TIME_FORMATTER.format(meanTickTime), TIME_FORMATTER.format(meanTPS)), false);
+                    ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.tps.summary.all", TIME_FORMATTER.format(meanTickTime), TIME_FORMATTER.format(meanTPS)), false);
 
                     return 0;
                 });
@@ -48,7 +48,7 @@ class TPSCommand {
         final Registry<DimensionType> reg = cs.registryAccess().registryOrThrow(Registries.DIMENSION_TYPE);
         double worldTickTime = mean(times) * 1.0E-6D;
         double worldTPS = Math.min(1000.0 / worldTickTime, 20);
-        cs.sendSuccess(() -> Component.translatable("commands.forge.tps.summary.named", dim.dimension().location().toString(), reg.getKey(dim.dimensionType()), TIME_FORMATTER.format(worldTickTime), TIME_FORMATTER.format(worldTPS)), false);
+        cs.sendSuccess(() -> Component.translatable("commands.neoforge.tps.summary.named", dim.dimension().location().toString(), reg.getKey(dim.dimensionType()), TIME_FORMATTER.format(worldTickTime), TIME_FORMATTER.format(worldTPS)), false);
 
         return 1;
     }

--- a/src/main/java/net/neoforged/neoforge/server/command/TagsCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TagsCommand.java
@@ -58,9 +58,9 @@ class TagsCommand {
     private static final long PAGE_SIZE = 8;
     private static final ResourceKey<Registry<Registry<?>>> ROOT_REGISTRY_KEY = ResourceKey.createRegistryKey(new ResourceLocation("root"));
 
-    private static final DynamicCommandExceptionType UNKNOWN_REGISTRY = new DynamicCommandExceptionType(key -> Component.translatable("commands.forge.tags.error.unknown_registry", key));
-    private static final Dynamic2CommandExceptionType UNKNOWN_TAG = new Dynamic2CommandExceptionType((tag, registry) -> Component.translatable("commands.forge.tags.error.unknown_tag", tag, registry));
-    private static final Dynamic2CommandExceptionType UNKNOWN_ELEMENT = new Dynamic2CommandExceptionType((tag, registry) -> Component.translatable("commands.forge.tags.error.unknown_element", tag, registry));
+    private static final DynamicCommandExceptionType UNKNOWN_REGISTRY = new DynamicCommandExceptionType(key -> Component.translatable("commands.neoforge.tags.error.unknown_registry", key));
+    private static final Dynamic2CommandExceptionType UNKNOWN_TAG = new Dynamic2CommandExceptionType((tag, registry) -> Component.translatable("commands.neoforge.tags.error.unknown_tag", tag, registry));
+    private static final Dynamic2CommandExceptionType UNKNOWN_ELEMENT = new Dynamic2CommandExceptionType((tag, registry) -> Component.translatable("commands.neoforge.tags.error.unknown_element", tag, registry));
 
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         /*
@@ -99,9 +99,9 @@ class TagsCommand {
         final long tagCount = registry.getTags().count();
 
         ctx.getSource().sendSuccess(() -> createMessage(
-                Component.translatable("commands.forge.tags.registry_key", Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.GOLD)),
-                "commands.forge.tags.tag_count",
-                "commands.forge.tags.copy_tag_names",
+                Component.translatable("commands.neoforge.tags.registry_key", Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.GOLD)),
+                "commands.neoforge.tags.tag_count",
+                "commands.neoforge.tags.copy_tag_names",
                 tagCount,
                 page,
                 ChatFormatting.DARK_GREEN,
@@ -126,11 +126,11 @@ class TagsCommand {
                 .orElseThrow(() -> UNKNOWN_TAG.create(tagKey.location(), registryKey.location()));
 
         ctx.getSource().sendSuccess(() -> createMessage(
-                Component.translatable("commands.forge.tags.tag_key",
+                Component.translatable("commands.neoforge.tags.tag_key",
                         Component.literal(tagKey.registry().location().toString()).withStyle(ChatFormatting.GOLD),
                         Component.literal(tagKey.location().toString()).withStyle(ChatFormatting.DARK_GREEN)),
-                "commands.forge.tags.element_count",
-                "commands.forge.tags.copy_element_names",
+                "commands.neoforge.tags.element_count",
+                "commands.neoforge.tags.copy_element_names",
                 tag.size(),
                 page,
                 ChatFormatting.YELLOW,
@@ -154,11 +154,11 @@ class TagsCommand {
         final long containingTagsCount = elementHolder.tags().count();
 
         ctx.getSource().sendSuccess(() -> createMessage(
-                Component.translatable("commands.forge.tags.element",
+                Component.translatable("commands.neoforge.tags.element",
                         Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.GOLD),
                         Component.literal(elementLocation.toString()).withStyle(ChatFormatting.YELLOW)),
-                "commands.forge.tags.containing_tag_count",
-                "commands.forge.tags.copy_tag_names",
+                "commands.neoforge.tags.containing_tag_count",
+                "commands.neoforge.tags.copy_tag_names",
                 containingTagsCount,
                 page,
                 ChatFormatting.DARK_GREEN,
@@ -186,7 +186,7 @@ class TagsCommand {
                     .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, allElementNames))
                     .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
                             Component.translatable(copyHoverText)))));
-            containsComponent = Component.translatable("commands.forge.tags.page_info",
+            containsComponent = Component.translatable("commands.neoforge.tags.page_info",
                     containsComponent, actualPage, totalPages);
         }
 


### PR DESCRIPTION
A couple of these were missed, noticed when some commands just printed translation keys