### PR TITLE
Use `Entity#positionRider` to resync player with vehicle position

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -17,14 +17,37 @@
              }
  
              entity.absMoveTo(d3, d4, d5, f, f1);
-+            this.player.absMoveTo(d3, d4, d5, this.player.getYRot(), this.player.getXRot()); // Forge - Resync player position on vehicle moving
++            resyncPlayerWithVehicle(entity); // Neo - Resync player position on vehicle moving
              boolean flag3 = serverlevel.noCollision(entity, entity.getBoundingBox().deflate(0.0625));
              if (flag && (flag2 || !flag3)) {
                 entity.absMoveTo(d0, d1, d2, f, f1);
-+               this.player.absMoveTo(d3, d4, d5, this.player.getYRot(), this.player.getXRot()); // Forge - Resync player position on vehicle moving
++               resyncPlayerWithVehicle(entity); // Neo - Resync player position on vehicle moving
                 this.send(new ClientboundMoveVehiclePacket(entity));
                 return;
              }
+@@ -443,6 +_,22 @@
+       }
+    }
+ 
++   private void resyncPlayerWithVehicle(Entity vehicle) {
++      Vec3 oldPos = this.player.position();
++      float yRot = this.player.getYRot();
++      float xRot = this.player.getXRot();
++      float yHeadRot = this.player.getYHeadRot();
++      vehicle.positionRider(this.player);
++      // keep old rotation
++      this.player.setYRot(yRot);
++      this.player.setXRot(xRot);
++      this.player.setYHeadRot(yHeadRot);
++      // save old position
++      this.player.xo = oldPos.x;
++      this.player.yo = oldPos.y;
++      this.player.zo = oldPos.z;
++   }
++
+    private boolean noBlocksAround(Entity p_9794_) {
+       return p_9794_.level()
+          .getBlockStates(p_9794_.getBoundingBox().inflate(0.0625).expandTowards(0.0, -0.55, 0.0))
 @@ -1004,8 +_,10 @@
           case SWAP_ITEM_WITH_OFFHAND:
              if (!this.player.isSpectator()) {

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -25,7 +25,7 @@
                 this.send(new ClientboundMoveVehiclePacket(entity));
                 return;
              }
-@@ -443,6 +_,22 @@
+@@ -443,6 +_,23 @@
        }
     }
  
@@ -34,12 +34,13 @@
 +      float yRot = this.player.getYRot();
 +      float xRot = this.player.getXRot();
 +      float yHeadRot = this.player.getYHeadRot();
++
 +      vehicle.positionRider(this.player);
-+      // keep old rotation
++
++      // preserve old rotation and store old position in xo/yo/zo
 +      this.player.setYRot(yRot);
 +      this.player.setXRot(xRot);
 +      this.player.setYHeadRot(yHeadRot);
-+      // save old position
 +      this.player.xo = oldPos.x;
 +      this.player.yo = oldPos.y;
 +      this.player.zo = oldPos.z;


### PR DESCRIPTION
In https://github.com/MinecraftForge/MinecraftForge/pull/5160, a patch was introduced to avoid entity tracking issues by syncing players' server-side positions with that of their vehicles. However, this patch causes thrashing of the chunk system in modern versions, because it assumes that players ride directly above the center of their vehicle. This is not the case for various modded vehicles, as well as boats in vanilla if there are two riders.

To address this issue, we switch to using the `positionRider` method to reposition the player, and preserve their rotation to avoid issues on the client ([reference](https://github.com/MinecraftForge/MinecraftForge/pull/5233)). 

This fixes https://github.com/neoforged/NeoForge/issues/169. I added a mixin version of this to ModernFix some time ago and confirmed that it fixed the known reproduction cases of that bug.