### PR TITLE
[1.20.4] Made mod list search bar 2 pixels wider

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -262,7 +262,7 @@ public class ModListScreen extends Screen {
         y -= 20 + PADDING;
         configButton = Button.builder(Component.translatable("fml.menu.mods.config"), b -> ModListScreen.this.displayModConfig()).bounds(6, y, this.listWidth, 20).build();
         y -= 14 + PADDING;
-        search = new EditBox(getFontRenderer(), PADDING + 1, y, listWidth - 2, 14, Component.translatable("fml.menu.mods.search"));
+        search = new EditBox(getFontRenderer(), PADDING + 1, y, listWidth - 1, 14, Component.translatable("fml.menu.mods.search"));
 
         this.modList = new ModListWidget(this, listWidth, fullButtonHeight, search.getY() - getFontRenderer().lineHeight - PADDING);
         this.modList.setX(6);

--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -262,7 +262,7 @@ public class ModListScreen extends Screen {
         y -= 20 + PADDING;
         configButton = Button.builder(Component.translatable("fml.menu.mods.config"), b -> ModListScreen.this.displayModConfig()).bounds(6, y, this.listWidth, 20).build();
         y -= 14 + PADDING;
-        search = new EditBox(getFontRenderer(), PADDING + 1, y, listWidth - 1, 14, Component.translatable("fml.menu.mods.search"));
+        search = new EditBox(getFontRenderer(), PADDING, y, listWidth, 14, Component.translatable("fml.menu.mods.search"));
 
         this.modList = new ModListWidget(this, listWidth, fullButtonHeight, search.getY() - getFontRenderer().lineHeight - PADDING);
         this.modList.setX(6);

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -9,7 +9,7 @@
   "fml.menu.mods.openmodsfolder": "Open mods folder",
   "fml.menu.modoptions": "Mod Options...",
   "fml.menu.mods.info.version":"Version: {0}",
-  "fml.menu.mods.info.idstate":"ModID: {0} State:{1,lower}",
+  "fml.menu.mods.info.idstate":"ModID: {0} State: {1,lower}",
   "fml.menu.mods.info.credits":"Credits: {0}",
   "fml.menu.mods.info.authors":"Authors: {0}",
   "fml.menu.mods.info.displayurl":"Homepage: {0}",


### PR DESCRIPTION
Resolves Sciwhiz12's notice of search bar being 2 pixel too short. (Was originally moved right by 1 and shrunk width by 2)
https://github.com/neoforged/NeoForge/issues/108

Fixed search bar looks:
![image](https://github.com/neoforged/NeoForge/assets/40846040/6231ccb5-b6b5-4183-884f-46b02ae1ce7b)

The main issue in that issue report is not reproducible in my testing which leads me to believe it was already fixed.