### PR TITLE
[1.20.2] Reimplement ID offset on modded EntityDataSerializers

### DIFF
--- a/patches/net/minecraft/network/syncher/EntityDataSerializers.java.patch
+++ b/patches/net/minecraft/network/syncher/EntityDataSerializers.java.patch
@@ -1,11 +1,23 @@
 --- a/net/minecraft/network/syncher/EntityDataSerializers.java
 +++ b/net/minecraft/network/syncher/EntityDataSerializers.java
-@@ -153,16 +_,16 @@
+@@ -152,17 +_,28 @@
+       FriendlyByteBuf::writeQuaternion, FriendlyByteBuf::readQuaternion
     );
  
++   private static final org.slf4j.Logger LOGGER = com.mojang.logging.LogUtils.getLogger();
++   private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
++   /**
++    * @deprecated NeoForge: Use {@link net.neoforged.neoforge.registries.NeoForgeRegistries#ENTITY_DATA_SERIALIZERS} instead
++    */
++   @Deprecated
     public static void registerSerializer(EntityDataSerializer<?> p_135051_) {
 -      SERIALIZERS.add(p_135051_);
-+      if (SERIALIZERS.add(p_135051_) >= 256) throw new RuntimeException("Vanilla DataSerializer ID limit exceeded");
++      if (!STACK_WALKER.getCallerClass().equals(EntityDataSerializers.class)) {
++         LOGGER.error("Modded EntityDataSerializers must be registered to NeoForgeRegistries.ENTITY_DATA_SERIALIZERS instead to prevent ID mismatches between client and server!", new Throwable());
++      }
++
++      if (SERIALIZERS.add(p_135051_) >= net.neoforged.neoforge.common.CommonHooks.VANILLA_SERIALIZER_LIMIT)
++         throw new RuntimeException("Vanilla EntityDataSerializer ID limit exceeded");
     }
  
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -949,11 +949,13 @@ public class CommonHooks {
     @Deprecated(forRemoval = true, since = "1.20.1") // Tags use a codec now This was never used in 1.20
     public static <T> void deserializeTagAdditions(List<TagEntry> list, JsonObject json, List<TagEntry> allList) {}
 
+    public static final int VANILLA_SERIALIZER_LIMIT = 256;
+
     @Nullable
     public static EntityDataSerializer<?> getSerializer(int id, CrudeIncrementalIntIdentityHashBiMap<EntityDataSerializer<?>> vanilla) {
         EntityDataSerializer<?> serializer = vanilla.byId(id);
         if (serializer == null) {
-            return NeoForgeRegistries.ENTITY_DATA_SERIALIZERS.byId(id);
+            return NeoForgeRegistries.ENTITY_DATA_SERIALIZERS.byId(id - VANILLA_SERIALIZER_LIMIT);
         }
         return serializer;
     }
@@ -961,7 +963,10 @@ public class CommonHooks {
     public static int getSerializerId(EntityDataSerializer<?> serializer, CrudeIncrementalIntIdentityHashBiMap<EntityDataSerializer<?>> vanilla) {
         int id = vanilla.getId(serializer);
         if (id < 0) {
-            return NeoForgeRegistries.ENTITY_DATA_SERIALIZERS.getId(serializer);
+            id = NeoForgeRegistries.ENTITY_DATA_SERIALIZERS.getId(serializer);
+            if (id >= 0) {
+                return id + VANILLA_SERIALIZER_LIMIT;
+            }
         }
         return id;
     }


### PR DESCRIPTION
Backport of #425 to 1.20.2

This PR reimplements the ID offset previously applied to modded `EntityDataSerializer`s which was lost during the registry rework. Previously this was achieved by setting a minimum ID on the registry:

https://github.com/neoforged/NeoForge/blob/6302718cc167b4b8b0e18cfc09696670788ee1f8/src/main/java/net/minecraftforge/registries/GameData.java#L141-L144

Due to the modified vanilla registries not supporting this, the IDs of modded serializers now also start at 0 which leads to the client using the vanilla serializer corresponding to the ID of the modded one and potentially blowing up while deserializing the data item, i.e. by reading past the buffer's length.