### PR TITLE
Fix entity loot datagen not using getKnownEntityTypes()

### DIFF
--- a/patches/net/minecraft/data/loot/EntityLootSubProvider.java.patch
+++ b/patches/net/minecraft/data/loot/EntityLootSubProvider.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/loot/EntityLootSubProvider.java
 +++ b/net/minecraft/data/loot/EntityLootSubProvider.java
-@@ -56,6 +_,10 @@
+@@ -56,12 +_,16 @@
  
     public abstract void generate();
  
@@ -11,6 +11,14 @@
     @Override
     public void generate(BiConsumer<ResourceLocation, LootTable.Builder> p_251751_) {
        this.generate();
+       Set<ResourceLocation> set = Sets.newHashSet();
+-      BuiltInRegistries.ENTITY_TYPE
+-         .holders()
++      this.getKnownEntityTypes()
++         .map(EntityType::builtInRegistryHolder)
+          .forEach(
+             p_266624_ -> {
+                EntityType<?> entitytype = p_266624_.value();
 @@ -111,7 +_,7 @@
        }
     }


### PR DESCRIPTION
At some point (I assume it was a missed 1.20.2 patch?), `EntityLootSubProvider` stopped using `getKnownEntityTypes` when generating entity loot tables, causing modded data generators to fail as they don't define vanilla entities. This PR fixes this issue and makes use of the method once again. 