### PR TITLE
Restore smelting result count and nbt extensions

### DIFF
--- a/patches/net/minecraft/world/item/crafting/SimpleCookingSerializer.java.patch
+++ b/patches/net/minecraft/world/item/crafting/SimpleCookingSerializer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/crafting/SimpleCookingSerializer.java
++++ b/net/minecraft/world/item/crafting/SimpleCookingSerializer.java
+@@ -19,7 +_,7 @@
+                   ExtraCodecs.strictOptionalField(Codec.STRING, "group", "").forGetter(p_300832_ -> p_300832_.group),
+                   CookingBookCategory.CODEC.fieldOf("category").orElse(CookingBookCategory.MISC).forGetter(p_300828_ -> p_300828_.category),
+                   Ingredient.CODEC_NONEMPTY.fieldOf("ingredient").forGetter(p_300833_ -> p_300833_.ingredient),
+-                  BuiltInRegistries.ITEM.byNameCodec().xmap(ItemStack::new, ItemStack::getItem).fieldOf("result").forGetter(p_300827_ -> p_300827_.result),
++                  net.neoforged.neoforge.common.crafting.CraftingHelper.smeltingResultCodec().fieldOf("result").forGetter(p_300827_ -> p_300827_.result),
+                   Codec.FLOAT.fieldOf("experience").orElse(0.0F).forGetter(p_300826_ -> p_300826_.experience),
+                   Codec.INT.fieldOf("cookingtime").orElse(p_44331_).forGetter(p_300834_ -> p_300834_.cookingTime)
+                )

--- a/tests/src/main/resources/data/recipe_extensions/recipes/smelting_multi_output.json
+++ b/tests/src/main/resources/data/recipe_extensions/recipes/smelting_multi_output.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "item": "minecraft:diamond_block"
+  },
+  "result": {
+    "item": "minecraft:diamond",
+    "count": 9
+  },
+  "cookingtime": 100
+}


### PR DESCRIPTION
They were not ported to the new codec recipe system during the 1.20.2 port. The furnace still has the patches to support this extra information, only the serialization needs to be restored.

Fixes #290.