### PR TITLE
Remove glazed terracotta as farmland for `DESERT` plant type

### DIFF
--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -150,7 +150,7 @@
 +            return true;
 +
 +        if (net.neoforged.neoforge.common.PlantType.DESERT.equals(type)) {
-+            return state.is(BlockTags.SAND) || this == Blocks.TERRACOTTA || this instanceof GlazedTerracottaBlock;
++            return state.is(BlockTags.SAND) || this == Blocks.TERRACOTTA;
 +        } else if (net.neoforged.neoforge.common.PlantType.NETHER.equals(type)) {
 +            return this == Blocks.SOUL_SAND;
 +        } else if (net.neoforged.neoforge.common.PlantType.CROP.equals(type)) {

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -150,7 +150,7 @@
 +            return true;
 +
 +        if (net.neoforged.neoforge.common.PlantType.DESERT.equals(type)) {
-+            return state.is(BlockTags.SAND) || this == Blocks.TERRACOTTA;
++            return state.is(BlockTags.SAND) || state.is(BlockTags.TERRACOTTA);
 +        } else if (net.neoforged.neoforge.common.PlantType.NETHER.equals(type)) {
 +            return this == Blocks.SOUL_SAND;
 +        } else if (net.neoforged.neoforge.common.PlantType.CROP.equals(type)) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -103,7 +103,10 @@ public class BlockTests {
 
     @GameTest
     @EmptyTemplate(floor = true)
-    @TestHolder(description = "Dead bushes should be placeable on regular terracotta (colored or not), but not on glazed terracotta")
+    @TestHolder(description = {
+            "Dead bushes should be placeable on regular terracotta (colored or not), but not on glazed terracotta",
+            "(neoforged/NeoForge#306)"
+    })
     static void deadBushTerracottaTest(final ExtendedGameTestHelper helper) {
         final BlockPos farmlandBlock = new BlockPos(1, 1, 1);
         helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.block;
 
+import java.util.Optional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTest;
@@ -36,8 +37,6 @@ import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.registration.RegistrationHelper;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Optional;
 
 @ForEachTest(groups = BlockTests.GROUP)
 public class BlockTests {
@@ -121,7 +120,6 @@ public class BlockTests {
                 .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
                 .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DEAD_BUSH, farmlandBlock.above()))
 
-                .thenSucceed()
-        );
+                .thenSucceed());
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -5,8 +5,8 @@
 
 package net.neoforged.neoforge.debug.block;
 
-import java.util.Optional;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
 import net.minecraft.resources.ResourceLocation;
@@ -17,6 +17,8 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
@@ -34,6 +36,8 @@ import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.registration.RegistrationHelper;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 @ForEachTest(groups = BlockTests.GROUP)
 public class BlockTests {
@@ -95,5 +99,32 @@ public class BlockTests {
                         EntityType.PLAYER,
                         1, 3, 2))
                 .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate(floor = true)
+    @TestHolder(description = "Dead bushes should be placeable on regular terracotta (colored or not), but not on glazed terracotta")
+    static void deadBushTerracottaTest(final DynamicTest test) {
+        final BlockPos farmlandBlock = new BlockPos(1, 1, 1);
+        test.onGameTest(helper -> helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))
+                .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.TERRACOTTA))
+                .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
+                .thenExecute(() -> helper.assertBlock(farmlandBlock.above(), Blocks.DEAD_BUSH::equals,
+                        "Dead bush was not planted on raw terracotta"))
+
+                .thenExecute(() -> helper.setBlock(farmlandBlock.above(), Blocks.AIR))
+                .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.WHITE_TERRACOTTA))
+                .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
+                .thenExecute(() -> helper.assertBlock(farmlandBlock.above(), Blocks.DEAD_BUSH::equals,
+                        "Dead bush was not planted on white stained terracotta"))
+
+                .thenExecute(() -> helper.setBlock(farmlandBlock.above(), Blocks.AIR))
+                .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.WHITE_GLAZED_TERRACOTTA))
+                .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
+                .thenExecute(() -> helper.assertBlock(farmlandBlock.above(), Blocks.AIR::equals,
+                        "Dead bush was planted on glazed terracotta"))
+
+                .thenSucceed()
+        );
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -35,6 +35,7 @@ import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.registration.RegistrationHelper;
 import org.jetbrains.annotations.Nullable;
 
@@ -103,9 +104,9 @@ public class BlockTests {
     @GameTest
     @EmptyTemplate(floor = true)
     @TestHolder(description = "Dead bushes should be placeable on regular terracotta (colored or not), but not on glazed terracotta")
-    static void deadBushTerracottaTest(final DynamicTest test) {
+    static void deadBushTerracottaTest(final ExtendedGameTestHelper helper) {
         final BlockPos farmlandBlock = new BlockPos(1, 1, 1);
-        test.onGameTest(helper -> helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))
+        helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))
                 .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.TERRACOTTA))
                 .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
                 .thenExecute(() -> helper.assertBlockPresent(Blocks.DEAD_BUSH, farmlandBlock.above()))
@@ -120,6 +121,6 @@ public class BlockTests {
                 .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
                 .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DEAD_BUSH, farmlandBlock.above()))
 
-                .thenSucceed());
+                .thenSucceed();
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -109,20 +109,17 @@ public class BlockTests {
         test.onGameTest(helper -> helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))
                 .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.TERRACOTTA))
                 .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
-                .thenExecute(() -> helper.assertBlock(farmlandBlock.above(), Blocks.DEAD_BUSH::equals,
-                        "Dead bush was not planted on raw terracotta"))
+                .thenExecute(() -> helper.assertBlockPresent(Blocks.DEAD_BUSH, farmlandBlock.above()))
 
                 .thenExecute(() -> helper.setBlock(farmlandBlock.above(), Blocks.AIR))
                 .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.WHITE_TERRACOTTA))
                 .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
-                .thenExecute(() -> helper.assertBlock(farmlandBlock.above(), Blocks.DEAD_BUSH::equals,
-                        "Dead bush was not planted on white stained terracotta"))
+                .thenExecute(() -> helper.assertBlockPresent(Blocks.DEAD_BUSH, farmlandBlock.above()))
 
                 .thenExecute(() -> helper.setBlock(farmlandBlock.above(), Blocks.AIR))
                 .thenExecute(() -> helper.setBlock(farmlandBlock, Blocks.WHITE_GLAZED_TERRACOTTA))
                 .thenExecute(player -> helper.useBlock(farmlandBlock, player, new ItemStack(Items.DEAD_BUSH), Direction.UP))
-                .thenExecute(() -> helper.assertBlock(farmlandBlock.above(), Blocks.AIR::equals,
-                        "Dead bush was planted on glazed terracotta"))
+                .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DEAD_BUSH, farmlandBlock.above()))
 
                 .thenSucceed()
         );


### PR DESCRIPTION
This PR fixes #306 by removing glazed terracotta as acceptable farmland for the `DESERT` plant type.

This PR also includes a related fix to expand `DESERT` plant types to be plantable on both uncolored/raw terracotta and stained terracotta, to match with the plantability of dead bushes on both. (This only really matters for modded plants, because dead bushes extend `BushBlock` and therefore have their `mayPlaceOn` method called to allow placing on stained terracotta anyway.)