### PR TITLE
Use the correct namespace in the MobEffectIdFix patch

### DIFF
--- a/patches/net/minecraft/util/datafix/fixes/MobEffectIdFix.java.patch
+++ b/patches/net/minecraft/util/datafix/fixes/MobEffectIdFix.java.patch
@@ -14,7 +14,7 @@
 +
     private static <T> Dynamic<T> updateMobEffectInstance(Dynamic<T> p_298320_) {
 -      p_298320_ = updateMobEffectIdField(p_298320_, "Id", "id");
-+      p_298320_ = updateMobEffectIdFieldConsideringForge(p_298320_, "Id", p_298320_, "id", "neoforge:id");
++      p_298320_ = updateMobEffectIdFieldConsideringForge(p_298320_, "Id", p_298320_, "id", "forge:id");
        p_298320_ = renameField(p_298320_, "Ambient", "ambient");
        p_298320_ = renameField(p_298320_, "Amplifier", "amplifier");
        p_298320_ = renameField(p_298320_, "Duration", "duration");
@@ -23,7 +23,7 @@
  
     private static <T> Dynamic<T> updateSuspiciousStewEntry(Dynamic<T> p_298902_, Dynamic<T> p_299113_) {
 -      p_299113_ = updateMobEffectIdField(p_298902_, "EffectId", p_299113_, "id");
-+      p_299113_ = updateMobEffectIdFieldConsideringForge(p_298902_, "EffectId", p_299113_, "id", "neoforge:effect_id");
++      p_299113_ = updateMobEffectIdFieldConsideringForge(p_298902_, "EffectId", p_299113_, "id", "forge:effect_id");
        Optional<Dynamic<T>> optional = p_298902_.get("EffectDuration").result();
        return replaceField(p_299113_, "EffectDuration", "duration", optional);
     }


### PR DESCRIPTION
The namespace rename that was done to convert from `forge:` to `neoforge:` also caused a change in the new effect ID patch, but there are no such pre-1.20.2 fields with the `neoforge` namespace, only with the `forge` one.