### PR TITLE
[1.20.4] Render demo mode remaining time text properly

### DIFF
--- a/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
@@ -40,6 +40,20 @@
          this.renderLines(p_281261_, list, false);
      }
  
+@@ -508,6 +_,13 @@
+             GlUtil.getRenderer(),
+             GlUtil.getOpenGLVersion()
+         );
++        if (this.minecraft.isDemo()) {
++            if (this.minecraft.level.getGameTime() >= 120500L) {
++                list.add(0, net.minecraft.network.chat.Component.translatable("demo.demoExpired").getString());
++            } else {
++                list.add(0, net.minecraft.network.chat.Component.translatable("demo.remainingTime", net.minecraft.util.StringUtil.formatTickDuration((int)(120500L - this.minecraft.level.getGameTime()), this.minecraft.level.tickRateManager().tickrate())).getString());
++            }
++        }
+         if (this.minecraft.showOnlyReducedInfo()) {
+             return list;
+         } else {
 @@ -544,6 +_,7 @@
                  list.add("");
                  list.add(ChatFormatting.UNDERLINE + "Targeted Entity");

--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
@@ -483,12 +483,6 @@ public class ExtendedGui extends Gui {
         RenderSystem.disableBlend();
     }
 
-    protected void renderDemo(GuiGraphics guiGraphics) {
-        if (this.minecraft.isDemo()) {
-            this.renderDemoOverlay(guiGraphics);
-        }
-    }
-
     //Helper macros
     private boolean pre(NamedGuiOverlay overlay, GuiGraphics guiGraphics) {
         return NeoForge.EVENT_BUS.post(new RenderGuiOverlayEvent.Pre(minecraft.getWindow(), guiGraphics, minecraft.getFrameTime(), overlay)).isCanceled();

--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
@@ -483,6 +483,12 @@ public class ExtendedGui extends Gui {
         RenderSystem.disableBlend();
     }
 
+    protected void renderDemo(GuiGraphics guiGraphics) {
+        if (this.minecraft.isDemo()) {
+            this.renderDemoOverlay(guiGraphics);
+        }
+    }
+
     //Helper macros
     private boolean pre(NamedGuiOverlay overlay, GuiGraphics guiGraphics) {
         return NeoForge.EVENT_BUS.post(new RenderGuiOverlayEvent.Pre(minecraft.getWindow(), guiGraphics, minecraft.getFrameTime(), overlay)).isCanceled();

--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/VanillaGuiOverlay.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/VanillaGuiOverlay.java
@@ -138,8 +138,8 @@ public enum VanillaGuiOverlay {
         gui.renderSleepFade(screenWidth, screenHeight, guiGraphics);
     }),
     DEMO_OVERLAY("demo_overlay", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {
-        if (!gui.getDebugOverlay().showDebugScreen()) {
-            gui.renderDemo(guiGraphics);
+        if (gui.getMinecraft().isDemo() && !gui.getDebugOverlay().showDebugScreen()) {
+            gui.renderDemoOverlay(guiGraphics);
         }
     }),
     POTION_ICONS("potion_icons", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {

--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/VanillaGuiOverlay.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/VanillaGuiOverlay.java
@@ -137,6 +137,11 @@ public enum VanillaGuiOverlay {
     SLEEP_FADE("sleep_fade", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {
         gui.renderSleepFade(screenWidth, screenHeight, guiGraphics);
     }),
+    DEMO_OVERLAY("demo_overlay", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {
+        if (!gui.getDebugOverlay().showDebugScreen()) {
+            gui.renderDemo(guiGraphics);
+        }
+    }),
     POTION_ICONS("potion_icons", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {
         gui.renderEffects(guiGraphics);
     }),


### PR DESCRIPTION
Resolves: https://github.com/neoforged/NeoForge/issues/166

Remaining time will be incorporated into debug text in a clean way too.

![image](https://github.com/neoforged/NeoForge/assets/40846040/8899f6e4-78b8-4363-84ea-1e57bba3cacf)

![image](https://github.com/neoforged/NeoForge/assets/40846040/a8b73b74-3841-4bb5-93a4-04b4289c97f1)
