### PR TITLE
[1.20.4] Split mod logo filepath on slashes for mod list menu

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -383,7 +383,7 @@ public class ModListScreen extends Screen {
                     .orElse(ResourcePackLoader.getPackFor("neoforge").orElseThrow(() -> new RuntimeException("Can't find neoforge, WHAT!")));
             try {
                 NativeImage logo = null;
-                IoSupplier<InputStream> logoResource = resourcePack.getRootResource(logoFile);
+                IoSupplier<InputStream> logoResource = resourcePack.getRootResource(logoFile.split("[/\\\\]"));
                 if (logoResource != null)
                     logo = NativeImage.read(logoResource.get());
                 if (logo != null) {


### PR DESCRIPTION
Resolves: https://github.com/neoforged/NeoForge/issues/347

I did both / and \ just in case someone tries either slash. In the end, the slashes will be ignored and handled properly by MC with this PR