### PR TITLE
Remove obsolete obfuscation workaround

### DIFF
--- a/patches/net/minecraft/Util.java.patch
+++ b/patches/net/minecraft/Util.java.patch
@@ -1,17 +1,5 @@
 --- a/net/minecraft/Util.java
 +++ b/net/minecraft/Util.java
-@@ -186,6 +_,11 @@
-         return 255;
-     }
- 
-+    // We add these inner classes to compensate for Mojang's missing inner classes and shift the anonymous class index.
-+    // This allows us to obfuscate subsequent anonymous inner classes correctly.
-+    @SuppressWarnings("unused") private static java.util.function.LongSupplier INNER_CLASS_SHIFT1 = new java.util.function.LongSupplier() { public long getAsLong() { return 0; } };
-+    @SuppressWarnings("unused") private static java.util.function.LongSupplier INNER_CLASS_SHIFT2 = new java.util.function.LongSupplier() { public long getAsLong() { return 0; } };
-+
-     public static ExecutorService backgroundExecutor() {
-         return BACKGROUND_EXECUTOR;
-     }
 @@ -261,7 +_,7 @@
                  .getSchema(DataFixUtils.makeKey(SharedConstants.getCurrentVersion().getDataVersion().getVersion()))
                  .getChoiceType(p_137552_, p_137553_);


### PR DESCRIPTION
Someone found these leftover stub classes left in `Util` to work around some obfuscation bug; I suspect this is now irrelevant since we don't have any form of obfuscation at runtime.