### PR TITLE
Rename certain DR subclass helpers as being 'simple'

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -51,12 +51,15 @@ import org.jetbrains.annotations.Nullable;
  * public static final DeferredItem<BlockItem> ROCK_ITEM = ITEMS.registerSimpleBlockItem(ROCK_BLOCK, new Item.Properties());
  *
  * // Otherwise, use the regular (non-'simple') variants
- * public static final DeferredBlock<SpecialRockBlock> SPECIAL_ROCK_BLOCK = BLOCKS.registerBlock("special_rock", SpecialRockBlock::new, Block.Properties.create(Material.ROCK));
+ * public static final DeferredBlock<SpecialRockBlock> SPECIAL_ROCK_BLOCK = BLOCKS.registerBlock("special_rock",
+ *         SpecialRockBlock::new, Block.Properties.create(Material.ROCK));
  * // (#registerSimpleBlockItem does not have a non-'simple' variant -- register an item in the usual way)
- * public static final DeferredItem<SpecialRockItem> SPECIAL_ROCK_ITEM = ITEMS.register("special_rock", () -> new SpecialRockItem(SPECIAL_ROCK_BLOCK.get(), new Item.Properties()))
+ * public static final DeferredItem<SpecialRockItem> SPECIAL_ROCK_ITEM = ITEMS.register("special_rock",
+ *         () -> new SpecialRockItem(SPECIAL_ROCK_BLOCK.get(), new Item.Properties()))
  *
  * // (Can be DeferredHolder<BlockEntityType<?>, BlockEntityType<RockBlockEntity>> if you prefer)
- * public static final Supplier<BlockEntityType<RockBlockEntity>> ROCK_BLOCK_ENTITY = BLOCK_ENTITIES.register("rock", () -> BlockEntityType.Builder.of(RockBlockEntity::new, ROCK_BLOCK.get()).build(null));
+ * public static final Supplier<BlockEntityType<RockBlockEntity>> ROCK_BLOCK_ENTITY = BLOCK_ENTITIES.register("rock",
+ *         () -> BlockEntityType.Builder.of(RockBlockEntity::new, ROCK_BLOCK.get()).build(null));
  *
  * public ExampleMod(IEventBus modBus) {
  *     ITEMS.register(modBus);

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -42,8 +42,15 @@ import org.jetbrains.annotations.Nullable;
  * private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
  * private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MODID);
  *
- * public static final DeferredBlock<Block> ROCK_BLOCK = BLOCKS.registerBlock("rock", Block.Properties.create(Material.ROCK));
- * public static final DeferredItem<BlockItem> ROCK_ITEM = ITEMS.registerBlockItem(ROCK_BLOCK, new Item.Properties());
+ * // If you don't care about the actual Block class, use the simple variants
+ * public static final DeferredBlock<Block> ROCK_BLOCK = BLOCKS.registerSimpleBlock("rock", Block.Properties.create(Material.ROCK));
+ * public static final DeferredItem<BlockItem> ROCK_ITEM = ITEMS.registerSimpleBlockItem(ROCK_BLOCK, new Item.Properties());
+ *
+ * // Otherwise, use the regular (non-'simple') variants
+ * public static final DeferredBlock<SpecialRockBlock> SPECIAL_ROCK_BLOCK = BLOCKS.registerBlock("special_rock", SpecialRockBlock::new, Block.Properties.create(Material.ROCK));
+ * // (#registerSimpleBlockItem does not have a non-'simple' variant -- register an item in the usual way)
+ * public static final DeferredItem<SpecialRockItem> SPECIAL_ROCK_ITEM = ITEMS.register("special_rock", () -> new SpecialRockItem(SPECIAL_ROCK_BLOCK.get(), new Item.Properties()))
+ *
  * // (Can be DeferredHolder<BlockEntityType<?>, BlockEntityType<RockBlockEntity>> if you prefer)
  * public static final Supplier<BlockEntityType<RockBlockEntity>> ROCK_BLOCK_ENTITY = BLOCK_ENTITIES.register("rock", () -> BlockEntityType.Builder.of(RockBlockEntity::new, ROCK_BLOCK.get()).build(null));
  *

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -107,7 +107,7 @@ public class DeferredRegister<T> {
 
     /**
      * Factory for a specialized {@link DeferredRegister} for {@link Item Items}.
-     * 
+     *
      * @param modid The namespace for all objects registered to this {@link DeferredRegister}
      * @see #create(Registry, String)
      * @see #create(ResourceKey, String)
@@ -186,7 +186,7 @@ public class DeferredRegister<T> {
 
     /**
      * Create a {@link DeferredHolder} or an inheriting type to be stored.
-     * 
+     *
      * @param registryKey The key of the registry.
      * @param key         The resource location of the entry.
      * @return The new instance of {@link DeferredHolder} or an inheriting type.
@@ -465,7 +465,7 @@ public class DeferredRegister<T> {
          * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          * Where the name is determined by the name of the given block.
-         * 
+         *
          * @param block      The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @param properties The properties for the created {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
@@ -481,7 +481,7 @@ public class DeferredRegister<T> {
          * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          * Where the name is determined by the name of the given block and uses the default {@link Item.Properties}.
-         * 
+         *
          * @param block The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
          * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
@@ -510,7 +510,7 @@ public class DeferredRegister<T> {
         /**
          * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
          * This method uses the default {@link Item.Properties}.
-         * 
+         *
          * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param func A factory for the new item. The factory should not cache the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
@@ -525,7 +525,7 @@ public class DeferredRegister<T> {
         /**
          * Adds a new simple {@link Item} with the given {@link Item.Properties properties} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
-         * 
+         *
          * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param props A factory for the new item. The factory should not cache the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -370,21 +370,21 @@ public class DeferredRegister<T> {
          * @param func  A factory for the new block. The factory should not cache the created block.
          * @param props The properties for the created block.
          * @return A {@link DeferredHolder} that will track updates from the registry for this block.
-         * @see #registerBlock(String, BlockBehaviour.Properties)
+         * @see #registerSimpleBlock(String, BlockBehaviour.Properties)
          */
         public <B extends Block> DeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, BlockBehaviour.Properties props) {
             return this.register(name, () -> func.apply(props));
         }
 
         /**
-         * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+         * Adds a new simple {@link Block} to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
          *
          * @param name  The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param props The properties for the created block.
          * @return A {@link DeferredHolder} that will track updates from the registry for this block.
          * @see #registerBlock(String, Function, BlockBehaviour.Properties)
          */
-        public DeferredBlock<Block> registerBlock(String name, BlockBehaviour.Properties props) {
+        public DeferredBlock<Block> registerSimpleBlock(String name, BlockBehaviour.Properties props) {
             return this.registerBlock(name, Block::new, props);
         }
 
@@ -430,66 +430,66 @@ public class DeferredRegister<T> {
         }
 
         /**
-         * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          *
          * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param block      The supplier for the block to create a {@link BlockItem} for.
          * @param properties The properties for the created {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerBlockItem(String, Supplier)
-         * @see #registerBlockItem(Holder, Item.Properties)
-         * @see #registerBlockItem(Holder)
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, Item.Properties)
+         * @see #registerSimpleBlockItem(Holder)
          */
-        public DeferredItem<BlockItem> registerBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
+        public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
             return this.register(name, key -> new BlockItem(block.get(), properties));
         }
 
         /**
-         * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          * This method uses the default {@link Item.Properties}.
          *
          * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param block The supplier for the block to create a {@link BlockItem} for.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerBlockItem(String, Supplier, Item.Properties)
-         * @see #registerBlockItem(Holder, Item.Properties)
-         * @see #registerBlockItem(Holder)
+         * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
+         * @see #registerSimpleBlockItem(Holder, Item.Properties)
+         * @see #registerSimpleBlockItem(Holder)
          */
-        public DeferredItem<BlockItem> registerBlockItem(String name, Supplier<? extends Block> block) {
-            return this.registerBlockItem(name, block, new Item.Properties());
+        public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block) {
+            return this.registerSimpleBlockItem(name, block, new Item.Properties());
         }
 
         /**
-         * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          * Where the name is determined by the name of the given block.
          * 
          * @param block      The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @param properties The properties for the created {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerBlockItem(String, Supplier, Item.Properties)
-         * @see #registerBlockItem(String, Supplier)
-         * @see #registerBlockItem(Holder)
+         * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder)
          */
-        public DeferredItem<BlockItem> registerBlockItem(Holder<Block> block, Item.Properties properties) {
-            return this.registerBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
+        public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, Item.Properties properties) {
+            return this.registerSimpleBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
         }
 
         /**
-         * Adds a new {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          * Where the name is determined by the name of the given block and uses the default {@link Item.Properties}.
          * 
          * @param block The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerBlockItem(String, Supplier, Item.Properties)
-         * @see #registerBlockItem(String, Supplier)
-         * @see #registerBlockItem(Holder, Item.Properties)
+         * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, Item.Properties)
          */
-        public DeferredItem<BlockItem> registerBlockItem(Holder<Block> block) {
-            return this.registerBlockItem(block, new Item.Properties());
+        public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block) {
+            return this.registerSimpleBlockItem(block, new Item.Properties());
         }
 
         /**
@@ -500,8 +500,8 @@ public class DeferredRegister<T> {
          * @param props The properties for the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
          * @see #registerItem(String, Function)
-         * @see #registerItem(String, Item.Properties)
-         * @see #registerItem(String)
+         * @see #registerSimpleItem(String, Item.Properties)
+         * @see #registerSimpleItem(String)
          */
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Item.Properties props) {
             return this.register(name, () -> func.apply(props));
@@ -515,15 +515,15 @@ public class DeferredRegister<T> {
          * @param func A factory for the new item. The factory should not cache the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
          * @see #registerItem(String, Function, Item.Properties)
-         * @see #registerItem(String, Item.Properties)
-         * @see #registerItem(String)
+         * @see #registerSimpleItem(String, Item.Properties)
+         * @see #registerSimpleItem(String)
          */
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func) {
             return this.registerItem(name, func, new Item.Properties());
         }
 
         /**
-         * Adds a new {@link Item} with the given {@link Item.Properties properties} to the list of entries to be registered and
+         * Adds a new simple {@link Item} with the given {@link Item.Properties properties} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          * 
          * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
@@ -531,23 +531,23 @@ public class DeferredRegister<T> {
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
          * @see #registerItem(String, Function, Item.Properties)
          * @see #registerItem(String, Function)
-         * @see #registerItem(String)
+         * @see #registerSimpleItem(String)
          */
-        public DeferredItem<Item> registerItem(String name, Item.Properties props) {
+        public DeferredItem<Item> registerSimpleItem(String name, Item.Properties props) {
             return this.registerItem(name, Item::new, props);
         }
 
         /**
-         * Adds a new {@link Item} with the default {@link Item.Properties properties} to the list of entries to be registered and
+         * Adds a new simple {@link Item} with the default {@link Item.Properties properties} to the list of entries to be registered and
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          *
          * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
          * @see #registerItem(String, Function, Item.Properties)
          * @see #registerItem(String, Function)
-         * @see #registerItem(String, Item.Properties)
+         * @see #registerSimpleItem(String, Item.Properties)
          */
-        public DeferredItem<Item> registerItem(String name) {
+        public DeferredItem<Item> registerSimpleItem(String name) {
             return this.registerItem(name, Item::new, new Item.Properties());
         }
 

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -39,6 +39,12 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Suppliers should return <em>new</em> instances every time they are invoked.
  *
+ * <p>To create an instance of this helper class, use any of the three factory methods: {@link #create(Registry, String)},
+ * {@link #create(ResourceKey, String)}, or {@link #create(ResourceLocation, String)}. There are also specialized
+ * subclasses of this helper for {@link Block}s and {@link Item}s, created through {@link #createBlocks(String)} and
+ * {@link #createItems(String)} respectively. (Be sure to <em>store the concrete type</em> of those subclasses, rather than
+ * storing them generically as {@code DeferredRegister<Block>} or {@code DeferredRegister<Item>}.)
+ *
  * <p>Here are some common examples for using this class:
  *
  * <pre>{@code
@@ -69,6 +75,9 @@ import org.jetbrains.annotations.Nullable;
  * }</pre>
  *
  * @param <T> the base registry type
+ *
+ * @see DeferredRegister.Blocks
+ * @see DeferredRegister.Items
  */
 public class DeferredRegister<T> {
     /**

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -31,11 +31,15 @@ import net.neoforged.bus.api.IEventBus;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A DeferredRegister is a helper class to aid in registering objects to modded and {@linkplain BuiltInRegistries vanilla registries} and provide deferred suppliers to access those objects. <br>
- * This class maintains a list of all suppliers for entries and registers them during the proper {@link RegisterEvent} event, after being {@linkplain #register(IEventBus) registered} to an event bus.
- * Suppliers should return NEW instances every time.
- * <p>
- * Example Usage:
+ * A helper class to aid in registering objects to modded and {@linkplain BuiltInRegistries vanilla registries} and
+ * provide deferred suppliers to access those objects.
+ *
+ * <p>This class maintains a list of all suppliers for entries and registers them during the proper {@link RegisterEvent}
+ * event, after being {@linkplain #register(IEventBus) registered} to an event bus.
+ *
+ * <p>Suppliers should return <em>new</em> instances every time they are invoked.
+ *
+ * <p>Here are some common examples for using this class:
  *
  * <pre>{@code
  * private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/CustomSoundTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/CustomSoundTypeTest.java
@@ -36,10 +36,10 @@ public class CustomSoundTypeTest {
             () -> SoundEvent.createVariableRangeEvent(new ResourceLocation(MODID, "block.sound_type_test.step")));
     private static final SoundType TEST_SOUND_TYPE = new DeferredSoundType(1.0F, 1.0F, TEST_STEP_EVENT, TEST_STEP_EVENT, TEST_STEP_EVENT, TEST_STEP_EVENT, TEST_STEP_EVENT);
 
-    private static final DeferredBlock<Block> TEST_STEP_BLOCK = BLOCKS.registerBlock("test_block",
+    private static final DeferredBlock<Block> TEST_STEP_BLOCK = BLOCKS.registerSimpleBlock("test_block",
             BlockBehaviour.Properties.of().mapColor(MapColor.WOOD).sound(TEST_SOUND_TYPE));
 
-    private static final DeferredItem<BlockItem> TEST_STEP_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_STEP_BLOCK);
+    private static final DeferredItem<BlockItem> TEST_STEP_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_STEP_BLOCK);
 
     public CustomSoundTypeTest() {
         final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/DeferredRegistryTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/DeferredRegistryTest.java
@@ -47,7 +47,7 @@ public class DeferredRegistryTest {
     private static final DeferredRegister<PosRuleTestType<?>> POS_RULE_TEST_TYPES = DeferredRegister.create(Registries.POS_RULE_TEST, MODID);
 
     private static final DeferredBlock<Block> BLOCK = BLOCKS.register("test", () -> new Block(Block.Properties.of().mapColor(MapColor.STONE)));
-    private static final DeferredItem<BlockItem> ITEM = ITEMS.registerBlockItem(BLOCK);
+    private static final DeferredItem<BlockItem> ITEM = ITEMS.registerSimpleBlockItem(BLOCK);
     private static final DeferredHolder<Custom, Custom> CUSTOM = CUSTOMS.register("test", () -> new Custom() {});
     // Should never be created as the registry doesn't exist - this should silently fail and remain empty
     private static final DeferredHolder<Object, Object> DOESNT_EXIST = DOESNT_EXIST_REG.register("test", Object::new);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEntityOnLoadTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEntityOnLoadTest.java
@@ -41,7 +41,7 @@ public class BlockEntityOnLoadTest {
     private static final DeferredRegister<BlockEntityType<?>> BE_TYPES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, "be_onload_test");
 
     private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.register("be_onload_testblock", () -> new TestBlock(Properties.of().mapColor(MapColor.SAND)));
-    private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_BLOCK);
+    private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
     private static final DeferredHolder<BlockEntityType<?>, BlockEntityType<TestBlockEntity>> TEST_BE_TYPE = BE_TYPES.register("be_onload_testbe", () -> BlockEntityType.Builder.of(TestBlockEntity::new, TEST_BLOCK.get()).build(null));
 
     public BlockEntityOnLoadTest() {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/CustomBreakSoundTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/CustomBreakSoundTest.java
@@ -40,7 +40,7 @@ public class CustomBreakSoundTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
     private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock("testblock", TestBlock::new, BlockBehaviour.Properties.of());
-    private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_BLOCK);
+    private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 
     public CustomBreakSoundTest() {
         if (ENABLED) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/CustomRespawnTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/CustomRespawnTest.java
@@ -39,7 +39,7 @@ public class CustomRespawnTest {
     public static final DeferredBlock<Block> TEST_RESPAWN_BLOCK = BLOCKS.register("test_respawn_block", () -> new CustomRespawnBlock(Block.Properties.of().mapColor(MapColor.WOOD)));
 
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    public static final DeferredItem<BlockItem> TEST_RESPAWN_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_RESPAWN_BLOCK);
+    public static final DeferredItem<BlockItem> TEST_RESPAWN_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_RESPAWN_BLOCK);
 
     public CustomRespawnTest() {
         if (ENABLE) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/FullPotsAccessorDemo.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/FullPotsAccessorDemo.java
@@ -82,7 +82,7 @@ public class FullPotsAccessorDemo {
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MOD_ID);
 
     private static final DeferredBlock<Block> DIORITE_POT = BLOCKS.register("diorite_pot", DioriteFlowerPotBlock::new);
-    private static final DeferredItem<BlockItem> DIORITE_POT_ITEM = ITEMS.registerBlockItem(DIORITE_POT);
+    private static final DeferredItem<BlockItem> DIORITE_POT_ITEM = ITEMS.registerSimpleBlockItem(DIORITE_POT);
     private static final DeferredHolder<BlockEntityType<?>, BlockEntityType<DioriteFlowerPotBlockEntity>> DIORITE_POT_BLOCK_ENTITY = BLOCK_ENTITIES.register(
             "diorite_pot",
             () -> BlockEntityType.Builder.of(DioriteFlowerPotBlockEntity::new, DIORITE_POT.get()).build(null));

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/HideNeighborFaceTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/HideNeighborFaceTest.java
@@ -34,7 +34,7 @@ public class HideNeighborFaceTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
     private static final DeferredBlock<Block> GLASS_SLAB = BLOCKS.register("glass_slab", GlassSlab::new);
-    private static final DeferredItem<BlockItem> GLASS_SLAB_ITEM = ITEMS.registerBlockItem(GLASS_SLAB);
+    private static final DeferredItem<BlockItem> GLASS_SLAB_ITEM = ITEMS.registerSimpleBlockItem(GLASS_SLAB);
 
     public HideNeighborFaceTest() {
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/LevelSensitiveLightBlockTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/LevelSensitiveLightBlockTest.java
@@ -45,7 +45,7 @@ public class LevelSensitiveLightBlockTest {
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MOD_ID);
 
     private static final DeferredBlock<Block> LIGHT_BLOCK = BLOCKS.register("light_block", LightBlock::new);
-    private static final DeferredItem<BlockItem> LIGHT_BLOCK_ITEM = ITEMS.registerBlockItem(LIGHT_BLOCK);
+    private static final DeferredItem<BlockItem> LIGHT_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(LIGHT_BLOCK);
     private static final DeferredHolder<BlockEntityType<?>, BlockEntityType<LightBlockEntity>> LIGHT_BLOCK_ENTITY = BLOCK_ENTITIES.register(
             "light_block", () -> BlockEntityType.Builder.of(LightBlockEntity::new, LIGHT_BLOCK.get()).build(null));
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/OnTreeGrowBlockTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/OnTreeGrowBlockTest.java
@@ -64,8 +64,8 @@ public class OnTreeGrowBlockTest {
             return plantable instanceof SaplingBlock;
         }
     });
-    public static final DeferredItem<BlockItem> TEST_GRASS_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_GRASS_BLOCK);
-    public static final DeferredItem<BlockItem> TEST_DIRT_ITEM = ITEMS.registerBlockItem(TEST_DIRT);
+    public static final DeferredItem<BlockItem> TEST_GRASS_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_GRASS_BLOCK);
+    public static final DeferredItem<BlockItem> TEST_DIRT_ITEM = ITEMS.registerSimpleBlockItem(TEST_DIRT);
 
     public OnTreeGrowBlockTest() {
         if (ENABLED) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/PistonEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/PistonEventTest.java
@@ -55,7 +55,7 @@ public class PistonEventTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
     private static final DeferredBlock<Block> SHIFT_ON_MOVE = BLOCKS.register(blockName, () -> new Block(Block.Properties.of().mapColor(MapColor.STONE)));
-    private static final DeferredItem<BlockItem> SHIFT_ON_MOVE_ITEM = ITEMS.registerBlockItem(SHIFT_ON_MOVE);
+    private static final DeferredItem<BlockItem> SHIFT_ON_MOVE_ITEM = ITEMS.registerSimpleBlockItem(SHIFT_ON_MOVE);
 
     public PistonEventTest() {
         IEventBus modBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/RedstoneSidedConnectivityTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/RedstoneSidedConnectivityTest.java
@@ -33,7 +33,7 @@ public class RedstoneSidedConnectivityTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
     private static final DeferredBlock<Block> TEST_REDSTONE_BLOCK = BLOCKS.register(BLOCK_ID, EastRedstoneBlock::new);
-    private static final DeferredItem<BlockItem> TEST_REDSTONE_BLOCKITEM = ITEMS.registerBlockItem(TEST_REDSTONE_BLOCK);
+    private static final DeferredItem<BlockItem> TEST_REDSTONE_BLOCKITEM = ITEMS.registerSimpleBlockItem(TEST_REDSTONE_BLOCK);
 
     public RedstoneSidedConnectivityTest() {
         if (!ENABLE)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/StickyBlockTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/StickyBlockTest.java
@@ -51,8 +51,8 @@ public class StickyBlockTest {
         }
     });
 
-    public static final DeferredItem<BlockItem> BLUE_BLOCK_ITEM = ITEMS.registerBlockItem(BLUE_BLOCK);
-    public static final DeferredItem<BlockItem> RED_BLOCK_ITEM = ITEMS.registerBlockItem(RED_BLOCK);
+    public static final DeferredItem<BlockItem> BLUE_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(BLUE_BLOCK);
+    public static final DeferredItem<BlockItem> RED_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(RED_BLOCK);
 
     public StickyBlockTest() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/ValidRailShapeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/ValidRailShapeTest.java
@@ -36,7 +36,7 @@ public class ValidRailShapeTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
     private static final DeferredBlock<Block> RAIL_SLOPE_BLOCK = BLOCKS.register("rail_slope", RailSlopeBlock::new);
-    private static final DeferredItem<BlockItem> RAIL_SLOPE_ITEM = ITEMS.registerBlockItem(RAIL_SLOPE_BLOCK);
+    private static final DeferredItem<BlockItem> RAIL_SLOPE_ITEM = ITEMS.registerSimpleBlockItem(RAIL_SLOPE_BLOCK);
 
     public ValidRailShapeTest() {
         if (ENABLED) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/AmbientOcclusionElementsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/AmbientOcclusionElementsTest.java
@@ -29,14 +29,14 @@ public class AmbientOcclusionElementsTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    public static final Holder<Block> AO_BLOCK_SHADE = BLOCKS.registerBlock("ambient_occlusion_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final Holder<Block> AO_BLOCK_NO_SHADE = BLOCKS.registerBlock("ambient_occlusion_no_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final Holder<Block> NO_AO_BLOCK_SHADE = BLOCKS.registerBlock("no_ambient_occlusion_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final Holder<Block> NO_AO_BLOCK_NO_SHADE = BLOCKS.registerBlock("no_ambient_occlusion_no_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final DeferredItem<BlockItem> AO_BLOCK_SHADE_ITEM = ITEMS.registerBlockItem(AO_BLOCK_SHADE);
-    public static final DeferredItem<BlockItem> AO_BLOCK_NO_SHADE_ITEM = ITEMS.registerBlockItem(AO_BLOCK_NO_SHADE);
-    public static final DeferredItem<BlockItem> NO_AO_BLOCK_SHADE_ITEM = ITEMS.registerBlockItem(NO_AO_BLOCK_SHADE);
-    public static final DeferredItem<BlockItem> NO_AO_BLOCK_NO_SHADE_ITEM = ITEMS.registerBlockItem(NO_AO_BLOCK_NO_SHADE);
+    public static final Holder<Block> AO_BLOCK_SHADE = BLOCKS.registerSimpleBlock("ambient_occlusion_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final Holder<Block> AO_BLOCK_NO_SHADE = BLOCKS.registerSimpleBlock("ambient_occlusion_no_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final Holder<Block> NO_AO_BLOCK_SHADE = BLOCKS.registerSimpleBlock("no_ambient_occlusion_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final Holder<Block> NO_AO_BLOCK_NO_SHADE = BLOCKS.registerSimpleBlock("no_ambient_occlusion_no_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final DeferredItem<BlockItem> AO_BLOCK_SHADE_ITEM = ITEMS.registerSimpleBlockItem(AO_BLOCK_SHADE);
+    public static final DeferredItem<BlockItem> AO_BLOCK_NO_SHADE_ITEM = ITEMS.registerSimpleBlockItem(AO_BLOCK_NO_SHADE);
+    public static final DeferredItem<BlockItem> NO_AO_BLOCK_SHADE_ITEM = ITEMS.registerSimpleBlockItem(NO_AO_BLOCK_SHADE);
+    public static final DeferredItem<BlockItem> NO_AO_BLOCK_NO_SHADE_ITEM = ITEMS.registerSimpleBlockItem(NO_AO_BLOCK_NO_SHADE);
 
     public AmbientOcclusionElementsTest() {
         if (!ENABLED)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/CustomColorResolverTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/CustomColorResolverTest.java
@@ -38,7 +38,7 @@ public class CustomColorResolverTest {
         ITEMS.register(modBus);
         BLOCKS.register(modBus);
 
-        ITEMS.registerBlockItem(BLOCK);
+        ITEMS.registerSimpleBlockItem(BLOCK);
     }
 
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/EmissiveElementsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/EmissiveElementsTest.java
@@ -28,7 +28,7 @@ public class EmissiveElementsTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
     public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.register("emissive", () -> new Block(BlockBehaviour.Properties.of().mapColor(MapColor.STONE)));
-    public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_BLOCK);
+    public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 
     public EmissiveElementsTest() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/model/MegaModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/model/MegaModelTest.java
@@ -75,7 +75,7 @@ public class MegaModelTest {
 
     private static final String REG_NAME = "test_block";
     public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.register(REG_NAME, TestBlock::new);
-    public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_BLOCK);
+    public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
     public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<?>> TEST_BLOCK_ENTITY = BLOCK_ENTITIES.register(REG_NAME, () -> new BlockEntityType<>(
             TestBlock.Entity::new, Set.of(TEST_BLOCK.get()), null));
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/model/MultiLayerModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/model/MultiLayerModelTest.java
@@ -31,7 +31,7 @@ public class MultiLayerModelTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
     private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.register(blockName, () -> new Block(Block.Properties.of().mapColor(MapColor.WOOD).noOcclusion()));
-    private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerBlockItem(TEST_BLOCK);
+    private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 
     public MultiLayerModelTest() {
         if (!ENABLED)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/model/NewModelLoaderTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/model/NewModelLoaderTest.java
@@ -85,15 +85,15 @@ public class NewModelLoaderTest {
         }
     });
 
-    public static DeferredItem<Item> custom_transforms = ITEMS.registerItem("custom_transforms");
+    public static DeferredItem<Item> custom_transforms = ITEMS.registerSimpleItem("custom_transforms");
 
-    public static DeferredItem<Item> custom_vanilla_loader = ITEMS.registerItem("custom_vanilla_loader");
+    public static DeferredItem<Item> custom_vanilla_loader = ITEMS.registerSimpleItem("custom_vanilla_loader");
 
-    public static DeferredItem<Item> custom_loader = ITEMS.registerItem("custom_loader");
+    public static DeferredItem<Item> custom_loader = ITEMS.registerSimpleItem("custom_loader");
 
-    public static DeferredItem<Item> item_layers = ITEMS.registerItem("item_layers");
+    public static DeferredItem<Item> item_layers = ITEMS.registerSimpleItem("item_layers");
 
-    public static DeferredItem<Item> separate_perspective = ITEMS.registerItem("separate_perspective");
+    public static DeferredItem<Item> separate_perspective = ITEMS.registerSimpleItem("separate_perspective");
 
     public NewModelLoaderTest() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/TagBasedToolTypesTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/TagBasedToolTypesTest.java
@@ -55,11 +55,11 @@ public class TagBasedToolTypesTest {
             List.of(Tiers.DIAMOND), List.of());
 
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
-    private static final DeferredBlock<Block> STONE = BLOCKS.registerBlock("test_stone", BlockBehaviour.Properties.of().mapColor(MapColor.DIRT).requiresCorrectToolForDrops().strength(1.5F, 6.0F));
+    private static final DeferredBlock<Block> STONE = BLOCKS.registerSimpleBlock("test_stone", BlockBehaviour.Properties.of().mapColor(MapColor.DIRT).requiresCorrectToolForDrops().strength(1.5F, 6.0F));
 
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
     @SuppressWarnings("unused")
-    private static final DeferredItem<BlockItem> ORE_ITEM = ITEMS.registerBlockItem(STONE);
+    private static final DeferredItem<BlockItem> ORE_ITEM = ITEMS.registerSimpleBlockItem(STONE);
     private static final DeferredItem<Item> TOOL = ITEMS.register("test_tool", () -> {
         return new DiggerItem(1, 1, MY_TIER, MINEABLE_TAG, new Item.Properties()) {
             @Override

--- a/tests/src/main/java/net/neoforged/neoforge/debug/misc/GameTestTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/misc/GameTestTest.java
@@ -53,7 +53,7 @@ public class GameTestTest {
     private static final DeferredBlock<Block> ENERGY_BLOCK = BLOCKS.register("energy_block",
             () -> new EnergyBlock(Properties.of().mapColor(MapColor.STONE)));
     @SuppressWarnings("unused")
-    private static final DeferredItem<BlockItem> ENERGY_BLOCK_ITEM = ITEMS.registerBlockItem(ENERGY_BLOCK);
+    private static final DeferredItem<BlockItem> ENERGY_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(ENERGY_BLOCK);
     private static final DeferredHolder<BlockEntityType<?>, BlockEntityType<?>> ENERGY_BLOCK_ENTITY = BLOCK_ENTITIES.register("energy",
             () -> BlockEntityType.Builder.of(EnergyBlockEntity::new, ENERGY_BLOCK.get()).build(null));
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/world/ForgeChunkManagerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/world/ForgeChunkManagerTest.java
@@ -38,7 +38,7 @@ public class ForgeChunkManagerTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
     private static final DeferredBlock<Block> CHUNK_LOADER_BLOCK = BLOCKS.register("chunk_loader", () -> new ChunkLoaderBlock(Properties.of().mapColor(MapColor.STONE)));
-    private static final DeferredItem<BlockItem> CHUNK_LOADER_ITEM = ITEMS.registerBlockItem(CHUNK_LOADER_BLOCK);
+    private static final DeferredItem<BlockItem> CHUNK_LOADER_ITEM = ITEMS.registerSimpleBlockItem(CHUNK_LOADER_BLOCK);
 
     public ForgeChunkManagerTest() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();


### PR DESCRIPTION
This PR renames certain helper methods on the two specializations of `DeferredRegister` to mark them as being 'simple' -- that they use the `Block`, `Item`, and `BlockItem` classes for creating the corresponding instance, without a parameter to change what class or constructor is used. (Other methods exist for specifying one's own classes to be used for creating the instances: the standard `register` method, or the `registerBlock` and `registerItem` methods.)

Renaming these methods to include `simple` in their name reduces possible confusion that may arise. This is particularly evident with the previously-named `registerBlock` overload. A user may use that method while intending to pass a `Supplier`, not realizing the proper method would be the `register` method, and facing a compile error about their lambda's target (which is `BlockBehaviour.Properties`) not being a functional interface.

This is a product of various discussions in the `#neoforge-github` and `#maintenance-talk` channels on the Discord server. See [my message in the `maintenance-talk` channel](https://canary.discord.com/channels/313125603924639766/1154167065519861831/1177573250528706642), and the surrounding conversation.

This PR also includes various additions and cleanup to the javadocs in `DeferredRegister`, chiefly to the class javadoc for expanding its example code to use both simple and non-simple `register*` methods.