### PR TITLE
Add public getters for shaped recipe width and height fields

### DIFF
--- a/patches/net/minecraft/world/item/crafting/ShapedRecipePattern.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapedRecipePattern.java.patch
@@ -6,8 +6,8 @@
  public record ShapedRecipePattern(int width, int height, NonNullList<Ingredient> ingredients, Optional<ShapedRecipePattern.Data> data) {
 +    /** @deprecated Neo: use {@link #MAX_WIDTH} and {@link #MAX_HEIGHT} */ @Deprecated
      private static final int MAX_SIZE = 3;
-+    static int MAX_WIDTH = 3;
-+    static int MAX_HEIGHT = 3;
++    public static int MAX_WIDTH = 3;
++    public static int MAX_HEIGHT = 3;
 +    /**
 +     * Expand the max width and height allowed in the deserializer.
 +     * This should be called by modders who add custom crafting tables that are larger than the vanilla 3x3.

--- a/patches/net/minecraft/world/item/crafting/ShapedRecipePattern.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapedRecipePattern.java.patch
@@ -1,13 +1,22 @@
 --- a/net/minecraft/world/item/crafting/ShapedRecipePattern.java
 +++ b/net/minecraft/world/item/crafting/ShapedRecipePattern.java
-@@ -19,7 +_,21 @@
+@@ -19,7 +_,30 @@
  import net.minecraft.world.inventory.CraftingContainer;
  
  public record ShapedRecipePattern(int width, int height, NonNullList<Ingredient> ingredients, Optional<ShapedRecipePattern.Data> data) {
-+    /** @deprecated Neo: use {@link #MAX_WIDTH} and {@link #MAX_HEIGHT} */ @Deprecated
++    /** @deprecated Neo: use {@link #getMaxWidth} and {@link #getMaxHeight} */ @Deprecated
      private static final int MAX_SIZE = 3;
-+    public static int MAX_WIDTH = 3;
-+    public static int MAX_HEIGHT = 3;
++    static int MAX_WIDTH = 3;
++    static int MAX_HEIGHT = 3;
++
++    public static int getMaxWidth() {
++        return MAX_WIDTH;
++    }
++
++    public static int getMaxHeight() {
++        return MAX_HEIGHT;
++    }
++
 +    /**
 +     * Expand the max width and height allowed in the deserializer.
 +     * This should be called by modders who add custom crafting tables that are larger than the vanilla 3x3.

--- a/patches/net/minecraft/world/item/crafting/ShapedRecipePattern.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapedRecipePattern.java.patch
@@ -6,15 +6,15 @@
  public record ShapedRecipePattern(int width, int height, NonNullList<Ingredient> ingredients, Optional<ShapedRecipePattern.Data> data) {
 +    /** @deprecated Neo: use {@link #getMaxWidth} and {@link #getMaxHeight} */ @Deprecated
      private static final int MAX_SIZE = 3;
-+    static int MAX_WIDTH = 3;
-+    static int MAX_HEIGHT = 3;
++    static int maxWidth = 3;
++    static int maxHeight = 3;
 +
 +    public static int getMaxWidth() {
-+        return MAX_WIDTH;
++        return maxWidth;
 +    }
 +
 +    public static int getMaxHeight() {
-+        return MAX_HEIGHT;
++        return maxHeight;
 +    }
 +
 +    /**
@@ -24,8 +24,8 @@
 +     * @param height your max recipe height
 +     */
 +    public static void setCraftingSize(int width, int height) {
-+        if (MAX_WIDTH < width) MAX_WIDTH = width;
-+        if (MAX_HEIGHT < height) MAX_HEIGHT = height;
++        if (maxWidth < width) maxWidth = width;
++        if (maxHeight < height) maxHeight = height;
 +    }
 +
      public static final MapCodec<ShapedRecipePattern> MAP_CODEC = ShapedRecipePattern.Data.MAP_CODEC
@@ -37,8 +37,8 @@
          private static final Codec<List<String>> PATTERN_CODEC = Codec.STRING.listOf().comapFlatMap(p_312085_ -> {
 -            if (p_312085_.size() > 3) {
 -                return DataResult.error(() -> "Invalid pattern: too many rows, 3 is maximum");
-+            if (p_312085_.size() > MAX_HEIGHT) {
-+                return DataResult.error(() -> "Invalid pattern: too many rows, %s is maximum".formatted(MAX_HEIGHT));
++            if (p_312085_.size() > maxHeight) {
++                return DataResult.error(() -> "Invalid pattern: too many rows, %s is maximum".formatted(maxHeight));
              } else if (p_312085_.isEmpty()) {
                  return DataResult.error(() -> "Invalid pattern: empty pattern not allowed");
              } else {
@@ -47,8 +47,8 @@
                  for(String s : p_312085_) {
 -                    if (s.length() > 3) {
 -                        return DataResult.error(() -> "Invalid pattern: too many columns, 3 is maximum");
-+                    if (s.length() > MAX_WIDTH) {
-+                        return DataResult.error(() -> "Invalid pattern: too many columns, %s is maximum".formatted(MAX_WIDTH));
++                    if (s.length() > maxWidth) {
++                        return DataResult.error(() -> "Invalid pattern: too many columns, %s is maximum".formatted(maxWidth));
                      }
  
                      if (i != s.length()) {

--- a/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -59,8 +59,8 @@
                                      } else {
 -                                        return aingredient.length > 9
 -                                            ? DataResult.error(() -> "Too many ingredients for shapeless recipe")
-+                                        return aingredient.length > ShapedRecipePattern.MAX_HEIGHT * ShapedRecipePattern.MAX_WIDTH
-+                                            ? DataResult.error(() -> "Too many ingredients for shapeless recipe. The maximum is: %s".formatted(ShapedRecipePattern.MAX_HEIGHT * ShapedRecipePattern.MAX_WIDTH))
++                                        return aingredient.length > ShapedRecipePattern.maxHeight * ShapedRecipePattern.maxWidth
++                                            ? DataResult.error(() -> "Too many ingredients for shapeless recipe. The maximum is: %s".formatted(ShapedRecipePattern.maxHeight * ShapedRecipePattern.maxWidth))
                                              : DataResult.success(NonNullList.of(Ingredient.EMPTY, aingredient));
                                      }
                                  },


### PR DESCRIPTION
The javadoc ` /** @deprecated Neo: use {@link #MAX_WIDTH} and {@link #MAX_HEIGHT} */ @Deprecated` says to use these fields but the fields are package-private. This was a bug due to converting this from an interface (where the fields were implicitly public) to a record.