### PR TITLE
Fix GameTestHelper#forEveryBlockInStructure including blocks that are not in the structure

### DIFF
--- a/patches/net/minecraft/gametest/framework/GameTestHelper.java.patch
+++ b/patches/net/minecraft/gametest/framework/GameTestHelper.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/gametest/framework/GameTestHelper.java
++++ b/net/minecraft/gametest/framework/GameTestHelper.java
+@@ -836,7 +_,8 @@
+ 
+     public void forEveryBlockInStructure(Consumer<BlockPos> p_177293_) {
+         AABB aabb = this.getRelativeBounds();
+-        BlockPos.MutableBlockPos.betweenClosedStream(aabb.move(0.0, 1.0, 0.0)).forEach(p_177293_);
++        // Neo: Shrink AABB by one as an aabb surrounding two blocks is increased by one compared to the actual positions
++        BlockPos.MutableBlockPos.betweenClosedStream(aabb.contract(1.0, 1.0, 1.0)).forEach(p_177293_);
+     }
+ 
+     public void onEachTick(Runnable p_177424_) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/structure/StructureTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/structure/StructureTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.structure;
+
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.world.level.block.Blocks;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
+
+@ForEachTest(groups = StructureTests.GROUP)
+public class StructureTests {
+    public static final String GROUP = "structure";
+
+    @GameTest
+    @TestHolder(description = "Tests that the structure bounds for use in Game Tests is correct")
+    static void everyBlockInStructure(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(3, 3, 3)
+                .fill(0, 0, 0, 2, 2, 2, Blocks.DIAMOND_BLOCK));
+
+        test.onGameTest(helper -> helper.startSequence()
+                .thenWaitUntil(0, () -> helper.forEveryBlockInStructure(pos -> helper.assertBlockPresent(Blocks.DIAMOND_BLOCK, pos)))
+                .thenExecute(test::pass)
+                .thenSucceed());
+    }
+}


### PR DESCRIPTION
I believe in 1.20.3 Mojang changed the logic used in `StructureUtils#getStructureBounds` to make sure the AABB contains the full structure instead of missing parts of the edge blocks. They also made it get adjusted by the structure block's positioning (which is what the previous removed `move(0, 1, 0)` was doing). While I think it makes sense for the bounds to include the full structure, when iterating all the blocks in the structure we need to shrink the AABB by one as `MutableBlockPos#betweenClosedStream(AABB)` uses the full value of the AABB, which in this case includes the block starting just past the last block in the structure.