### PR TITLE
New event: ClientPauseUpdateEvent

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -242,6 +242,14 @@
          }
  
          if (this.fpsPieResults != null) {
+@@ -1269,6 +_,7 @@
+             }
+ 
+             this.pause = flag1;
++            net.neoforged.neoforge.client.ClientHooks.onClientPauseUpdate(this.pause);
+         }
+ 
+         long l = Util.getNanos();
 @@ -1361,10 +_,12 @@
          this.window.setGuiScale((double)i);
          if (this.screen != null) {

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -137,6 +137,7 @@ import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.ClientChatReceivedEvent;
+import net.neoforged.neoforge.client.event.ClientPauseUpdatedEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerChangeGameTypeEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
@@ -251,6 +252,10 @@ public class ClientHooks {
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, EquipmentSlot slot, String type) {
         String result = armor.getItem().getArmorTexture(armor, entity, slot, type);
         return result != null ? result : _default;
+    }
+
+    public static void onClientPauseUpdate(boolean paused) {
+        NeoForge.EVENT_BUS.post(new ClientPauseUpdatedEvent(paused));
     }
 
     public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource) {

--- a/src/main/java/net/neoforged/neoforge/client/event/ClientPauseUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ClientPauseUpdatedEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import net.minecraft.client.Minecraft;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+
+/**
+ * Fired when the client is {@linkplain Minecraft#pause pause} and no longer performing ticks.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class ClientPauseUpdatedEvent extends Event {
+    private final boolean paused;
+
+    public ClientPauseUpdatedEvent(boolean isPaused) {
+        this.paused = isPaused;
+    }
+
+    /**
+     * {@return game is paused}
+     */
+    public boolean isPaused() {
+        return paused;
+    }
+}


### PR DESCRIPTION
Simple hook fired when game pause is updated (``Minecraft#paused``)
Simple explanation of why this event: https://github.com/MinecraftForge/MinecraftForge/pull/9763#issuecomment-1783904855