### PR TITLE
Deprecate mod id inference to prepare for the move of registration events to the Forge bus

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -156,9 +156,21 @@ public abstract class ModelEvent extends Event {
 
         /**
          * Registers a new geometry loader.
+         * 
+         * @deprecated Use {@link #register(ResourceLocation, IGeometryLoader) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
          */
+        @Deprecated(forRemoval = true, since = "1.20.2")
         public void register(String name, IGeometryLoader<?> loader) {
-            var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name);
+            register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), loader);
+        }
+
+        /**
+         * Registers a new geometry loader.
+         * 
+         * @param key    the ID of the loader
+         * @param loader the geometry loader to register
+         */
+        public void register(ResourceLocation key, IGeometryLoader<?> loader) {
             Preconditions.checkArgument(!loaders.containsKey(key), "Geometry loader already registered: " + key);
             loaders.put(key, loader);
         }

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterGuiOverlaysEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterGuiOverlaysEvent.java
@@ -43,8 +43,20 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent {
      *
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
+     * @deprecated Use {@link #registerBelowAll(ResourceLocation, IGuiOverlay) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
      */
+    @Deprecated(forRemoval = true, since = "1.20.2")
     public void registerBelowAll(@NotNull String id, @NotNull IGuiOverlay overlay) {
+        registerBelowAll(new ResourceLocation(id, ModLoadingContext.get().getActiveNamespace()), overlay);
+    }
+
+    /**
+     * Registers an overlay that renders below all others.
+     *
+     * @param id      A unique resource id for this overlay
+     * @param overlay The overlay
+     */
+    public void registerBelowAll(@NotNull ResourceLocation id, @NotNull IGuiOverlay overlay) {
         register(Ordering.BEFORE, null, id, overlay);
     }
 
@@ -55,8 +67,22 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent {
      *                {@link VanillaGuiOverlay vanilla overlay}. Do not use other mods' overlays.
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
+     * @deprecated Use {@link #registerBelow(ResourceLocation, ResourceLocation, IGuiOverlay) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
      */
+    @Deprecated(forRemoval = true, since = "1.20.2")
     public void registerBelow(@NotNull ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay) {
+        registerBelow(other, new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), id), overlay);
+    }
+
+    /**
+     * Registers an overlay that renders below another.
+     *
+     * @param other   The id of the overlay to render below. This must be an overlay you have already registered or a
+     *                {@link VanillaGuiOverlay vanilla overlay}. Do not use other mods' overlays.
+     * @param id      A unique resource id for this overlay
+     * @param overlay The overlay
+     */
+    public void registerBelow(@NotNull ResourceLocation other, @NotNull ResourceLocation id, @NotNull IGuiOverlay overlay) {
         register(Ordering.BEFORE, other, id, overlay);
     }
 
@@ -67,8 +93,22 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent {
      *                {@link VanillaGuiOverlay vanilla overlay}. Do not use other mods' overlays.
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
+     * @deprecated Use {@link #registerAbove(ResourceLocation, ResourceLocation, IGuiOverlay) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
      */
+    @Deprecated(forRemoval = true, since = "1.20.2")
     public void registerAbove(@NotNull ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay) {
+        registerAbove(other, new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), id), overlay);
+    }
+
+    /**
+     * Registers an overlay that renders above another.
+     *
+     * @param other   The id of the overlay to render above. This must be an overlay you have already registered or a
+     *                {@link VanillaGuiOverlay vanilla overlay}. Do not use other mods' overlays.
+     * @param id      A unique resource id for this overlay
+     * @param overlay The overlay
+     */
+    public void registerAbove(@NotNull ResourceLocation other, @NotNull ResourceLocation id, @NotNull IGuiOverlay overlay) {
         register(Ordering.AFTER, other, id, overlay);
     }
 
@@ -77,13 +117,24 @@ public class RegisterGuiOverlaysEvent extends Event implements IModBusEvent {
      *
      * @param id      A unique resource id for this overlay
      * @param overlay The overlay
+     * @deprecated Use {@link #registerAboveAll(ResourceLocation, IGuiOverlay) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
      */
+    @Deprecated(forRemoval = true, since = "1.20.2")
     public void registerAboveAll(@NotNull String id, @NotNull IGuiOverlay overlay) {
+        registerAboveAll(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), id), overlay);
+    }
+
+    /**
+     * Registers an overlay that renders above all others.
+     *
+     * @param id      A unique resource id for this overlay
+     * @param overlay The overlay
+     */
+    public void registerAboveAll(@NotNull ResourceLocation id, @NotNull IGuiOverlay overlay) {
         register(Ordering.AFTER, null, id, overlay);
     }
 
-    private void register(@NotNull Ordering ordering, @Nullable ResourceLocation other, @NotNull String id, @NotNull IGuiOverlay overlay) {
-        var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), id);
+    private void register(@NotNull Ordering ordering, @Nullable ResourceLocation other, @NotNull ResourceLocation key, @NotNull IGuiOverlay overlay) {
         Preconditions.checkArgument(!overlays.containsKey(key), "Overlay already registered: " + key);
 
         int insertPosition;

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterNamedRenderTypesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterNamedRenderTypesEvent.java
@@ -40,9 +40,22 @@ public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
      * @param name             The name
      * @param blockRenderType  One of the values returned by {@link RenderType#chunkBufferLayers()}
      * @param entityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
+     * @deprecated Use {@link #register(ResourceLocation, RenderType, RenderType) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
      */
+    @Deprecated(forRemoval = true, since = "1.20.2")
     public void register(String name, RenderType blockRenderType, RenderType entityRenderType) {
-        register(name, blockRenderType, entityRenderType, entityRenderType);
+        register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), blockRenderType, entityRenderType, entityRenderType);
+    }
+
+    /**
+     * Registers a named {@link RenderTypeGroup}.
+     *
+     * @param key              The ID of the group
+     * @param blockRenderType  One of the values returned by {@link RenderType#chunkBufferLayers()}
+     * @param entityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
+     */
+    public void register(ResourceLocation key, RenderType blockRenderType, RenderType entityRenderType) {
+        register(key, blockRenderType, entityRenderType, entityRenderType);
     }
 
     /**
@@ -53,9 +66,23 @@ public class RegisterNamedRenderTypesEvent extends Event implements IModBusEvent
      * @param entityRenderType         A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
      * @param fabulousEntityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY} for use when
      *                                 "fabulous" rendering is enabled
+     * @deprecated Use {@link #register(ResourceLocation, RenderType, RenderType, RenderType) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
      */
+    @Deprecated(forRemoval = true, since = "1.20.2")
     public void register(String name, RenderType blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType) {
-        var key = new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name);
+        register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), blockRenderType, entityRenderType, fabulousEntityRenderType);
+    }
+
+    /**
+     * Registers a named {@link RenderTypeGroup}.
+     *
+     * @param key                      The ID of the group
+     * @param blockRenderType          One of the values returned by {@link RenderType#chunkBufferLayers()}
+     * @param entityRenderType         A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY}
+     * @param fabulousEntityRenderType A {@link RenderType} using {@link DefaultVertexFormat#NEW_ENTITY} for use when
+     *                                 "fabulous" rendering is enabled
+     */
+    public void register(ResourceLocation key, RenderType blockRenderType, RenderType entityRenderType, RenderType fabulousEntityRenderType) {
         Preconditions.checkArgument(!renderTypes.containsKey(key), "Render type already registered: " + key);
         Preconditions.checkArgument(blockRenderType.format() == DefaultVertexFormat.BLOCK, "The block render type must use the BLOCK vertex format.");
         Preconditions.checkArgument(blockRenderType.getChunkLayerId() >= 0, "Only chunk render types can be used for block rendering. Query RenderType#chunkBufferLayers() for a list.");

--- a/src/main/java/net/neoforged/neoforge/registries/RegisterEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/RegisterEvent.java
@@ -99,7 +99,9 @@ public class RegisterEvent extends Event implements IModBusEvent {
          *
          * @param name  the name of the object to register as its key with the namespaced inferred from the active mod container
          * @param value the object value
+         * @deprecated Use {@link #register(ResourceLocation, Object) the RL-explicit variant} instead; mod ID inference will be removed in a later update, alongside the move of registration events to the NeoForge main bus
          */
+        @Deprecated(forRemoval = true, since = "1.20.2")
         default void register(String name, T value) {
             register(new ResourceLocation(ModLoadingContext.get().getActiveNamespace(), name), value);
         }


### PR DESCRIPTION
Affected events:
- `ModelEvent$RegisterGeometryLoaders`
- `RegisterGuiOverlaysEvent`
- `RegisterNamedRenderTypesEvent`
- `RegisterEvent$RegisterHelper`