### PR TITLE
NeoForge chunk generate command improvements

### DIFF
--- a/src/main/java/net/neoforged/neoforge/server/command/generation/CoarseOnionIterator.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/generation/CoarseOnionIterator.java
@@ -75,7 +75,7 @@ public class CoarseOnionIterator extends AbstractIterator<ChunkPos> {
 
         @Override
         public boolean hasNext() {
-            return this.z <= this.z1;
+            return this.x <= this.x1 && this.z <= this.z1;
         }
 
         @Override

--- a/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
@@ -185,16 +185,14 @@ public class GenerationTask {
         int i = 0;
         while (i < count && iterator.hasNext()) {
             ChunkPos chunkPosInLocalSpace = iterator.next();
-            if (Math.abs(chunkPosInLocalSpace.x) <= this.radius && Math.abs(chunkPosInLocalSpace.z) <= this.radius) {
-                if (isChunkFullyGenerated(chunkPosInLocalSpace)) {
-                    this.skippedCount.incrementAndGet();
-                    this.listener.update(this.okCount.get(), this.errorCount.get(), this.skippedCount.get(), this.totalCount);
-                    continue;
-                }
-
-                chunks.add(ChunkPos.asLong(chunkPosInLocalSpace.x + this.x, chunkPosInLocalSpace.z + this.z));
-                i++;
+            if (isChunkFullyGenerated(chunkPosInLocalSpace)) {
+                this.skippedCount.incrementAndGet();
+                this.listener.update(this.okCount.get(), this.errorCount.get(), this.skippedCount.get(), this.totalCount);
+                continue;
             }
+
+            chunks.add(ChunkPos.asLong(chunkPosInLocalSpace.x + this.x, chunkPosInLocalSpace.z + this.z));
+            i++;
         }
 
         return chunks;

--- a/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
@@ -12,7 +12,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.StringTag;

--- a/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
@@ -96,7 +96,8 @@ public class GenerationTask {
 
         this.listener = listener;
 
-        this.server.submit(() -> CompletableFuture.runAsync(this::tryEnqueueTasks));
+        // Off thread chunk scanning to skip already generated chunks
+        CompletableFuture.runAsync(this::tryEnqueueTasks);
     }
 
     public void stop() {
@@ -125,6 +126,8 @@ public class GenerationTask {
             }
 
             this.queuedCount.getAndAdd(chunks.size());
+
+            // Keep on server thread as chunk acquiring and releasing (tickets) is not thread safe.
             this.server.submit(() -> this.enqueueChunks(chunks));
         }
     }

--- a/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationTask.java
@@ -12,6 +12,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.visitors.CollectFields;
@@ -97,7 +99,7 @@ public class GenerationTask {
         this.listener = listener;
 
         // Off thread chunk scanning to skip already generated chunks
-        CompletableFuture.runAsync(this::tryEnqueueTasks);
+        CompletableFuture.runAsync(this::tryEnqueueTasks, Util.backgroundExecutor());
     }
 
     public void stop() {


### PR DESCRIPTION
Based on some additional feedback from:
https://github.com/jaskarth/fabric-chunkpregenerator/pull/27

I removed the workaround fix radius check out of GenerationTask class and instead, added the missing x radius check into CoarseOnionIterator since that was the real original cause of the command going beyond 100% at times.

I also removed scheduling the completable future in a server task runnable because that was an unneeded redirection by mistake. I also added comments to state which parts of the code is safe to be on off thread and which has to be on server to help future maintainability. Added correct executor to the runAsync call as well