### PR TITLE
[1.20.4] Restore serversided onInteractEntityAt event firing

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -109,3 +109,16 @@
                  p_9866_.dispatch(
                      new ServerboundInteractPacket.Handler() {
                          private void performInteraction(InteractionHand p_143679_, ServerGamePacketListenerImpl.EntityInteraction p_143680_) {
+@@ -1502,7 +_,11 @@
+     
+                         @Override
+                         public void onInteraction(InteractionHand p_143682_, Vec3 p_143683_) {
+-                            this.performInteraction(p_143682_, (p_143686_, p_143687_, p_143688_) -> p_143687_.interactAt(p_143686_, p_143683_, p_143688_));
++                            this.performInteraction(p_143682_, (p_143686_, p_143687_, p_143688_) -> {
++                                InteractionResult onInteractEntityAtResult = net.neoforged.neoforge.common.CommonHooks.onInteractEntityAt(player, entity, p_143683_, p_143682_);
++                                if (onInteractEntityAtResult != null) return onInteractEntityAtResult;
++                                return p_143687_.interactAt(p_143686_, p_143683_, p_143688_);
++                            });
+                         }
+     
+                         @Override

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
@@ -5,9 +5,16 @@
 
 package net.neoforged.neoforge.debug.entity.player;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.GameType;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -33,6 +40,26 @@ public class PlayerEventTests {
                     "display name",
                     "hello world");
             helper.succeed();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if the on entity interact event is fired")
+    static void entityInteractEvent(final DynamicTest test) {
+        test.eventListeners().forge().addListener((final PlayerInteractEvent.EntityInteractSpecific event) -> {
+            if (event.getTarget().getType() == EntityType.ILLUSIONER) {
+                String oldName = event.getTarget().getName().getString();
+                event.getTarget().setCustomName(Component.literal(oldName + " entityInteractEventTest"));
+            }
+        });
+
+        test.onGameTest(helper -> {
+            Mob illusioner = helper.spawnWithNoFreeWill(EntityType.ILLUSIONER, 1, 1, 1);
+            helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))
+                    .thenExecute(player -> player.connection.handleInteract(ServerboundInteractPacket.createInteractionPacket(illusioner, player.isShiftKeyDown(), InteractionHand.MAIN_HAND, helper.absoluteVec(new BlockPos(1, 1, 1).getCenter()))))
+                    .thenExecute(player -> helper.assertTrue(illusioner.getName().getString().contains("entityInteractEventTest"), "Illager name did not get changed on player interact"))
+                    .thenSucceed();
         });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/neoforged/NeoForge/issues/363

Should match the old patch here for reference:
https://github.com/neoforged/NeoForge/blob/1.20.1/patches/minecraft/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch#L88-L89