### PR TITLE
[1.20.2] Temporarily disable update checker for Neo

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -8,7 +8,7 @@ license="LGPL v2.1"
     modId="neoforge"
     # We use the global NeoForge version
     version="${global.neoForgeVersion}"
-    updateJSONURL="https://maven.neoforged.net/releases/net/neoforged/forge/promotions_slim.json"
+    #updateJSONURL="https://maven.neoforged.net/releases/net/neoforged/forge/promotions_slim.json"
     displayName="NeoForge"
     credits="Anyone who has contributed on Github and supports our development"
     authors="The NeoForged Team"


### PR DESCRIPTION
This PR disables the update checker for Neo itself to fix the error spam caused by the specified file not existing until such a file is either provided again or the update checker is updated to work with another applicable file which the maven already provides.
This was briefly discussed on [Discord](https://discord.com/channels/313125603924639766/852298000042164244/1170063492070527087).

Fixes #52