### PR TITLE
Patch cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 plugins {
     id 'net.neoforged.gradleutils' version '3.0.0-alpha.10' apply false
     id 'com.diffplug.spotless' version '6.22.0' apply false
@@ -87,6 +90,19 @@ spotless {
             }
             return fileContents
         }
-        bumpThisNumberIfACustomStepChanges(1)
+
+        //Trim any trailing whitespace from patch additions
+        def trailingWhitespace = Pattern.compile('^\\+.*[ \t]+\$', Pattern.UNIX_LINES | Pattern.MULTILINE)
+        custom 'trimTrailingWhitespacePatches', { String fileContents ->
+            Matcher matcher = trailingWhitespace.matcher(fileContents)
+            StringBuilder sb = new StringBuilder()
+            while (matcher.find()) {
+                matcher.appendReplacement(sb, matcher.group().trim())
+            }
+            matcher.appendTail(sb)
+            return sb.toString()
+        }
+
+        bumpThisNumberIfACustomStepChanges(2)
     }
 }

--- a/patches/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java.patch
+++ b/patches/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java.patch
@@ -1,10 +1,9 @@
 --- a/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java
 +++ b/com/mojang/realmsclient/gui/screens/RealmsGenericErrorScreen.java
-@@ -65,6 +_,15 @@
-         return Component.empty().append(this.lines.title).append(": ").append(this.lines.detail);
+@@ -66,6 +_,15 @@
      }
  
-+    @Override 
+     @Override
 +    public boolean keyPressed(int key, int scanCode, int modifiers) {
 +        if (key == org.lwjgl.glfw.GLFW.GLFW_KEY_ESCAPE) {
 +            minecraft.setScreen(this.nextScreen);
@@ -13,6 +12,7 @@
 +        return super.keyPressed(key, scanCode, modifiers);
 +    }
 +
-     @Override
++    @Override
      public void render(GuiGraphics p_283497_, int p_88680_, int p_88681_, float p_88682_) {
          super.render(p_283497_, p_88680_, p_88681_, p_88682_);
+         p_283497_.drawCenteredString(this.font, this.lines.title, this.width / 2, 80, -1);

--- a/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
@@ -10,7 +10,7 @@
 +            final List<String> systemInformation = new java.util.ArrayList<>();
 +            var event = new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText(minecraft.getWindow(), p_281427_, minecraft.getFrameTime(), gameInformation, systemInformation);
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
-+            
++
 +            this.drawGameInformation(p_281427_, gameInformation);
 +            this.drawSystemInformation(p_281427_, systemInformation);
              if (this.renderFpsCharts) {

--- a/patches/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java.patch
+++ b/patches/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java.patch
@@ -1,11 +1,6 @@
 --- a/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java
 +++ b/net/minecraft/client/gui/screens/worldselection/WorldCreationUiState.java
-@@ -223,11 +_,11 @@
-     public WorldCreationUiState.WorldTypeEntry getWorldType() {
-         return this.worldType;
-     }
--
-+    
+@@ -227,7 +_,7 @@
      @Nullable
      public PresetEditor getPresetEditor() {
          Holder<WorldPreset> holder = this.getWorldType().preset();

--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -28,7 +28,7 @@
 +        if (!net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().canSendPacket(p_295097_, this)) {
 +            return;
 +        }
-+        
++
          this.connection.send(p_295097_);
      }
  
@@ -47,7 +47,7 @@
          static record PendingRequest(UUID id, URL url, String hash) {
          }
 +    }
-+    
++
 +    @Override
 +    public Connection getConnection() {
 +        return connection;

--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -38,7 +38,7 @@
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().onModdedPacketAtClient(this, p_295727_);
 +            return;
 +        }
-+        
++
          this.handleUnknownCustomPayload(p_295411_);
      }
  
@@ -69,13 +69,13 @@
          super.onDisconnect(p_314649_);
          this.minecraft.clearDownloadedResourcePacks();
 +    }
-+    
++
 +    @Override
 +    protected net.minecraft.client.gui.screens.Screen createDisconnectScreen(net.minecraft.network.chat.Component p_296470_) {
 +        final net.minecraft.client.gui.screens.Screen superScreen = super.createDisconnectScreen(p_296470_);
 +        if (failureReasons.isEmpty())
 +            return superScreen;
-+        
++
 +        return new net.neoforged.neoforge.client.gui.ModMismatchDisconnectedScreen(superScreen, p_296470_, failureReasons);
      }
  }

--- a/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
@@ -102,7 +102,7 @@
          BlockState blockstate = p_203157_.getBlockState(p_203159_);
          return this.getHeight(p_203157_, p_203158_, p_203159_, blockstate, blockstate.getFluidState());
 +    }
-+    
++
 +    private void vertex(VertexConsumer p_110985_, double p_110986_, double p_110987_, double p_110988_, float p_110989_, float p_110990_, float p_110991_, float alpha, float p_110992_, float p_110993_, int p_110994_) {
 +        p_110985_.vertex(p_110986_, p_110987_, p_110988_).color(p_110989_, p_110990_, p_110991_, alpha).uv(p_110992_, p_110993_).uv2(p_110994_).normal(0.0F, 1.0F, 0.0F).endVertex();
      }

--- a/patches/net/minecraft/network/ConnectionProtocol.java.patch
+++ b/patches/net/minecraft/network/ConnectionProtocol.java.patch
@@ -36,37 +36,33 @@
                      .addPacket(ServerboundFinishConfigurationPacket.class, ServerboundFinishConfigurationPacket::new)
                      .addPacket(ServerboundKeepAlivePacket.class, ServerboundKeepAlivePacket::new)
                      .addPacket(ServerboundPongPacket.class, ServerboundPongPacket::new)
-@@ -466,7 +_,23 @@
-     public static final int NOT_REGISTERED = -1;
+@@ -467,6 +_,22 @@
      private final String id;
      private final Map<PacketFlow, ConnectionProtocol.CodecData<?>> flows;
--
-+    
+ 
 +    private static ConnectionProtocol play() {
 +        return PLAY;
 +    }
-+    
++
 +    private static ConnectionProtocol configuration() {
 +        return CONFIGURATION;
 +    }
-+    
++
 +    public boolean isPlay() {
 +        return this == PLAY;
 +    }
-+    
++
 +    public boolean isConfiguration() {
 +        return this == CONFIGURATION;
 +    }
-+    
++
      private static ConnectionProtocol.ProtocolBuilder protocol() {
          return new ConnectionProtocol.ProtocolBuilder();
      }
-@@ -523,11 +_,28 @@
-             this.packetSet.classToId.forEach((p_294840_, p_295455_) -> int2objectmap.put(p_295455_.intValue(), p_294840_));
+@@ -524,11 +_,28 @@
              return int2objectmap;
          }
--
-+        
+ 
 +        /**
 +         * @deprecated Use {@link #createPacket(int, FriendlyByteBuf, io.netty.channel.ChannelHandlerContext)} instead, which provides the channel context for creating custom packet payloads.
 +         */
@@ -75,7 +71,7 @@
          public Packet<?> createPacket(int p_294972_, FriendlyByteBuf p_296217_) {
              return this.packetSet.createPacket(p_294972_, p_296217_);
          }
-+        
+ 
 +        /**
 +         * Creates a new packet from the discriminator and the buffer.
 +         *
@@ -88,9 +84,10 @@
 +        public Packet<?> createPacket(int p_294972_, FriendlyByteBuf p_296217_, io.netty.channel.ChannelHandlerContext p_130535_) {
 +            return this.packetSet.createPacket(p_294972_, p_296217_, p_130535_);
 +        }
- 
++
          public boolean isValidPacketType(Packet<?> p_294142_) {
              return this.packetSet.isKnownPacket(p_294142_.getClass());
+         }
 @@ -539,12 +_,22 @@
          final Object2IntMap<Class<? extends Packet<? super T>>> classToId = Util.make(
              new Object2IntOpenHashMap<>(), p_129613_ -> p_129613_.defaultReturnValue(-1)
@@ -110,7 +107,7 @@
 +            if (i != k) {
 +                throw new IllegalStateException("Deserializer lists must be equal in length! Somebody externally modified the registration!");
 +            }
-+            
++
              int j = this.classToId.put(p_178331_, i);
              if (j != -1) {
                  String s = "Packet " + p_178331_ + " is already registered to ID " + j;
@@ -118,18 +115,23 @@
                  throw new IllegalArgumentException(s);
              } else {
                  this.idToDeserializer.add(p_178332_);
+-                return this;
+-            }
+-        }
+-
+-        public <P extends BundlePacket<T>> ConnectionProtocol.PacketSet<T> withBundlePacket(Class<P> p_265034_, Function<Iterable<Packet<T>>, P> p_265591_) {
 +                this.contextualIdToDeserializer.add((p_296217_, p_130535_) -> p_178332_.apply(p_296217_)); //NeoForge: We always want to be able to create a packet from a buffer, even if we don't have a channel context
 +                return this;
 +            }
 +        }
-+        
++
 +        public <P extends Packet<? super T>> ConnectionProtocol.PacketSet<T> addContextualPacket(Class<P> p_178331_, java.util.function.BiFunction<FriendlyByteBuf, io.netty.channel.ChannelHandlerContext, P> readerBuilder) {
 +            int i = this.contextualIdToDeserializer.size();
 +            int k = this.idToDeserializer.size();
 +            if (i != k) {
 +                throw new IllegalStateException("Deserializer lists must be equal in length! Somebody externally modified the registration!");
 +            }
-+            
++
 +            int j = this.classToId.put(p_178331_, i);
 +            if (j != -1) {
 +                String s = "Packet " + p_178331_ + " is already registered to ID " + j;
@@ -140,21 +142,18 @@
 +                    throw new IllegalStateException("Cannot deserialize contextual packet: " + p_178331_.getSimpleName() + " without context");
 +                }));
 +                this.contextualIdToDeserializer.add(readerBuilder);
-                 return this;
-             }
-         }
- 
--        public <P extends BundlePacket<T>> ConnectionProtocol.PacketSet<T> withBundlePacket(Class<P> p_265034_, Function<Iterable<Packet<T>>, P> p_265591_) {
++                return this;
++            }
++        }
++
 +        public <P extends BundlePacket<T>> ConnectionProtocol.PacketSet<T> withBundlePacket(Class<P> p_265034_, Function<Iterable<Packet<? super T>>, P> p_265591_) {
              if (this.bundlerInfo != BundlerInfo.EMPTY) {
                  throw new IllegalStateException("Bundle packet already configured");
              } else {
-@@ -575,11 +_,29 @@
-         public boolean isKnownPacket(Class<?> p_295070_) {
+@@ -576,10 +_,28 @@
              return this.classToId.containsKey(p_295070_) || this.extraClasses.contains(p_295070_);
          }
--
-+        
+ 
 +        /**
 +         * @deprecated Use {@link #createPacket(int, FriendlyByteBuf, io.netty.channel.ChannelHandlerContext)} instead, which provides the channel context for creating custom packet payloads.
 +         */
@@ -164,7 +163,7 @@
              Function<FriendlyByteBuf, ? extends Packet<? super T>> function = this.idToDeserializer.get(p_178328_);
              return function != null ? function.apply(p_178329_) : null;
 +        }
-+        
++
 +        /**
 +         * Creates a new packet from the given discriminator and buffer.
 +         *

--- a/patches/net/minecraft/network/protocol/BundlerInfo.java.patch
+++ b/patches/net/minecraft/network/protocol/BundlerInfo.java.patch
@@ -32,7 +32,7 @@
 +                    packetSender.accept(bundlePacket);
 +                }
 +            }
-+            
++
              @Nullable
              @Override
              public BundlerInfo.Bundler startPacketBundling(Packet<?> p_265097_) {

--- a/patches/net/minecraft/resources/RegistryOps.java.patch
+++ b/patches/net/minecraft/resources/RegistryOps.java.patch
@@ -1,17 +1,17 @@
 --- a/net/minecraft/resources/RegistryOps.java
 +++ b/net/minecraft/resources/RegistryOps.java
-@@ -45,6 +_,11 @@
-         super(p_256313_);
+@@ -46,6 +_,11 @@
          this.lookupProvider = p_255799_;
      }
-+    
+ 
 +    protected RegistryOps(RegistryOps<T> p_256313_) {
 +        super(p_256313_);
 +        this.lookupProvider = p_256313_.lookupProvider;
 +    }
- 
++
      public <E> Optional<HolderOwner<E>> owner(ResourceKey<? extends Registry<? extends E>> p_255757_) {
          return this.lookupProvider.lookup(p_255757_).map(RegistryOps.RegistryInfo::owner);
+     }
 @@ -64,6 +_,20 @@
                          : DataResult.error(() -> "Not a registry ops")
              )

--- a/patches/net/minecraft/resources/ResourceLocation.java.patch
+++ b/patches/net/minecraft/resources/ResourceLocation.java.patch
@@ -1,18 +1,15 @@
 --- a/net/minecraft/resources/ResourceLocation.java
 +++ b/net/minecraft/resources/ResourceLocation.java
-@@ -142,8 +_,14 @@
-         if (i == 0) {
-             i = this.namespace.compareTo(p_135826_.namespace);
-         }
--
-+        
+@@ -146,6 +_,12 @@
          return i;
-+    }
-+
+     }
+ 
 +    // Normal compare sorts by path first, this compares namespace first.
 +    public int compareNamespaced(ResourceLocation o) {
 +        int ret = this.namespace.compareTo(o.namespace);
 +        return ret != 0 ? ret : this.path.compareTo(o.path);
-     }
- 
++    }
++
      public String toDebugFileName() {
+         return this.toString().replace('/', '_').replace(':', '_');
+     }

--- a/patches/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/net/minecraft/server/level/ServerLevel.java.patch
@@ -197,8 +197,7 @@
 +                              "onTrackingStart called during navigation iteration", new IllegalStateException("onTrackingStart called during navigation iteration")
                      );
                  }
--
-+                
+ 
                  ServerLevel.this.navigatingMobs.remove(mob);
              }
  

--- a/patches/net/minecraft/server/network/ConfigurationTask.java.patch
+++ b/patches/net/minecraft/server/network/ConfigurationTask.java.patch
@@ -7,7 +7,7 @@
 +        public Type(net.minecraft.resources.ResourceLocation location) {
 +            this(location.toString());
 +        }
-+        
++
          @Override
          public String toString() {
              return this.id;

--- a/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -9,7 +9,7 @@
 +        if (!net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().canSendPacket(p_295099_, this)) {
 +            return;
 +        }
-+        
++
          boolean flag = !this.suspendFlushingOnServerThread || !this.server.isSameThread();
  
          try {
@@ -28,7 +28,7 @@
      protected CommonListenerCookie createCookie(ClientInformation p_301973_) {
          return new CommonListenerCookie(this.playerProfile(), this.latency, p_301973_);
 +    }
-+    
++
 +    /**
 +     * Creates a new cookie for this connection.
 +     *
@@ -39,7 +39,7 @@
 +    protected CommonListenerCookie createCookie(ClientInformation p_301973_, boolean isModdedConnection) {
 +        return new CommonListenerCookie(this.playerProfile(), this.latency, p_301973_, isModdedConnection);
 +    }
-+    
++
 +    @Override
 +    public Connection getConnection() {
 +        return connection;

--- a/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -21,13 +21,11 @@
          this.send(new ClientboundCustomPayloadPacket(new BrandPayload(this.server.getServerModName())));
          LayeredRegistryAccess<RegistryLayer> layeredregistryaccess = this.server.registries();
          this.send(new ClientboundUpdateEnabledFeaturesPacket(FeatureFlags.REGISTRY.toNames(this.server.getWorldData().enabledFeatures())));
-@@ -86,8 +_,45 @@
+@@ -86,6 +_,43 @@
  
      private void addOptionalTasks() {
          this.server.getServerResourcePack().ifPresent(p_296496_ -> this.configurationTasks.add(new ServerResourcePackConfigurationTask(p_296496_)));
--    }
--
-+        
++
 +        this.configurationTasks.add(new net.neoforged.neoforge.network.configuration.ModdedConfigurationPhaseStarted(this));
 +        this.configurationTasks.addAll(net.neoforged.fml.ModLoader.get().postEventWithReturn(new net.neoforged.neoforge.network.event.OnGameConfigurationEvent(this)).getConfigurationTasks());
 +        this.configurationTasks.add(new net.neoforged.neoforge.network.configuration.ModdedConfigurationPhaseCompleted(this));
@@ -45,7 +43,7 @@
 +                    );
 +            return;
 +        }
-+        
++
 +        if (!isHandlingModdedConfigurationPhase) {
 +            super.handleCustomPayload(p_294276_);
 +            return;
@@ -61,14 +59,12 @@
 +            if (!this.isModdedConnection && !net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().onVanillaConnectionDetectedAtServer(this)) {
 +                return;
 +            }
-+            
++
 +            this.runConfiguration();
 +        }
-+    }
-+    
+     }
+ 
      @Override
-     public void handleClientInformation(ServerboundClientInformationPacket p_302032_) {
-         this.clientInformation = p_302032_.information();
 @@ -121,7 +_,7 @@
              }
  
@@ -83,12 +79,12 @@
              this.startNextTask();
          }
 +    }
-+    
++
 +    public void onModdedConfigurationPhaseStarted() {
 +        isHandlingModdedConfigurationPhase = true;
 +        finishCurrentTask(net.neoforged.neoforge.network.configuration.ModdedConfigurationPhaseStarted.TYPE);
 +    }
-+    
++
 +    public void onModdedConfigurationPhaseEnded() {
 +        isHandlingModdedConfigurationPhase = false;
 +        finishCurrentTask(net.neoforged.neoforge.network.configuration.ModdedConfigurationPhaseCompleted.TYPE);

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -152,13 +152,13 @@
      interface EntityInteraction {
          InteractionResult run(ServerPlayer p_143695_, Entity p_143696_, InteractionHand p_143697_);
 +    }
-+    
++
 +    @Override
 +    public void handleCustomPayload(net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket p_294276_) {
 +        if (!this.isModdedConnection) {
 +            super.handleCustomPayload(p_294276_);
 +        }
-+        
++
 +        net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().onModdedPacketAtServer(
 +                this, p_294276_
 +        );

--- a/patches/net/minecraft/server/packs/repository/BuiltInPackSource.java.patch
+++ b/patches/net/minecraft/server/packs/repository/BuiltInPackSource.java.patch
@@ -4,14 +4,14 @@
              }
          };
      }
-+    
++
 +    public static Pack.ResourcesSupplier fromName(final Function<String, PackResources> onName) {
 +        return new Pack.ResourcesSupplier() {
 +            @Override
 +            public PackResources openPrimary(String p_294636_) {
 +                return onName.apply(p_294636_);
 +            }
-+            
++
 +            @Override
 +            public PackResources openFull(String p_251717_, Pack.Info p_294956_) {
 +                return onName.apply(p_251717_);

--- a/patches/net/minecraft/server/rcon/thread/RconClient.java.patch
+++ b/patches/net/minecraft/server/rcon/thread/RconClient.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/rcon/thread/RconClient.java
 +++ b/net/minecraft/server/rcon/thread/RconClient.java
-@@ -123,16 +_,17 @@
+@@ -123,13 +_,14 @@
      }
  
      private void sendCmdResponse(int p_11595_, String p_11596_) throws IOException {
@@ -19,8 +19,4 @@
 +            start += j;
          } while(0 != i);
      }
--
-+    
-     @Override
-     public void stop() {
-         this.running = false;
+ 

--- a/patches/net/minecraft/tags/TagFile.java.patch
+++ b/patches/net/minecraft/tags/TagFile.java.patch
@@ -15,7 +15,7 @@
                  )
                  .apply(p_215967_, TagFile::new)
      );
-+    
++
 +    /**
 +     * @deprecated Forge: Use {@link TagFile#TagFile(List, boolean, List)} which has support for remove entries.
 +     */

--- a/patches/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/net/minecraft/world/entity/Mob.java.patch
@@ -47,28 +47,15 @@
      }
  
      @Override
-@@ -521,15 +_,12 @@
-     public void aiStep() {
-         super.aiStep();
-         this.level().getProfiler().push("looting");
--        if (!this.level().isClientSide
--            && this.canPickUpLoot()
--            && this.isAlive()
--            && !this.dead
+@@ -525,7 +_,7 @@
+             && this.canPickUpLoot()
+             && this.isAlive()
+             && !this.dead
 -            && this.level().getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
--            Vec3i vec3i = this.getPickupReach();
--
--            for(ItemEntity itementity : this.level()
--                .getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate((double)vec3i.getX(), (double)vec3i.getY(), (double)vec3i.getZ()))) {
-+        Vec3i vec3i = this.getPickupReach();
-+        
-+        for(ItemEntity itementity : this.level()
-+                                                     .getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate((double)vec3i.getX(), (double)vec3i.getY(), (double)vec3i.getZ()))) {
-+            if (!this.level().isClientSide && this.canPickUpLoot() && this.isAlive() && !this.dead &&
-+                         net.neoforged.neoforge.event.EventHooks.getMobGriefingEvent(this.level(), this)) {
-                 if (!itementity.isRemoved() && !itementity.getItem().isEmpty() && !itementity.hasPickUpDelay() && this.wantsToPickUp(itementity.getItem())) {
-                     this.pickUpItem(itementity);
-                 }
++            && net.neoforged.neoforge.event.EventHooks.getMobGriefingEvent(this.level(), this)) {
+             Vec3i vec3i = this.getPickupReach();
+ 
+             for(ItemEntity itementity : this.level()
 @@ -698,6 +_,14 @@
              this.discard();
          } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {

--- a/patches/net/minecraft/world/entity/raid/Raid.java.patch
+++ b/patches/net/minecraft/world/entity/raid/Raid.java.patch
@@ -14,7 +14,7 @@
              this.entityType = p_37821_;
              this.spawnsPerWaveBeforeBonus = p_37822_;
 +        }
-+        
++
 +        /**
 +         * The waveCountsIn integer decides how many entities of the EntityType defined in typeIn will spawn in each wave.
 +         * For example, one ravager will always spawn in wave 3.
@@ -22,7 +22,7 @@
 +        public static RaiderType create(String name, EntityType<? extends Raider> typeIn, int[] waveCountsIn) {
 +            throw new IllegalStateException("Enum not extended");
 +        }
-+        
++
 +        @Override
 +        @Deprecated
 +        public void init() {

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -1,21 +1,20 @@
 --- a/net/minecraft/world/item/crafting/Ingredient.java
 +++ b/net/minecraft/world/item/crafting/Ingredient.java
-@@ -34,17 +_,37 @@
+@@ -34,15 +_,35 @@
      private ItemStack[] itemStacks;
      @Nullable
      private IntList stackingIds;
 -    public static final Codec<Ingredient> CODEC = codec(true);
 -    public static final Codec<Ingredient> CODEC_NONEMPTY = codec(false);
--
 +    private final java.util.function.Supplier<? extends net.neoforged.neoforge.common.crafting.IngredientType<?>> type;
-+    
++
 +    public static final Codec<Ingredient> VANILLA_CODEC = codec(true);
 +    public static final Codec<Ingredient> VANILLA_CODEC_NONEMPTY = codec(false);
 +    public static final Codec<Ingredient> CODEC = net.neoforged.neoforge.common.crafting.CraftingHelper.makeIngredientCodec(true, VANILLA_CODEC);
 +    public static final Codec<Ingredient> CODEC_NONEMPTY = net.neoforged.neoforge.common.crafting.CraftingHelper.makeIngredientCodec(false, VANILLA_CODEC_NONEMPTY);
 +    public static final Codec<List<Ingredient>> LIST_CODEC = CODEC.listOf();
 +    public static final Codec<List<Ingredient>> LIST_CODEC_NONEMPTY = CODEC_NONEMPTY.listOf();
-+    
+ 
      protected Ingredient(Stream<? extends Ingredient.Value> p_43907_) {
 -        this.values = p_43907_.toArray(p_43933_ -> new Ingredient.Value[p_43933_]);
 +        this(p_43907_, net.neoforged.neoforge.common.NeoForgeMod.VANILLA_INGREDIENT_TYPE);
@@ -33,15 +32,13 @@
 +    private Ingredient(Ingredient.Value[] p_301044_, java.util.function.Supplier<? extends net.neoforged.neoforge.common.crafting.IngredientType<?>> type) {
          this.values = p_301044_;
 +        this.type = type;
-     }
- 
++    }
++
 +    public net.neoforged.neoforge.common.crafting.IngredientType<?> getType() {
 +        return type.get();
-+    }
-+    
+     }
+ 
      public ItemStack[] getItems() {
-         if (this.itemStacks == null) {
-             this.itemStacks = Arrays.stream(this.values)
 @@ -63,7 +_,7 @@
              return p_43914_.isEmpty();
          } else {
@@ -51,17 +48,17 @@
                      return true;
                  }
              }
-@@ -71,6 +_,10 @@
-             return false;
+@@ -72,6 +_,10 @@
          }
      }
-+    
+ 
 +    protected boolean areStacksEqual(ItemStack left, ItemStack right) {
 +        return left.is(right.getItem());
 +    }
- 
++
      public IntList getStackingIds() {
          if (this.stackingIds == null) {
+             ItemStack[] aitemstack = this.getItems();
 @@ -88,11 +_,24 @@
      }
  

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -31,7 +31,7 @@
 -        return new RecipeHolder<>(p_44046_, recipe);
 +        return fromJson(p_44046_, p_44047_, JsonOps.INSTANCE).orElseThrow();
 +    }
-+    
++
 +    public static Optional<RecipeHolder<?>> fromJson(ResourceLocation p_44046_, JsonObject p_44047_, com.mojang.serialization.DynamicOps<com.google.gson.JsonElement> jsonElementOps) {
 +        Optional<? extends Recipe<?>> recipe = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_RECIPE_CODEC, jsonElementOps, p_44047_);
 +        return recipe.map(r -> new RecipeHolder<>(p_44046_, r));


### PR DESCRIPTION
Adds an extra custom format step to the spotless patch checks to ensure that there is no trailing whitespace in lines being patched in (trailing whitespace is allowed in lines being patched out, though I don't expect that will come up). I am not sure how to best handle the fact that if there was any whitespace trimmed it could shift where diffpatch thinks the best surrounding diff is for a given hunk, so it is optimal to do a `setup` and `unpackSourcePatches` if any trailing whitespace in patches was fixed. Though if we still have the GHA that validates that `setup` -> `unpackSourcePatches` doesn't cause any changes to patches maybe that is fine as then we just won't merge a PR until the author fixes that.

This PR also fixes a misplaced patch that I noticed while working on the whitespace changes as it just so happens the patch had trailing whitespace in it:
- Fixes the misplaced patch in `Mob` that was leading to always looking up nearby items even on the client and when the mob can't pick up items or mob griefing is disabled.