### PR TITLE
Fix finalize spawn playing ambient sounds for cancelled mob spawns

### DIFF
--- a/patches/net/minecraft/world/entity/EntityType.java.patch
+++ b/patches/net/minecraft/world/entity/EntityType.java.patch
@@ -46,11 +46,10 @@
      }
  
      @Nullable
-@@ -760,7 +_,14 @@
+@@ -760,6 +_,15 @@
                  mob.yHeadRot = mob.getYRot();
                  mob.yBodyRot = mob.getYRot();
                  mob.finalizeSpawn(p_262637_, p_262637_.getCurrentDifficultyAt(mob.blockPosition()), p_262666_, null, p_262687_);
--                mob.playAmbientSound();
 +
 +                if (mob.isSpawnCancelled()) {
 +                    // Neo: Discord mob, spawn was cancelled
@@ -59,9 +58,10 @@
 +                    // fixes llamas for wandering trader spawning if wandering trader was cancelled
 +                    return null;
 +                }
++
+                 mob.playAmbientSound();
              }
  
-             if (p_262629_ != null) {
 @@ -811,6 +_,9 @@
      }
  

--- a/patches/net/minecraft/world/entity/EntityType.java.patch
+++ b/patches/net/minecraft/world/entity/EntityType.java.patch
@@ -52,7 +52,7 @@
                  mob.finalizeSpawn(p_262637_, p_262637_.getCurrentDifficultyAt(mob.blockPosition()), p_262666_, null, p_262687_);
 +
 +                if (mob.isSpawnCancelled()) {
-+                    // Neo: Discord mob, spawn was cancelled
++                    // Neo: Discard mob, spawn was cancelled
 +                    mob.discard();
 +                    // return null, mob was killed, context should be lost
 +                    // fixes llamas for wandering trader spawning if wandering trader was cancelled

--- a/patches/net/minecraft/world/entity/EntityType.java.patch
+++ b/patches/net/minecraft/world/entity/EntityType.java.patch
@@ -46,6 +46,22 @@
      }
  
      @Nullable
+@@ -760,7 +_,14 @@
+                 mob.yHeadRot = mob.getYRot();
+                 mob.yBodyRot = mob.getYRot();
+                 mob.finalizeSpawn(p_262637_, p_262637_.getCurrentDifficultyAt(mob.blockPosition()), p_262666_, null, p_262687_);
+-                mob.playAmbientSound();
++
++                if (mob.isSpawnCancelled()) {
++                    // Neo: Discord mob, spawn was cancelled
++                    mob.discard();
++                    // return null, mob was killed, context should be lost
++                    // fixes llamas for wandering trader spawning if wandering trader was cancelled
++                    return null;
++                }
+             }
+ 
+             if (p_262629_ != null) {
 @@ -811,6 +_,9 @@
      }
  

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/FinalizeSpawnTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/FinalizeSpawnTest.java
@@ -7,7 +7,6 @@ package net.neoforged.neoforge.oldtest;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.Mob;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
@@ -26,7 +25,7 @@ public class FinalizeSpawnTest {
             // - ambient sounds dont play for cancelled mob spawns
             // - llamas dont spawn for cancelled trader spawns
             // but this test is not specific to wandering traders
-            if(ENABLED && entity.getType() == entityType) {
+            if (ENABLED && entity.getType() == entityType) {
                 // some debug message to say entity spawn was cancelled
                 event.getLevel().players().forEach(player -> player.displayClientMessage(Component.literal("Cancelled %s spawn @ %s".formatted(entityType.getDescription().getString(), entity.position())), true));
                 event.setSpawnCancelled(true);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/FinalizeSpawnTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/FinalizeSpawnTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.oldtest;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Mob;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
+
+@Mod(FinalizeSpawnTest.ID)
+public class FinalizeSpawnTest {
+    public static final String ID = "finalize_spawn_fix_test";
+    public static final boolean ENABLED = false;
+
+    public FinalizeSpawnTest() {
+        NeoForge.EVENT_BUS.addListener(MobSpawnEvent.FinalizeSpawn.class, event -> {
+            var entityType = EntityType.WANDERING_TRADER;
+            var entity = event.getEntity();
+
+            // testing with wandering trader to validate the following
+            // - ambient sounds dont play for cancelled mob spawns
+            // - llamas dont spawn for cancelled trader spawns
+            // but this test is not specific to wandering traders
+            if(ENABLED && entity.getType() == entityType) {
+                // some debug message to say entity spawn was cancelled
+                event.getLevel().players().forEach(player -> player.displayClientMessage(Component.literal("Cancelled %s spawn @ %s".formatted(entityType.getDescription().getString(), entity.position())), true));
+                event.setSpawnCancelled(true);
+            }
+        });
+    }
+}

--- a/tests/src/main/resources/META-INF/mods.toml
+++ b/tests/src/main/resources/META-INF/mods.toml
@@ -27,6 +27,9 @@ license="LGPL v2.1"
 [[mods]]
     modId="custom_break_sound_test"
 
+[[mods]]
+    modId="finalize_spawn_fix_test"
+
 # LEGACY TEST CASES
 ###### The mods below are from the old test framework and need to be yeeted later again.
 


### PR DESCRIPTION
This PR stops ambient mob sounds from playing if mob was spawn was cancelled via the `MobSpawnEvent.FinalizeSpawn` event, with this change also comes added benefit of mob spawning side effects not occurring if mob spawn was cancelled (wandering trader spawning llamas).

If the mob spawn was cancelled we now discard the mob and return null from `EntityType.spawn`, this tells callers of the method that the entity failed to spawn, leading to side effects of initial spawn not occurring since the `mob` is now null.