### PR TITLE
[1.20.2] Fix player renderer getter in EntityRenderersEvent.AddLayers

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
@@ -151,15 +151,15 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
         /**
          * Returns a player skin renderer for the given skin name.
          *
-         * @param skinName the name of the skin to get the renderer for
+         * @param skinModel the skin model to get the renderer for
          * @param <R>      the type of the skin renderer, usually {@link PlayerRenderer}
          * @return the skin renderer, or {@code null} if no renderer is registered for that skin name
          * @see #getSkins()
          */
         @Nullable
         @SuppressWarnings("unchecked")
-        public <R extends LivingEntityRenderer<? extends Player, ? extends EntityModel<? extends Player>>> R getSkin(String skinName) {
-            return (R) skinMap.get(skinName);
+        public <R extends LivingEntityRenderer<? extends Player, ? extends EntityModel<? extends Player>>> R getSkin(PlayerSkin.Model skinModel) {
+            return (R) skinMap.get(skinModel);
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
@@ -152,7 +152,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
          * Returns a player skin renderer for the given skin name.
          *
          * @param skinModel the skin model to get the renderer for
-         * @param <R>      the type of the skin renderer, usually {@link PlayerRenderer}
+         * @param <R>       the type of the skin renderer, usually {@link PlayerRenderer}
          * @return the skin renderer, or {@code null} if no renderer is registered for that skin name
          * @see #getSkins()
          */


### PR DESCRIPTION
This PR fixes `EntityRenderersEvent.AddLayers#getSkin()` incorrectly using a String key to look up the player renderer for a given skin type. The player renderer map now uses the `PlayerSkin.Model` enum as its key instead of a String.

Fixes #236 