### PR TITLE
[1.20.4] Use ID-only snapshot to revert to frozen registry state when leaving singleplayer or disconnecting from server

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/RegistryManager.java
+++ b/src/main/java/net/neoforged/neoforge/registries/RegistryManager.java
@@ -75,7 +75,7 @@ public class RegistryManager {
     }
 
     static void takeFrozenSnapshot() {
-        frozenSnapshot = takeSnapshot(SnapshotType.FULL);
+        frozenSnapshot = takeSnapshot(SnapshotType.SYNC_TO_CLIENT);
     }
 
     public static void revertToVanilla() {


### PR DESCRIPTION
This PR switches the frozen snapshot from full to ID-only such that only ID mappings are reverted when leaving a singleplayer world or disconnecting from a server. This fixes the issue of intrusive holders in applicable registries (i.e. blocks, items, etc.) being replaced with standalone reference holders during the revert, which causes certain worldgen features to break.

Quoting from Discord:
> Through Commoble's findings that intrusive holders in registries are getting replaced with standalone reference holders and embeddedt's hint with the registry snapshots I have found why the worldgen bug happens. When leaving a world or disconnecting from a server, the client's registries are reverted to the frozen snapshot. Since the snapshot being applied here is a full snapshot, the registry is cleared entirely and the contents of the snapshot's registry copy are registered to it. The process of fully clearing a registry also clears (it should already be empty anyway at this point) and nulls out the `unregisteredIntrusiveHolders` map. This is necessary as the map being empty but present would cause an exception when re-registering the entries from the snapshot. The problem is that nulling out this map effectively marks the registry as not supporting intrusive holders, which then causes the creation of standalone reference holders when the entries are re-registered.

It's worth noting that reverting to the vanilla snapshot in case of an error during the registration phase will still excibit this issue but since that is only ever used to achieve a stable state for displaying a friendly error, it shouldn't have any consequences.

Other proposed solutions were to either store a map of registered intrusive holders, which would however interfere with the revert to vanilla wanting to get rid of modded entries, or using an additional flag to mark the registry as supporting intrusive holders, which would however require patching all classes holding intrusive holders as the getters for them don't originate from a shared interface. There is also (as far as I can find) no reason to do a full revert as the snapshot sent by a server can only modify a registry's ID mapping and never its entry set, so both of these solutions are unnecessarily complicated.

Fixes #323