### PR TITLE
[1.20.2] Fix blending issues caused by item decorators

### DIFF
--- a/patches/com/mojang/blaze3d/platform/GlStateManager.java.patch
+++ b/patches/com/mojang/blaze3d/platform/GlStateManager.java.patch
@@ -17,3 +17,58 @@
     }
  
     public static void _texParameter(int p_84332_, int p_84333_, int p_84334_) {
+@@ -945,5 +952,54 @@
+       public static int height() {
+          return INSTANCE.height;
+       }
++   }
++
++   public static void _backupGlState(net.neoforged.neoforge.client.GlStateBackup state) {
++      state.blendEnabled = BLEND.mode.enabled;
++      state.blendSrcRgb = BLEND.srcRgb;
++      state.blendDestRgb = BLEND.dstRgb;
++      state.blendSrcAlpha = BLEND.srcAlpha;
++      state.blendDestAlpha = BLEND.dstAlpha;
++      state.depthEnabled = DEPTH.mode.enabled;
++      state.depthMask = DEPTH.mask;
++      state.depthFunc = DEPTH.func;
++      state.cullEnabled = CULL.enable.enabled;
++      state.polyOffsetFillEnabled = POLY_OFFSET.fill.enabled;
++      state.polyOffsetLineEnabled = POLY_OFFSET.line.enabled;
++      state.polyOffsetFactor = POLY_OFFSET.factor;
++      state.polyOffsetUnits = POLY_OFFSET.units;
++      state.colorLogicEnabled = COLOR_LOGIC.enable.enabled;
++      state.colorLogicOp = COLOR_LOGIC.op;
++      state.stencilFuncFunc = STENCIL.func.func;
++      state.stencilFuncRef = STENCIL.func.ref;
++      state.stencilFuncMask = STENCIL.func.mask;
++      state.stencilMask = STENCIL.mask;
++      state.stencilFail = STENCIL.fail;
++      state.stencilZFail = STENCIL.zfail;
++      state.stencilZPass = STENCIL.zpass;
++      state.scissorEnabled = SCISSOR.mode.enabled;
++      state.colorMaskRed = COLOR_MASK.red;
++      state.colorMaskGreen = COLOR_MASK.green;
++      state.colorMaskBlue = COLOR_MASK.blue;
++      state.colorMaskAlpha = COLOR_MASK.alpha;
++   }
++
++   public static void _restoreGlState(net.neoforged.neoforge.client.GlStateBackup state) {
++      BLEND.mode.setEnabled(state.blendEnabled);
++      _blendFuncSeparate(state.blendSrcRgb, state.blendDestRgb, state.blendSrcAlpha, state.blendDestAlpha);
++      DEPTH.mode.setEnabled(state.depthEnabled);
++      _depthMask(state.depthMask);
++      _depthFunc(state.depthFunc);
++      CULL.enable.setEnabled(state.cullEnabled);
++      POLY_OFFSET.fill.setEnabled(state.polyOffsetFillEnabled);
++      POLY_OFFSET.line.setEnabled(state.polyOffsetLineEnabled);
++      _polygonOffset(state.polyOffsetFactor, state.polyOffsetUnits);
++      COLOR_LOGIC.enable.setEnabled(state.colorLogicEnabled);
++      _logicOp(state.colorLogicOp);
++      _stencilFunc(state.stencilFuncFunc, state.stencilFuncRef, state.stencilFuncMask);
++      _stencilMask(state.stencilMask);
++      _stencilOp(state.stencilFail, state.stencilZFail, state.stencilZPass);
++      SCISSOR.mode.setEnabled(state.scissorEnabled);
++      _colorMask(state.colorMaskRed, state.colorMaskGreen, state.colorMaskBlue, state.colorMaskAlpha);
+    }
+ }

--- a/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
+++ b/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
@@ -1,23 +1,17 @@
 --- a/com/mojang/blaze3d/systems/RenderSystem.java
 +++ b/com/mojang/blaze3d/systems/RenderSystem.java
-@@ -1025,4 +1025,20 @@
+@@ -1025,4 +1025,14 @@
           void accept(it.unimi.dsi.fastutil.ints.IntConsumer p_157488_, int p_157489_);
        }
     }
 +
 +   public static void backupGlState(net.neoforged.neoforge.client.GlStateBackup state) {
-+      if (!isOnRenderThread()) {
-+         recordRenderCall(() -> GlStateManager._backupGlState(state));
-+      } else {
-+         GlStateManager._backupGlState(state);
-+      }
++      assertOnRenderThread();
++      GlStateManager._backupGlState(state);
 +   }
 +
 +   public static void restoreGlState(net.neoforged.neoforge.client.GlStateBackup state) {
-+      if (!isOnRenderThread()) {
-+         recordRenderCall(() -> GlStateManager._restoreGlState(state));
-+      } else {
-+         GlStateManager._restoreGlState(state);
-+      }
++      assertOnRenderThread();
++      GlStateManager._restoreGlState(state);
 +   }
  }

--- a/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
+++ b/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
@@ -1,0 +1,23 @@
+--- a/com/mojang/blaze3d/systems/RenderSystem.java
++++ b/com/mojang/blaze3d/systems/RenderSystem.java
+@@ -1025,4 +1025,20 @@
+          void accept(it.unimi.dsi.fastutil.ints.IntConsumer p_157488_, int p_157489_);
+       }
+    }
++
++   public static void backupGlState(net.neoforged.neoforge.client.GlStateBackup state) {
++      if (!isOnRenderThread()) {
++         recordRenderCall(() -> GlStateManager._backupGlState(state));
++      } else {
++         GlStateManager._backupGlState(state);
++      }
++   }
++
++   public static void restoreGlState(net.neoforged.neoforge.client.GlStateBackup state) {
++      if (!isOnRenderThread()) {
++         recordRenderCall(() -> GlStateManager._restoreGlState(state));
++      } else {
++         GlStateManager._restoreGlState(state);
++      }
++   }
+ }

--- a/src/main/java/net/neoforged/neoforge/client/GlStateBackup.java
+++ b/src/main/java/net/neoforged/neoforge/client/GlStateBackup.java
@@ -1,5 +1,19 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client;
 
+import com.mojang.blaze3d.systems.RenderSystem;
+
+/**
+ * Backup of the OpenGL render state, for use in GUI rendering that needs to be able to go back to the previous
+ * render state after calling third-party renderers which may apply arbitrary modifications to the render state.
+ *
+ * <p>Create a backup before changing the global render state with {@link RenderSystem#backupGlState(GlStateBackup)},
+ * and apply the backup with {@link RenderSystem#restoreGlState(GlStateBackup)}.
+ */
 public final class GlStateBackup {
     public boolean blendEnabled;
     public int blendSrcRgb;

--- a/src/main/java/net/neoforged/neoforge/client/GlStateBackup.java
+++ b/src/main/java/net/neoforged/neoforge/client/GlStateBackup.java
@@ -1,0 +1,31 @@
+package net.neoforged.neoforge.client;
+
+public final class GlStateBackup {
+    public boolean blendEnabled;
+    public int blendSrcRgb;
+    public int blendDestRgb;
+    public int blendSrcAlpha;
+    public int blendDestAlpha;
+    public boolean depthEnabled;
+    public boolean depthMask;
+    public int depthFunc;
+    public boolean cullEnabled;
+    public boolean polyOffsetFillEnabled;
+    public boolean polyOffsetLineEnabled;
+    public float polyOffsetFactor;
+    public float polyOffsetUnits;
+    public boolean colorLogicEnabled;
+    public int colorLogicOp;
+    public int stencilFuncFunc;
+    public int stencilFuncRef;
+    public int stencilFuncMask;
+    public int stencilMask;
+    public int stencilFail;
+    public int stencilZFail;
+    public int stencilZPass;
+    public boolean scissorEnabled;
+    public boolean colorMaskRed;
+    public boolean colorMaskGreen;
+    public boolean colorMaskBlue;
+    public boolean colorMaskAlpha;
+}

--- a/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
+++ b/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
@@ -54,6 +54,7 @@ public final class ItemDecoratorHandler {
             if (itemDecorator.render(guiGraphics, font, stack, xOffset, yOffset))
                 resetRenderState();
         }
+        RenderSystem.disableBlend();
     }
 
     private void resetRenderState() {

--- a/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
+++ b/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public final class ItemDecoratorHandler {
     private final List<IItemDecorator> itemDecorators;
+    private final GlStateBackup stateBackup = new GlStateBackup();
 
     private static Map<Item, ItemDecoratorHandler> DECORATOR_LOOKUP = ImmutableMap.of();
 
@@ -49,12 +50,15 @@ public final class ItemDecoratorHandler {
     }
 
     public void render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
+        RenderSystem.backupGlState(stateBackup);
+
         resetRenderState();
         for (IItemDecorator itemDecorator : itemDecorators) {
             if (itemDecorator.render(guiGraphics, font, stack, xOffset, yOffset))
                 resetRenderState();
         }
-        RenderSystem.disableBlend();
+
+        RenderSystem.restoreGlState(stateBackup);
     }
 
     private void resetRenderState() {


### PR DESCRIPTION
This PR fixes blending issues in inventories by properly resetting the render state - disabling blending specifically - after the `ItemDecoratorHandler` has drawn all decorators. As far as I can tell, this doesn't cause any regressions in other places that call any of the two `GuiGraphics#renderItemDecorations()` overloads (i.e. recipe book ghost recipe, bundle tooltip, merchant list, etc.), but I would appreciate it if someone else would cross-check this.

Fixes #185