### PR TITLE
[1.20.4] Add thread-safe side-band system for lighting driven by BlockEntity data

### DIFF
--- a/patches/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
@@ -20,7 +20,7 @@
      }
  
      @Override
-@@ -73,5 +_,16 @@
+@@ -73,5 +_,23 @@
      @Override
      public int getHeight() {
          return this.level.getHeight();
@@ -35,5 +35,12 @@
 +    @Nullable
 +    public net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot getModelDataManager() {
 +        return modelDataManager;
++    }
++
++    @Override
++    public net.neoforged.neoforge.common.world.AuxiliaryLightManager getAuxLightManager(net.minecraft.world.level.ChunkPos pos) {
++        int relX = pos.x - this.centerX;
++        int relZ = pos.z - this.centerZ;
++        return this.chunks[relX][relZ].wrapped.getAuxLightManager(pos);
      }
  }

--- a/patches/net/minecraft/server/network/PlayerChunkSender.java.patch
+++ b/patches/net/minecraft/server/network/PlayerChunkSender.java.patch
@@ -6,7 +6,7 @@
      private static void sendChunk(ServerGamePacketListenerImpl p_295237_, ServerLevel p_294963_, LevelChunk p_295144_) {
 -        p_295237_.send(new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null));
 +        p_295237_.send(p_295144_.getAuxLightManager(p_295144_.getPos()).sendLightDataTo(
-+                p_295237_.player, new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null)
++                new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null)
 +        ));
          ChunkPos chunkpos = p_295144_.getPos();
          DebugPackets.sendPoiPacketsForChunk(p_294963_, chunkpos);

--- a/patches/net/minecraft/server/network/PlayerChunkSender.java.patch
+++ b/patches/net/minecraft/server/network/PlayerChunkSender.java.patch
@@ -1,7 +1,13 @@
 --- a/net/minecraft/server/network/PlayerChunkSender.java
 +++ b/net/minecraft/server/network/PlayerChunkSender.java
-@@ -77,6 +_,7 @@
-         p_295237_.send(new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null));
+@@ -74,9 +_,12 @@
+     }
+ 
+     private static void sendChunk(ServerGamePacketListenerImpl p_295237_, ServerLevel p_294963_, LevelChunk p_295144_) {
+-        p_295237_.send(new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null));
++        p_295237_.send(p_295144_.getAuxLightManager(p_295144_.getPos()).sendLightDataTo(
++                p_295237_.player, new ClientboundLevelChunkWithLightPacket(p_295144_, p_294963_.getLightEngine(), null, null)
++        ));
          ChunkPos chunkpos = p_295144_.getPos();
          DebugPackets.sendPoiPacketsForChunk(p_294963_, chunkpos);
 +        net.neoforged.neoforge.event.EventHooks.fireChunkSent(p_295237_.player, p_295144_, p_294963_);

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -95,12 +95,13 @@
          this.blockEntities.values().forEach(p_187988_ -> {
              Level level = this.level;
              if (level instanceof ServerLevel serverlevel) {
-@@ -646,6 +_,27 @@
+@@ -646,6 +_,33 @@
          return new LevelChunk.BoundTickingBlockEntity<>(p_156376_, p_156377_);
      }
  
 +    // FORGE START
 +    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
++    private final net.neoforged.neoforge.common.world.AuxiliaryLightManager auxLightManager = new net.neoforged.neoforge.common.world.AuxiliaryLightManager(this);
 +
 +    @Override
 +    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
@@ -117,6 +118,11 @@
 +    public <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
 +        setUnsaved(true);
 +        return attachmentHolder.setData(type, data);
++    }
++
++    @Override
++    public net.neoforged.neoforge.common.world.AuxiliaryLightManager getAuxLightManager(ChunkPos pos) {
++        return auxLightManager;
 +    }
 +    // FORGE END
 +

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -117,7 +117,7 @@
  
 +    // FORGE START
 +    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
-+    private final net.neoforged.neoforge.common.world.AuxiliaryLightManager auxLightManager = new net.neoforged.neoforge.common.world.AuxiliaryLightManager(this);
++    private final net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager auxLightManager = new net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager(this);
 +
 +    @Override
 +    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
@@ -137,7 +137,7 @@
 +    }
 +
 +    @Override
-+    public net.neoforged.neoforge.common.world.AuxiliaryLightManager getAuxLightManager(ChunkPos pos) {
++    public net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager getAuxLightManager(ChunkPos pos) {
 +        return auxLightManager;
 +    }
 +    // FORGE END

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -55,6 +55,14 @@
          }
      }
  
+@@ -385,6 +_,7 @@
+             BlockEntity blockentity = this.blockEntities.put(blockpos.immutable(), p_156374_);
+             if (blockentity != null && blockentity != p_156374_) {
+                 blockentity.setRemoved();
++                auxLightManager.removeLightAt(blockpos);
+             }
+         }
+     }
 @@ -394,9 +_,14 @@
      public CompoundTag getBlockEntityNbtForSaving(BlockPos p_62932_) {
          BlockEntity blockentity = this.getBlockEntity(p_62932_);
@@ -70,6 +78,14 @@
          } else {
              CompoundTag compoundtag = this.pendingBlockEntities.get(p_62932_);
              if (compoundtag != null) {
+@@ -419,6 +_,7 @@
+                 }
+ 
+                 blockentity.setRemoved();
++                auxLightManager.removeLightAt(p_62919_);
+             }
+         }
+ 
 @@ -479,7 +_,7 @@
          p_187974_.accept((p_187968_, p_187969_, p_187970_) -> {
              BlockEntity blockentity = this.getBlockEntity(p_187968_, LevelChunk.EntityCreationType.IMMEDIATE);

--- a/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
@@ -1,10 +1,13 @@
 --- a/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-@@ -180,6 +_,7 @@
+@@ -180,6 +_,10 @@
                  postLoadChunk(p_188231_, p_188234_),
                  blendingdata
              );
-+            if (p_188234_.contains(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND)) ((LevelChunk)chunkaccess).readAttachmentsFromNBT(p_188234_.getCompound(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY));
++            if (p_188234_.contains(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND))
++                ((LevelChunk)chunkaccess).readAttachmentsFromNBT(p_188234_.getCompound(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY));
++            if (p_188234_.contains(net.neoforged.neoforge.common.world.AuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_LIST))
++                Objects.requireNonNull(chunkaccess.getAuxLightManager(p_188233_)).deserializeNBT(p_188234_.getList(net.neoforged.neoforge.common.world.AuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND));
          } else {
              ProtoChunkTicks<Block> protochunkticks = ProtoChunkTicks.load(
                  p_188234_.getList("block_ticks", 10), p_258992_ -> BuiltInRegistries.BLOCK.getOptional(ResourceLocation.tryParse(p_258992_)), p_188233_
@@ -24,7 +27,7 @@
              return protochunk1;
          }
      }
-@@ -372,6 +_,14 @@
+@@ -372,6 +_,17 @@
              }
  
              compoundtag.put("CarvingMasks", compoundtag4);
@@ -36,6 +39,9 @@
 +             } catch (Exception exception) {
 +                  LOGGER.error("Failed to write chunk attachments. An attachment has likely thrown an exception trying to write state. It will not persist. Report this to the mod author", exception);
 +             }
++
++             Tag lightTag = levelChunk.getAuxLightManager(chunkpos).serializeNBT();
++             if (lightTag != null) compoundtag.put(net.neoforged.neoforge.common.world.AuxiliaryLightManager.LIGHT_NBT_KEY, lightTag);
          }
  
          saveTicks(p_63455_, compoundtag, p_63456_.getTicksForSerialization());

--- a/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
@@ -6,8 +6,8 @@
              );
 +            if (p_188234_.contains(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND))
 +                ((LevelChunk)chunkaccess).readAttachmentsFromNBT(p_188234_.getCompound(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY));
-+            if (p_188234_.contains(net.neoforged.neoforge.common.world.AuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_LIST))
-+                Objects.requireNonNull(chunkaccess.getAuxLightManager(p_188233_)).deserializeNBT(p_188234_.getList(net.neoforged.neoforge.common.world.AuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND));
++            if (p_188234_.contains(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_LIST))
++                Objects.requireNonNull(((LevelChunk)chunkaccess).getAuxLightManager(p_188233_)).deserializeNBT(p_188234_.getList(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND));
          } else {
              ProtoChunkTicks<Block> protochunkticks = ProtoChunkTicks.load(
                  p_188234_.getList("block_ticks", 10), p_258992_ -> BuiltInRegistries.BLOCK.getOptional(ResourceLocation.tryParse(p_258992_)), p_188233_
@@ -41,7 +41,7 @@
 +             }
 +
 +             Tag lightTag = levelChunk.getAuxLightManager(chunkpos).serializeNBT();
-+             if (lightTag != null) compoundtag.put(net.neoforged.neoforge.common.world.AuxiliaryLightManager.LIGHT_NBT_KEY, lightTag);
++             if (lightTag != null) compoundtag.put(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, lightTag);
          }
  
          saveTicks(p_63455_, compoundtag, p_63456_.getTicksForSerialization());

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -18,6 +18,7 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.common.util.FakePlayerFactory;
 import net.neoforged.neoforge.common.util.LogicalSidedProvider;
+import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
@@ -25,6 +26,7 @@ import net.neoforged.neoforge.event.TickEvent;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.level.ChunkWatchEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.server.command.ConfigCommand;
 import net.neoforged.neoforge.server.command.NeoForgeCommand;
@@ -124,6 +126,14 @@ public class NeoForgeEventHandler {
     public void builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
         if (event.getEntity() instanceof Mob mob && mob.isSpawnCancelled()) {
             event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public void onChunkSent(ChunkWatchEvent.Sent event) {
+        AuxiliaryLightManager lightManager = event.getChunk().getAuxLightManager(event.getPos());
+        if (lightManager != null) {
+            lightManager.sendLightDataTo(event.getPlayer());
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -18,7 +18,6 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.common.util.FakePlayerFactory;
 import net.neoforged.neoforge.common.util.LogicalSidedProvider;
-import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
@@ -26,7 +25,6 @@ import net.neoforged.neoforge.event.TickEvent;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
-import net.neoforged.neoforge.event.level.ChunkWatchEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.server.command.ConfigCommand;
 import net.neoforged.neoforge.server.command.NeoForgeCommand;
@@ -126,14 +124,6 @@ public class NeoForgeEventHandler {
     public void builtinMobSpawnBlocker(EntityJoinLevelEvent event) {
         if (event.getEntity() instanceof Mob mob && mob.isSpawnCancelled()) {
             event.setCanceled(true);
-        }
-    }
-
-    @SubscribeEvent
-    public void onChunkSent(ChunkWatchEvent.Sent event) {
-        AuxiliaryLightManager lightManager = event.getChunk().getAuxLightManager(event.getPos());
-        if (lightManager != null) {
-            lightManager.sendLightDataTo(event.getPlayer());
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -75,6 +75,7 @@ import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.IPlantable;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
+import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("deprecation")
@@ -121,9 +122,10 @@ public interface IBlockExtension {
      *           will cause issues such as wrapping coordinates returning values from the opposing chunk edge
      *           </li>
      *           <li>
-     *           This method may be called on a worker thread and must therefore use
-     *           {@link IBlockGetterExtension#getExistingBlockEntity(BlockPos)} to retrieve the {@link BlockEntity}
-     *           at the given position
+     *           If the light value depends on data from a {@link BlockEntity} then the light level must be stored in
+     *           the {@link AuxiliaryLightManager} by the {@code BlockEntity} and retrieved from the
+     *           {@code AuxiliaryLightManager} in this method. This is to ensure thread-safety and availability of
+     *           the data during chunk load from disk.
      *           </li>
      *           </ul>
      */
@@ -826,13 +828,11 @@ public interface IBlockExtension {
      * This method should only be used for blocks you don't control, for your own blocks override
      * {@link Block#skipRendering(BlockState, BlockState, Direction)} on the respective block instead
      * <p>
-     * WARNING: This method is likely to be called from a worker thread! If you want to retrieve a
-     * {@link net.minecraft.world.level.block.entity.BlockEntity} from the given level, make sure to use
-     * {@link IBlockGetterExtension#getExistingBlockEntity(BlockPos)} to not
-     * accidentally create a new or delete an old {@link net.minecraft.world.level.block.entity.BlockEntity}
-     * off of the main thread as this would cause a write operation to the given {@link BlockGetter} and cause
-     * a CME in the process. Any other direct or indirect write operation to the {@link BlockGetter} will have
-     * the same outcome.
+     * <b>Note that this method may be called on any of the client's meshing threads.</b><br/>
+     * As such, if you need any data from your {@link BlockEntity}, you should put it in {@link ModelData} to guarantee
+     * safe concurrent access to it on the client.<br/>
+     * {@link ModelDataManager#getAt(BlockPos)} will return the {@link ModelData} for the queried block,
+     * or {@code null} if none is present.
      *
      * @param level         The world
      * @param pos           The blocks position in the world

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockGetterExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockGetterExtension.java
@@ -6,9 +6,11 @@
 package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkSource;
 import net.minecraft.world.level.chunk.ImposterProtoChunk;
 import net.minecraft.world.level.chunk.LightChunk;
 import net.neoforged.neoforge.client.model.data.ModelDataManager;
@@ -25,7 +27,8 @@ public interface IBlockGetterExtension {
      * where {@code BlockEntity}s are not yet added to the chunk.
      *
      * @param pos The position for whose containing chunk the light manager is requested
-     * @return the light manager or {@code null} if the chunk is not accessible
+     * @return the light manager or {@code null} if the chunk is not accessible ({@link ChunkSource#getChunkForLighting(int, int)}
+     *         returned {@code null}) or the given implementation of {@link BlockGetter} does not implement {@link #getAuxLightManager(ChunkPos)}
      */
     @Nullable
     @ApiStatus.NonExtendable
@@ -41,7 +44,8 @@ public interface IBlockGetterExtension {
      * where {@code BlockEntity}s are not yet added to the chunk.
      *
      * @param pos The position of the chunk from which the light manager is requested
-     * @return the light manager or {@code null} if the chunk is not accessible
+     * @return the light manager or {@code null} if the chunk is not accessible ({@link ChunkSource#getChunkForLighting(int, int)}
+     *         returned {@code null}) or the given implementation of {@link BlockGetter} does not implement this method
      */
     @Nullable
     default AuxiliaryLightManager getAuxLightManager(ChunkPos pos) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFriendlyByteBufExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFriendlyByteBufExtension.java
@@ -133,4 +133,14 @@ public interface IFriendlyByteBufExtension {
         }
         return self();
     }
+
+    /**
+     * Writes a byte to the buffer
+     *
+     * @param value The value to be written
+     * @return The buffer
+     */
+    default FriendlyByteBuf writeByte(byte value) {
+        return self().writeByte((int) value);
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/world/AuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/AuxiliaryLightManager.java
@@ -11,19 +11,21 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 /**
  * Manager for light values controlled by dynamic data in {@link BlockEntity}s.
  */
-public abstract class AuxiliaryLightManager {
+public interface AuxiliaryLightManager {
     /**
      * Set the light value at the given position to the given value
      */
-    public abstract void setLightAt(BlockPos pos, int value);
+    void setLightAt(BlockPos pos, int value);
 
     /**
      * Remove the light value at the given position
      */
-    public abstract void removeLightAt(BlockPos pos);
+    default void removeLightAt(BlockPos pos) {
+        setLightAt(pos, 0);
+    }
 
     /**
      * {@return the light value at the given position or 0 if none is present}
      */
-    public abstract int getLightAt(BlockPos pos);
+    int getLightAt(BlockPos pos);
 }

--- a/src/main/java/net/neoforged/neoforge/common/world/AuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/AuxiliaryLightManager.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.common.world;
 
 import java.util.Map;

--- a/src/main/java/net/neoforged/neoforge/common/world/AuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/AuxiliaryLightManager.java
@@ -1,0 +1,79 @@
+package net.neoforged.neoforge.common.world;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.neoforged.neoforge.common.util.INBTSerializable;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Manager for light values controlled by dynamic data in {@link BlockEntity}s.
+ */
+public final class AuxiliaryLightManager implements INBTSerializable<ListTag> {
+    public static final String LIGHT_NBT_KEY = "neoforge:aux_lights";
+
+    private final LevelChunk owner;
+    private final Map<BlockPos, Integer> lights = new ConcurrentHashMap<>();
+
+    @ApiStatus.Internal
+    public AuxiliaryLightManager(LevelChunk owner) {
+        this.owner = owner;
+    }
+
+    /**
+     * Set the light value at the given position to the given value
+     */
+    public void setLightAt(BlockPos pos, int value) {
+        if (value > 0) {
+            lights.put(pos, value);
+        } else {
+            lights.remove(pos);
+        }
+        owner.setUnsaved(true);
+    }
+
+    /**
+     * Remove the light value at the given position
+     */
+    public void removeLightAt(BlockPos pos) {
+        lights.remove(pos);
+        owner.setUnsaved(true);
+    }
+
+    /**
+     * {@return the light value at the given position or 0 if none is present}
+     */
+    public int getLightAt(BlockPos pos) {
+        return lights.getOrDefault(pos, 0);
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public ListTag serializeNBT() {
+        if (lights.isEmpty()) {
+            return null;
+        }
+
+        ListTag list = new ListTag();
+        lights.forEach((pos, light) -> {
+            CompoundTag tag = new CompoundTag();
+            tag.putLong("pos", pos.asLong());
+            tag.putByte("level", light.byteValue());
+            list.add(tag);
+        });
+        return list;
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public void deserializeNBT(ListTag list) {
+        for (int i = 0; i < list.size(); i++) {
+            CompoundTag tag = list.getCompound(i);
+            lights.put(BlockPos.of(tag.getLong("pos")), (int) tag.getByte("level"));
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
+import net.minecraft.network.protocol.game.ClientboundBundlePacket;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.lighting.LightEngine;
+import net.neoforged.neoforge.common.util.INBTSerializable;
+import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class LevelChunkAuxiliaryLightManager extends AuxiliaryLightManager implements INBTSerializable<ListTag> {
+    public static final String LIGHT_NBT_KEY = "neoforge:aux_lights";
+
+    private final LevelChunk owner;
+    private final Map<BlockPos, Byte> lights = new ConcurrentHashMap<>();
+
+    public LevelChunkAuxiliaryLightManager(LevelChunk owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public void setLightAt(BlockPos pos, int value) {
+        pos = pos.immutable();
+        value = Mth.clamp(value, 0, LightEngine.MAX_LEVEL);
+
+        Byte oldValue;
+        if (value > 0) {
+            oldValue = lights.put(pos, (byte) value);
+        } else {
+            oldValue = lights.remove(pos);
+        }
+        if (Objects.requireNonNullElse(oldValue, (byte) 0) != value) {
+            owner.getLevel().getChunkSource().getLightEngine().checkBlock(pos);
+            owner.setUnsaved(true);
+        }
+    }
+
+    @Override
+    public void removeLightAt(BlockPos pos) {
+        Byte oldValue = lights.remove(pos);
+        if (oldValue != null) {
+            owner.getLevel().getChunkSource().getLightEngine().checkBlock(pos);
+            owner.setUnsaved(true);
+        }
+    }
+
+    @Override
+    public int getLightAt(BlockPos pos) {
+        return lights.getOrDefault(pos, (byte) 0);
+    }
+
+    @Override
+    public ListTag serializeNBT() {
+        if (lights.isEmpty()) {
+            return null;
+        }
+
+        ListTag list = new ListTag();
+        lights.forEach((pos, light) -> {
+            CompoundTag tag = new CompoundTag();
+            tag.putLong("pos", pos.asLong());
+            tag.putByte("level", light);
+            list.add(tag);
+        });
+        return list;
+    }
+
+    @Override
+    public void deserializeNBT(ListTag list) {
+        for (int i = 0; i < list.size(); i++) {
+            CompoundTag tag = list.getCompound(i);
+            lights.put(BlockPos.of(tag.getLong("pos")), tag.getByte("level"));
+        }
+    }
+
+    public Packet<?> sendLightDataTo(ClientboundLevelChunkWithLightPacket chunkPacket) {
+        return new ClientboundBundlePacket(List.of(chunkPacket, new ClientboundCustomPayloadPacket(
+                new AuxiliaryLightDataPayload(owner.getPos(), Map.copyOf(lights)))));
+    }
+
+    public void handleLightDataSync(Map<BlockPos, Byte> lights) {
+        this.lights.clear();
+        this.lights.putAll(lights);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
@@ -24,7 +24,7 @@ import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-public final class LevelChunkAuxiliaryLightManager extends AuxiliaryLightManager implements INBTSerializable<ListTag> {
+public final class LevelChunkAuxiliaryLightManager implements AuxiliaryLightManager, INBTSerializable<ListTag> {
     public static final String LIGHT_NBT_KEY = "neoforge:aux_lights";
 
     private final LevelChunk owner;
@@ -46,15 +46,6 @@ public final class LevelChunkAuxiliaryLightManager extends AuxiliaryLightManager
             oldValue = lights.remove(pos);
         }
         if (Objects.requireNonNullElse(oldValue, (byte) 0) != value) {
-            owner.getLevel().getChunkSource().getLightEngine().checkBlock(pos);
-            owner.setUnsaved(true);
-        }
-    }
-
-    @Override
-    public void removeLightAt(BlockPos pos) {
-        Byte oldValue = lights.remove(pos);
-        if (oldValue != null) {
             owner.getLevel().getChunkSource().getLightEngine().checkBlock(pos);
             owner.setUnsaved(true);
         }

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -13,6 +13,7 @@ import net.neoforged.neoforge.network.handlers.ClientPayloadHandler;
 import net.neoforged.neoforge.network.handlers.ServerPayloadHandler;
 import net.neoforged.neoforge.network.payload.AdvancedAddEntityPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
+import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
@@ -64,6 +65,10 @@ public class NetworkInitialization {
                 .play(
                         AdvancedOpenScreenPayload.ID,
                         AdvancedOpenScreenPayload::new,
+                        handlers -> handlers.client(ClientPayloadHandler.getInstance()::handle))
+                .play(
+                        AuxiliaryLightDataPayload.ID,
+                        AuxiliaryLightDataPayload::new,
                         handlers -> handlers.client(ClientPayloadHandler.getInstance()::handle));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -140,7 +140,7 @@ public class ClientPayloadHandler {
     }
 
     public void handle(AuxiliaryLightDataPayload msg, PlayPayloadContext context) {
-        context.workHandler().execute(() -> {
+        context.workHandler().submitAsync(() -> {
             Minecraft mc = Minecraft.getInstance();
             if (mc.level == null) return;
 
@@ -148,6 +148,9 @@ public class ClientPayloadHandler {
             if (lightManager != null) {
                 lightManager.handleLightDataSync(msg.entries());
             }
+        }).exceptionally(e -> {
+            context.packetHandler().disconnect(Component.translatable("neoforge.network.aux_light_data.failed", msg.pos(), e.getMessage()));
+            return null;
         });
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -24,12 +24,14 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.neoforged.neoforge.common.TierSortingRegistry;
+import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.entity.IEntityWithComplexSpawn;
 import net.neoforged.neoforge.network.ConfigSync;
 import net.neoforged.neoforge.network.handling.ConfigurationPayloadContext;
 import net.neoforged.neoforge.network.handling.PlayPayloadContext;
 import net.neoforged.neoforge.network.payload.AdvancedAddEntityPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
+import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
@@ -134,6 +136,18 @@ public class ClientPayloadHandler {
             Screen s = f.create(menuType.create(windowId, mc.player.getInventory(), buf), mc.player.getInventory(), name);
             mc.player.containerMenu = ((MenuAccess<?>) s).getMenu();
             mc.setScreen(s);
+        });
+    }
+
+    public void handle(AuxiliaryLightDataPayload msg, PlayPayloadContext context) {
+        context.workHandler().execute(() -> {
+            Minecraft mc = Minecraft.getInstance();
+            if (mc.level == null) return;
+
+            AuxiliaryLightManager lightManager = mc.level.getAuxLightManager(msg.pos());
+            if (lightManager != null) {
+                lightManager.handleLightDataSync(msg.entries());
+            }
         });
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.neoforged.neoforge.common.TierSortingRegistry;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
+import net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager;
 import net.neoforged.neoforge.entity.IEntityWithComplexSpawn;
 import net.neoforged.neoforge.network.ConfigSync;
 import net.neoforged.neoforge.network.handling.ConfigurationPayloadContext;
@@ -145,8 +146,8 @@ public class ClientPayloadHandler {
             if (mc.level == null) return;
 
             AuxiliaryLightManager lightManager = mc.level.getAuxLightManager(msg.pos());
-            if (lightManager != null) {
-                lightManager.handleLightDataSync(msg.entries());
+            if (lightManager instanceof LevelChunkAuxiliaryLightManager manager) {
+                manager.handleLightDataSync(msg.entries());
             }
         }).exceptionally(e -> {
             context.packetHandler().disconnect(Component.translatable("neoforge.network.aux_light_data.failed", msg.pos(), e.getMessage()));

--- a/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
@@ -11,20 +11,21 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ChunkPos;
+import net.neoforged.neoforge.common.extensions.IFriendlyByteBufExtension;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
-public record AuxiliaryLightDataPayload(ChunkPos pos, Map<BlockPos, Integer> entries) implements CustomPacketPayload {
+public record AuxiliaryLightDataPayload(ChunkPos pos, Map<BlockPos, Byte> entries) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "auxiliary_light_data");
 
     public AuxiliaryLightDataPayload(FriendlyByteBuf buf) {
-        this(buf.readChunkPos(), buf.readMap(FriendlyByteBuf::readBlockPos, FriendlyByteBuf::readInt));
+        this(buf.readChunkPos(), buf.readMap(FriendlyByteBuf::readBlockPos, FriendlyByteBuf::readByte));
     }
 
     @Override
     public void write(FriendlyByteBuf buf) {
         buf.writeChunkPos(pos);
-        buf.writeMap(entries, FriendlyByteBuf::writeBlockPos, FriendlyByteBuf::writeInt);
+        buf.writeMap(entries, FriendlyByteBuf::writeBlockPos, IFriendlyByteBufExtension::writeByte);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
@@ -15,7 +15,7 @@ import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
 public record AuxiliaryLightDataPayload(ChunkPos pos, Map<BlockPos, Integer> entries) implements CustomPacketPayload {
 
-    public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "aux_light_data");
+    public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "auxiliary_light_data");
 
     public AuxiliaryLightDataPayload(FriendlyByteBuf buf) {
         this(buf.readChunkPos(), buf.readMap(FriendlyByteBuf::readBlockPos, FriendlyByteBuf::readInt));

--- a/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
@@ -1,0 +1,29 @@
+package net.neoforged.neoforge.network.payload;
+
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.ChunkPos;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+
+public record AuxiliaryLightDataPayload(ChunkPos pos, Map<BlockPos, Integer> entries) implements CustomPacketPayload {
+
+    public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "aux_light_data");
+
+    public AuxiliaryLightDataPayload(FriendlyByteBuf buf) {
+        this(buf.readChunkPos(), buf.readMap(FriendlyByteBuf::readBlockPos, FriendlyByteBuf::readInt));
+    }
+
+    @Override
+    public void write(FriendlyByteBuf buf) {
+        buf.writeChunkPos(pos);
+        buf.writeMap(entries, FriendlyByteBuf::writeBlockPos, FriendlyByteBuf::writeInt);
+    }
+
+    @Override
+    public ResourceLocation id() {
+        return ID;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.network.payload;
 
 import java.util.Map;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -142,6 +142,7 @@ public net.minecraft.client.renderer.RenderStateShard$TransparencyStateShard
 public net.minecraft.client.renderer.RenderStateShard$WriteMaskStateShard
 public net.minecraft.client.renderer.RenderType create(Ljava/lang/String;Lcom/mojang/blaze3d/vertex/VertexFormat;Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;IZZLnet/minecraft/client/renderer/RenderType$CompositeState;)Lnet/minecraft/client/renderer/RenderType$CompositeRenderType; # create
 public net.minecraft.client.renderer.RenderType$CompositeState
+default net.minecraft.client.renderer.chunk.RenderChunk wrapped
 public net.minecraft.client.renderer.block.model.BlockElement uvsByFace(Lnet/minecraft/core/Direction;)[F # uvsByFace
 public net.minecraft.client.renderer.block.model.BlockElement$Deserializer
 public net.minecraft.client.renderer.block.model.BlockElement$Deserializer <init>()V # constructor

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -254,5 +254,6 @@
   "neoforge.network.advanced_open_screen.failed": "Failed to open a screen with advanced data: %s",
   "neoforge.network.registries.sync.missing": "Not all expected registries were received from the server! (missing: %s)",
   "neoforge.network.registries.sync.server-with-unknown-keys": "The server send registries with unknown keys: %s",
-  "neoforge.network.registries.sync.failed": "Failed to sync registries from the server: %s"
+  "neoforge.network.registries.sync.failed": "Failed to sync registries from the server: %s",
+  "neoforge.network.aux_light_data.failed": "Failed to handle auxiliary light data for chunk %s: %s"
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -29,28 +30,49 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.eventtest.internal.TestsMod;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.RegisterStructureTemplate;
 import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 import net.neoforged.testframework.registration.RegistrationHelper;
 
 @ForEachTest(groups = BlockTests.GROUP + ".properties")
 public class BlockPropertyTests {
-    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    private static final String TEMPLATE_3x4_BOX = "neotests_level_sensitive_light:light_box_3x3:";
+
+    @RegisterStructureTemplate(TEMPLATE_3x4_BOX)
+    public static final StructureTemplate TEMPLATE3x4 = StructureTemplateBuilder.withSize(3, 4, 3)
+            .fill(0, 0, 0, 2, 3, 2, Blocks.STONE)
+            .set(1, 1, 1, Blocks.AIR.defaultBlockState())
+            .set(1, 2, 1, Blocks.AIR.defaultBlockState())
+            .build();
+
+    @GameTest(template = TEMPLATE_3x4_BOX)
     @TestHolder(description = "Adds a toggleable light source to test if level-sensitive light emission works")
     static void levelSensitiveLight(final DynamicTest test, final RegistrationHelper reg) {
         final var lightBlock = reg.blocks().registerBlockWithBEType("light_block", LightBlock::new, LightBlockEntity::new, BlockBehaviour.Properties.of())
                 .withLang("Light block").withBlockItem();
 
+        BlockPos lightPos = new BlockPos(1, 2, 1);
+        BlockPos testPos = new BlockPos(1, 3, 1);
+
         test.onGameTest(helper -> helper.startSequence()
-                .thenExecute(() -> helper.setBlock(new BlockPos(1, 1, 1), lightBlock.get()))
-                .thenExecute(() -> helper.useBlock(new BlockPos(1, 1, 1), helper.makeMockPlayer(), Items.ACACIA_BUTTON.getDefaultInstance()))
-                .thenMap(() -> helper.getLevel().getChunkAt(helper.absolutePos(new BlockPos(1, 2, 1))))
+                .thenExecute(() -> helper.setBlock(lightPos, lightBlock.get()))
+                .thenExecute(() -> helper.useBlock(lightPos, helper.makeMockPlayer(), Items.ACACIA_BUTTON.getDefaultInstance()))
+                .thenMap(() -> helper.getLevel().getChunkAt(helper.absolutePos(testPos)))
                 .thenMap(chunk -> ((ThreadedLevelLightEngine) helper.getLevel().getLightEngine()).waitForPendingTasks(chunk.getPos().x, chunk.getPos().z))
-                .thenWaitUntil(future -> helper.assertTrue(future.isDone(), "Light engine did not update"))
-                .thenExecute(() -> helper.assertTrue(helper.getLevel().getLightEngine().getRawBrightness(helper.absolutePos(new BlockPos(1, 2, 1)), 15) == 14, "light level was not as expected"))
+                .thenWaitUntil(future -> helper.assertTrue(future.isDone(), "Light engine did not update to lit"))
+                .thenExecute(() -> helper.assertTrue(helper.getLevel().getLightEngine().getRawBrightness(helper.absolutePos(testPos), 15) == 14, "Lit light level was not as expected"))
+                .thenExecute(() -> helper.destroyBlock(lightPos))
+                .thenMap(() -> helper.getLevel().getChunkAt(helper.absolutePos(new BlockPos(1, 3, 1))))
+                .thenMap(chunk -> ((ThreadedLevelLightEngine) helper.getLevel().getLightEngine()).waitForPendingTasks(chunk.getPos().x, chunk.getPos().z))
+                .thenWaitUntil(future -> helper.assertTrue(future.isDone(), "Light engine did not update to unlit"))
+                .thenExecute(() -> helper.assertTrue(helper.getLevel().getLightEngine().getRawBrightness(helper.absolutePos(testPos), 15) == 0, "Unlit light level was not as expected"))
                 .thenSucceed());
     }
 
@@ -105,8 +127,9 @@ public class BlockPropertyTests {
 
         @Override
         public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
-            if (pos == BlockPos.ZERO || (level.getExistingBlockEntity(pos) instanceof LightBlockEntity be && be.lit)) {
-                return 15;
+            AuxiliaryLightManager lightManager = level.getAuxLightManager(pos);
+            if (lightManager != null) {
+                return lightManager.getLightAt(pos);
             }
             return 0;
         }
@@ -133,7 +156,11 @@ public class BlockPropertyTests {
         private void setLit(boolean lit) {
             if (lit != this.lit) {
                 this.lit = lit;
-                level.getLightEngine().checkBlock(worldPosition);
+                AuxiliaryLightManager lightManager = level.getAuxLightManager(worldPosition);
+                if (lightManager != null) {
+                    lightManager.setLightAt(worldPosition, lit ? 15 : 0);
+                    level.getLightEngine().checkBlock(worldPosition);
+                }
             }
         }
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
@@ -30,33 +30,28 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.minecraft.world.phys.BlockHitResult;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.eventtest.internal.TestsMod;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
-import net.neoforged.testframework.annotation.RegisterStructureTemplate;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 import net.neoforged.testframework.registration.RegistrationHelper;
 
 @ForEachTest(groups = BlockTests.GROUP + ".properties")
 public class BlockPropertyTests {
-    private static final String TEMPLATE_3x4_BOX = "neotests_level_sensitive_light:light_box_3x3:";
 
-    @RegisterStructureTemplate(TEMPLATE_3x4_BOX)
-    public static final StructureTemplate TEMPLATE3x4 = StructureTemplateBuilder.withSize(3, 4, 3)
-            .fill(0, 0, 0, 2, 3, 2, Blocks.STONE)
-            .set(1, 1, 1, Blocks.AIR.defaultBlockState())
-            .set(1, 2, 1, Blocks.AIR.defaultBlockState())
-            .build();
-
-    @GameTest(template = TEMPLATE_3x4_BOX)
+    @GameTest
     @TestHolder(description = "Adds a toggleable light source to test if level-sensitive light emission works")
     static void levelSensitiveLight(final DynamicTest test, final RegistrationHelper reg) {
         final var lightBlock = reg.blocks().registerBlockWithBEType("light_block", LightBlock::new, LightBlockEntity::new, BlockBehaviour.Properties.of())
                 .withLang("Light block").withBlockItem();
+
+        test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 4, 3)
+                .fill(0, 0, 0, 2, 3, 2, Blocks.STONE)
+                .set(1, 1, 1, Blocks.AIR.defaultBlockState())
+                .set(1, 2, 1, Blocks.AIR.defaultBlockState()));
 
         BlockPos lightPos = new BlockPos(1, 2, 1);
         BlockPos testPos = new BlockPos(1, 3, 1);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
@@ -154,7 +154,6 @@ public class BlockPropertyTests {
                 AuxiliaryLightManager lightManager = level.getAuxLightManager(worldPosition);
                 if (lightManager != null) {
                     lightManager.setLightAt(worldPosition, lit ? 15 : 0);
-                    level.getLightEngine().checkBlock(worldPosition);
                 }
             }
         }


### PR DESCRIPTION
This PR adds an API for safely handling lighting data driven by dynamic data stored in `BlockEntity`s that provides both thread-safety and availability of the data during chunk loading from disk.

## The problem

The current solution to provide data from a BE to the light engine is to (attempt to) get the BE from the level in `IBlockExtension#getLightEmission()` and return the light value directly from the BE. This has two significant issues:

1. Access to BEs is not thread-safe due to them being stored in a plain `HashMap` in the `LevelChunk` which is problematic due to the light engine running on a worker and calling `getLightEmission()` from there
2. BEs are not yet accessible when the initial lighting pass runs over the chunk when a chunk is loaded from disk
3. The vanilla implementation of `ServerLevel#getBlockEntity()` returns `null` for off-thread calls and the helper method added by Neo (`IBlockGetterExtension#getExistingBlockEntity()`) to bypass that protection and avoid the side effects is not actually thread-safe and can cause deadlocks due to `LevelReader#hasChunk()` returning true but `LevelReader#getChunk()` still ending up in an unfinished chunk future under certain circumstances

The first point could be fixed fairly trivially by patching the map field to use a `ConcurrentHashMap` instead of a `HashMap`. The second issue would however require extensive changes to the way vanilla loads chunks from disk which is not a viable option.

## The proposed solution

The solution proposed in this PR is to remove the broken helper method and add a thread-safe manager for these BE-driven light values that is stored in the `LevelChunk`, written to and read from the chunk's NBT data for immediate availability in the initial lighting pass during loading from disk and provided through the same safe path vanilla uses to get blocks during lighting updates. 
When a modded `BlockEntity` wants to change its emitted light level, it would retrieve the `AuxiliaryLightManager` from its `Level`, set the new light level for its position on the manager and then request an update from the `Level`'s `LightEngine` (the last part is already required with the current approach). When `IBlockExtension#getLightEmission()` is called, the modded block would retrieve the light manager again and return the light level stored in the manager for its position. Both of these parts must be done on both server and client (this is already required with the current approach). The light data is synced to the client when the initial chunk data is sent to ensure consistency between server and clients and prevent stale ghost lights on the client. When a `BlockEntity` is removed from a `LevelChunk` (i.e. due to the block being broken), then the light at the respective position is automatically removed from the manager if present.

This solution was tested with the game test, which is adapted to cover the full lifecycle of such a dynamic light source, and the BE-based lighting in FramedBlocks.

## Considerations

In principle, the proposed implementation is extremely similar to the attachment system introduced in the capability rework and the light manager could theoretically be implemented almost the exact same way with it. In practice this is however not possible due to the attachment system not being thread-safe. Forcing every mod that needs BE-driven lighting to add their own attachment to chunks also doesn't sound like a particularly nice solution to me and would likely lead to more issues with respect to thread-safety.