### PR TITLE
Rename RegisterCapabilitiesEvent to RegisterCapabilityProvidersEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/BlockCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/BlockCapability.java
@@ -39,10 +39,10 @@ import org.jetbrains.annotations.Nullable;
  * <p>For repeated queries at a specific position, use {@link BlockCapabilityCache} to improve performance.
  *
  * <h3>Providing a capability for a block entity</h3>
- * <p>To provide objects of type {@code T}, register providers to {@link RegisterCapabilitiesEvent}. For example:
+ * <p>To provide objects of type {@code T}, register providers to {@link RegisterCapabilityProvidersEvent}. For example:
  * 
  * <pre>{@code
- * modBus.addListener(RegisterCapabilitiesEvent.class, event -> {
+ * modBus.addListener(RegisterCapabilityProvidersEvent.class, event -> {
  *     event.registerBlockEntity(
  *         Capabilities.ItemHandler.BLOCK, // capability to register for
  *         MY_BLOCK_ENTITY_TYPE,
@@ -55,10 +55,10 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h3>Providing a capability for a plain block</h3>
  * For blocks without a block entity,
- * we use {@link RegisterCapabilitiesEvent#registerBlock registerBlock} instead:
+ * we use {@link RegisterCapabilityProvidersEvent#registerBlock registerBlock} instead:
  *
  * <pre>{@code
- * modBus.addListener(RegisterCapabilitiesEvent.class, event -> {
+ * modBus.addListener(RegisterCapabilityProvidersEvent.class, event -> {
  *     event.registerBlock(
  *         Capabilities.ItemHandler.BLOCK, // capability to register for
  *         (level, pos, state, be, side) -> <return the IItemHandler>,

--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.capabilities;
 
-import java.util.List;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.WorldlyContainerHolder;
@@ -24,15 +23,10 @@ import net.neoforged.neoforge.event.TickEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.fluids.capability.wrappers.FluidBucketWrapper;
 import net.neoforged.neoforge.items.VanillaHopperItemHandler;
-import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
-import net.neoforged.neoforge.items.wrapper.EntityArmorInvWrapper;
-import net.neoforged.neoforge.items.wrapper.EntityHandsInvWrapper;
-import net.neoforged.neoforge.items.wrapper.ForwardingItemHandler;
-import net.neoforged.neoforge.items.wrapper.InvWrapper;
-import net.neoforged.neoforge.items.wrapper.PlayerInvWrapper;
-import net.neoforged.neoforge.items.wrapper.ShulkerItemStackInvWrapper;
-import net.neoforged.neoforge.items.wrapper.SidedInvWrapper;
+import net.neoforged.neoforge.items.wrapper.*;
 import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
 
 @ApiStatus.Internal
 public class CapabilityHooks {
@@ -44,13 +38,13 @@ public class CapabilityHooks {
             throw new IllegalArgumentException("CapabilityHooks.init() called twice");
         initialized = true;
 
-        var event = new RegisterCapabilitiesEvent();
+        var event = new RegisterCapabilityProvidersEvent();
         ModLoader.get().postEventWrapContainerInModOrder(event);
 
         initFinished = true;
     }
 
-    public static void registerVanillaProviders(RegisterCapabilitiesEvent event) {
+    public static void registerVanillaProviders(RegisterCapabilityProvidersEvent event) {
         // Blocks
         var composterBlock = (WorldlyContainerHolder) Blocks.COMPOSTER;
         event.registerBlock(Capabilities.ItemHandler.BLOCK, (level, pos, state, blockEntity, side) -> {

--- a/src/main/java/net/neoforged/neoforge/capabilities/EntityCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/EntityCapability.java
@@ -32,10 +32,10 @@ import org.jetbrains.annotations.Nullable;
  * }</pre>
  *
  * <h3>Providing an entity capability</h3>
- * <p>To provide objects of type {@code T}, register providers to {@link RegisterCapabilitiesEvent}. For example:
+ * <p>To provide objects of type {@code T}, register providers to {@link RegisterCapabilityProvidersEvent}. For example:
  * 
  * <pre>{@code
- * modBus.addListener((RegisterCapabilitiesEvent event) -> {
+ * modBus.addListener((RegisterCapabilityProvidersEvent event) -> {
  *     event.registerEntity(
  *         Capabilities.ItemHandler.ENTITY, // capability to register for
  *         MY_ENTITY_TYPE,

--- a/src/main/java/net/neoforged/neoforge/capabilities/ItemCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/ItemCapability.java
@@ -31,10 +31,10 @@ import org.jetbrains.annotations.Nullable;
  * }</pre>
  *
  * <h3>Providing an item capability</h3>
- * <p>To provide objects of type {@code T}, register providers to {@link RegisterCapabilitiesEvent}. For example:
+ * <p>To provide objects of type {@code T}, register providers to {@link RegisterCapabilityProvidersEvent}. For example:
  * 
  * <pre>{@code
- * modBus.addListener((RegisterCapabilitiesEvent event) -> {
+ * modBus.addListener((RegisterCapabilityProvidersEvent event) -> {
  *     event.registerItem(
  *         Capabilities.ItemHandler.ITEM, // capability to register for
  *         (itemStack, context) -> <return the IItemHandler for the itemStack>,

--- a/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilitiesEvent.java
@@ -23,7 +23,7 @@ import net.neoforged.fml.event.IModBusEvent;
 /**
  * Fired to register capability providers at an appropriate time.
  */
-public class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
+public class RegisterCapabilityProvidersEvent extends Event implements IModBusEvent {
     RegisterCapabilitiesEvent() {}
 
     // BLOCKS

--- a/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilityProvidersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilityProvidersEvent.java
@@ -24,7 +24,7 @@ import net.neoforged.fml.event.IModBusEvent;
  * Fired to register capability providers at an appropriate time.
  */
 public class RegisterCapabilityProvidersEvent extends Event implements IModBusEvent {
-    RegisterCapabilitiesEvent() {}
+    RegisterCapabilityProvidersEvent() {}
 
     // BLOCKS
 

--- a/src/main/java/net/neoforged/neoforge/fluids/CauldronFluidContent.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/CauldronFluidContent.java
@@ -17,7 +17,7 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.capabilities.Capabilities;
-import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.capabilities.RegisterCapabilityProvidersEvent;
 import net.neoforged.neoforge.fluids.capability.wrappers.CauldronWrapper;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -159,7 +159,7 @@ public final class CauldronFluidContent {
     }
 
     @ApiStatus.Internal
-    public static void registerCapabilities(RegisterCapabilitiesEvent event) {
+    public static void registerCapabilities(RegisterCapabilityProvidersEvent event) {
         if (BLOCK_TO_CAULDRON.isEmpty()) {
             throw new IllegalStateException("CauldronFluidContent.init() should have been called before the capability event!");
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -5,9 +5,6 @@
 
 package net.neoforged.neoforge.oldtest.item;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.Nonnull;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
@@ -21,7 +18,7 @@ import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.capabilities.Capabilities;
-import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.capabilities.RegisterCapabilityProvidersEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.fluids.FluidActionResult;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -30,6 +27,10 @@ import net.neoforged.neoforge.fluids.FluidUtil;
 import net.neoforged.neoforge.fluids.capability.templates.FluidHandlerItemStackSimple;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Mod(CustomFluidContainerTest.MODID)
 public class CustomFluidContainerTest {
@@ -53,7 +54,7 @@ public class CustomFluidContainerTest {
             event.accept(CUSTOM_FLUID_CONTAINER);
     }
 
-    private void registerCaps(RegisterCapabilitiesEvent event) {
+    private void registerCaps(RegisterCapabilityProvidersEvent event) {
         event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidHandlerItemStackSimple(stack, FluidType.BUCKET_VOLUME), CUSTOM_FLUID_CONTAINER.get());
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/GameTestTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/GameTestTest.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.oldtest.misc;
 
-import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.gametest.framework.GameTest;
@@ -29,7 +28,7 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.capabilities.Capabilities;
-import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.capabilities.RegisterCapabilityProvidersEvent;
 import net.neoforged.neoforge.energy.EnergyStorage;
 import net.neoforged.neoforge.energy.IEnergyStorage;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
@@ -40,6 +39,8 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 @Mod(GameTestTest.MODID)
 public class GameTestTest {
@@ -72,7 +73,7 @@ public class GameTestTest {
             event.accept(ENERGY_BLOCK_ITEM);
     }
 
-    private void registerCaps(RegisterCapabilitiesEvent event) {
+    private void registerCaps(RegisterCapabilityProvidersEvent event) {
         event.registerBlockEntity(Capabilities.EnergyStorage.BLOCK, ENERGY_BLOCK_ENTITY.get(), (be, side) -> be.energyStorage);
     }
 


### PR DESCRIPTION
This feels like a more appropriate event, taking into consideration what event is purposed to do.