### PR TITLE
Redirect crash reports to NeoForge discord instead of Forge forums

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -1,6 +1,6 @@
 ---
 name: Issue report
-about: Visit the forum first for issues with crashes.
+about: Visit the discord first for issues with crashes.
 title: ''
 labels: triage
 assignees: ''
@@ -9,8 +9,8 @@ assignees: ''
 
 <!-- Thank you for reporting! -->
 
-<!-- For support with crashes and issues, please create a post on the forum instead: -->
-<!-- https://www.minecraftforge.net/forum/forum/18-support-bug-reports/ -->
+<!-- For support with crashes and issues, please make a post in #user-support channel in NeoForge Discord instead: -->
+<!-- https://discord.gg/UvedJ9m -->
 
 **Minecraft Version:** {Minecraft version}
 


### PR DESCRIPTION
What title says yeah since Forge forum won't help with NeoForge stuff