### PR TITLE
[1.20.2] Fix mouse scroll events and scroll axis handling

### DIFF
--- a/patches/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/net/minecraft/client/MouseHandler.java.patch
@@ -1,11 +1,6 @@
 --- a/net/minecraft/client/MouseHandler.java
 +++ b/net/minecraft/client/MouseHandler.java
-@@ -70,10 +70,11 @@
-             if (this.minecraft.options.touchscreen().get() && --this.clickDepth > 0) {
-                return;
-             }
--
-+            
+@@ -74,6 +74,7 @@
              this.activeButton = -1;
           }
  
@@ -39,7 +34,7 @@
                 }
              }
           }
-@@ -113,21 +124,29 @@
+@@ -113,6 +124,7 @@
                 }
              }
           }
@@ -47,39 +42,28 @@
        }
     }
  
-    private void onScroll(long p_91527_, double p_91528_, double p_91529_) {
-       if (p_91527_ == Minecraft.getInstance().getWindow().getWindow()) {
-+         // FORGE: Allows for Horizontal Scroll to be recognized as Vertical Scroll - Fixes MC-121772
-+         double offset = p_91529_;
-+         if (Minecraft.ON_OSX && p_91529_ == 0) {
-+            offset = p_91528_;
-+         }
-          boolean flag = this.minecraft.options.discreteMouseScroll().get();
-          double d0 = this.minecraft.options.mouseWheelSensitivity().get();
-          double d1 = (flag ? Math.signum(p_91528_) : p_91528_) * d0;
--         double d2 = (flag ? Math.signum(p_91529_) : p_91529_) * d0;
-+         double d2 = (flag ? Math.signum(offset) : offset) * d0;
-          if (this.minecraft.getOverlay() == null) {
+@@ -126,7 +138,11 @@
              if (this.minecraft.screen != null) {
                 double d3 = this.xpos * (double)this.minecraft.getWindow().getGuiScaledWidth() / (double)this.minecraft.getWindow().getScreenWidth();
                 double d4 = this.ypos * (double)this.minecraft.getWindow().getGuiScaledHeight() / (double)this.minecraft.getWindow().getScreenHeight();
 -               this.minecraft.screen.mouseScrolled(d3, d4, d1, d2);
++               if (!net.neoforged.neoforge.client.ClientHooks.onScreenMouseScrollPre(this, this.minecraft.screen, d1, d2)) {
++                  if (!this.minecraft.screen.mouseScrolled(d3, d4, d1, d2)) {
++                     net.neoforged.neoforge.client.ClientHooks.onScreenMouseScrollPost(this, this.minecraft.screen, d1, d2);
++                  }
++               }
                 this.minecraft.screen.afterMouseAction();
-+               if (net.neoforged.neoforge.client.ClientHooks.onScreenMouseScrollPre(this, this.minecraft.screen, d0)) return;
-+               if (this.minecraft.screen.mouseScrolled(d3, d4, d1, d2)) return;
-+               net.neoforged.neoforge.client.ClientHooks.onScreenMouseScrollPost(this, this.minecraft.screen, d0);
              } else if (this.minecraft.player != null) {
                 if (this.accumulatedScrollX != 0.0 && Math.signum(d1) != Math.signum(this.accumulatedScrollX)) {
-                   this.accumulatedScrollX = 0.0;
-@@ -148,6 +167,7 @@
+@@ -148,6 +164,7 @@
                 this.accumulatedScrollX -= (double)j;
                 this.accumulatedScrollY -= (double)i;
                 int k = i == 0 ? -j : i;
-+               if (net.neoforged.neoforge.client.ClientHooks.onMouseScroll(this, d0)) return;
++               if (net.neoforged.neoforge.client.ClientHooks.onMouseScroll(this, d1, d2)) return;
                 if (this.minecraft.player.isSpectator()) {
                    if (this.minecraft.gui.getSpectatorGui().isMenuActive()) {
                       this.minecraft.gui.getSpectatorGui().onMouseScrolled(-k);
-@@ -290,6 +310,14 @@
+@@ -290,6 +307,14 @@
  
     public double ypos() {
        return this.ypos;

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -578,19 +578,19 @@ public class ClientHooks {
         NeoForge.EVENT_BUS.post(event);
     }
 
-    public static boolean onScreenMouseScrollPre(MouseHandler mouseHelper, Screen guiScreen, double scrollDelta) {
+    public static boolean onScreenMouseScrollPre(MouseHandler mouseHelper, Screen guiScreen, double scrollDeltaX, double scrollDeltaY) {
         Window mainWindow = guiScreen.getMinecraft().getWindow();
         double mouseX = mouseHelper.xpos() * (double) mainWindow.getGuiScaledWidth() / (double) mainWindow.getScreenWidth();
         double mouseY = mouseHelper.ypos() * (double) mainWindow.getGuiScaledHeight() / (double) mainWindow.getScreenHeight();
-        var event = new ScreenEvent.MouseScrolled.Pre(guiScreen, mouseX, mouseY, scrollDelta);
+        var event = new ScreenEvent.MouseScrolled.Pre(guiScreen, mouseX, mouseY, scrollDeltaX, scrollDeltaY);
         return NeoForge.EVENT_BUS.post(event).isCanceled();
     }
 
-    public static void onScreenMouseScrollPost(MouseHandler mouseHelper, Screen guiScreen, double scrollDelta) {
+    public static void onScreenMouseScrollPost(MouseHandler mouseHelper, Screen guiScreen, double scrollDeltaX, double scrollDeltaY) {
         Window mainWindow = guiScreen.getMinecraft().getWindow();
         double mouseX = mouseHelper.xpos() * (double) mainWindow.getGuiScaledWidth() / (double) mainWindow.getScreenWidth();
         double mouseY = mouseHelper.ypos() * (double) mainWindow.getGuiScaledHeight() / (double) mainWindow.getScreenHeight();
-        Event event = new ScreenEvent.MouseScrolled.Post(guiScreen, mouseX, mouseY, scrollDelta);
+        Event event = new ScreenEvent.MouseScrolled.Post(guiScreen, mouseX, mouseY, scrollDeltaX, scrollDeltaY);
         NeoForge.EVENT_BUS.post(event);
     }
 
@@ -637,8 +637,8 @@ public class ClientHooks {
         NeoForge.EVENT_BUS.post(new InputEvent.MouseButton.Post(button, action, mods));
     }
 
-    public static boolean onMouseScroll(MouseHandler mouseHelper, double scrollDelta) {
-        var event = new InputEvent.MouseScrollingEvent(scrollDelta, mouseHelper.isLeftPressed(), mouseHelper.isMiddlePressed(), mouseHelper.isRightPressed(), mouseHelper.xpos(), mouseHelper.ypos());
+    public static boolean onMouseScroll(MouseHandler mouseHelper, double scrollDeltaX, double scrollDeltaY) {
+        var event = new InputEvent.MouseScrollingEvent(scrollDeltaX, scrollDeltaY, mouseHelper.isLeftPressed(), mouseHelper.isMiddlePressed(), mouseHelper.isRightPressed(), mouseHelper.xpos(), mouseHelper.ypos());
         return NeoForge.EVENT_BUS.post(event).isCanceled();
     }
 

--- a/src/main/java/net/neoforged/neoforge/client/event/InputEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/InputEvent.java
@@ -134,7 +134,8 @@ public abstract class InputEvent extends Event {
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
      */
     public static class MouseScrollingEvent extends InputEvent implements ICancellableEvent {
-        private final double scrollDelta;
+        private final double scrollDeltaX;
+        private final double scrollDeltaY;
         private final double mouseX;
         private final double mouseY;
         private final boolean leftDown;
@@ -142,8 +143,9 @@ public abstract class InputEvent extends Event {
         private final boolean rightDown;
 
         @ApiStatus.Internal
-        public MouseScrollingEvent(double scrollDelta, boolean leftDown, boolean middleDown, boolean rightDown, double mouseX, double mouseY) {
-            this.scrollDelta = scrollDelta;
+        public MouseScrollingEvent(double scrollDeltaX, double scrollDeltaY, boolean leftDown, boolean middleDown, boolean rightDown, double mouseX, double mouseY) {
+            this.scrollDeltaX = scrollDeltaX;
+            this.scrollDeltaY = scrollDeltaY;
             this.leftDown = leftDown;
             this.middleDown = middleDown;
             this.rightDown = rightDown;
@@ -152,10 +154,17 @@ public abstract class InputEvent extends Event {
         }
 
         /**
-         * {@return the amount of change / delta of the mouse scroll}
+         * {@return the amount of change / delta of the mouse scroll on the X axis}
          */
-        public double getScrollDelta() {
-            return this.scrollDelta;
+        public double getScrollDeltaX() {
+            return this.scrollDeltaX;
+        }
+
+        /**
+         * {@return the amount of change / delta of the mouse scroll on the Y axis}
+         */
+        public double getScrollDeltaY() {
+            return this.scrollDeltaY;
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -587,19 +587,28 @@ public abstract class ScreenEvent extends Event {
      * @see MouseScrolled.Post
      */
     public static abstract class MouseScrolled extends MouseInput {
-        private final double scrollDelta;
+        private final double scrollDeltaX;
+        private final double scrollDeltaY;
 
         @ApiStatus.Internal
-        public MouseScrolled(Screen screen, double mouseX, double mouseY, double scrollDelta) {
+        public MouseScrolled(Screen screen, double mouseX, double mouseY, double scrollDeltaX, double scrollDeltaY) {
             super(screen, mouseX, mouseY);
-            this.scrollDelta = scrollDelta;
+            this.scrollDeltaX = scrollDeltaX;
+            this.scrollDeltaY = scrollDeltaY;
         }
 
         /**
-         * {@return the amount of change / delta of the mouse scroll}
+         * {@return the amount of change / delta of the mouse scroll on the X axis}
          */
-        public double getScrollDelta() {
-            return scrollDelta;
+        public double getScrollDeltaX() {
+            return scrollDeltaX;
+        }
+
+        /**
+         * {@return the amount of change / delta of the mouse scroll on the Y axis}
+         */
+        public double getScrollDeltaY() {
+            return scrollDeltaY;
         }
 
         /**
@@ -614,8 +623,8 @@ public abstract class ScreenEvent extends Event {
          */
         public static class Pre extends MouseScrolled implements ICancellableEvent {
             @ApiStatus.Internal
-            public Pre(Screen screen, double mouseX, double mouseY, double scrollDelta) {
-                super(screen, mouseX, mouseY, scrollDelta);
+            public Pre(Screen screen, double mouseX, double mouseY, double scrollDeltaX, double scrollDeltaY) {
+                super(screen, mouseX, mouseY, scrollDeltaX, scrollDeltaY);
             }
         }
 
@@ -631,8 +640,8 @@ public abstract class ScreenEvent extends Event {
          */
         public static class Post extends MouseScrolled {
             @ApiStatus.Internal
-            public Post(Screen screen, double mouseX, double mouseY, double scrollDelta) {
-                super(screen, mouseX, mouseY, scrollDelta);
+            public Post(Screen screen, double mouseX, double mouseY, double scrollDeltaX, double scrollDeltaY) {
+                super(screen, mouseX, mouseY, scrollDeltaX, scrollDeltaY);
             }
         }
     }


### PR DESCRIPTION
This PR updates the mouse scroll events - `InputEvent.MouseScrollingEvent` and `ScreenEvent.MouseScrolled.Pre/Post` to be specific - to match the separate handling of horizontal and vertical scrolling, which was implemented by vanilla in 1.20.2, by exposing the separate deltas on the events and removing the patch that previously made scrolling on both axis work on macOS.
Also included is a change to restore the order of operations with regards to `Screen#mouseScrolled()` plus the associated events and `Screen#afterMouseAction()`.

Fixes #229 