### PR TITLE
Add Crowdin configuration file

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,27 @@
+base_path: "."
+base_url: "https://neoforged.api.crowdin.com"
+
+# For interacting with Crowdin locally (via CLI), set these environment variables to their proper values
+project_id_env: "NEOFORGE_CROWDIN_PROJECT_ID"
+api_token_env: "NEOFORGE_CROWDIN_API_TOKEN"
+
+# Preserve directory structure (required by the use of the 'dest' field below)
+preserve_hierarchy: true
+
+# Prevent Crowdin-created commits from automatically triggering builds
+commit_message: "[ci skip]"
+# Automatically label PRs made by Crowdin
+pull_request_labels: [ "l10n" ]
+
+files:
+    -   source: "/src/main/resources/assets/neoforge/lang/en_us.json"
+        # Unfortunately, Crowdin doesn't have a placeholder which matches Minecraft's expected naming scheme: underscores
+        # with lowercase letters (since resource location are required to be fully lowercase).
+        #
+        # To make up for this unfortunate defect, **in the Crowdin interface**, we specify custom language mappings for
+        # the "%locale_with_underscore%" placeholder, converting the uppercase to lowercase in the original value.
+        #
+        # If you are adding a new language to the Crowdin project,
+        # ** MAKE SURE YOU ADD THE APPROPRIATE CUSTOM LANGUAGE MAPPING FOR THE PLACEHOLDER. **
+        translation: "/src/main/resources/assets/neoforge/lang/%locale_with_underscore%.%file_extension%"
+        dest: "/messages.%file_extension%"


### PR DESCRIPTION
This PR introduces a Crowdin configuration file, as one of the necessary steps to enabling Crowdin-GitHub integration for NeoForge.

Once this PR is merged, a Crowdin project manager (such as I) will correspondingly configure the integration on the Crowdin side, to load the configuration file.

### Background

Our predecessor Minecraft Forge (MCF) uses [Crowdin](https://crowdin.com/) as its crowdsourced localization platform. When NeoForged forked from MCF, we lost access to the Crowdin project attached to MCF. For months, NeoForge had no localization present, due to prioritization of other efforts drawing attention away from fixing the localization situation.

After some consultation with other projects which use crowdsourced localization platforms, we've decided to stick with Crowdin, instead of other platforms such as a self-hosted [Weblate](https://weblate.org/en/) instance. One primary reason behind the decision is familiary and preference of the wider community of translators (as relayed by those we consulted) for Crowdin.

### Details

Our Crowdin instance is available at <https://crowdin.neoforged.net/>.[^1] Currently, it contains one project: NeoForge (this repository).

For integration of the localizations into NeoForge proper, we will activate the [GitHub Integration](https://support.crowdin.com/github-integration/) for the project. This means a `l10n_`-prefixed service branch will be made for each targeted branch, where Crowdin will push localization-updating commits to. Crowdin will also automatically create (and recreate) a PR for the service branch when localizations need to be updated.

To ease potential burden, commits made by the integration will have the `[ci skip]` commit message, to prevent Actions from automatically running on them.

For local development (using the Crowdin CLI locally), the `NEOFORGE_CROWDIN_PROJECT_ID` and `NEOFORGE_CROWDIN_API_TOKEN` may be specified to supply the project ID and the personal API token.

---

### TODOs

- [ ] Check what account is used for creating the commits and pull requests.
   - I hope it isn't the account used to create the integration (i.e., _my_ account).
- [ ] Consider using a machine account for connecting the integration.
   - Can be considered part of the immediately-above point (if it does use my account).
   - We could use an existing one, or create a fresh account solely for translations.

[^1]: It's been visible for a while now, though under the `neoforged.crowdin.com` domain. As of writing, the URL linked above is the canonical domain for our Crowdin instance.