### PR TITLE
[1.20.4] Make player feet and eyes both need to be in swimmable fluid to swim

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -142,7 +142,7 @@
          } else {
              this.setSwimming(
 -                this.isSprinting() && this.isUnderWater() && !this.isPassenger() && this.level().getFluidState(this.blockPosition).is(FluidTags.WATER)
-+                this.isSprinting() && (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger() && this.level().getFluidState(this.blockPosition).getFluidType().canSwim(this)
++                this.isSprinting() && (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger()
              );
          }
      }

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -142,7 +142,7 @@
          } else {
              this.setSwimming(
 -                this.isSprinting() && this.isUnderWater() && !this.isPassenger() && this.level().getFluidState(this.blockPosition).is(FluidTags.WATER)
-+                this.isSprinting() &&  (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger() && this.level().getFluidState(this.blockPosition).getFluidType().canSwim(this)
++                this.isSprinting() && (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger() && this.level().getFluidState(this.blockPosition).getFluidType().canSwim(this)
              );
          }
      }

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -142,7 +142,7 @@
          } else {
              this.setSwimming(
 -                this.isSprinting() && this.isUnderWater() && !this.isPassenger() && this.level().getFluidState(this.blockPosition).is(FluidTags.WATER)
-+                this.isSprinting() && (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger()
++                this.isSprinting() &&  (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger() && this.level().getFluidState(this.blockPosition).getFluidType().canSwim(this)
              );
          }
      }
@@ -510,7 +510,7 @@
  
 +    /**
 +     * Gets the value of the legacy {@link #maxUpStep} field. Only used by players when the modified value causes issues.
-+     * @deprecated Use {@link IEntityExtension#getStepHeight()} to get the real step height value.
++     * @deprecated Use {@link net.neoforged.neoforge.common.extensions.IEntityExtension#getStepHeight()} to get the real step height value.
 +     */
 +    @Deprecated
      public float maxUpStep() {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
@@ -298,7 +298,7 @@ public interface IEntityExtension extends INBTSerializable<CompoundTag> {
      * @return {@code true} if the entity can start swimming, {@code false} otherwise
      */
     default boolean canStartSwimming() {
-        return !this.getEyeInFluidType().isAir() && this.canSwimInFluidType(this.getEyeInFluidType()) && this.self().level().getFluidState(this.self().blockPosition()).getFluidType().canSwim(this.self());
+        return !this.getEyeInFluidType().isAir() && this.canSwimInFluidType(this.getEyeInFluidType()) && this.canSwimInFluidType(this.self().level().getFluidState(this.self().blockPosition()).getFluidType());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
@@ -298,7 +298,7 @@ public interface IEntityExtension extends INBTSerializable<CompoundTag> {
      * @return {@code true} if the entity can start swimming, {@code false} otherwise
      */
     default boolean canStartSwimming() {
-        return !this.getEyeInFluidType().isAir() && this.canSwimInFluidType(this.getEyeInFluidType());
+        return !this.getEyeInFluidType().isAir() && this.canSwimInFluidType(this.getEyeInFluidType()) && this.self().level().getFluidState(this.self().blockPosition()).getFluidType().canSwim(this.self());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/neoforged/NeoForge/issues/220

Issue was the patch to Entity$updateSwimming removed the vanilla check that verified the player's feet was in water before allowing swimming. I added back the feet check for canSwim fluidtype.

The vanilla behavior in my testing is both the eye and feet bottom has to be in the fluid for swimming to be allowed. If either are out of fluid, you cannot go into swimming mode.

In testing this fix, I get that exact behavior now with neoforge. Both eyes and feet has to be in fluid to allow swimming which makes sense as canStartSwimming already checks eyes and now my check adds back feet