### PR TITLE
[1.20.2] Band-aid fix connections between Neo and vanilla

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -19,3 +19,11 @@
        LOGGER.warn("Unknown custom packet payload: {}", p_296412_.id());
     }
  
+@@ -92,6 +_,7 @@
+          );
+       this.connection.resumeInboundAfterProtocolChange();
+       this.connection.send(new ServerboundFinishConfigurationPacket());
++      net.neoforged.neoforge.network.NetworkHooks.handleClientLoginSuccess(this.connection);
+    }
+ 
+    @Override

--- a/patches/net/minecraft/network/protocol/handshake/ClientIntentionPacket.java.patch
+++ b/patches/net/minecraft/network/protocol/handshake/ClientIntentionPacket.java.patch
@@ -33,7 +33,7 @@
     public void write(FriendlyByteBuf p_134737_) {
        p_134737_.writeVarInt(this.protocolVersion);
 -      p_134737_.writeUtf(this.hostName);
-+      p_134737_.writeUtf(this.hostName + "\0" + this.fmlVersion + "\0");
++      p_134737_.writeUtf(this.hostName + "\0" + this.fmlVersion);
        p_134737_.writeShort(this.port);
        p_134737_.writeVarInt(this.intention.id());
     }

--- a/patches/net/minecraft/network/protocol/handshake/ClientIntentionPacket.java.patch
+++ b/patches/net/minecraft/network/protocol/handshake/ClientIntentionPacket.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/network/protocol/handshake/ClientIntentionPacket.java
 +++ b/net/minecraft/network/protocol/handshake/ClientIntentionPacket.java
-@@ -4,19 +_,16 @@
+@@ -4,25 +_,29 @@
  import net.minecraft.network.FriendlyByteBuf;
  import net.minecraft.network.protocol.Packet;
  
@@ -8,6 +8,13 @@
 +public record ClientIntentionPacket(int protocolVersion, String hostName, int port, ClientIntent intention, String fmlVersion) implements Packet<ServerHandshakePacketListener> {
     private static final int MAX_HOST_LENGTH = 255;
  
++   public ClientIntentionPacket {
++      if (fmlVersion == null) {
++         fmlVersion = net.neoforged.neoforge.network.NetworkHooks.getFMLVersion(hostName);
++         hostName = hostName.split("\0")[0];
++      }
++   }
++
     @Deprecated
     public ClientIntentionPacket(int protocolVersion, String hostName, int port, ClientIntent intention) {
 -      this.protocolVersion = protocolVersion;
@@ -19,18 +26,17 @@
  
     public ClientIntentionPacket(FriendlyByteBuf p_179801_) {
 -      this(p_179801_.readVarInt(), p_179801_.readUtf(255), p_179801_.readUnsignedShort(), ClientIntent.byId(p_179801_.readVarInt()));
-+      this(p_179801_.readVarInt(), p_179801_.readUtf(255), p_179801_.readUnsignedShort(), ClientIntent.byId(p_179801_.readVarInt()), p_179801_.readUtf(255));
++      this(p_179801_.readVarInt(), p_179801_.readUtf(255), p_179801_.readUnsignedShort(), ClientIntent.byId(p_179801_.readVarInt()), null);
     }
  
     @Override
-@@ -25,6 +_,7 @@
-       p_134737_.writeUtf(this.hostName);
+    public void write(FriendlyByteBuf p_134737_) {
+       p_134737_.writeVarInt(this.protocolVersion);
+-      p_134737_.writeUtf(this.hostName);
++      p_134737_.writeUtf(this.hostName + "\0" + this.fmlVersion + "\0");
        p_134737_.writeShort(this.port);
        p_134737_.writeVarInt(this.intention.id());
-+      p_134737_.writeUtf(this.fmlVersion);
     }
- 
-    public void handle(ServerHandshakePacketListener p_134734_) {
 @@ -34,5 +_,9 @@
     @Override
     public ConnectionProtocol nextProtocol() {


### PR DESCRIPTION
This PR implements a band-aid fix for the connection issue between Neo clients and vanilla servers and vice-versa.
This serves as a holdover until it's fixed properly in the networking refactor and to make sure Neo<->vanilla connections work fine in 1.20.2 in case the networking refactor is retargeted to 1.20.3.

Fixes #205