### PR TITLE
Avoid O(n) complexity in MappedRegistry register methods

### DIFF
--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -44,7 +44,7 @@
        this.byLocation.put(p_256594_.location(), reference);
        this.byValue.put(p_256374_, reference);
 -      this.byId.size(Math.max(this.byId.size(), p_256563_ + 1));
-+      while(this.byId.size() < (p_256563_ + 1)) this.byId.add(null);
++      while (this.byId.size() < (p_256563_ + 1)) this.byId.add(null);
        this.byId.set(p_256563_, reference);
        this.toId.put(p_256374_, p_256563_);
        if (this.nextId <= p_256563_) {
@@ -155,7 +155,7 @@
 +         this.nextId = id + 1;
 +      }
 +      var holder = byKey.get(key);
-+      while(this.byId.size() < (id + 1)) this.byId.add(null);
++      while (this.byId.size() < (id + 1)) this.byId.add(null);
 +      this.byId.set(id, holder);
 +      this.toId.put(holder.value(), id);
 +   }

--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -32,7 +32,7 @@
        if (this.byLocation.containsKey(p_256594_.location())) {
           Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256594_ + "' to registry"));
        }
-@@ -147,6 +_,8 @@
+@@ -147,12 +_,14 @@
           reference.bindKey(p_256594_);
        } else {
           reference = this.byKey.computeIfAbsent(p_256594_, p_258168_ -> Holder.Reference.createStandAlone(this.holderOwner(), p_258168_));
@@ -41,6 +41,13 @@
        }
  
        this.byKey.put(p_256594_, reference);
+       this.byLocation.put(p_256594_.location(), reference);
+       this.byValue.put(p_256374_, reference);
+-      this.byId.size(Math.max(this.byId.size(), p_256563_ + 1));
++      while(this.byId.size() < (p_256563_ + 1)) this.byId.add(null);
+       this.byId.set(p_256563_, reference);
+       this.toId.put(p_256374_, p_256563_);
+       if (this.nextId <= p_256563_) {
 @@ -162,6 +_,7 @@
        this.lifecycles.put(p_256374_, p_256469_);
        this.registryLifecycle = this.registryLifecycle.add(p_256469_);
@@ -148,7 +155,7 @@
 +         this.nextId = id + 1;
 +      }
 +      var holder = byKey.get(key);
-+      this.byId.size(Math.max(this.byId.size(), id + 1));
++      while(this.byId.size() < (id + 1)) this.byId.add(null);
 +      this.byId.set(id, holder);
 +      this.toId.put(holder.value(), id);
 +   }


### PR DESCRIPTION
Mojang uses `ObjectList#size(int)` to resize the `byId` list that is used as a map from ID -> value. This is incredibly inefficient because every registration will grow the list by exactly one element, but require a full allocation of a new array and copying of all the old elements to the new array. In practice, it means that registering a block runs in O(n) time complexity, where n is the number of previously registered blocks, so registration will slow down as more modded content is added.

To avoid this, we just add the required number of `null` elements using a loop calling `add`. The `add` method will do proper amortized growth of the list which is much faster.