### PR TITLE
[1.20.4] Fix inconsistency between custom registry ID getters and the vanilla one

### DIFF
--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -162,12 +162,12 @@
 +
 +    @Override
 +    public int getId(ResourceLocation name) {
-+        return toId.getOrDefault(get(name), -1);
++        return getId(get(name));
 +    }
 +
 +    @Override
 +    public int getId(ResourceKey<T> key) {
-+        return toId.getOrDefault(get(key), -1);
++        return getId(get(key));
 +    }
 +
 +    @Override

--- a/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
@@ -92,20 +92,20 @@ public interface IRegistryExtension<T> {
     ResourceKey<T> resolve(ResourceKey<T> key);
 
     /**
-     * Gets the integer id linked to the given key.
+     * Gets the integer id linked to the given key. If the key is not present in the registry, the default entry's
+     * integer id is returned if the registry is defaulted or {@code -1} if the registry is not defaulted
      *
      * @param key the resource key to lookup
-     * @return the integer id linked to the given key,
-     *         or {@code -1} if the key is not present in this registry
+     * @return the integer id linked to the given key
      */
     int getId(ResourceKey<T> key);
 
     /**
-     * Gets the integer id linked to the given name.
+     * Gets the integer id linked to the given name. If the name is not present in the registry, the default entry's
+     * integer id is returned if the registry is defaulted or {@code -1} if the registry is not defaulted
      *
      * @param name the resource name to lookup
-     * @return the integer id linked to the given name,
-     *         or {@code -1} if the name is not present in this registry
+     * @return the integer id linked to the given name
      */
     int getId(ResourceLocation name);
 


### PR DESCRIPTION
This PR fixes the ID getters patched into `MappedRegistry` deviating in behavior from the vanilla one when the registry is a defaulted one. Vanilla's `getId(T)` method is overriden in `DefaultedMappedRegistry` to return the ID of the default value when the requested value is not in the registry. The two patched-in `getId()` methods for lookups by `ResourceLocation` and `ResourceKey` respectively are not overriden in `DefaultedMappedRegistry` and therefore always return `-1` for unknown entries regardless of the registry being defaulted or not. I opted to make them defer to the vanilla method to avoid duplicating the vanilla logic unnecessarily.

This was tested by generating two worlds without restart in between and running around in both for a few minutes.

I'm opening this as a draft first as I'm not 100% sure whether this was intentionally done this way in the registry rework (in which case I will document that instead) or just overlooked.