### PR TITLE
[1.20.4] Pass correct position into FireBlock's canCatchFire patch

### DIFF
--- a/patches/net/minecraft/world/level/block/FireBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FireBlock.java.patch
@@ -5,7 +5,7 @@
          BlockPos blockpos = p_53472_.below();
          BlockState blockstate = p_53471_.getBlockState(blockpos);
 -        if (!this.canBurn(blockstate) && !blockstate.isFaceSturdy(p_53471_, blockpos, Direction.UP)) {
-+        if (!this.canCatchFire(p_53471_, p_53472_, Direction.UP) && !blockstate.isFaceSturdy(p_53471_, blockpos, Direction.UP)) {
++        if (!this.canCatchFire(p_53471_, blockpos, Direction.UP) && !blockstate.isFaceSturdy(p_53471_, blockpos, Direction.UP)) {
              BlockState blockstate1 = this.defaultBlockState();
  
              for(Direction direction : Direction.values()) {


### PR DESCRIPTION
Fixes: https://github.com/neoforged/NeoForge/issues/302

Was passing the air position and since air is not flammable, it was causing inconsistent behavior. Passing the position below properly matches the vanilla behavior again