### PR TITLE
Bump FML version and use FML SPI artifact.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ java_version=17
 minecraft_version=1.20.4
 neoform_version=20231207.154220
 
-spi_version=9.0.2
 mergetool_version=2.0.0
 accesstransformers_version=10.0.1
 coremods_version=6.0.2
@@ -30,7 +29,7 @@ jetbrains_annotations_version=24.0.1
 slf4j_api_version=2.0.7
 apache_maven_artifact_version=3.8.5
 jarjar_version=0.4.0
-fancy_mod_loader_version=2.0.4
+fancy_mod_loader_version=2.0.6
 mojang_logging_version=1.1.1
 log4j_version=2.19.0
 guava_version=31.1.2-jre

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     installer "org.ow2.asm:asm-analysis:${project.asm_version}"
     installer "net.neoforged:accesstransformers:${project.accesstransformers_version}"
     installer "net.neoforged:bus:${project.eventbus_version}"
-    installer "net.neoforged:neoforgespi:${project.spi_version}"
+    installer "net.neoforged.fancymodloader:spi:${project.fancy_mod_loader_version}"
     installer "net.neoforged:coremods:${project.coremods_version}"
     installer "cpw.mods:modlauncher:${project.modlauncher_version}"
     installer "net.minecraftforge:unsafe:${project.unsafe_version}"


### PR DESCRIPTION
Update FML to 2.0.6 to include neoforged/FancyModLoader#60
Replace SPI dependency with the FML SPI artifact, since the old one was deprecated in neoforged/FancyModLoader#58

Fixes #407 