### PR TITLE
[1.20.4] Fixed NeoForge pack version and description

### DIFF
--- a/src/generated/resources/pack.mcmeta
+++ b/src/generated/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
   "pack": {
     "description": {
-      "translate": "pack.forge.description"
+      "translate": "pack.neoforge.description"
     },
     "neoforge": {
       "versions": {
@@ -9,6 +9,6 @@
         "server_data": 26
       }
     },
-    "pack_format": 22
+    "pack_format": 26
   }
 }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -532,7 +532,7 @@ public class NeoForgeMod {
         ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
         gen.addProvider(true, new PackMetadataGenerator(packOutput)
                 .add(PackMetadataSection.TYPE, new PackMetadataSection(
-                        Component.translatable("pack.forge.description"),
+                        Component.translatable("pack.neoforge.description"),
                         DetectedVersion.BUILT_IN.getPackVersion(PackType.CLIENT_RESOURCES),
                         Optional.empty(),
                         Optional.of(new PackMetadataSection.NeoForgeData(Optional.of(Arrays.stream(PackType.values()).collect(Collectors.toMap(Function.identity(), DetectedVersion.BUILT_IN::getPackVersion))))))));

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -218,5 +218,5 @@
 
   "neoforge.chatType.system": "{0}",
 
-  "pack.neoforge.description": "NeoForge resource pack"
+  "pack.neoforge.description": "NeoForge data/resource pack"
 }


### PR DESCRIPTION
Fixes both https://github.com/neoforged/NeoForge/issues/278 and https://github.com/neoforged/NeoForge/issues/360

pack_format had to be 26 since the datapack screen is reading that number instead. The resourcepack screen does not show this pack so not seeing issue there. Unless the server_data version was supposed to override pack_format