### PR TITLE
[1.20.2] Retain insertion order of tag entries

### DIFF
--- a/patches/net/minecraft/tags/TagLoader.java.patch
+++ b/patches/net/minecraft/tags/TagLoader.java.patch
@@ -13,7 +13,7 @@
  
     private Either<Collection<TagLoader.EntryWithSource>, Collection<T>> build(TagEntry.Lookup<T> p_215979_, List<TagLoader.EntryWithSource> p_215980_) {
 -      Builder<T> builder = ImmutableSet.builder();
-+      var builder = new java.util.HashSet<T>();
++      var builder = new java.util.LinkedHashSet<T>();
        List<TagLoader.EntryWithSource> list = new ArrayList<>();
  
        for(TagLoader.EntryWithSource tagloader$entrywithsource : p_215980_) {

--- a/patches/net/minecraft/tags/TagLoader.java.patch
+++ b/patches/net/minecraft/tags/TagLoader.java.patch
@@ -13,7 +13,7 @@
  
     private Either<Collection<TagLoader.EntryWithSource>, Collection<T>> build(TagEntry.Lookup<T> p_215979_, List<TagLoader.EntryWithSource> p_215980_) {
 -      Builder<T> builder = ImmutableSet.builder();
-+      var builder = new java.util.LinkedHashSet<T>();
++      var builder = new java.util.LinkedHashSet<T>(); // Set must retain insertion order, some tag consumers rely on this being the case (see NeoForge#256)
        List<TagLoader.EntryWithSource> list = new ArrayList<>();
  
        for(TagLoader.EntryWithSource tagloader$entrywithsource : p_215980_) {


### PR DESCRIPTION
This PR modifies the `TagLoader` patch to use a `LinkedHashSet` to retain the insertion order of tag entries again. The behaviour of retaining insertion order is only documented on `ImmutableSet.Builder`, which is most likely why it was missed when this patch was initially implemented.

Fixes #256