### PR TITLE
Unquote game dir in runs

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -160,7 +160,7 @@ runs.configureEach { it ->
     gameDir.mkdirs();
 
     it.workingDirectory.set gameDir
-    it.programArguments.addAll '--gameDir', "\"${gameDir.absolutePath}\""
+    it.programArguments.addAll '--gameDir', gameDir.absolutePath
 }
 
 launcherProfile {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -78,7 +78,7 @@ runs {
         gameDir.mkdirs();
 
         workingDirectory.set gameDir
-        programArguments.addAll '--gameDir', "\"${gameDir.absolutePath}\""
+        programArguments.addAll '--gameDir', gameDir.absolutePath
     }
 }
 


### PR DESCRIPTION
The referenced NeoGradle version will already quote this argument, leading to double-quoted arguments if the directory contains spaces.