### PR TITLE
Expose BlockBehaviour#propertiesCodec via AT

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -481,6 +481,7 @@ public net.minecraft.world.level.block.PointedDripstoneBlock WATER_TRANSFER_PROB
 public net.minecraft.world.level.block.entity.BlockEntityType$BlockEntitySupplier
 public net.minecraft.world.level.block.entity.HopperBlockEntity setCooldown(I)V # setCooldown
 public net.minecraft.world.level.block.entity.HopperBlockEntity isOnCustomCooldown()Z # isOnCustomCooldown
+public net.minecraft.world.level.block.state.BlockBehaviour propertiesCodec()Lcom/mojang/serialization/codecs/RecordCodecBuilder;
 public net.minecraft.world.level.block.state.properties.BlockSetType register(Lnet/minecraft/world/level/block/state/properties/BlockSetType;)Lnet/minecraft/world/level/block/state/properties/BlockSetType; # register
 public net.minecraft.world.level.block.state.properties.WoodType register(Lnet/minecraft/world/level/block/state/properties/WoodType;)Lnet/minecraft/world/level/block/state/properties/WoodType; # register
 public net.minecraft.world.level.chunk.ChunkStatus <init>(Lnet/minecraft/world/level/chunk/ChunkStatus;IZLjava/util/EnumSet;Lnet/minecraft/world/level/chunk/ChunkStatus$ChunkType;Lnet/minecraft/world/level/chunk/ChunkStatus$GenerationTask;Lnet/minecraft/world/level/chunk/ChunkStatus$LoadingTask;)V # constructor


### PR DESCRIPTION
Makes it easier for mods to implement BlockType codecs from DeferredRegisters rather than having to make the codec in the block's class and then reference the codec that way.