### PR TITLE
[1.20.2] Reinstate chunk watch events

### DIFF
--- a/patches/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/net/minecraft/server/level/ChunkMap.java.patch
@@ -47,6 +47,18 @@
              this.write(chunkpos, compoundtag);
              this.markPosition(chunkpos, chunkstatus.getChunkType());
              return true;
+@@ -894,9 +_,11 @@
+ 
+    private static void markChunkPendingToSend(ServerPlayer p_295834_, LevelChunk p_296281_) {
+       p_295834_.connection.chunkSender.markChunkPendingToSend(p_296281_);
++      net.neoforged.neoforge.event.EventHooks.fireChunkWatch(p_295834_, p_296281_, p_295834_.serverLevel());
+    }
+ 
+    private static void dropChunk(ServerPlayer p_294215_, ChunkPos p_294758_) {
++      net.neoforged.neoforge.event.EventHooks.fireChunkUnWatch(p_294215_, p_294758_, p_294215_.serverLevel());
+       p_294215_.connection.chunkSender.dropChunk(p_294215_, p_294758_);
+    }
+ 
 @@ -1089,6 +_,7 @@
              this.playerMap.unIgnorePlayer(p_140185_);
           }

--- a/patches/net/minecraft/server/network/PlayerChunkSender.java.patch
+++ b/patches/net/minecraft/server/network/PlayerChunkSender.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/network/PlayerChunkSender.java
++++ b/net/minecraft/server/network/PlayerChunkSender.java
+@@ -77,6 +_,7 @@
+       p_295237_.send(new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null));
+       ChunkPos chunkpos = p_295144_.getPos();
+       DebugPackets.sendPoiPacketsForChunk(p_294963_, chunkpos);
++      net.neoforged.neoforge.event.EventHooks.fireChunkSent(p_295237_.player, p_295144_, p_294963_);
+    }
+ 
+    private List<LevelChunk> collectChunksToSend(ChunkMap p_296053_, ChunkPos p_295659_) {

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -691,6 +691,10 @@ public class EventHooks {
         NeoForge.EVENT_BUS.post(new ChunkWatchEvent.Watch(entity, chunk, level));
     }
 
+    public static void fireChunkSent(ServerPlayer entity, LevelChunk chunk, ServerLevel level) {
+        NeoForge.EVENT_BUS.post(new ChunkWatchEvent.Sent(entity, chunk, level));
+    }
+
     public static void fireChunkUnWatch(ServerPlayer entity, ChunkPos chunkpos, ServerLevel level) {
         NeoForge.EVENT_BUS.post(new ChunkWatchEvent.UnWatch(entity, chunkpos, level));
     }

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkWatchEvent.java
@@ -62,7 +62,7 @@ public abstract class ChunkWatchEvent extends Event {
      * sending to the client (see {@link net.minecraft.server.level.ChunkMap#markChunkPendingToSend(ServerPlayer, LevelChunk)}).
      * <p>
      * This event must NOT be used to send additional chunk-related data to the client as the client will not be aware
-     * of the chunk yet when this event fires.
+     * of the chunk yet when this event fires. {@link ChunkWatchEvent.Sent} should be used for this purpose instead
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>

--- a/tests/src/main/java/net/neoforged/neoforge/debug/world/ChunkWatchEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/world/ChunkWatchEventTest.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.world;
 
+import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.UUID;
@@ -14,42 +15,45 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.level.ChunkWatchEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 
 @Mod(ChunkWatchEventTest.MODID)
 public class ChunkWatchEventTest {
     public static final String MODID = "chunkwatchworldtest";
 
     private static final boolean ENABLED = false;
-    private static Logger logger;
-    private static Object2IntMap<UUID> watchedByPlayer = new Object2IntOpenHashMap<>();
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final Object2IntMap<UUID> WATCHED_BY_PLAYER = new Object2IntOpenHashMap<>();
 
     public ChunkWatchEventTest() {
-        logger = LogManager.getLogger();
-
         if (ENABLED) {
             NeoForge.EVENT_BUS.register(ChunkWatchEventTest.class);
         }
     }
 
     @SubscribeEvent
-    public static void onUnwatch(ChunkWatchEvent.UnWatch event) {
-        int watched = watchedByPlayer.getInt(event.getPlayer().getUUID());
-        --watched;
-        watchedByPlayer.put(event.getPlayer().getUUID(), watched);
-        logger.info("Unwatching chunk {} in dimension {}. Player's dimension: {}, total chunks watched by player {}",
+    public static void onWatch(ChunkWatchEvent.Watch event) {
+        int watched = WATCHED_BY_PLAYER.getInt(event.getPlayer().getUUID());
+        ++watched;
+        WATCHED_BY_PLAYER.put(event.getPlayer().getUUID(), watched);
+        LOGGER.info("Watching chunk {} in dimension {}. Player's dimension: {}, total chunks watched by player {}",
                 event.getPos(), getDimensionName(event.getLevel()), getDimensionName(event.getPlayer().getCommandSenderWorld()),
                 watched);
     }
 
     @SubscribeEvent
-    public static void onWatch(ChunkWatchEvent.Watch event) {
-        int watched = watchedByPlayer.getInt(event.getPlayer().getUUID());
-        ++watched;
-        watchedByPlayer.put(event.getPlayer().getUUID(), watched);
-        logger.info("Watching chunk {} in dimension {}. Player's dimension: {}, total chunks watched by player {}",
+    public static void onSent(ChunkWatchEvent.Sent event) {
+        LOGGER.info("Watched chunk {} in dimension {} sent to client. Player's dimension: {}",
+                event.getPos(), getDimensionName(event.getLevel()), getDimensionName(event.getPlayer().getCommandSenderWorld()));
+    }
+
+    @SubscribeEvent
+    public static void onUnwatch(ChunkWatchEvent.UnWatch event) {
+        int watched = WATCHED_BY_PLAYER.getInt(event.getPlayer().getUUID());
+        --watched;
+        WATCHED_BY_PLAYER.put(event.getPlayer().getUUID(), watched);
+        LOGGER.info("Unwatching chunk {} in dimension {}. Player's dimension: {}, total chunks watched by player {}",
                 event.getPos(), getDimensionName(event.getLevel()), getDimensionName(event.getPlayer().getCommandSenderWorld()),
                 watched);
     }


### PR DESCRIPTION
This PR reinstates the chunk watch events. Due to tracking start and actual transmission to the client now being separated, a third event is introduced which fires right after the chunk is actually sent to the client to allow mods to send additional data related to the given chunk. This also means that the `ChunkWatchEvent.Watch` must not be used for sending additional data anymore. The existing events once again fire when a player starts and stops tracking a chunk, though with the caveat that a chunk for which `ChunkWatchEvent.Watch` is fired may never be known to the client and a chunk for which `ChunkWatchEvent.UnWatch` is fired may never have been known to the client if the player's connection or client is too slow such that the chunk goes out of range again before being synced to the client.

Fixes #280