### PR TITLE
Fix DeferredSpawnEggItem registering dispenser behaviors off-thread

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/DeferredSpawnEggItem.java
+++ b/src/main/java/net/neoforged/neoforge/common/DeferredSpawnEggItem.java
@@ -83,13 +83,15 @@ public class DeferredSpawnEggItem extends SpawnEggItem {
     private static class CommonHandler {
         @SubscribeEvent
         public static void onCommonSetup(FMLCommonSetupEvent event) {
-            MOD_EGGS.forEach(egg -> {
-                DispenseItemBehavior dispenseBehavior = egg.createDispenseBehavior();
-                if (dispenseBehavior != null) {
-                    DispenserBlock.registerBehavior(egg, dispenseBehavior);
-                }
+            event.enqueueWork(() -> {
+                MOD_EGGS.forEach(egg -> {
+                    DispenseItemBehavior dispenseBehavior = egg.createDispenseBehavior();
+                    if (dispenseBehavior != null) {
+                        DispenserBlock.registerBehavior(egg, dispenseBehavior);
+                    }
 
-                TYPE_MAP.put(egg.typeSupplier.get(), egg);
+                    TYPE_MAP.put(egg.typeSupplier.get(), egg);
+                });
             });
         }
     }
@@ -98,7 +100,7 @@ public class DeferredSpawnEggItem extends SpawnEggItem {
     private static class ColorRegisterHandler {
         @SubscribeEvent(priority = EventPriority.HIGHEST)
         public static void registerSpawnEggColors(RegisterColorHandlersEvent.Item event) {
-            MOD_EGGS.forEach(egg -> event.getItemColors().register((stack, layer) -> egg.getColor(layer), egg));
+            MOD_EGGS.forEach(egg -> event.register((stack, layer) -> egg.getColor(layer), egg));
         }
     }
 }


### PR DESCRIPTION
Also cleans up `registerSpawnEggColors` to use the `register` method of the event instead of retrieving the `ItemColors` instance.