### PR TITLE
Rename RegisterCapabilitiesEvent to RegisterCapabilityProvidersEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilitiesEvent.java
@@ -23,7 +23,7 @@ import net.neoforged.fml.event.IModBusEvent;
 /**
  * Fired to register capability providers at an appropriate time.
  */
-public class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
+public class RegisterCapabilityProvidersEvent extends Event implements IModBusEvent {
     RegisterCapabilitiesEvent() {}
 
     // BLOCKS


### PR DESCRIPTION
This feels like an appropriate rename