### PR TITLE
[1.20.4] Fix grouped mod datapacks being dropped when reloading data

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -176,6 +176,15 @@
      }
  
      public SystemReport fillSystemReport(SystemReport p_177936_) {
+@@ -1379,7 +_,7 @@
+     public CompletableFuture<Void> reloadResources(Collection<String> p_129862_) {
+         RegistryAccess.Frozen registryaccess$frozen = this.registries.getAccessForLoading(RegistryLayer.RELOADABLE);
+         CompletableFuture<Void> completablefuture = CompletableFuture.<ImmutableList>supplyAsync(
+-                () -> p_129862_.stream().map(this.packRepository::getPack).filter(Objects::nonNull).map(Pack::open).collect(ImmutableList.toImmutableList()),
++                () -> p_129862_.stream().map(this.packRepository::getPack).filter(Objects::nonNull).flatMap(Pack::streamSelfAndChildren).map(Pack::open).collect(ImmutableList.toImmutableList()),
+                 this
+             )
+             .thenCompose(
 @@ -1416,6 +_,7 @@
                      this.getPlayerList().reloadResources();
                      this.functionManager.replaceLibrary(this.resources.managers.getFunctionLibrary());

--- a/patches/net/minecraft/server/packs/repository/Pack.java.patch
+++ b/patches/net/minecraft/server/packs/repository/Pack.java.patch
@@ -52,13 +52,17 @@
              }
  
              return pack$info;
-@@ -172,6 +_,33 @@
+@@ -172,6 +_,37 @@
          return this.packSource;
      }
  
 +    public boolean isHidden() { return hidden; }
 +
 +    public List<Pack> getChildren() { return children; }
++
++    public java.util.stream.Stream<Pack> streamSelfAndChildren() {
++        return java.util.stream.Stream.concat(java.util.stream.Stream.of(this), children.stream());
++    }
 +
 +    /**
 +     * {@return a copy of the pack with the provided children in place of any children this pack currently has}

--- a/tests/src/generated/resources/data/neotests_mod_datapack/advancements/recipes/misc/test_advancement.json
+++ b/tests/src/generated/resources/data/neotests_mod_datapack/advancements/recipes/misc/test_advancement.json
@@ -1,0 +1,27 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_scute": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:scute"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    }
+  },
+  "requirements": [
+    [
+      "has_scute"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:turtle_helmet"
+    ]
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/resources/ModDatapackTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/resources/ModDatapackTest.java
@@ -26,7 +26,7 @@ import net.neoforged.testframework.annotation.TestHolder;
 public class ModDatapackTest {
     public static final String GROUP = "resources";
 
-    @TestHolder(description = "Tests that mod datapacks are loaded properly on initial load and reload", enabledByDefault = true, side = Dist.CLIENT)
+    @TestHolder(description = "Tests that mod datapacks are loaded properly on initial load and reload", enabledByDefault = true)
     static void modDatapack(final DynamicTest test) {
         final ResourceLocation testAdvancement = new ResourceLocation(test.createModId(), "recipes/misc/test_advancement");
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/resources/ModDatapackTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/resources/ModDatapackTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.resources;
+
+import java.util.List;
+import java.util.Optional;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.critereon.InventoryChangeTrigger;
+import net.minecraft.advancements.critereon.ItemPredicate;
+import net.minecraft.data.recipes.RecipeBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Items;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.neoforge.common.data.AdvancementProvider;
+import net.neoforged.neoforge.event.OnDatapackSyncEvent;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+
+@ForEachTest(groups = ModDatapackTest.GROUP)
+public class ModDatapackTest {
+    public static final String GROUP = "resources";
+
+    @TestHolder(description = "Tests that mod datapacks are loaded properly on initial load and reload", enabledByDefault = true, side = Dist.CLIENT)
+    static void modDatapack(final DynamicTest test) {
+        final ResourceLocation testAdvancement = new ResourceLocation(test.createModId(), "recipes/misc/test_advancement");
+
+        test.registrationHelper().addProvider(event -> {
+            List<AdvancementProvider.AdvancementGenerator> generators = List.of((registries, saver, existingFileHelper) -> Advancement.Builder.recipeAdvancement()
+                    .parent(RecipeBuilder.ROOT_RECIPE_ADVANCEMENT)
+                    .addCriterion("has_scute", CriteriaTriggers.INVENTORY_CHANGED.createCriterion(
+                            new InventoryChangeTrigger.TriggerInstance(
+                                    Optional.empty(), InventoryChangeTrigger.TriggerInstance.Slots.ANY, List.of(
+                                            ItemPredicate.Builder.item().of(Items.SCUTE).build()))))
+                    .rewards(AdvancementRewards.Builder.recipe(new ResourceLocation("minecraft:turtle_helmet")))
+                    .save(saver, testAdvancement, existingFileHelper));
+            return new AdvancementProvider(event.getGenerator().getPackOutput(), event.getLookupProvider(), event.getExistingFileHelper(), generators);
+        });
+
+        test.eventListeners().forge().addListener((OnDatapackSyncEvent event) -> {
+            if (event.getPlayerList().getServer().getAdvancements().get(testAdvancement) != null) {
+                test.pass();
+            } else {
+                test.fail("Test advancement not loaded");
+            }
+        });
+    }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/resources/ModDatapackTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/resources/ModDatapackTest.java
@@ -15,7 +15,6 @@ import net.minecraft.advancements.critereon.ItemPredicate;
 import net.minecraft.data.recipes.RecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
-import net.neoforged.api.distmarker.Dist;
 import net.neoforged.neoforge.common.data.AdvancementProvider;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.testframework.DynamicTest;


### PR DESCRIPTION
This PR fixes modded datapacks not being included in the resource manager during datapack reloads initiated by the `/reload` and `/datapack` commands. This is a regression caused by the pack grouping changes.

Fixes #402