### PR TITLE
[1.20.2] Move access change in AbstractButton to AT

### DIFF
--- a/patches/net/minecraft/client/gui/components/AbstractButton.java.patch
+++ b/patches/net/minecraft/client/gui/components/AbstractButton.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/client/gui/components/AbstractButton.java
 +++ b/net/minecraft/client/gui/components/AbstractButton.java
-@@ -14,7 +_,7 @@
- @OnlyIn(Dist.CLIENT)
- public abstract class AbstractButton extends AbstractWidget {
-    protected static final int TEXT_MARGIN = 2;
--   private static final WidgetSprites SPRITES = new WidgetSprites(
-+   protected static final WidgetSprites SPRITES = new WidgetSprites(
-       new ResourceLocation("widget/button"), new ResourceLocation("widget/button_disabled"), new ResourceLocation("widget/button_highlighted")
-    );
- 
 @@ -32,7 +_,7 @@
        RenderSystem.enableDepthTest();
        p_281670_.blitSprite(SPRITES.get(this.active, this.isHoveredOrFocused()), this.getX(), this.getY(), this.getWidth(), this.getHeight());

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -93,6 +93,7 @@ protected net.minecraft.client.gui.Gui renderPortalOverlay(Lnet/minecraft/client
 public net.minecraft.client.gui.Gui renderHotbar(FLnet/minecraft/client/gui/GuiGraphics;)V # renderHotbar
 public net.minecraft.client.gui.Gui renderEffects(Lnet/minecraft/client/gui/GuiGraphics;)V # renderEffects
 protected net.minecraft.client.gui.Gui drawBackdrop(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;III)V # drawBackdrop
+protected net.minecraft.client.gui.components.AbstractButton SPRITES
 protected net.minecraft.client.gui.components.AbstractSelectionList$Entry list # list
 protected net.minecraft.client.gui.components.AbstractSliderButton getSprite()Lnet/minecraft/resources/ResourceLocation; # getSprite
 protected net.minecraft.client.gui.components.AbstractSliderButton getHandleSprite()Lnet/minecraft/resources/ResourceLocation; # getHandleSprite


### PR DESCRIPTION
This PR moves the access change of the `AbstractButton.SPRITES` field from a patch to an AT.

Fixes #265