### PR TITLE
Fix advancement existing file helper checks in datagen

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IAdvancementBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IAdvancementBuilderExtension.java
@@ -39,6 +39,7 @@ public interface IAdvancementBuilderExtension {
         }
 
         saver.accept(advancementholder);
+        fileHelper.trackGenerated(id, PackType.SERVER_DATA, ".json", "advancements");
         return advancementholder;
     }
 }

--- a/tests/src/generated/resources/data/minecraft/advancements/obtain_diamond_block.json
+++ b/tests/src/generated/resources/data/minecraft/advancements/obtain_diamond_block.json
@@ -1,4 +1,5 @@
 {
+  "parent": "data_gen_test:obtain_dirt",
   "criteria": {
     "obtained_diamond_block": {
       "conditions": {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/DataGeneratorTest.java
@@ -912,25 +912,28 @@ public class DataGeneratorTest {
 
         @Override
         public void generate(HolderLookup.Provider registries, Consumer<AdvancementHolder> saver, ExistingFileHelper existingFileHelper) {
-            Advancement.Builder.advancement().display(Items.DIRT,
-                    Component.translatable(Items.DIRT.getDescriptionId()),
-                    Component.translatable("dirt_description"),
-                    new ResourceLocation("textures/gui/advancements/backgrounds/stone.png"),
-                    FrameType.TASK,
-                    true,
-                    true,
-                    false)
+            var obtainDirt = Advancement.Builder.advancement()
+                    .display(Items.DIRT,
+                            Component.translatable(Items.DIRT.getDescriptionId()),
+                            Component.translatable("dirt_description"),
+                            new ResourceLocation("textures/gui/advancements/backgrounds/stone.png"),
+                            FrameType.TASK,
+                            true,
+                            true,
+                            false)
                     .addCriterion("has_dirt", InventoryChangeTrigger.TriggerInstance.hasItems(Items.DIRT))
                     .save(saver, new ResourceLocation(MODID, "obtain_dirt"), existingFileHelper);
 
-            Advancement.Builder.advancement().display(Items.DIAMOND_BLOCK,
-                    Component.translatable(Items.DIAMOND_BLOCK.getDescriptionId()),
-                    Component.literal("You obtained a DiamondBlock"),
-                    new ResourceLocation("textures/gui/advancements/backgrounds/stone.png"),
-                    FrameType.CHALLENGE,
-                    true,
-                    true,
-                    false)
+            Advancement.Builder.advancement()
+                    .parent(obtainDirt)
+                    .display(Items.DIAMOND_BLOCK,
+                            Component.translatable(Items.DIAMOND_BLOCK.getDescriptionId()),
+                            Component.literal("You obtained a DiamondBlock"),
+                            new ResourceLocation("textures/gui/advancements/backgrounds/stone.png"),
+                            FrameType.CHALLENGE,
+                            true,
+                            true,
+                            false)
                     .addCriterion("obtained_diamond_block", InventoryChangeTrigger.TriggerInstance.hasItems(Items.DIAMOND_BLOCK))
                     .save(saver, new ResourceLocation("obtain_diamond_block"), existingFileHelper);
 


### PR DESCRIPTION
Vanilla doesn't write the advancement file immediately anymore, so we tell the `ExistingFileHelper` that the file will be generated using `trackGenerated`.

Fixes #238.