### PR TITLE
Expand particle bounding boxes by 1 unit in all directions when culling

### DIFF
--- a/patches/net/minecraft/client/particle/ParticleEngine.java.patch
+++ b/patches/net/minecraft/client/particle/ParticleEngine.java.patch
@@ -83,7 +83,7 @@
                  particlerendertype.begin(bufferbuilder, this.textureManager);
  
                  for(Particle particle : iterable) {
-+                    if (clippingHelper != null && particle.shouldCull() && !clippingHelper.isVisible(particle.getBoundingBox())) continue;
++                    if (clippingHelper != null && particle.shouldCull() && !clippingHelper.isVisible(particle.getBoundingBox().inflate(1.0))) continue;
                      try {
                          particle.render(bufferbuilder, p_107340_, p_107341_);
                      } catch (Throwable throwable) {


### PR DESCRIPTION
This is a potential solution for #187. The default particle hitbox is not always centered properly, so a workaround is to expand it by 1 block in all directions. This should be good enough for most particles.

~~An alternative approach would be to throw out particle culling entirely if it turns out not to improve performance. To aid with testing that, a system property (`neoforge.useParticleCulling`) is added that can be set to `false` to disable culling globally.~~ Basic testing by @XFactHD shows that [particle culling is still effective](https://discord.com/channels/313125603924639766/1154166981205962792/1191537234436968448) in 1.20.4.