### PR TITLE
Make `Range` public

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -745,7 +745,7 @@ public class ModConfigSpec extends UnmodifiableConfigWrapper<UnmodifiableConfig>
     }
 
     @SuppressWarnings("unused")
-    private static class Range<V extends Comparable<? super V>> implements Predicate<Object> {
+    public static class Range<V extends Comparable<? super V>> implements Predicate<Object> {
         private final Class<? extends V> clazz;
         private final V min;
         private final V max;


### PR DESCRIPTION
This class can be accessed via [getRange](https://github.com/neoforged/NeoForge/blob/1.20.x/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java#L709), but since it is private, it cannot be accessed