### PR TITLE
[1.20.4] Reinstate early return on empty block pick result

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -425,18 +425,15 @@
              boolean flag = this.player.getAbilities().instabuild;
              BlockEntity blockentity = null;
              HitResult.Type hitresult$type = this.hitResult.getType();
-@@ -2336,10 +_,7 @@
+@@ -2336,7 +_,7 @@
                  }
  
                  Block block = blockstate.getBlock();
 -                itemstack = block.getCloneItemStack(this.level, blockpos, blockstate);
--                if (itemstack.isEmpty()) {
--                    return;
--                }
 +                itemstack = blockstate.getCloneItemStack(this.hitResult, this.level, blockpos, this.player);
- 
-                 if (flag && Screen.hasControlDown() && blockstate.hasBlockEntity()) {
-                     blockentity = this.level.getBlockEntity(blockpos);
+                 if (itemstack.isEmpty()) {
+                     return;
+                 }
 @@ -2350,7 +_,7 @@
                  }
  


### PR DESCRIPTION
This PR reinstates an incorrectly removed early return when the pick operation (middle mouse click) on a block returns an empty stack. Without this check, a warning is logged: `Picking on: [BLOCK] minecraft:frosted_ice gave null item`. An example of a vanilla block this applies to is the Frosted Ice block used by the Frost Walker enchantment as it doesn't have an associated item.

Fixes #418