### PR TITLE
Fix world deletion cancel not working

### DIFF
--- a/patches/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
+++ b/patches/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
@@ -22,7 +22,7 @@
                              }
 -            
 +
-+                            if (this.minecraft.screen instanceof ProgressScreen) // Neo - fix MC-251068
++                            if (this.minecraft.screen instanceof ProgressScreen || this.minecraft.screen instanceof ConfirmScreen) // Neo - fix MC-251068
                              this.minecraft.setScreen(this.screen);
                          },
                          Component.translatable("selectWorld.deleteQuestion"),


### PR DESCRIPTION
This PR fixes #406 by adding `ConfirmScreen` to the patched-in `if`-condition in `WorldSelectionList`. When the deletion is canceled, the screen is still `ConfirmScreen`, so the `if` condition needs to also check for that alongside `ProgressScreen` (when deletion succeeds and there is at least one world left).

See https://github.com/neoforged/NeoForge/issues/406#issuecomment-1864345932 for more details.