### PR TITLE
[1.20.4] Have Fishing Rods call onPlayerDestroyItem when they break

### DIFF
--- a/patches/net/minecraft/world/item/FishingRodItem.java.patch
+++ b/patches/net/minecraft/world/item/FishingRodItem.java.patch
@@ -1,14 +1,27 @@
 --- a/net/minecraft/world/item/FishingRodItem.java
 +++ b/net/minecraft/world/item/FishingRodItem.java
-@@ -64,4 +_,11 @@
+@@ -22,7 +_,11 @@
+         if (p_41291_.fishing != null) {
+             if (!p_41290_.isClientSide) {
+                 int i = p_41291_.fishing.retrieve(itemstack);
++                ItemStack original = itemstack.copy();
+                 itemstack.hurtAndBreak(i, p_41291_, p_41288_ -> p_41288_.broadcastBreakEvent(p_41292_));
++                if(itemstack.isEmpty()) {
++                    net.neoforged.neoforge.event.EventHooks.onPlayerDestroyItem(p_41291_, original, p_41292_);
++                }
+             }
+ 
+             p_41290_.playSound(
+@@ -63,5 +_,12 @@
+     @Override
      public int getEnchantmentValue() {
          return 1;
-     }
++    }
 +
 +     /* ******************** FORGE START ******************** */
 +
 +     @Override
 +    public boolean canPerformAction(ItemStack stack, net.neoforged.neoforge.common.ToolAction toolAction) {
 +        return net.neoforged.neoforge.common.ToolActions.DEFAULT_FISHING_ROD_ACTIONS.contains(toolAction);
-+    }
+     }
  }


### PR DESCRIPTION
Resolves this issue report
https://github.com/neoforged/NeoForge/issues/111