### PR TITLE
Add `neoforge:alternatives` to conditional codecs

### DIFF
--- a/patches/net/minecraft/data/recipes/RecipeOutput.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeOutput.java.patch
@@ -8,7 +8,7 @@
 -    void accept(ResourceLocation p_312249_, Recipe<?> p_312328_, @Nullable AdvancementHolder p_312176_);
 +public interface RecipeOutput extends net.neoforged.neoforge.common.extensions.IRecipeOutputExtension {
 +    default void accept(ResourceLocation p_312249_, Recipe<?> p_312328_, @Nullable AdvancementHolder p_312176_) {
-+        accept(p_312249_, p_312328_, p_312176_, new net.neoforged.neoforge.common.conditions.ICondition[0]);
++        accept(p_312249_, p_312328_, p_312176_, java.util.List.of(), java.util.List.of());
 +    }
  
      Advancement.Builder advancement();

--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -1,13 +1,20 @@
 --- a/net/minecraft/data/recipes/RecipeProvider.java
 +++ b/net/minecraft/data/recipes/RecipeProvider.java
-@@ -46,6 +_,7 @@
- public abstract class RecipeProvider implements DataProvider {
+@@ -43,11 +_,12 @@
+ import net.minecraft.world.level.block.Block;
+ import net.minecraft.world.level.block.Blocks;
+ 
+-public abstract class RecipeProvider implements DataProvider {
++public abstract class RecipeProvider implements DataProvider, net.neoforged.neoforge.common.conditions.IConditionBuilder {
      protected final PackOutput.PathProvider recipePathProvider;
      protected final PackOutput.PathProvider advancementPathProvider;
 +    protected final CompletableFuture<net.minecraft.core.HolderLookup.Provider> lookupProvider;
      private static final Map<BlockFamily.Variant, BiFunction<ItemLike, ItemLike, RecipeBuilder>> SHAPE_BUILDERS = ImmutableMap.<BlockFamily.Variant, BiFunction<ItemLike, ItemLike, RecipeBuilder>>builder(
-             
+-            
++
          )
+         .put(BlockFamily.Variant.BUTTON, (p_176733_, p_176734_) -> buttonBuilder(p_176733_, Ingredient.of(p_176734_)))
+         .put(BlockFamily.Variant.CHISELED, (p_248037_, p_248038_) -> chiseledBuilder(RecipeCategory.BUILDING_BLOCKS, p_248037_, Ingredient.of(p_248038_)))
 @@ -66,27 +_,29 @@
          .put(BlockFamily.Variant.WALL, (p_248024_, p_248025_) -> wallBuilder(RecipeCategory.DECORATIONS, p_248024_, Ingredient.of(p_248025_)))
          .build();
@@ -28,17 +35,17 @@
              new RecipeOutput() {
                  @Override
 -                public void accept(ResourceLocation p_312039_, Recipe<?> p_312254_, @Nullable AdvancementHolder p_311794_) {
-+                public void accept(ResourceLocation p_312039_, Recipe<?> p_312254_, @org.jetbrains.annotations.Nullable AdvancementHolder p_311794_, net.neoforged.neoforge.common.conditions.ICondition... conditions) {
++                public void accept(ResourceLocation p_312039_, Recipe<?> p_312254_, @org.jetbrains.annotations.Nullable AdvancementHolder p_311794_, List<net.neoforged.neoforge.common.conditions.ICondition> conditions, List<net.neoforged.neoforge.common.conditions.WithConditions<com.mojang.datafixers.util.Pair<Recipe<?>, Advancement>>> alternatives) {
                      if (!set.add(p_312039_)) {
                          throw new IllegalStateException("Duplicate recipe " + p_312039_);
                      } else {
 -                        list.add(DataProvider.saveStable(p_254020_, Recipe.CODEC, p_312254_, RecipeProvider.this.recipePathProvider.json(p_312039_)));
-+                        list.add(DataProvider.saveStable(p_254020_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_RECIPE_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, conditions)), RecipeProvider.this.recipePathProvider.json(p_312039_)));
++                        list.add(DataProvider.saveStable(p_254020_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_RECIPE_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.ConditionalObject<>(conditions, p_312254_, alternatives.stream().<net.neoforged.neoforge.common.conditions.WithConditions<Recipe<?>>>map(w -> new net.neoforged.neoforge.common.conditions.WithConditions<>(w.conditions(), w.carrier().getFirst())).toList())), RecipeProvider.this.recipePathProvider.json(p_312039_)));
                          if (p_311794_ != null) {
                              list.add(
                                  DataProvider.saveStable(
 -                                    p_254020_, Advancement.CODEC, p_311794_.value(), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
-+                                    p_254020_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), conditions)), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
++                                    p_254020_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.ConditionalObject<>(conditions, p_311794_.value(), alternatives.stream().filter(w -> w.carrier().getSecond() != null).map(w -> new net.neoforged.neoforge.common.conditions.WithConditions<>(w.conditions(), w.carrier().getSecond())).toList())), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
                                  )
                              );
                          }

--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/recipes/RecipeProvider.java
 +++ b/net/minecraft/data/recipes/RecipeProvider.java
-@@ -43,11 +_,12 @@
+@@ -43,11 +_,11 @@
  import net.minecraft.world.level.block.Block;
  import net.minecraft.world.level.block.Blocks;
  
@@ -11,7 +11,6 @@
 +    protected final CompletableFuture<net.minecraft.core.HolderLookup.Provider> lookupProvider;
      private static final Map<BlockFamily.Variant, BiFunction<ItemLike, ItemLike, RecipeBuilder>> SHAPE_BUILDERS = ImmutableMap.<BlockFamily.Variant, BiFunction<ItemLike, ItemLike, RecipeBuilder>>builder(
 -            
-+
          )
          .put(BlockFamily.Variant.BUTTON, (p_176733_, p_176734_) -> buttonBuilder(p_176733_, Ingredient.of(p_176734_)))
          .put(BlockFamily.Variant.CHISELED, (p_248037_, p_248038_) -> chiseledBuilder(RecipeCategory.BUILDING_BLOCKS, p_248037_, Ingredient.of(p_248038_)))

--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/recipes/RecipeProvider.java
 +++ b/net/minecraft/data/recipes/RecipeProvider.java
-@@ -43,11 +_,11 @@
+@@ -43,9 +_,10 @@
  import net.minecraft.world.level.block.Block;
  import net.minecraft.world.level.block.Blocks;
  
@@ -10,10 +10,8 @@
      protected final PackOutput.PathProvider advancementPathProvider;
 +    protected final CompletableFuture<net.minecraft.core.HolderLookup.Provider> lookupProvider;
      private static final Map<BlockFamily.Variant, BiFunction<ItemLike, ItemLike, RecipeBuilder>> SHAPE_BUILDERS = ImmutableMap.<BlockFamily.Variant, BiFunction<ItemLike, ItemLike, RecipeBuilder>>builder(
--            
+             
          )
-         .put(BlockFamily.Variant.BUTTON, (p_176733_, p_176734_) -> buttonBuilder(p_176733_, Ingredient.of(p_176734_)))
-         .put(BlockFamily.Variant.CHISELED, (p_248037_, p_248038_) -> chiseledBuilder(RecipeCategory.BUILDING_BLOCKS, p_248037_, Ingredient.of(p_248038_)))
 @@ -66,27 +_,29 @@
          .put(BlockFamily.Variant.WALL, (p_248024_, p_248025_) -> wallBuilder(RecipeCategory.DECORATIONS, p_248024_, Ingredient.of(p_248025_)))
          .build();

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
@@ -5,11 +5,10 @@
 
 package net.neoforged.neoforge.common.conditions;
 
-import org.apache.commons.lang3.Validate;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.apache.commons.lang3.Validate;
 
 public final class ConditionalObject<A> extends WithConditions<A> {
     private final List<WithConditions<A>> alternatives;

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
@@ -5,6 +5,8 @@
 
 package net.neoforged.neoforge.common.conditions;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public final class ConditionalObject<A> extends WithConditions<A> {
@@ -15,6 +17,7 @@ public final class ConditionalObject<A> extends WithConditions<A> {
         this.alternatives = alternatives;
     }
 
+    @SafeVarargs
     public ConditionalObject(List<ICondition> conditions, A carrier, WithConditions<A>... alternatives) {
         this(conditions, carrier, List.of(alternatives));
     }
@@ -25,5 +28,39 @@ public final class ConditionalObject<A> extends WithConditions<A> {
 
     public List<WithConditions<A>> alternatives() {
         return alternatives;
+    }
+
+    public static <A> Builder<A> builder(A carrier) {
+        return new Builder<A>().withCarrier(carrier);
+    }
+
+    public static class Builder<T> extends WithConditions.Builder<T> {
+        private final List<WithConditions<T>> alternatives = new ArrayList<>();
+
+        @Override
+        public Builder<T> addCondition(ICondition... condition) {
+            return (Builder<T>) super.addCondition(condition);
+        }
+
+        @Override
+        public Builder<T> addCondition(Collection<ICondition> conditions) {
+            return (Builder<T>) super.addCondition(conditions);
+        }
+
+        @Override
+        public Builder<T> withCarrier(T carrier) {
+            return (Builder<T>) super.withCarrier(carrier);
+        }
+
+        public Builder<T> addAlternative(T alternative, ICondition... conditions) {
+            this.alternatives.add(new WithConditions<>(alternative, conditions));
+            return this;
+        }
+
+        @Override
+        public ConditionalObject<T> build() {
+            validate();
+            return new ConditionalObject<>(conditions, carrier, alternatives);
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.conditions;
+
+import java.util.List;
+
+public final class ConditionalObject<A> extends WithConditions<A> {
+    private final List<WithConditions<A>> alternatives;
+
+    public ConditionalObject(List<ICondition> conditions, A carrier, List<WithConditions<A>> alternatives) {
+        super(conditions, carrier);
+        this.alternatives = alternatives;
+    }
+
+    public ConditionalObject(List<ICondition> conditions, A carrier, WithConditions<A>... alternatives) {
+        this(conditions, carrier, List.of(alternatives));
+    }
+
+    public ConditionalObject(A carrier) {
+        this(List.of(), carrier, List.of());
+    }
+
+    public List<WithConditions<A>> alternatives() {
+        return alternatives;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalObject.java
@@ -5,6 +5,8 @@
 
 package net.neoforged.neoforge.common.conditions;
 
+import org.apache.commons.lang3.Validate;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -15,6 +17,8 @@ public final class ConditionalObject<A> extends WithConditions<A> {
     public ConditionalObject(List<ICondition> conditions, A carrier, List<WithConditions<A>> alternatives) {
         super(conditions, carrier);
         this.alternatives = alternatives;
+
+        Validate.isTrue(alternatives.stream().noneMatch(ConditionalObject.class::isInstance), "Alternatives cannot have alternatives");
     }
 
     @SafeVarargs

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
@@ -56,6 +56,10 @@ public class ConditionalOps<T> extends RegistryOps<T> {
      */
     public static final String DEFAULT_CONDITIONS_KEY = "neoforge:conditions";
     /**
+     * Key used for the alternatives inside an object.
+     */
+    public static final String ALTERNATIVES_KEY = "neoforge:alternatives";
+    /**
      * Key used to store the value associated with conditions,
      * when the value is not represented as a map.
      * For example, if we wanted to store the value 2 with some conditions, we could do:
@@ -156,7 +160,7 @@ public class ConditionalOps<T> extends RegistryOps<T> {
             if (!alternatives.isEmpty()) {
                 final var alt = ops.listBuilder();
                 alternatives.forEach(a -> alt.add(this.encode(Optional.of(a), ops, ops.empty(), false)));
-                recordBuilder.add("neoforge:alternatives", alt.build(ops.empty()));
+                recordBuilder.add(ALTERNATIVES_KEY, alt.build(ops.empty()));
             }
 
             // Serialize the object
@@ -230,7 +234,7 @@ public class ConditionalOps<T> extends RegistryOps<T> {
 
                         final boolean conditionsMatch = conditions.stream().allMatch(c -> c.test(context));
                         if (!conditionsMatch) {
-                            final T alternatives = inputMap.get("neoforge:alternatives");
+                            final T alternatives = inputMap.get(ALTERNATIVES_KEY);
                             if (alternatives == null || !supportsAlternatives) {
                                 return DataResult.success(Pair.of(Optional.empty(), input));
                             }

--- a/src/main/java/net/neoforged/neoforge/common/conditions/WithConditions.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/WithConditions.java
@@ -10,13 +10,29 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.commons.lang3.Validate;
 
-public record WithConditions<A>(List<ICondition> conditions, A carrier) {
+public sealed class WithConditions<A> permits ConditionalObject {
+    private final List<ICondition> conditions;
+    private final A carrier;
+
     public WithConditions(A carrier, ICondition... conditions) {
         this(List.of(conditions), carrier);
     }
 
     public WithConditions(A carrier) {
         this(List.of(), carrier);
+    }
+
+    public WithConditions(List<ICondition> conditions, A carrier) {
+        this.conditions = conditions;
+        this.carrier = carrier;
+    }
+
+    public List<ICondition> conditions() {
+        return this.conditions;
+    }
+
+    public A carrier() {
+        return this.carrier;
     }
 
     public static <A> Builder<A> builder(A carrier) {

--- a/src/main/java/net/neoforged/neoforge/common/conditions/WithConditions.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/WithConditions.java
@@ -40,8 +40,8 @@ public sealed class WithConditions<A> permits ConditionalObject {
     }
 
     public static class Builder<T> {
-        private final List<ICondition> conditions = new ArrayList<>();
-        private T carrier;
+        protected final List<ICondition> conditions = new ArrayList<>();
+        protected T carrier;
 
         public Builder<T> addCondition(ICondition... condition) {
             this.conditions.addAll(List.of(condition));
@@ -58,10 +58,13 @@ public sealed class WithConditions<A> permits ConditionalObject {
             return this;
         }
 
-        public WithConditions<T> build() {
+        protected void validate() {
             Validate.notNull(this.carrier, "You need to supply a carrier to create a WithConditions");
             Validate.notEmpty(this.conditions, "You need to supply at least one condition to create a WithConditions");
+        }
 
+        public WithConditions<T> build() {
+            validate();
             return new WithConditions<>(this.conditions, this.carrier);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ConditionalRecipeOutput.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ConditionalRecipeOutput.java
@@ -26,9 +26,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Wrapper around a {@link RecipeOutput} that adds conditions to all received recipes.
- * Do not use directly, obtain via {@link RecipeOutput#withConditions(ICondition...)}.
+ * Do not construct directly, obtain via {@link RecipeOutput#withConditions(ICondition...)}.
  */
-@ApiStatus.Internal
 public class ConditionalRecipeOutput implements RecipeOutput {
     public static final Criterion<?> DUMMY = CriteriaTriggers.TICK.createCriterion(new PlayerTrigger.TriggerInstance(Optional.empty()));
 
@@ -36,6 +35,7 @@ public class ConditionalRecipeOutput implements RecipeOutput {
     private final ICondition[] conditions;
     private final List<WithConditions<RecipeBuilder>> alternatives = new ArrayList<>();
 
+    @ApiStatus.Internal
     public ConditionalRecipeOutput(RecipeOutput inner, ICondition[] conditions) {
         this.inner = inner;
         this.conditions = conditions;
@@ -53,6 +53,9 @@ public class ConditionalRecipeOutput implements RecipeOutput {
 
     private boolean inheritAdvancements;
 
+    /**
+     * Inherit advancements in alternative recipes.
+     */
     public ConditionalRecipeOutput inheritAdvancements() {
         this.inheritAdvancements = true;
         return this;
@@ -62,6 +65,7 @@ public class ConditionalRecipeOutput implements RecipeOutput {
     public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder superAdvancement, List<ICondition> conditions, List<WithConditions<Pair<Recipe<?>, Advancement>>> alternatives) {
         final var actualAlternatives = Lists.newArrayList(alternatives);
         this.alternatives.forEach(alt -> {
+            // If we're inheriting advancements, this will simply make sure that recipes have a criterion and don't complain
             if (inheritAdvancements) {
                 alt.carrier().unlockedBy("dummy", DUMMY);
             }

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ConditionalRecipeOutput.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ConditionalRecipeOutput.java
@@ -5,13 +5,22 @@
 
 package net.neoforged.neoforge.common.crafting;
 
+import com.google.common.collect.Lists;
+import com.mojang.datafixers.util.Pair;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.critereon.PlayerTrigger;
+import net.minecraft.data.recipes.RecipeBuilder;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.neoforge.common.conditions.ICondition;
-import org.apache.commons.lang3.ArrayUtils;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,12 +30,20 @@ import org.jetbrains.annotations.Nullable;
  */
 @ApiStatus.Internal
 public class ConditionalRecipeOutput implements RecipeOutput {
+    public static final Criterion<?> DUMMY = CriteriaTriggers.TICK.createCriterion(new PlayerTrigger.TriggerInstance(Optional.empty()));
+
     private final RecipeOutput inner;
     private final ICondition[] conditions;
+    private final List<WithConditions<RecipeBuilder>> alternatives = new ArrayList<>();
 
     public ConditionalRecipeOutput(RecipeOutput inner, ICondition[] conditions) {
         this.inner = inner;
         this.conditions = conditions;
+    }
+
+    public ConditionalRecipeOutput withAlternative(RecipeBuilder alternative, ICondition... conditions) {
+        this.alternatives.add(new WithConditions<>(alternative, conditions));
+        return this;
     }
 
     @Override
@@ -34,16 +51,45 @@ public class ConditionalRecipeOutput implements RecipeOutput {
         return inner.advancement();
     }
 
+    private boolean inheritAdvancements;
+
+    public ConditionalRecipeOutput inheritAdvancements() {
+        this.inheritAdvancements = true;
+        return this;
+    }
+
     @Override
-    public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
-        ICondition[] innerConditions;
-        if (conditions.length == 0) {
-            innerConditions = this.conditions;
-        } else if (this.conditions.length == 0) {
-            innerConditions = conditions;
-        } else {
-            innerConditions = ArrayUtils.addAll(this.conditions, conditions);
-        }
-        inner.accept(id, recipe, advancement, innerConditions);
+    public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder superAdvancement, List<ICondition> conditions, List<WithConditions<Pair<Recipe<?>, Advancement>>> alternatives) {
+        final var actualAlternatives = Lists.newArrayList(alternatives);
+        this.alternatives.forEach(alt -> {
+            if (inheritAdvancements) {
+                alt.carrier().unlockedBy("dummy", DUMMY);
+            }
+
+            alt.carrier().save(new RecipeOutput() {
+                @Override
+                public Advancement.Builder advancement() {
+                    return inner.advancement();
+                }
+
+                @Override
+                public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, List<ICondition> conditions, List<WithConditions<Pair<Recipe<?>, Advancement>>> alternatives) {
+                    conditions = Lists.newArrayList(conditions);
+                    conditions.addAll(alt.conditions());
+                    final Advancement actualAdvancement;
+                    if (advancement == null || inheritAdvancements) {
+                        actualAdvancement = superAdvancement == null ? null : superAdvancement.value();
+                    } else {
+                        actualAdvancement = advancement.value();
+                    }
+                    actualAlternatives.add(new WithConditions<>(conditions, Pair.of(recipe, actualAdvancement)));
+                }
+            });
+        });
+
+        conditions = Lists.newArrayList(conditions);
+        conditions.addAll(List.of(this.conditions));
+
+        inner.accept(id, recipe, superAdvancement, conditions, actualAlternatives);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/JsonCodecProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/JsonCodecProvider.java
@@ -111,7 +111,7 @@ public abstract class JsonCodecProvider<T> implements DataProvider {
         process(id, new ConditionalObject<>(List.of(), value));
     }
 
-    public void conditionally(ResourceLocation id, Consumer<WithConditions.Builder<T>> configurator) {
+    public void conditionally(ResourceLocation id, Consumer<ConditionalObject.Builder<T>> configurator) {
         final ConditionalObject.Builder<T> builder = new ConditionalObject.Builder<>();
         configurator.accept(builder);
 

--- a/src/main/java/net/neoforged/neoforge/common/data/JsonCodecProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/JsonCodecProvider.java
@@ -26,6 +26,7 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
+import net.neoforged.neoforge.common.conditions.ConditionalObject;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.conditions.WithConditions;
@@ -51,7 +52,7 @@ public abstract class JsonCodecProvider<T> implements DataProvider {
     protected final String modid;
     protected final String directory;
     protected final Codec<T> codec;
-    protected final Map<ResourceLocation, WithConditions<T>> conditions = Maps.newHashMap();
+    protected final Map<ResourceLocation, ConditionalObject<T>> conditions = Maps.newHashMap();
 
     /**
      * @param output    {@linkplain PackOutput} provided by the {@link DataGenerator}.
@@ -107,18 +108,18 @@ public abstract class JsonCodecProvider<T> implements DataProvider {
     }
 
     public void unconditional(ResourceLocation id, T value) {
-        process(id, new WithConditions<>(List.of(), value));
+        process(id, new ConditionalObject<>(List.of(), value));
     }
 
     public void conditionally(ResourceLocation id, Consumer<WithConditions.Builder<T>> configurator) {
-        final WithConditions.Builder<T> builder = new WithConditions.Builder<>();
+        final ConditionalObject.Builder<T> builder = new ConditionalObject.Builder<>();
         configurator.accept(builder);
 
-        final WithConditions<T> withConditions = builder.build();
+        final ConditionalObject<T> withConditions = builder.build();
         process(id, withConditions);
     }
 
-    private void process(ResourceLocation id, WithConditions<T> withConditions) {
+    private void process(ResourceLocation id, ConditionalObject<T> withConditions) {
         this.existingFileHelper.trackGenerated(id, this.resourceType);
 
         this.conditions.put(id, withConditions);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.common.data.internal;
 
+import com.mojang.datafixers.util.Pair;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -38,6 +39,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.neoforged.fml.util.ObfuscationReflectionHelper;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 import org.jetbrains.annotations.Nullable;
 
 public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
@@ -98,10 +100,10 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
 
         super.buildRecipes(new RecipeOutput() {
             @Override
-            public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
+            public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, List<ICondition> conditions, List<WithConditions<Pair<Recipe<?>, Advancement>>> alternatives) {
                 Recipe<?> modified = enhance(id, recipe);
                 if (modified != null)
-                    recipeOutput.accept(id, modified, null, conditions);
+                    recipeOutput.accept(id, modified, null, conditions, alternatives);
             }
 
             @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IRecipeOutputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IRecipeOutputExtension.java
@@ -30,10 +30,6 @@ public interface IRecipeOutputExtension {
      */
     void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, List<ICondition> conditions, List<WithConditions<Pair<Recipe<?>, Advancement>>> alternatives);
 
-    default void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
-        accept(id, recipe, advancement, List.of(conditions), List.of());
-    }
-
     /**
      * Builds a wrapper around this recipe output that adds conditions to all received recipes.
      */

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IRecipeOutputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IRecipeOutputExtension.java
@@ -5,11 +5,15 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import com.mojang.datafixers.util.Pair;
+import java.util.List;
+import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 import net.neoforged.neoforge.common.crafting.ConditionalRecipeOutput;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,12 +28,16 @@ public interface IRecipeOutputExtension {
     /**
      * Generates a recipe with the given conditions.
      */
-    void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions);
+    void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, List<ICondition> conditions, List<WithConditions<Pair<Recipe<?>, Advancement>>> alternatives);
+
+    default void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
+        accept(id, recipe, advancement, List.of(conditions), List.of());
+    }
 
     /**
      * Builds a wrapper around this recipe output that adds conditions to all received recipes.
      */
-    default RecipeOutput withConditions(ICondition... conditions) {
+    default ConditionalRecipeOutput withConditions(ICondition... conditions) {
         return new ConditionalRecipeOutput(self(), conditions);
     }
 }

--- a/tests/src/generated/resources/assets/neotests_snow_boots/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_snow_boots/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "item.neotests_snow_boots.snow_boots": "Snow Boots"
+}

--- a/tests/src/generated/resources/data/neotests_recipe_alternative/advancements/recipes/brewing/betterdiamond.json
+++ b/tests/src/generated/resources/data/neotests_recipe_alternative/advancements/recipes/brewing/betterdiamond.json
@@ -1,0 +1,75 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:false"
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_stick": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:stick"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_recipe_alternative:betterdiamond"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "neoforge:alternatives": [
+    {
+      "parent": "minecraft:recipes/root",
+      "criteria": {
+        "has_stick": {
+          "conditions": {
+            "items": [
+              {
+                "items": [
+                  "minecraft:stick"
+                ]
+              }
+            ]
+          },
+          "trigger": "minecraft:inventory_changed"
+        },
+        "has_the_recipe": {
+          "conditions": {
+            "recipe": "neotests_recipe_alternative:betterdiamond"
+          },
+          "trigger": "minecraft:recipe_unlocked"
+        }
+      },
+      "requirements": [
+        [
+          "has_the_recipe",
+          "has_stick"
+        ]
+      ],
+      "rewards": {
+        "recipes": [
+          "neotests_recipe_alternative:betterdiamond"
+        ]
+      }
+    }
+  ],
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_stick"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_recipe_alternative:betterdiamond"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_recipe_alternative/recipes/betterdiamond.json
+++ b/tests/src/generated/resources/data/neotests_recipe_alternative/recipes/betterdiamond.json
@@ -1,0 +1,37 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:false"
+    }
+  ],
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "S": {
+      "item": "minecraft:stick"
+    }
+  },
+  "neoforge:alternatives": [
+    {
+      "type": "minecraft:crafting_shaped",
+      "category": "misc",
+      "key": {
+        "S": {
+          "item": "minecraft:stick"
+        }
+      },
+      "pattern": [
+        "S S"
+      ],
+      "result": {
+        "item": "minecraft:diamond"
+      }
+    }
+  ],
+  "pattern": [
+    "SSS"
+  ],
+  "result": {
+    "item": "minecraft:diamond"
+  }
+}


### PR DESCRIPTION
This PR adds a `neoforge:alternatives` list to conditional codecs, that will try to find an alternative to load by checking the conditions of each one, in order and if they match return the object.  
To achieve that the `WithConditions` record has been made into a sealed class, and a new `ConditionalObject` children has been added. When a `ConditionalObject` is detected at the root, the encoder will write its alternatives.  
Only the root object can have alternatives, and an alternative cannot be of the type `ConditionalObject`.