### PR TITLE
[1.20.2] Use map backing the atlas instead of the atlas itself for liquid texture lookups

### DIFF
--- a/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
@@ -1,12 +1,20 @@
 --- a/net/minecraft/client/renderer/block/LiquidBlockRenderer.java
 +++ b/net/minecraft/client/renderer/block/LiquidBlockRenderer.java
+@@ -38,6 +_,7 @@
+       this.waterIcons[0] = Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(Blocks.WATER.defaultBlockState()).getParticleIcon();
+       this.waterIcons[1] = ModelBakery.WATER_FLOW.sprite();
+       this.waterOverlay = ModelBakery.WATER_OVERLAY.sprite();
++      net.neoforged.neoforge.client.textures.FluidSpriteCache.reload();
+    }
+ 
+    private static boolean isNeighborSameFluid(FluidState p_203186_, FluidState p_203187_) {
 @@ -70,8 +_,9 @@
  
     public void tesselate(BlockAndTintGetter p_234370_, BlockPos p_234371_, VertexConsumer p_234372_, BlockState p_234373_, FluidState p_234374_) {
        boolean flag = p_234374_.is(FluidTags.LAVA);
 -      TextureAtlasSprite[] atextureatlassprite = flag ? this.lavaIcons : this.waterIcons;
 -      int i = flag ? 16777215 : BiomeColors.getAverageWaterColor(p_234370_, p_234371_);
-+      TextureAtlasSprite[] atextureatlassprite = net.neoforged.neoforge.client.ClientHooks.getFluidSprites(p_234370_, p_234371_, p_234374_);
++      TextureAtlasSprite[] atextureatlassprite = net.neoforged.neoforge.client.textures.FluidSpriteCache.getFluidSprites(p_234370_, p_234371_, p_234374_);
 +      int i = net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(p_234374_).getTintColor(p_234374_, p_234370_, p_234371_);
 +      float alpha = (float)(i >> 24 & 255) / 255.0F;
        float f = (float)(i >> 16 & 0xFF) / 255.0F;

--- a/patches/net/minecraft/client/renderer/texture/TextureAtlas.java.patch
+++ b/patches/net/minecraft/client/renderer/texture/TextureAtlas.java.patch
@@ -9,16 +9,13 @@
     }
  
     @Override
-@@ -172,5 +_,12 @@
+@@ -172,5 +_,9 @@
  
     public void updateFilter(SpriteLoader.Preparations p_251993_) {
        this.setFilter(false, p_251993_.mipLevel() > 0);
 +   }
 +
-+   /**
-+    * {@return the set of sprites in this atlas.}
-+    */
-+   public java.util.Set<ResourceLocation> getTextureLocations() {
-+      return java.util.Collections.unmodifiableSet(texturesByName.keySet());
++   public Map<ResourceLocation, TextureAtlasSprite> getTextures() {
++      return java.util.Collections.unmodifiableMap(texturesByName);
     }
  }

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -74,7 +74,6 @@ import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.texture.TextureAtlas;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.Material;
@@ -432,17 +431,6 @@ public class ClientHooks {
     public static BakedModel handleCameraTransforms(PoseStack poseStack, BakedModel model, ItemDisplayContext cameraTransformType, boolean applyLeftHandTransform) {
         model = model.applyTransform(cameraTransformType, poseStack, applyLeftHandTransform);
         return model;
-    }
-
-    @SuppressWarnings("deprecation")
-    public static TextureAtlasSprite[] getFluidSprites(BlockAndTintGetter level, BlockPos pos, FluidState fluidStateIn) {
-        IClientFluidTypeExtensions props = IClientFluidTypeExtensions.of(fluidStateIn);
-        ResourceLocation overlayTexture = props.getOverlayTexture(fluidStateIn, level, pos);
-        return new TextureAtlasSprite[] {
-                Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(props.getStillTexture(fluidStateIn, level, pos)),
-                Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(props.getFlowingTexture(fluidStateIn, level, pos)),
-                overlayTexture == null ? null : Minecraft.getInstance().getTextureAtlas(TextureAtlas.LOCATION_BLOCKS).apply(overlayTexture),
-        };
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.client.textures;
 
 import java.util.Map;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.LiquidBlockRenderer;
 import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -17,10 +18,18 @@ import net.minecraft.world.level.material.FluidState;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * Helper class for safely accessing fluid textures on a render worker (such as in {@link LiquidBlockRenderer})
+ * to avoid potential issues when a chunk gets re-batched while resources are being reloaded.
+ */
 public final class FluidSpriteCache {
     private static Map<ResourceLocation, TextureAtlasSprite> textureLookup = Map.of();
     private static TextureAtlasSprite missingSprite = null;
 
+    /**
+     * {@return an array holding the still sprite, the flowing sprite and the overlay sprite (if specified,
+     * otherwise null) of the given fluid at the given position}
+     */
     public static TextureAtlasSprite[] getFluidSprites(BlockAndTintGetter level, BlockPos pos, FluidState fluid) {
         IClientFluidTypeExtensions props = IClientFluidTypeExtensions.of(fluid);
         ResourceLocation overlay = props.getOverlayTexture(fluid, level, pos);

--- a/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
@@ -15,6 +15,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.material.FluidState;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import org.jetbrains.annotations.ApiStatus;
 
 public final class FluidSpriteCache {
     private static Map<ResourceLocation, TextureAtlasSprite> textureLookup = Map.of();
@@ -32,6 +33,7 @@ public final class FluidSpriteCache {
         };
     }
 
+    @ApiStatus.Internal
     @SuppressWarnings("deprecation")
     public static void reload() {
         TextureAtlas atlas = Minecraft.getInstance().getModelManager().getAtlas(TextureAtlas.LOCATION_BLOCKS);

--- a/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.textures;
+
+import java.util.Map;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.MissingTextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.material.FluidState;
+import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+
+public final class FluidSpriteCache {
+    private static Map<ResourceLocation, TextureAtlasSprite> textureLookup = Map.of();
+    private static TextureAtlasSprite missingSprite = null;
+
+    public static TextureAtlasSprite[] getFluidSprites(BlockAndTintGetter level, BlockPos pos, FluidState fluid) {
+        IClientFluidTypeExtensions props = IClientFluidTypeExtensions.of(fluid);
+        ResourceLocation overlay = props.getOverlayTexture(fluid, level, pos);
+        Map<ResourceLocation, TextureAtlasSprite> textures = textureLookup;
+
+        return new TextureAtlasSprite[] {
+                textures.getOrDefault(props.getStillTexture(fluid, level, pos), missingSprite),
+                textures.getOrDefault(props.getFlowingTexture(fluid, level, pos), missingSprite),
+                overlay == null ? null : textures.getOrDefault(overlay, missingSprite),
+        };
+    }
+
+    @SuppressWarnings("deprecation")
+    public static void reload() {
+        TextureAtlas atlas = Minecraft.getInstance().getModelManager().getAtlas(TextureAtlas.LOCATION_BLOCKS);
+        textureLookup = atlas.getTextures();
+        missingSprite = textureLookup.get(MissingTextureAtlasSprite.getLocation());
+    }
+
+    private FluidSpriteCache() {}
+}


### PR DESCRIPTION
This PR changes the liquid texture lookups in `LiquidBlockRenderer` to directly use the map backing the texture atlas instead of going through the atlas in order to prevent crashes when a chunk is re-batched while reloading resources.

I would appreciate testing by others who can reproduce the initial issue as I am completely unable to reproduce it.

Fixes #200