### PR TITLE
Bump CoreMods version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ neoform_version=20231207.154220
 
 mergetool_version=2.0.0
 accesstransformers_version=10.0.1
-coremods_version=6.0.2
+coremods_version=6.0.4
 eventbus_version=7.2.0
 modlauncher_version=10.0.9
 securejarhandler_version=2.1.24


### PR DESCRIPTION
Update CoreMods version to 6.0.4 which uses the new SPI artifact.
This fixes the duplicate SPI dependencies which caused a `NoClassDefFoundError` in certain situations.