### PR TITLE
Use Correct PoseStack in AFTER_LEVEL

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -122,7 +122,7 @@
           .prepareCullFrustum(p_109092_, camera.getPosition(), this.getProjectionMatrix(Math.max(d0, (double)this.minecraft.options.fov().get().intValue())));
        this.minecraft.levelRenderer.renderLevel(p_109092_, p_109090_, p_109091_, flag, camera, this, this.lightTexture, matrix4f);
 +      this.minecraft.getProfiler().popPush("forge_render_last");
-+      net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_LEVEL, this.minecraft.levelRenderer, posestack, matrix4f, this.minecraft.levelRenderer.getTicks(), camera, this.minecraft.levelRenderer.getFrustum());
++      net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_LEVEL, this.minecraft.levelRenderer, p_109092_, matrix4f, this.minecraft.levelRenderer.getTicks(), camera, this.minecraft.levelRenderer.getFrustum());
        this.minecraft.getProfiler().popPush("hand");
        if (this.renderHand) {
           RenderSystem.clear(256, Minecraft.ON_OSX);


### PR DESCRIPTION
the pose stack send to AFTER_LEVEL is the wrong pose stack, that being the projection posestack. this corrects it to use the same posestack as the other render stages.