### PR TITLE
[1.20.2] Add support for optional geometry loaders

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ModelBuilder.java
@@ -190,7 +190,10 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     public ElementBuilder element() {
-        Preconditions.checkState(customLoader == null, "Cannot use elements and custom loaders at the same time");
+        Preconditions.checkState(
+                customLoader == null || customLoader.allowInlineElements,
+                "Custom model loader %s does not support inline elements",
+                customLoader != null ? customLoader.loaderId : null);
         ElementBuilder ret = new ElementBuilder();
         elements.add(ret);
         return ret;
@@ -204,7 +207,10 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
      * @throws IndexOutOfBoundsException if {@code} index is out of bounds
      */
     public ElementBuilder element(int index) {
-        Preconditions.checkState(customLoader == null, "Cannot use elements and custom loaders at the same time");
+        Preconditions.checkState(
+                customLoader == null || customLoader.allowInlineElements,
+                "Custom model loader %s does not support inline elements",
+                customLoader != null ? customLoader.loaderId : null);
         Preconditions.checkElementIndex(index, elements.size(), "Element index");
         return elements.get(index);
     }
@@ -223,9 +229,12 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
      * @return the custom loader builder
      */
     public <L extends CustomLoaderBuilder<T>> L customLoader(BiFunction<T, ExistingFileHelper, L> customLoaderFactory) {
-        Preconditions.checkState(elements.size() == 0, "Cannot use elements and custom loaders at the same time");
         Preconditions.checkNotNull(customLoaderFactory, "customLoaderFactory must not be null");
         L customLoader = customLoaderFactory.apply(self(), existingFileHelper);
+        Preconditions.checkState(
+                customLoader.allowInlineElements || elements.isEmpty(),
+                "Custom model loader %s does not support inline elements",
+                customLoader.loaderId);
         this.customLoader = customLoader;
         return customLoader;
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/CompositeModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/CompositeModelBuilder.java
@@ -23,7 +23,7 @@ public class CompositeModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
     private final List<String> itemRenderOrder = new ArrayList<>();
 
     protected CompositeModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
-        super(new ResourceLocation("neoforge:composite"), parent, existingFileHelper);
+        super(new ResourceLocation("neoforge:composite"), parent, existingFileHelper, false);
     }
 
     public CompositeModelBuilder<T> child(String name, T modelBuilder) {

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/DynamicFluidContainerModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/DynamicFluidContainerModelBuilder.java
@@ -26,7 +26,7 @@ public class DynamicFluidContainerModelBuilder<T extends ModelBuilder<T>> extend
     private Boolean applyFluidLuminosity;
 
     protected DynamicFluidContainerModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
-        super(new ResourceLocation("neoforge:fluid_container"), parent, existingFileHelper);
+        super(new ResourceLocation("neoforge:fluid_container"), parent, existingFileHelper, false);
     }
 
     public DynamicFluidContainerModelBuilder<T> fluid(Fluid fluid) {

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/ItemLayerModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/ItemLayerModelBuilder.java
@@ -33,7 +33,7 @@ public class ItemLayerModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
     private final IntSet layersWithRenderTypes = new IntOpenHashSet();
 
     protected ItemLayerModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
-        super(new ResourceLocation("neoforge:item_layers"), parent, existingFileHelper);
+        super(new ResourceLocation("neoforge:item_layers"), parent, existingFileHelper, false);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/ObjModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/ObjModelBuilder.java
@@ -26,7 +26,7 @@ public class ObjModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuil
     private ResourceLocation mtlOverride;
 
     protected ObjModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
-        super(new ResourceLocation("neoforge:obj"), parent, existingFileHelper);
+        super(new ResourceLocation("neoforge:obj"), parent, existingFileHelper, false);
     }
 
     public ObjModelBuilder<T> modelLocation(ResourceLocation modelLocation) {

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/SeparateTransformsModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/SeparateTransformsModelBuilder.java
@@ -24,7 +24,7 @@ public class SeparateTransformsModelBuilder<T extends ModelBuilder<T>> extends C
     private final Map<String, T> childModels = new LinkedHashMap<>();
 
     protected SeparateTransformsModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
-        super(new ResourceLocation("neoforge:separate_transforms"), parent, existingFileHelper);
+        super(new ResourceLocation("neoforge:separate_transforms"), parent, existingFileHelper, false);
     }
 
     public SeparateTransformsModelBuilder<T> base(T modelBuilder) {


### PR DESCRIPTION
This PR adds the ability to mark a geometry loader as optional in a JSON model. This is mainly useful for custom geometry loaders which use the vanilla format as a base and just add additional data instead of wrapping an entire model. Going hand in hand with this, the datagen for custom loaders is modified allow combining elements and a custom loader if the loader builder has the added flag set. Being able to mark a loader as optional in datagen is coupled to that as well.

My use case is a connected textures implementation that embeds the CT data in the model instead of attaching it to the texture via an mcmeta file for example. Marking the loader as optional would then allow another mod to provide connected textures through my mod if it's installed and otherwise automatically fall back to a basic model without CT behavior since vanilla just silently ignores the additional data.