### PR TITLE
Fix the `test runthis` command

### DIFF
--- a/patches/net/minecraft/gametest/framework/GameTestInfo.java.patch
+++ b/patches/net/minecraft/gametest/framework/GameTestInfo.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/gametest/framework/GameTestInfo.java
++++ b/net/minecraft/gametest/framework/GameTestInfo.java
+@@ -206,6 +_,7 @@
+       this.structureBlockEntity = StructureUtils.spawnStructure(this.getStructureName(), p_127620_, this.getRotation(), p_127621_, this.level, false);
+       this.structureBlockPos = this.structureBlockEntity.getBlockPos();
+       this.structureBlockEntity.setStructureName(this.getTestName());
++      this.structureBlockEntity.setMetaData(this.getTestName()); // Neo: set the test name as metadata as it isn't always RL-compatible
+       StructureUtils.addCommandBlockAndButtonToStartTest(this.structureBlockPos, new BlockPos(1, 0, -1), this.getRotation(), this.level);
+       this.listeners.forEach(p_127630_ -> p_127630_.testStructureLoaded(this));
+    }

--- a/patches/net/minecraft/gametest/framework/TestCommand.java.patch
+++ b/patches/net/minecraft/gametest/framework/TestCommand.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/gametest/framework/TestCommand.java
++++ b/net/minecraft/gametest/framework/TestCommand.java
+@@ -315,7 +_,7 @@
+ 
+    private static void runTest(ServerLevel p_127930_, BlockPos p_127931_, @Nullable MultipleTestTracker p_127932_) {
+       StructureBlockEntity structureblockentity = (StructureBlockEntity)p_127930_.getBlockEntity(p_127931_);
+-      String s = structureblockentity.getStructurePath();
++      String s = structureblockentity.getMetaData().isBlank() ? structureblockentity.getStructureName() : structureblockentity.getMetaData(); // Neo: use the metadata for the structure name
+       TestFunction testfunction = GameTestRegistry.getTestFunction(s);
+       GameTestInfo gametestinfo = new GameTestInfo(testfunction, structureblockentity.getRotation(), p_127930_);
+       if (p_127932_ != null) {


### PR DESCRIPTION
Game test names aren't always RL-compatible, and since the structure name is a RL, `test runthis` / `test runthese` will not work for game tests that have upper-case characters in their name, or don't have a namespace in their name (namespace that `ResourceLocation#toString` includes)
The commands will now use the structure block metadata instead.