### PR TITLE
Change Main Menu layout to have full-width Realms and Mods buttons (fixes #249)

### DIFF
--- a/patches/net/minecraft/client/gui/screens/TitleScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/TitleScreen.java.patch
@@ -18,7 +18,7 @@
          } else {
              this.createNormalMenuOptions(l, 24);
 +            modButton = this.addRenderableWidget(Button.builder(Component.translatable("fml.menu.mods"), button -> this.minecraft.setScreen(new net.neoforged.neoforge.client.gui.ModListScreen(this)))
-+                .pos(this.width / 2 - 100, l + 24 * 2).size(200, 20).build());
++                .pos(this.width / 2 - 100, l + 24 * 3).size(200, 20).build());
          }
 +        modUpdateNotification = net.neoforged.neoforge.client.gui.TitleScreenModUpdateIndicator.init(this, modButton);
  
@@ -47,15 +47,6 @@
          this.addRenderableWidget(
              new PlainTextButton(
                  j, this.height - 10, i, 10, COPYRIGHT_TEXT, p_280834_ -> this.minecraft.setScreen(new CreditsAndAttributionScreen(this)), this.font
-@@ -179,7 +_,7 @@
-         }).bounds(this.width / 2 - 100, p_96764_ + p_96765_ * 1, 200, 20).tooltip(tooltip).build()).active = flag;
-         this.addRenderableWidget(
-                 Button.builder(Component.translatable("menu.online"), p_210872_ -> this.realmsButtonClicked())
--                    .bounds(this.width / 2 - 100, p_96764_ + p_96765_ * 2, 200, 20)
-+                    .bounds(this.width / 2 - 100, p_96764_ + p_96765_ * 3, 200, 20)
-                     .tooltip(tooltip)
-                     .build()
-             )
 @@ -294,6 +_,7 @@
                  this.warningLabel.render(p_282860_, i);
              }

--- a/patches/net/minecraft/client/gui/screens/TitleScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/TitleScreen.java.patch
@@ -18,7 +18,7 @@
          } else {
              this.createNormalMenuOptions(l, 24);
 +            modButton = this.addRenderableWidget(Button.builder(Component.translatable("fml.menu.mods"), button -> this.minecraft.setScreen(new net.neoforged.neoforge.client.gui.ModListScreen(this)))
-+                .pos(this.width / 2 - 100, l + 24 * 2).size(98, 20).build());
++                .pos(this.width / 2 - 100, l + 24 * 2).size(200, 20).build());
          }
 +        modUpdateNotification = net.neoforged.neoforge.client.gui.TitleScreenModUpdateIndicator.init(this, modButton);
  
@@ -29,7 +29,7 @@
          this.addRenderableWidget(
                  Button.builder(Component.translatable("menu.online"), p_210872_ -> this.realmsButtonClicked())
 -                    .bounds(this.width / 2 - 100, p_96764_ + p_96765_ * 2, 200, 20)
-+                    .bounds(this.width / 2 + 2, p_96764_ + p_96765_ * 2, 98, 20)
++                    .bounds(this.width / 2 - 100, p_96764_ + p_96765_ * 3, 200, 20)
                      .tooltip(tooltip)
                      .build()
              )

--- a/patches/net/minecraft/client/gui/screens/TitleScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/TitleScreen.java.patch
@@ -8,7 +8,7 @@
  
      public TitleScreen() {
          this(false);
-@@ -120,11 +_,15 @@
+@@ -120,30 +_,34 @@
          int j = this.width - i - 2;
          int k = 24;
          int l = this.height / 4 + 48;
@@ -24,6 +24,29 @@
  
          SpriteIconButton spriteiconbutton = this.addRenderableWidget(
              CommonButtons.language(
+                 20, p_280830_ -> this.minecraft.setScreen(new LanguageSelectScreen(this, this.minecraft.options, this.minecraft.getLanguageManager())), true
+             )
+         );
+-        spriteiconbutton.setPosition(this.width / 2 - 124, l + 72 + 12);
++        spriteiconbutton.setPosition(this.width / 2 - 124, l + 96 + 12);
+         this.addRenderableWidget(
+             Button.builder(Component.translatable("menu.options"), p_280838_ -> this.minecraft.setScreen(new OptionsScreen(this, this.minecraft.options)))
+-                .bounds(this.width / 2 - 100, l + 72 + 12, 98, 20)
++                .bounds(this.width / 2 - 100, l + 96 + 12, 98, 20)
+                 .build()
+         );
+         this.addRenderableWidget(
+-            Button.builder(Component.translatable("menu.quit"), p_280831_ -> this.minecraft.stop()).bounds(this.width / 2 + 2, l + 72 + 12, 98, 20).build()
++            Button.builder(Component.translatable("menu.quit"), p_280831_ -> this.minecraft.stop()).bounds(this.width / 2 + 2, l + 96 + 12, 98, 20).build()
+         );
+         SpriteIconButton spriteiconbutton1 = this.addRenderableWidget(
+             CommonButtons.accessibility(20, p_280835_ -> this.minecraft.setScreen(new AccessibilityOptionsScreen(this, this.minecraft.options)), true)
+         );
+-        spriteiconbutton1.setPosition(this.width / 2 + 104, l + 72 + 12);
++        spriteiconbutton1.setPosition(this.width / 2 + 104, l + 96 + 12);
+         this.addRenderableWidget(
+             new PlainTextButton(
+                 j, this.height - 10, i, 10, COPYRIGHT_TEXT, p_280834_ -> this.minecraft.setScreen(new CreditsAndAttributionScreen(this)), this.font
 @@ -179,7 +_,7 @@
          }).bounds(this.width / 2 - 100, p_96764_ + p_96765_ * 1, 200, 20).tooltip(tooltip).build()).active = flag;
          this.addRenderableWidget(


### PR DESCRIPTION
Currently, Forge positions the "Mods" button on the main menu next to the Realms button, shrinking the width of "Realms" to make room for "Mods." As described in #249, the "Realms" button is too narrow to display the little icons Mojang adds to the button when the game is in online mode, and they get all bunched up on the right of the button. This PR solves that by widening "Mods" to a full-width button and moving all the other buttons down by one row:

![image](https://github.com/neoforged/NeoForge/assets/115791356/53822f73-dfde-48eb-ae12-03e21ca86f3c)

A few notes on what I've done:

### Clipped text
Because the main menu is now 24 pixels taller, on some resolutions (such as my laptop in windowed mode), the bottom buttons collide with NeoForge's branding text and the copyright text, as you can see below. I don't know how much of a problem that is, seeing as they collide with the branding text even without the extra button.

![Screenshot 2024-01-01 121526](https://github.com/neoforged/NeoForge/assets/115791356/22c22764-331c-4430-ba8d-fff177426fdb)

### Button order
In the original issue, commenters suggested that the layout should be changed to be the same as Fabric's ModMenu mod, which places "Mods" below "Realms." Instead, I chose to put "Realms" below "Mods," partly because I think it looks better that way, but also so the Mods button occupies the same space as it did previously, to avoid breaking mods that hard-coded in its position (or at least lessen the impact), which someone suggested might be a problem. If we decide that the layout should be more similar to ModMenu, it's a very easy change to make.

### Pixel count
In order to move the four bottom buttons (Language, Options, Quit Game, Accessibility) down to compensate for the new Mods button, I had to patch the TitleScreen.java and change their relative heights on the screen by 24 pixels. I did this by changing the number 72 (pixels) to 96, as you can see here:
```
-            Button.builder(Component.translatable("menu.quit"), p_280831_ -> this.minecraft.stop()).bounds(this.width / 2 + 2, l + 72 + 12, 98, 20).build()
+            Button.builder(Component.translatable("menu.quit"), p_280831_ -> this.minecraft.stop()).bounds(this.width / 2 + 2, l + 96 + 12, 98, 20).build()
```
But I did consider adding on 24 to the total, to make it more obvious that it was changed:
```
-            Button.builder(Component.translatable("menu.quit"), p_280831_ -> this.minecraft.stop()).bounds(this.width / 2 + 2, l + 72 + 12, 98, 20).build()
+            Button.builder(Component.translatable("menu.quit"), p_280831_ -> this.minecraft.stop()).bounds(this.width / 2 + 2, l + 72 + 12 + 24, 98, 20).build()
```
I'm not sure which would be best although I prefer the first one, since anyone reading the patch could see the original line anyway.