### PR TITLE
Correctly filter out hidden packs from unselected packs in pack selection screen

### DIFF
--- a/patches/net/minecraft/client/gui/screens/packs/PackSelectionModel.java.patch
+++ b/patches/net/minecraft/client/gui/screens/packs/PackSelectionModel.java.patch
@@ -1,11 +1,14 @@
 --- a/net/minecraft/client/gui/screens/packs/PackSelectionModel.java
 +++ b/net/minecraft/client/gui/screens/packs/PackSelectionModel.java
-@@ -31,7 +_,7 @@
+@@ -31,9 +_,9 @@
          this.onListChanged = p_99909_;
          this.iconGetter = p_99910_;
          this.repository = p_99911_;
 -        this.selected = Lists.newArrayList(p_99911_.getSelectedPacks());
 +        this.selected = Lists.newArrayList(p_99911_.getSelectedPacks().stream().filter(p -> !p.isHidden()).toList());
          Collections.reverse(this.selected);
-         this.unselected = Lists.newArrayList(p_99911_.getAvailablePacks());
+-        this.unselected = Lists.newArrayList(p_99911_.getAvailablePacks());
++        this.unselected = Lists.newArrayList(p_99911_.getAvailablePacks().stream().filter(p -> !p.isHidden()).toList());
          this.unselected.removeAll(this.selected);
+         this.output = p_99912_;
+     }

--- a/patches/net/minecraft/client/gui/screens/packs/PackSelectionModel.java.patch
+++ b/patches/net/minecraft/client/gui/screens/packs/PackSelectionModel.java.patch
@@ -12,3 +12,12 @@
          this.unselected.removeAll(this.selected);
          this.output = p_99912_;
      }
+@@ -59,7 +_,7 @@
+         this.repository.reload();
+         this.selected.retainAll(this.repository.getAvailablePacks());
+         this.unselected.clear();
+-        this.unselected.addAll(this.repository.getAvailablePacks());
++        this.unselected.addAll(this.repository.getAvailablePacks().stream().filter(p -> !p.isHidden()).toList());
+         this.unselected.removeAll(this.selected);
+     }
+ 


### PR DESCRIPTION
Fixes an issue introduced by my resource grouping changes where available hidden packs at the root level (not child packs like those of mods) were always shown as unselected in the pack selection screen.