### PR TITLE
Make feature request template say NeoForge instead of Forge

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,6 +8,6 @@ assignees: ''
 ---
 
 <!-- Please note, feature requests that are submitted as GitHub issues here are rarely implemented. -->
-<!-- If you'd like to see something in Forge, you should be ready to implement it as a PR. -->
+<!-- If you'd like to see something in NeoForge, you should be ready to implement it as a PR. -->
 <!-- If you're not sure, open a Draft PR or discuss it in the Discord server. -->
 <!-- Discord: https://discord.gg/UvedJ9m -->


### PR DESCRIPTION
What title says. Discord link seems to be already corrected to NeoForge discord