### PR TITLE
Add copyOf and codecOf utility methods to NonNullList

### DIFF
--- a/patches/net/minecraft/core/NonNullList.java.patch
+++ b/patches/net/minecraft/core/NonNullList.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/core/NonNullList.java
++++ b/net/minecraft/core/NonNullList.java
+@@ -9,6 +_,22 @@
+ import org.apache.commons.lang3.Validate;
+ 
+ public class NonNullList<E> extends AbstractList<E> {
++
++    /**
++     * Neo: utility method to construct a Codec for a NonNullList
++     * @param entryCodec The codec to use for the elements
++     * @param <E> The element type
++     * @return A codec that encodes as a list, and decodes into NonNullList
++     */
++    public static <E> com.mojang.serialization.Codec<NonNullList<E>> codecOf(com.mojang.serialization.Codec<E> entryCodec) {
++        return entryCodec.listOf().xmap(NonNullList::copyOf, java.util.function.Function.identity());
++    }
++
++    // Neo: utility method to construct an immutable NonNullList from a given collection
++    public static <E> NonNullList<E> copyOf(java.util.Collection<? extends E> entries) {
++        return new NonNullList<>(List.copyOf(entries), null);
++    }
++
+     private final List<E> list;
+     @Nullable
+     private final E defaultValue;

--- a/patches/net/minecraft/core/NonNullList.java.patch
+++ b/patches/net/minecraft/core/NonNullList.java.patch
@@ -1,21 +1,26 @@
 --- a/net/minecraft/core/NonNullList.java
 +++ b/net/minecraft/core/NonNullList.java
-@@ -9,6 +_,22 @@
+@@ -9,6 +_,27 @@
  import org.apache.commons.lang3.Validate;
  
  public class NonNullList<E> extends AbstractList<E> {
 +
 +    /**
 +     * Neo: utility method to construct a Codec for a NonNullList
-+     * @param entryCodec The codec to use for the elements
-+     * @param <E> The element type
-+     * @return A codec that encodes as a list, and decodes into NonNullList
++     * @param entryCodec the codec to use for the elements
++     * @param <E> the element type
++     * @return a codec that encodes as a list, and decodes into NonNullList
 +     */
 +    public static <E> com.mojang.serialization.Codec<NonNullList<E>> codecOf(com.mojang.serialization.Codec<E> entryCodec) {
 +        return entryCodec.listOf().xmap(NonNullList::copyOf, java.util.function.Function.identity());
 +    }
 +
-+    // Neo: utility method to construct an immutable NonNullList from a given collection
++    /**
++     * Neo: utility method to construct an immutable NonNullList from a given collection
++     * @param entries the collection to make a copy of
++     * @param <E> the type of the elements in the list
++     * @return a new immutable NonNullList
++     */
 +    public static <E> NonNullList<E> copyOf(java.util.Collection<? extends E> entries) {
 +        return new NonNullList<>(List.copyOf(entries), null);
 +    }

--- a/patches/net/minecraft/core/NonNullList.java.patch
+++ b/patches/net/minecraft/core/NonNullList.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/core/NonNullList.java
 +++ b/net/minecraft/core/NonNullList.java
-@@ -9,6 +_,27 @@
+@@ -9,6 +_,28 @@
  import org.apache.commons.lang3.Validate;
  
  public class NonNullList<E> extends AbstractList<E> {
@@ -20,6 +20,7 @@
 +     * @param entries the collection to make a copy of
 +     * @param <E> the type of the elements in the list
 +     * @return a new immutable NonNullList
++     * @throws NullPointerException if entries is null, or if it contains any nulls
 +     */
 +    public static <E> NonNullList<E> copyOf(java.util.Collection<? extends E> entries) {
 +        return new NonNullList<>(List.copyOf(entries), null);


### PR DESCRIPTION
Rationale:

It is sometimes wanted to encode/decode a NonNullList using codecs. However, Minecraft doesn't have any `Codec<NonNullList<?>>`.

Additionally, in trying to implement such a codec, I realized NonNullList has no factory method to construct a NonNullList from a given collection of entries.

This PR adds two static methods to NonNullList: 
- `NonNullList.copyOf(collection)` constructs an immutable NonNullList backed by a copy of the given collection.
- `NonNullList.codecOf(entryCodec)` constructs a codec that serializes/deserializes a list of elements into a NonNullList.

~~With regards to null inputs, neither of the methods currently perform null checks on the contents. If it is deemed necessary to do so, I will adjust the code accordingly.~~ Apparently List.copyOf null-checks already, so nevermind that.