### PR TITLE
[1.20.2] Allow blocks complete control over breaking sounds

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -234,20 +234,17 @@
              }
              break;
           case 1011:
-@@ -3032,11 +_,8 @@
+@@ -3031,8 +_,8 @@
+             break;
           case 2001:
              BlockState blockstate1 = Block.stateById(p_234307_);
-             if (!blockstate1.isAir()) {
+-            if (!blockstate1.isAir()) {
 -               SoundType soundtype = blockstate1.getSoundType();
--               this.level
--                  .playLocalSound(
--                     p_234306_, soundtype.getBreakSound(), SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F, false
--                  );
++            if (!blockstate1.isAir() && !net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions.of(blockstate1).playBreakSound(blockstate1, this.level, p_234306_)) {
 +               SoundType soundtype = blockstate1.getSoundType(this.level, p_234306_, null);
-+               this.level.playLocalSound(p_234306_, soundtype.getBreakSound(), SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F, false);
-             }
- 
-             this.level.addDestroyBlockEffect(p_234306_, blockstate1);
+                this.level
+                   .playLocalSound(
+                      p_234306_, soundtype.getBreakSound(), SoundSource.BLOCKS, (soundtype.getVolume() + 1.0F) / 2.0F, soundtype.getPitch() * 0.8F, false
 @@ -3367,7 +_,7 @@
        } else {
           int i = p_109538_.getBrightness(LightLayer.SKY, p_109540_);

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
@@ -72,6 +72,19 @@ public interface IClientBlockExtensions {
     }
 
     /**
+     * Play breaking sound(s) when the block is destroyed. This allows playing sounds dependent on BE data
+     * as it is called before the block and BE are actually removed on the client.
+     *
+     * @param state The current state
+     * @param level The current level
+     * @param pos   The position of the block
+     * @return True to prevent vanilla break sounds from playing
+     */
+    default boolean playBreakSound(BlockState state, Level level, BlockPos pos) {
+        return false;
+    }
+
+    /**
      * NOT CURRENTLY IMPLEMENTED
      * <p>
      * Use this to change the fog color used when the entity is "inside" a material.

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/CustomBreakSoundTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/CustomBreakSoundTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.block;
+
+import java.util.function.Consumer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions;
+import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.RegistryObject;
+
+/**
+ * Adds a block and item to test custom client-controlled breaking sounds.
+ *
+ * To test it, place the "custom_break_sound_test:testblock" and break it. Depending on the modulus 3 of the block's
+ * X coordinate, the break sound has to be the cow's hurt sound, the zombie's death sound or the pig's hurt sound,
+ * but never the default stone break sound
+ */
+@Mod(CustomBreakSoundTest.MOD_ID)
+public class CustomBreakSoundTest {
+    public static final String MOD_ID = "custom_break_sound_test";
+    private static final boolean ENABLED = true;
+
+    private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, MOD_ID);
+    private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(Registries.ITEM, MOD_ID);
+
+    private static final RegistryObject<Block> TEST_BLOCK = BLOCKS.register("testblock", () -> new TestBlock(BlockBehaviour.Properties.of()));
+    private static final RegistryObject<Item> TEST_BLOCK_ITEM = ITEMS.register("testblock", () -> new BlockItem(TEST_BLOCK.get(), new Item.Properties()));
+
+    public CustomBreakSoundTest() {
+        if (ENABLED) {
+            IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();
+            BLOCKS.register(modBus);
+            ITEMS.register(modBus);
+            modBus.addListener(CustomBreakSoundTest::addCreative);
+        }
+    }
+
+    private static void addCreative(BuildCreativeModeTabContentsEvent event) {
+        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS)
+            event.accept(TEST_BLOCK_ITEM);
+    }
+
+    private static class TestBlock extends Block {
+        public TestBlock(Properties props) {
+            super(props);
+        }
+
+        @Override
+        public void initializeClient(Consumer<IClientBlockExtensions> consumer) {
+            consumer.accept(new IClientBlockExtensions() {
+                @Override
+                public boolean playBreakSound(BlockState state, Level level, BlockPos pos) {
+                    SoundEvent sound = switch (Math.abs(pos.getX()) % 3) {
+                        case 0 -> SoundEvents.COW_HURT;
+                        case 1 -> SoundEvents.ZOMBIE_DEATH;
+                        case 2 -> SoundEvents.PIG_HURT;
+                        default -> throw new IncompatibleClassChangeError();
+                    };
+                    level.playLocalSound(pos, sound, SoundSource.BLOCKS, 1.0F, 0.8F, false);
+                    return true;
+                }
+            });
+        }
+    }
+}

--- a/tests/src/main/resources/META-INF/mods.toml
+++ b/tests/src/main/resources/META-INF/mods.toml
@@ -34,6 +34,8 @@ license="LGPL v2.1"
 
 [[mods]]
     modId="living_swap_items_event_test"
+[[mods]]
+    modId="custom_break_sound_test"
 
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.


### PR DESCRIPTION
This PR adds a hook to allow mods full control over the sound being played when a block is broken.
This is useful in cases where the breaking sound is dependent on level context (i.e. position or blockentity data), cannot be provided as part of a `SoundType` from `IBlockExtension#getSoundType()` or multiple sounds are desired.
Sending custom packets instead of using the level event is not a viable option as these packets only get handled after the block is already fully gone and therefore the context wiped.
This is effectively the sound-equivalent to the `IClientBlockExtensions#addDestroyEffects()` particle hook.

My specific use case is a block imitating two other arbitrary blocks, which should both have their break sounds played and destroy particles added when the block is broken. Sending the "break block" level event (2001) myself twice with the two imitated blocks instead of the actual block is not an option as it prevents the destroy particle hook from being called on my block and may cause other client-side weirdness.