### PR TITLE
[1.20.4] Fix seams on generated item models (MC-73186)

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/ItemModelGenerator.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/ItemModelGenerator.java.patch
@@ -1,11 +1,42 @@
 --- a/net/minecraft/client/renderer/block/model/ItemModelGenerator.java
 +++ b/net/minecraft/client/renderer/block/model/ItemModelGenerator.java
-@@ -39,6 +_,8 @@
+@@ -32,17 +_,19 @@
+ 
+             Material material = p_111672_.getMaterial(s);
+             map.put(s, Either.left(material));
+-            SpriteContents spritecontents = p_111671_.apply(material).contents();
++            TextureAtlasSprite spritecontents = p_111671_.apply(material);
+             list.addAll(this.processFrames(i, s, spritecontents));
+         }
+ 
          map.put("particle", p_111672_.hasTexture("particle") ? Either.left(p_111672_.getMaterial("particle")) : map.get("layer0"));
          BlockModel blockmodel = new BlockModel(null, list, map, false, p_111672_.getGuiLight(), p_111672_.getTransforms(), p_111672_.getOverrides());
          blockmodel.name = p_111672_.name;
 +        blockmodel.customData.copyFrom(p_111672_.customData);
 +        blockmodel.customData.setGui3d(false);
          return blockmodel;
+     }
+ 
+-    public List<BlockElement> processFrames(int p_111639_, String p_111640_, SpriteContents p_251768_) {
++    public List<BlockElement> processFrames(int p_111639_, String p_111640_, TextureAtlasSprite p_251768_) {
+         Map<Direction, BlockElementFace> map = Maps.newHashMap();
+         map.put(Direction.SOUTH, new BlockElementFace(null, p_111639_, p_111640_, new BlockFaceUV(new float[]{0.0F, 0.0F, 16.0F, 16.0F}, 0)));
+         map.put(Direction.NORTH, new BlockElementFace(null, p_111639_, p_111640_, new BlockFaceUV(new float[]{16.0F, 0.0F, 0.0F, 16.0F}, 0)));
+@@ -52,7 +_,8 @@
+         return list;
+     }
+ 
+-    private List<BlockElement> createSideElements(SpriteContents p_248810_, String p_111663_, int p_111664_) {
++    private List<BlockElement> createSideElements(TextureAtlasSprite sprite, String p_111663_, int p_111664_) {
++        SpriteContents p_248810_ = sprite.contents();
+         float f = (float)p_248810_.width();
+         float f1 = (float)p_248810_.height();
+         List<BlockElement> list = Lists.newArrayList();
+@@ -139,6 +_,7 @@
+             }
+         }
+ 
++        net.neoforged.neoforge.client.ClientHooks.fixItemModelSeams(list, sprite); // Neo: fix MC-73186 on generated item models
+         return list;
      }
  

--- a/patches/net/minecraft/client/renderer/block/model/ItemModelGenerator.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/ItemModelGenerator.java.patch
@@ -1,12 +1,14 @@
 --- a/net/minecraft/client/renderer/block/model/ItemModelGenerator.java
 +++ b/net/minecraft/client/renderer/block/model/ItemModelGenerator.java
-@@ -32,17 +_,19 @@
+@@ -32,13 +_,16 @@
  
              Material material = p_111672_.getMaterial(s);
              map.put(s, Either.left(material));
 -            SpriteContents spritecontents = p_111671_.apply(material).contents();
-+            TextureAtlasSprite spritecontents = p_111671_.apply(material);
-             list.addAll(this.processFrames(i, s, spritecontents));
+-            list.addAll(this.processFrames(i, s, spritecontents));
++            TextureAtlasSprite sprite = p_111671_.apply(material);
++            // Neo: fix MC-73186 on generated item models
++            list.addAll(net.neoforged.neoforge.client.ClientHooks.fixItemModelSeams(this.processFrames(i, s, sprite.contents()), sprite));
          }
  
          map.put("particle", p_111672_.hasTexture("particle") ? Either.left(p_111672_.getMaterial("particle")) : map.get("layer0"));
@@ -15,28 +17,5 @@
 +        blockmodel.customData.copyFrom(p_111672_.customData);
 +        blockmodel.customData.setGui3d(false);
          return blockmodel;
-     }
- 
--    public List<BlockElement> processFrames(int p_111639_, String p_111640_, SpriteContents p_251768_) {
-+    public List<BlockElement> processFrames(int p_111639_, String p_111640_, TextureAtlasSprite p_251768_) {
-         Map<Direction, BlockElementFace> map = Maps.newHashMap();
-         map.put(Direction.SOUTH, new BlockElementFace(null, p_111639_, p_111640_, new BlockFaceUV(new float[]{0.0F, 0.0F, 16.0F, 16.0F}, 0)));
-         map.put(Direction.NORTH, new BlockElementFace(null, p_111639_, p_111640_, new BlockFaceUV(new float[]{16.0F, 0.0F, 0.0F, 16.0F}, 0)));
-@@ -52,7 +_,8 @@
-         return list;
-     }
- 
--    private List<BlockElement> createSideElements(SpriteContents p_248810_, String p_111663_, int p_111664_) {
-+    private List<BlockElement> createSideElements(TextureAtlasSprite sprite, String p_111663_, int p_111664_) {
-+        SpriteContents p_248810_ = sprite.contents();
-         float f = (float)p_248810_.width();
-         float f1 = (float)p_248810_.height();
-         List<BlockElement> list = Lists.newArrayList();
-@@ -139,6 +_,7 @@
-             }
-         }
- 
-+        net.neoforged.neoforge.client.ClientHooks.fixItemModelSeams(list, sprite); // Neo: fix MC-73186 on generated item models
-         return list;
      }
  

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -75,7 +75,6 @@ import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockElement;
-import net.minecraft.client.renderer.block.model.BlockFaceUV;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.culling.Frustum;
@@ -1083,14 +1082,18 @@ public class ClientHooks {
             element.to.y = Mth.clamp(Mth.lerp(expand, element.to.y, 8F), 0F, 16F);
 
             // Edge elements are guaranteed to have exactly one face
-            BlockFaceUV uv = element.faces.values().iterator().next().uv;
+            var faceEntry = element.faces.entrySet().iterator().next();
+            float[] uv = faceEntry.getValue().uv.uvs;
             // Counteract sprite expansion on edge quads to ensure alignment with pixels on the front and back quads
-            float centerU = (uv.uvs[0] + uv.uvs[0] + uv.uvs[2] + uv.uvs[2]) / 4.0F;
-            float centerV = (uv.uvs[1] + uv.uvs[1] + uv.uvs[3] + uv.uvs[3]) / 4.0F;
-            uv.uvs[0] = Mth.clamp(Mth.lerp(expand, uv.uvs[0], centerU), 0F, 16F);
-            uv.uvs[2] = Mth.clamp(Mth.lerp(expand, uv.uvs[2], centerU), 0F, 16F);
-            uv.uvs[1] = Mth.clamp(Mth.lerp(expand, uv.uvs[1], centerV), 0F, 16F);
-            uv.uvs[3] = Mth.clamp(Mth.lerp(expand, uv.uvs[3], centerV), 0F, 16F);
+            if (faceEntry.getKey().getAxis() == Direction.Axis.Y) {
+                float centerU = (uv[0] + uv[0] + uv[2] + uv[2]) / 4.0F;
+                uv[0] = Mth.clamp(Mth.lerp(expand, uv[0], centerU), 0F, 16F);
+                uv[2] = Mth.clamp(Mth.lerp(expand, uv[2], centerU), 0F, 16F);
+            } else {
+                float centerV = (uv[1] + uv[1] + uv[3] + uv[3]) / 4.0F;
+                uv[1] = Mth.clamp(Mth.lerp(expand, uv[1], centerV), 0F, 16F);
+                uv[3] = Mth.clamp(Mth.lerp(expand, uv[3], centerV), 0F, 16F);
+            }
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -1068,8 +1068,9 @@ public class ClientHooks {
     /**
      * Modify the position and UVs of the edge quads of generated item models to account for sprite expansion of the
      * front and back quad. Fixes <a href="https://bugs.mojang.com/browse/MC-73186">MC-73186</a> on generated item models.
+     * 
      * @param elements The generated elements, may include the front and back face
-     * @param sprite The texture from which the elements were generated
+     * @param sprite   The texture from which the elements were generated
      * @return the original elements list
      */
     public static List<BlockElement> fixItemModelSeams(List<BlockElement> elements, TextureAtlasSprite sprite) {

--- a/src/main/java/net/neoforged/neoforge/client/model/DynamicFluidContainerModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/DynamicFluidContainerModel.java
@@ -114,7 +114,7 @@ public class DynamicFluidContainerModel implements IUnbakedGeometry<DynamicFluid
 
         if (baseLocation != null && baseSprite != null) {
             // Base texture
-            var unbaked = UnbakedGeometryHelper.createUnbakedItemElements(0, baseSprite.contents());
+            var unbaked = UnbakedGeometryHelper.createUnbakedItemElements(0, baseSprite);
             var quads = UnbakedGeometryHelper.bakeElements(unbaked, $ -> baseSprite, modelState, modelLocation);
             modelBuilder.addQuads(normalRenderTypes, quads);
         }
@@ -124,7 +124,7 @@ public class DynamicFluidContainerModel implements IUnbakedGeometry<DynamicFluid
             if (templateSprite != null) {
                 // Fluid layer
                 var transformedState = new SimpleModelState(modelState.getRotation().compose(FLUID_TRANSFORM), modelState.isUvLocked());
-                var unbaked = UnbakedGeometryHelper.createUnbakedItemMaskElements(1, templateSprite.contents()); // Use template as mask
+                var unbaked = UnbakedGeometryHelper.createUnbakedItemMaskElements(1, templateSprite); // Use template as mask
                 var quads = UnbakedGeometryHelper.bakeElements(unbaked, $ -> fluidSprite, transformedState, modelLocation); // Bake with fluid texture
 
                 var emissive = applyFluidLuminosity && fluid.getFluidType().getLightLevel() > 0;
@@ -140,7 +140,7 @@ public class DynamicFluidContainerModel implements IUnbakedGeometry<DynamicFluid
             if (sprite != null) {
                 // Cover/overlay
                 var transformedState = new SimpleModelState(modelState.getRotation().compose(COVER_TRANSFORM), modelState.isUvLocked());
-                var unbaked = UnbakedGeometryHelper.createUnbakedItemMaskElements(2, coverSprite.contents()); // Use cover as mask
+                var unbaked = UnbakedGeometryHelper.createUnbakedItemMaskElements(2, coverSprite); // Use cover as mask
                 var quads = UnbakedGeometryHelper.bakeElements(unbaked, $ -> sprite, transformedState, modelLocation); // Bake with selected texture
                 modelBuilder.addQuads(normalRenderTypes, quads);
             }

--- a/src/main/java/net/neoforged/neoforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/ItemLayerModel.java
@@ -70,7 +70,7 @@ public class ItemLayerModel implements IUnbakedGeometry<ItemLayerModel> {
         CompositeModel.Baked.Builder builder = CompositeModel.Baked.builder(context, particle, overrides, context.getTransforms());
         for (int i = 0; i < textures.size(); i++) {
             TextureAtlasSprite sprite = spriteGetter.apply(textures.get(i));
-            var unbaked = UnbakedGeometryHelper.createUnbakedItemElements(i, sprite.contents(), this.layerData.get(i));
+            var unbaked = UnbakedGeometryHelper.createUnbakedItemElements(i, sprite, this.layerData.get(i));
             var quads = UnbakedGeometryHelper.bakeElements(unbaked, $ -> sprite, modelState, modelLocation);
             var renderTypeName = renderTypeNames.get(i);
             var renderTypes = renderTypeName != null ? context.getRenderType(renderTypeName) : null;

--- a/src/main/java/net/neoforged/neoforge/client/model/geometry/UnbakedGeometryHelper.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/geometry/UnbakedGeometryHelper.java
@@ -33,6 +33,7 @@ import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.client.model.ElementsModel;
 import net.neoforged.neoforge.client.model.ExtraFaceData;
 import net.neoforged.neoforge.client.model.IModelBuilder;
@@ -125,7 +126,8 @@ public class UnbakedGeometryHelper {
      * The {@link Direction#NORTH} and {@link Direction#SOUTH} faces take up the whole surface.
      */
     public static List<BlockElement> createUnbakedItemElements(int layerIndex, TextureAtlasSprite sprite, @Nullable ExtraFaceData faceData) {
-        var elements = ITEM_MODEL_GENERATOR.processFrames(layerIndex, "layer" + layerIndex, sprite);
+        var elements = ITEM_MODEL_GENERATOR.processFrames(layerIndex, "layer" + layerIndex, sprite.contents());
+        ClientHooks.fixItemModelSeams(elements, sprite);
         if (faceData != null) {
             elements.forEach(element -> element.setFaceData(faceData));
         }

--- a/src/main/java/net/neoforged/neoforge/client/model/geometry/UnbakedGeometryHelper.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/geometry/UnbakedGeometryHelper.java
@@ -112,10 +112,10 @@ public class UnbakedGeometryHelper {
     }
 
     /**
-     * @see #createUnbakedItemElements(int, SpriteContents, ExtraFaceData)
+     * @see #createUnbakedItemElements(int, TextureAtlasSprite, ExtraFaceData)
      */
-    public static List<BlockElement> createUnbakedItemElements(int layerIndex, SpriteContents spriteContents) {
-        return createUnbakedItemElements(layerIndex, spriteContents, null);
+    public static List<BlockElement> createUnbakedItemElements(int layerIndex, TextureAtlasSprite sprite) {
+        return createUnbakedItemElements(layerIndex, sprite, null);
     }
 
     /**
@@ -124,8 +124,8 @@ public class UnbakedGeometryHelper {
      * <p>
      * The {@link Direction#NORTH} and {@link Direction#SOUTH} faces take up the whole surface.
      */
-    public static List<BlockElement> createUnbakedItemElements(int layerIndex, SpriteContents spriteContents, @Nullable ExtraFaceData faceData) {
-        var elements = ITEM_MODEL_GENERATOR.processFrames(layerIndex, "layer" + layerIndex, spriteContents);
+    public static List<BlockElement> createUnbakedItemElements(int layerIndex, TextureAtlasSprite sprite, @Nullable ExtraFaceData faceData) {
+        var elements = ITEM_MODEL_GENERATOR.processFrames(layerIndex, "layer" + layerIndex, sprite);
         if (faceData != null) {
             elements.forEach(element -> element.setFaceData(faceData));
         }
@@ -133,10 +133,10 @@ public class UnbakedGeometryHelper {
     }
 
     /**
-     * @see #createUnbakedItemMaskElements(int, SpriteContents, ExtraFaceData)
+     * @see #createUnbakedItemMaskElements(int, TextureAtlasSprite, ExtraFaceData)
      */
-    public static List<BlockElement> createUnbakedItemMaskElements(int layerIndex, SpriteContents spriteContents) {
-        return createUnbakedItemMaskElements(layerIndex, spriteContents, null);
+    public static List<BlockElement> createUnbakedItemMaskElements(int layerIndex, TextureAtlasSprite sprite) {
+        return createUnbakedItemMaskElements(layerIndex, sprite, null);
     }
 
     /**
@@ -145,10 +145,11 @@ public class UnbakedGeometryHelper {
      * <p>
      * The {@link Direction#NORTH} and {@link Direction#SOUTH} faces take up only the pixels the texture uses.
      */
-    public static List<BlockElement> createUnbakedItemMaskElements(int layerIndex, SpriteContents spriteContents, @Nullable ExtraFaceData faceData) {
-        var elements = createUnbakedItemElements(layerIndex, spriteContents, faceData);
+    public static List<BlockElement> createUnbakedItemMaskElements(int layerIndex, TextureAtlasSprite sprite, @Nullable ExtraFaceData faceData) {
+        var elements = createUnbakedItemElements(layerIndex, sprite, faceData);
         elements.remove(0); // Remove north and south faces
 
+        SpriteContents spriteContents = sprite.contents();
         int width = spriteContents.width(), height = spriteContents.height();
         var bits = new BitSet(width * height);
 

--- a/tests/src/main/resources/assets/custom_fluid_container_test/models/item/custom_fluid_container.json
+++ b/tests/src/main/resources/assets/custom_fluid_container_test/models/item/custom_fluid_container.json
@@ -1,6 +1,11 @@
 {
-  "parent": "item/generated",
+  "parent": "neoforge:item/default",
+  "loader": "neoforge:fluid_container",
+  "fluid": "minecraft:empty",
+  "cover_is_mask": true,
   "textures": {
-    "layer0": "item/bucket"
+    "base": "item/bucket",
+    "fluid": "neoforge:item/mask/bucket_fluid_drip",
+    "cover": "neoforge:item/mask/bucket_fluid_cover_drip"
   }
 }


### PR DESCRIPTION
This PR fixes the large seams on generated item models, fixing [MC-73186](https://bugs.mojang.com/browse/MC-73186) for these models. Non-generated models and models which entirely replicate the item model generation are not impacted by this change in terms of outcome and should be unaffected by the method signature changes. Models which mix vanilla model generation and custom model generation such as the dynamic fluid container model loader included in NeoForge may be impacted slightly in their outcome and will be broken by the method signature changes. The aforementioned fluid container loader is entirely broken at the moment and will require a separate PR to fix it regardless.

When an item model is generated, two full-size quads are first added for the front and back face. Then additional quads are generated to cover the other four directions such that the model gains depth. These edge quads are generated at the original positions of the pixels in the texture. When the model is then baked, a sprite expansion is applied to all quads (the UVs are moved slightly towards the quad center) which then leads to the pixels on the front and back quad becoming misaligned with the edge quads. The fix is to modify the position and UVs of the edge quads to make them take the sprite expansion of the front and back quads into account.

It is worth noting that this solution cannot fix the tiny white dots at the edges between quads as these are caused by floating point errors and may be hardware-dependent.

Before:
![2023-12-28_09 12 17](https://github.com/neoforged/NeoForge/assets/11262040/d87963f5-3958-43a7-98dc-091b801a2217)

After:
![2023-12-28_09 12 34](https://github.com/neoforged/NeoForge/assets/11262040/1e953585-45d8-40fd-b89f-6d86cb54da6b)
