### PR TITLE
Apply getDropItem AT to correct class

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -295,7 +295,7 @@ public net.minecraft.world.entity.player.Player closeContainer()V # closeContain
 protected net.minecraft.world.entity.projectile.Projectile <init>(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/Level;)V # constructor
 private-f net.minecraft.world.entity.raid.Raid$RaiderType VALUES # VALUES
 public net.minecraft.world.entity.schedule.Activity <init>(Ljava/lang/String;)V # constructor
-protected net.minecraft.world.entity.vehicle.AbstractMinecart getDropItem()Lnet/minecraft/world/item/Item; # getDropItem - make AbstractMinecart implementable
+protected net.minecraft.world.entity.vehicle.VehicleEntity getDropItem()Lnet/minecraft/world/item/Item; # getDropItem - make VehicleEntity implementable
 public net.minecraft.world.inventory.AnvilMenu repairItemCountCost # repairItemCountCost
 public net.minecraft.world.inventory.MenuType <init>(Lnet/minecraft/world/inventory/MenuType$MenuSupplier;Lnet/minecraft/world/flag/FeatureFlagSet;)V # constructor
 public net.minecraft.world.inventory.MenuType$MenuSupplier


### PR DESCRIPTION
The method was moved from AbstractMinecart to its superclass VehicleEntity in some MC update. I have verified that the AT is applied correctly now.