### PR TITLE
[1.20.4 ] Add ItemStack parameter to BowItem#customArrow

### DIFF
--- a/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -17,7 +17,7 @@
 +        ItemStack itemstack = this.getProjectile(this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, item -> item instanceof net.minecraft.world.item.BowItem)));
          AbstractArrow abstractarrow = this.getArrow(itemstack, p_32142_);
 +        if (this.getMainHandItem().getItem() instanceof net.minecraft.world.item.BowItem)
-+            abstractarrow = ((net.minecraft.world.item.BowItem)this.getMainHandItem().getItem()).customArrow(abstractarrow);
++            abstractarrow = ((net.minecraft.world.item.BowItem)this.getMainHandItem().getItem()).customArrow(abstractarrow, itemstack);
          double d0 = p_32141_.getX() - this.getX();
          double d1 = p_32141_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32141_.getZ() - this.getZ();

--- a/patches/net/minecraft/world/entity/monster/Illusioner.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Illusioner.java.patch
@@ -8,7 +8,7 @@
 +        ItemStack itemstack = this.getProjectile(this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, item -> item instanceof net.minecraft.world.item.BowItem)));
          AbstractArrow abstractarrow = ProjectileUtil.getMobArrow(this, itemstack, p_32919_);
 +        if (this.getMainHandItem().getItem() instanceof net.minecraft.world.item.BowItem)
-+            abstractarrow = ((net.minecraft.world.item.BowItem)this.getMainHandItem().getItem()).customArrow(abstractarrow);
++            abstractarrow = ((net.minecraft.world.item.BowItem)this.getMainHandItem().getItem()).customArrow(abstractarrow, itemstack);
          double d0 = p_32918_.getX() - this.getX();
          double d1 = p_32918_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32918_.getZ() - this.getZ();

--- a/patches/net/minecraft/world/item/BowItem.java.patch
+++ b/patches/net/minecraft/world/item/BowItem.java.patch
@@ -22,7 +22,7 @@
                      if (!p_40668_.isClientSide) {
                          ArrowItem arrowitem = (ArrowItem)(itemstack.getItem() instanceof ArrowItem ? itemstack.getItem() : Items.ARROW);
                          AbstractArrow abstractarrow = arrowitem.createArrow(p_40668_, itemstack, player);
-+                        abstractarrow = customArrow(abstractarrow);
++                        abstractarrow = customArrow(abstractarrow, itemstack);
                          abstractarrow.shootFromRotation(player, player.getXRot(), player.getYRot(), 0.0F, f * 3.0F, 1.0F);
                          if (f == 1.0F) {
                              abstractarrow.setCritArrow(true);
@@ -43,7 +43,7 @@
          return ARROW_ONLY;
 +    }
 +
-+    public AbstractArrow customArrow(AbstractArrow arrow) {
++    public AbstractArrow customArrow(AbstractArrow arrow, ItemStack stack) {
 +        return arrow;
      }
  


### PR DESCRIPTION
As of 1.20.3, arrow entities now take a ItemStack in their constructor.
This PR simply passes the ItemStack into `BowItem#customArrow`, to allow for the same behavior as in vanillas `ArrowItem#createArrow`.