### PR TITLE
Fixed the README.md [Getting started] link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ our opencollective.*
 [Discord]: https://discord.neoforged.net/
 
 [Documentation]: https://docs.neoforged.net/
-[Getting-Started]: https://docs.neoforged.net/en/latest/gettingstarted/
+[Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
 [ForgeDev]: https://docs.neoforged.net/en/latest/forgedev/
 [Pull-Requests]: https://docs.neoforged.net/en/latest/forgedev/#making-changes-and-pull-requests
 [CurseForge]: https://curseforge.com/placeholder


### PR DESCRIPTION
https://docs.neoforged.net/en/latest/gettingstarted/ gives a 404 error, replaced it with https://docs.neoforged.net/docs/gettingstarted/