### PR TITLE
[1.20.2] Reallow Warden melee attacks to disable shields

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -771,8 +771,12 @@
        Equipable equipable = Equipable.get(p_147234_);
        return equipable != null ? equipable.getEquipmentSlot() : EquipmentSlot.MAINHAND;
     }
-@@ -3438,6 +_,11 @@
-       return this.getMainHandItem().getItem() instanceof AxeItem;
+@@ -3435,9 +_,14 @@
+    }
+ 
+    public boolean canDisableShield() {
+-      return this.getMainHandItem().getItem() instanceof AxeItem;
++      return this.getMainHandItem().canDisableShield(this.useItem, this, this);
     }
  
 +   /**

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -121,15 +121,6 @@
        if (this.isInvulnerableTo(p_36154_)) {
           return false;
        } else if (this.abilities.invulnerable && !p_36154_.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
-@@ -865,7 +_,7 @@
-    @Override
-    protected void blockUsingShield(LivingEntity p_36295_) {
-       super.blockUsingShield(p_36295_);
--      if (p_36295_.canDisableShield()) {
-+      if (p_36295_.getMainHandItem().canDisableShield(this.useItem, this, p_36295_)) {
-          this.disableShield(true);
-       }
-    }
 @@ -897,7 +_,7 @@
  
     @Override


### PR DESCRIPTION
This fixes #293 by moving the `p_36295_.getMainHandItem().canDisableShield(this.useItem, this, p_36295_)`  call from `Player#blockUsingShield` to `LivingEntity#canDisableShield().` With this change, Wardens are now once-again able to disable player shields with their melee attacks.