### PR TITLE
Add target generic to `AttachmentType`

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -5,7 +5,7 @@
  import org.slf4j.Logger;
  
 -public abstract class Entity implements Nameable, EntityAccess, CommandSource, ScoreHolder {
-+public abstract class Entity extends net.neoforged.neoforge.attachment.AttachmentHolder implements Nameable, EntityAccess, CommandSource, ScoreHolder, net.neoforged.neoforge.common.extensions.IEntityExtension {
++public abstract class Entity extends net.neoforged.neoforge.attachment.AttachmentHolder<Entity> implements Nameable, EntityAccess, CommandSource, ScoreHolder, net.neoforged.neoforge.common.extensions.IEntityExtension {
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final String ID_TAG = "id";
      public static final String PASSENGERS_TAG = "Passengers";
@@ -632,7 +632,7 @@
 +
 +    @Override
 +    @Nullable
-+    public final <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
++    public final <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<? super Entity, T> type, T data) {
 +        // Entities are always saved, no setChanged() call is necessary.
 +        return super.setData(type, data);
 +    }

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -5,7 +5,7 @@
  import org.slf4j.Logger;
  
 -public final class ItemStack {
-+public final class ItemStack extends net.neoforged.neoforge.attachment.AttachmentHolder implements net.neoforged.neoforge.common.extensions.IItemStackExtension {
++public final class ItemStack extends net.neoforged.neoforge.attachment.AttachmentHolder<ItemStack> implements net.neoforged.neoforge.common.extensions.IItemStackExtension {
 +    // TODO: add attachment support here
      public static final Codec<ItemStack> CODEC = RecordCodecBuilder.create(
          p_311716_ -> p_311716_.group(

--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -5,7 +5,7 @@
  import net.minecraft.world.scores.Scoreboard;
  
 -public abstract class Level implements LevelAccessor, AutoCloseable {
-+public abstract class Level extends net.neoforged.neoforge.attachment.AttachmentHolder implements LevelAccessor, AutoCloseable, net.neoforged.neoforge.common.extensions.ILevelExtension {
++public abstract class Level extends net.neoforged.neoforge.attachment.AttachmentHolder<Level> implements LevelAccessor, AutoCloseable, net.neoforged.neoforge.common.extensions.ILevelExtension {
      public static final Codec<ResourceKey<Level>> RESOURCE_KEY_CODEC = ResourceKey.codec(Registries.DIMENSION);
      public static final ResourceKey<Level> OVERWORLD = ResourceKey.create(Registries.DIMENSION, new ResourceLocation("overworld"));
      public static final ResourceKey<Level> NETHER = ResourceKey.create(Registries.DIMENSION, new ResourceLocation("the_nether"));

--- a/patches/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -5,7 +5,7 @@
  import org.slf4j.Logger;
  
 -public abstract class BlockEntity {
-+public abstract class BlockEntity extends net.neoforged.neoforge.attachment.AttachmentHolder implements net.neoforged.neoforge.common.extensions.IBlockEntityExtension {
++public abstract class BlockEntity extends net.neoforged.neoforge.attachment.AttachmentHolder<BlockEntity> implements net.neoforged.neoforge.common.extensions.IBlockEntityExtension {
      private static final Logger LOGGER = LogUtils.getLogger();
      private final BlockEntityType<?> type;
      @Nullable
@@ -62,7 +62,7 @@
 +
 +    @Override
 +    @Nullable
-+    public final <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
++    public final <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<? super BlockEntity, T> type, T data) {
 +        setChanged();
 +        return super.setData(type, data);
      }

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -100,7 +100,7 @@
      }
  
 +    // FORGE START
-+    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField();
++    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
 +
 +    @Override
 +    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -5,7 +5,7 @@
  import org.slf4j.Logger;
  
 -public class LevelChunk extends ChunkAccess {
-+public class LevelChunk extends ChunkAccess implements net.neoforged.neoforge.attachment.IAttachmentHolder {
++public class LevelChunk extends ChunkAccess implements net.neoforged.neoforge.attachment.IAttachmentHolder<LevelChunk> {
      static final Logger LOGGER = LogUtils.getLogger();
      private static final TickingBlockEntity NULL_TICKER = new TickingBlockEntity() {
          @Override
@@ -100,21 +100,21 @@
      }
  
 +    // FORGE START
-+    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
++    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField<LevelChunk> attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
 +
 +    @Override
-+    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
++    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<? super LevelChunk, ?> type) {
 +        return attachmentHolder.hasData(type);
 +    }
 +
 +    @Override
-+    public <T> T getData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++    public <T> T getData(net.neoforged.neoforge.attachment.AttachmentType<? super LevelChunk, T> type) {
 +        return attachmentHolder.getData(type);
 +    }
 +
 +    @Override
 +    @Nullable
-+    public <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
++    public <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<? super LevelChunk, T> type, T data) {
 +        setUnsaved(true);
 +        return attachmentHolder.setData(type, data);
 +    }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
@@ -84,7 +84,7 @@ public final class AttachmentInternals {
             @SuppressWarnings("unchecked")
             var serializer = (IAttachmentSerializer<Tag, Object>) type.serializer;
             if (serializer != null && filter.test(type)) {
-                to.attachments.put(type, serializer.read(serializer.write(entry.getValue())));
+                to.attachments.put(type, serializer.read(to.getExposedHolder(), serializer.write(entry.getValue())));
             }
         }
     }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
@@ -78,11 +78,11 @@ public final class AttachmentInternals {
     /**
      * Copy some attachments to another holder.
      */
-    private static <H extends AttachmentHolder> void copyAttachments(H from, H to, Predicate<AttachmentType<?>> filter) {
+    private static <H extends AttachmentHolder<H>> void copyAttachments(H from, H to, Predicate<AttachmentType<? super H, ?>> filter) {
         for (var entry : from.attachments.entrySet()) {
-            AttachmentType<?> type = entry.getKey();
+            AttachmentType<? super H, ?> type = entry.getKey();
             @SuppressWarnings("unchecked")
-            var serializer = (IAttachmentSerializer<Tag, Object>) type.serializer;
+            var serializer = (IAttachmentSerializer<H, Tag, Object>) type.serializer;
             if (serializer != null && filter.test(type)) {
                 to.attachments.put(type, serializer.read(to.getExposedHolder(), serializer.write(entry.getValue())));
             }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.attachment;
 
 import com.mojang.serialization.Codec;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
@@ -50,7 +51,7 @@ import org.jetbrains.annotations.Nullable;
  */
 // TODO Future work: maybe add copy handlers for stacks and entities, to customize copying behavior (instead of serializing, copying the NBT, deserializing).
 public final class AttachmentType<T> {
-    final Supplier<T> defaultValueSupplier;
+    final Function<IAttachmentHolder, T> defaultValueSupplier;
     @Nullable
     final IAttachmentSerializer<?, T> serializer;
     final boolean copyOnDeath;
@@ -75,21 +76,50 @@ public final class AttachmentType<T> {
     /**
      * Creates a builder for an attachment type.
      *
+     * <p>See {@link #builder(Function)} for attachments that want to capture a reference to their holder.
+     *
      * @param defaultValueSupplier A supplier for a new default value of this attachment type.
      */
     public static <T> Builder<T> builder(Supplier<T> defaultValueSupplier) {
+        return builder(holder -> defaultValueSupplier.get());
+    }
+
+    /**
+     * Creates a builder for an attachment type.
+     *
+     * <p>This overload allows capturing a reference to the {@link IAttachmentHolder} for the attachment.
+     * To obtain a specific subtype, the holder can be cast.
+     * See {@link #builder(Supplier)} for an overload that does not capture the holder.
+     *
+     * @param defaultValueSupplier A supplier for a new default value of this attachment type.
+     */
+    public static <T> Builder<T> builder(Function<IAttachmentHolder, T> defaultValueSupplier) {
         return new Builder<>(defaultValueSupplier);
     }
 
     /**
      * Create a builder for an attachment type that uses {@link INBTSerializable} for serialization.
      * Other kinds of serialization can be implemented using {@link #builder(Supplier)} and {@link Builder#serialize(IAttachmentSerializer)}.
+     *
+     * <p>See {@link #serializable(Function)} for attachments that want to capture a reference to their holder.
      */
     public static <S extends Tag, T extends INBTSerializable<S>> Builder<T> serializable(Supplier<T> defaultValueSupplier) {
+        return serializable(holder -> defaultValueSupplier.get());
+    }
+
+    /**
+     * Create a builder for an attachment type that uses {@link INBTSerializable} for serialization.
+     * Other kinds of serialization can be implemented using {@link #builder(Supplier)} and {@link Builder#serialize(IAttachmentSerializer)}.
+     *
+     * <p>This overload allows capturing a reference to the {@link IAttachmentHolder} for the attachment.
+     * To obtain a specific subtype, the holder can be cast.
+     * See {@link #serializable(Supplier)} for an overload that does not capture the holder.
+     */
+    public static <S extends Tag, T extends INBTSerializable<S>> Builder<T> serializable(Function<IAttachmentHolder, T> defaultValueSupplier) {
         return builder(defaultValueSupplier).serialize(new IAttachmentSerializer<S, T>() {
             @Override
-            public T read(S tag) {
-                var ret = defaultValueSupplier.get();
+            public T read(IAttachmentHolder holder, S tag) {
+                var ret = defaultValueSupplier.apply(holder);
                 ret.deserializeNBT(tag);
                 return ret;
             }
@@ -102,14 +132,14 @@ public final class AttachmentType<T> {
     }
 
     public static class Builder<T> {
-        private final Supplier<T> defaultValueSupplier;
+        private final Function<IAttachmentHolder, T> defaultValueSupplier;
         @Nullable
         private IAttachmentSerializer<?, T> serializer;
         private boolean copyOnDeath;
         @Nullable
         private IAttachmentComparator<T> comparator;
 
-        private Builder(Supplier<T> defaultValueSupplier) {
+        private Builder(Function<IAttachmentHolder, T> defaultValueSupplier) {
             this.defaultValueSupplier = defaultValueSupplier;
         }
 
@@ -133,6 +163,8 @@ public final class AttachmentType<T> {
          * <p>Using a {@link Codec} to serialize attachments is discouraged for item stack attachments,
          * for performance reasons. Prefer one of the other options.
          *
+         * <p>Codec-based attachments cannot capture a reference to their holder.
+         *
          * @param codec The codec to use.
          */
         public Builder<T> serialize(Codec<T> codec) {
@@ -140,7 +172,7 @@ public final class AttachmentType<T> {
             // TODO: better error handling
             return serialize(new IAttachmentSerializer<>() {
                 @Override
-                public T read(Tag tag) {
+                public T read(IAttachmentHolder holder, Tag tag) {
                     return codec.parse(NbtOps.INSTANCE, tag).result().get();
                 }
 

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -11,17 +11,16 @@ import org.jetbrains.annotations.Nullable;
 /**
  * An object that can hold data attachments.
  */
-public interface IAttachmentHolder {
+public interface IAttachmentHolder<H extends IAttachmentHolder<H>> {
     /**
      * Returns {@code true} if there is a data attachment of the give type, {@code false} otherwise.
      */
-    boolean hasData(AttachmentType<?> type);
+    boolean hasData(AttachmentType<? super H, ?> type);
 
     /**
      * Returns {@code true} if there is a data attachment of the give type, {@code false} otherwise.
      */
-    default <T> boolean hasData(Supplier<AttachmentType<T>> type) {
-        //Note: The unused T generic is necessary so that DeferredHolders can be properly matched as a Supplier
+    default <AT extends AttachmentType<? super H, ?>> boolean hasData(Supplier<AT> type) {
         return hasData(type.get());
     }
 
@@ -30,14 +29,14 @@ public interface IAttachmentHolder {
      *
      * <p>If there is no data attachment of the given type, <b>the default value is stored in this holder and returned.</b>
      */
-    <T> T getData(AttachmentType<T> type);
+    <T> T getData(AttachmentType<? super H, T> type);
 
     /**
      * {@return the data attachment of the given type}
      *
      * <p>If there is no data attachment of the given type, <b>the default value is stored in this holder and returned.</b>
      */
-    default <T> T getData(Supplier<AttachmentType<T>> type) {
+    default <T, AT extends AttachmentType<? super H, T>> T getData(Supplier<AT> type) {
         return getData(type.get());
     }
 
@@ -46,14 +45,14 @@ public interface IAttachmentHolder {
      *
      * @return the previous value for that attachment type, if any, or {@code null} if there was none
      */
-    <T> @Nullable T setData(AttachmentType<T> type, T data);
+    <T> @Nullable T setData(AttachmentType<? super H, T> type, T data);
 
     /**
      * Sets the data attachment of the given type.
      *
      * @return the previous value for that attachment type, if any, or {@code null} if there was none
      */
-    default <T> @Nullable T setData(Supplier<AttachmentType<T>> type, T data) {
+    default <T, AT extends AttachmentType<? super H, T>> @Nullable T setData(Supplier<AT> type, T data) {
         return setData(type.get(), data);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentSerializer.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentSerializer.java
@@ -10,33 +10,17 @@ import net.minecraft.nbt.Tag;
 /**
  * Serializer for data attachments.
  *
- * <p><b>The {@link #read(IAttachmentHolder, Tag)} method must be implemented by subclasses!</b>
- *
  * @param <S> A {@link Tag} subclass: the serialized representation.
  * @param <T> The type of the data attachment.
  */
-public interface IAttachmentSerializer<S extends Tag, T> {
-    /**
-     * @deprecated Implement {@link #read(IAttachmentHolder, Tag)} instead.
-     *             This method will be removed in a future version.
-     */
-    @Deprecated(forRemoval = true, since = "1.20.4")
-    default T read(S tag) {
-        throw new RuntimeException("IAttachmentSerializer must implement the read() that accepts a holder!");
-    }
-
+public interface IAttachmentSerializer<H, S extends Tag, T> {
     /**
      * Reads the attachment from NBT.
-     *
-     * <p>In a future version, the default implementation will be removed,
-     * but for now it exists for backwards compatibility with {@link #read(Tag)}.
      *
      * @param holder the holder for the attachment, can be cast if the subtype is known
      * @param tag    the serialized attachment
      */
-    default T read(IAttachmentHolder holder, S tag) {
-        return read(tag);
-    }
+    T read(H holder, S tag);
 
     /**
      * Writes the attachment to NBT.

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentSerializer.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentSerializer.java
@@ -10,11 +10,36 @@ import net.minecraft.nbt.Tag;
 /**
  * Serializer for data attachments.
  *
+ * <p><b>The {@link #read(IAttachmentHolder, Tag)} method must be implemented by subclasses!</b>
+ *
  * @param <S> A {@link Tag} subclass: the serialized representation.
  * @param <T> The type of the data attachment.
  */
 public interface IAttachmentSerializer<S extends Tag, T> {
-    T read(S tag);
+    /**
+     * @deprecated Implement {@link #read(IAttachmentHolder, Tag)} instead.
+     *             This method will be removed in a future version.
+     */
+    @Deprecated(forRemoval = true, since = "1.20.4")
+    default T read(S tag) {
+        throw new RuntimeException("IAttachmentSerializer must implement the read() that accepts a holder!");
+    }
 
+    /**
+     * Reads the attachment from NBT.
+     *
+     * <p>In a future version, the default implementation will be removed,
+     * but for now it exists for backwards compatibility with {@link #read(Tag)}.
+     *
+     * @param holder the holder for the attachment, can be cast if the subtype is known
+     * @param tag    the serialized attachment
+     */
+    default T read(IAttachmentHolder holder, S tag) {
+        return read(tag);
+    }
+
+    /**
+     * Writes the attachment to NBT.
+     */
     S write(T attachment);
 }

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
@@ -46,7 +46,7 @@ public class NeoForgeRegistries {
     public static final Registry<IngredientType<?>> INGREDIENT_TYPES = new RegistryBuilder<>(Keys.INGREDIENT_TYPES).create();
     public static final Registry<Codec<? extends ICondition>> CONDITION_SERIALIZERS = new RegistryBuilder<>(Keys.CONDITION_CODECS).create();
     public static final Registry<Codec<? extends ICustomItemPredicate>> ITEM_PREDICATE_SERIALIZERS = new RegistryBuilder<>(Keys.ITEM_PREDICATE_SERIALIZERS).create();
-    public static final Registry<AttachmentType<?>> ATTACHMENT_TYPES = new RegistryBuilder<>(Keys.ATTACHMENT_TYPES).create();
+    public static final Registry<AttachmentType<?, ?>> ATTACHMENT_TYPES = new RegistryBuilder<>(Keys.ATTACHMENT_TYPES).create();
 
     // Reminder: If you add a registry to NeoForge itself, remember to add it to NeoForgeRegistriesSetup#registerRegistries.
 
@@ -62,7 +62,7 @@ public class NeoForgeRegistries {
         public static final ResourceKey<Registry<IngredientType<?>>> INGREDIENT_TYPES = key("ingredient_serializer");
         public static final ResourceKey<Registry<Codec<? extends ICondition>>> CONDITION_CODECS = key("condition_codecs");
         public static final ResourceKey<Registry<Codec<? extends ICustomItemPredicate>>> ITEM_PREDICATE_SERIALIZERS = key("item_predicates");
-        public static final ResourceKey<Registry<AttachmentType<?>>> ATTACHMENT_TYPES = key("attachment_types");
+        public static final ResourceKey<Registry<AttachmentType<?, ?>>> ATTACHMENT_TYPES = key("attachment_types");
 
         // NeoForge Dynamic
         public static final ResourceKey<Registry<BiomeModifier>> BIOME_MODIFIERS = key("biome_modifier");

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -132,6 +132,30 @@ public class ExtendedGameTestHelper extends GameTestHelper {
         return serverplayer;
     }
 
+    public Player makeOpMockPlayer(int commandLevel) {
+        return new Player(this.getLevel(), BlockPos.ZERO, 0.0F, new GameProfile(UUID.randomUUID(), "test-mock-player")) {
+            @Override
+            public boolean isSpectator() {
+                return false;
+            }
+
+            @Override
+            public boolean isCreative() {
+                return true;
+            }
+
+            @Override
+            public boolean isLocalPlayer() {
+                return true;
+            }
+
+            @Override
+            protected int getPermissionLevel() {
+                return commandLevel;
+            }
+        };
+    }
+
     public Stream<BlockPos> blocksBetween(int x, int y, int z, int length, int height, int width) {
         final AABB bounds = AABB.encapsulatingFullBlocks(this.absolutePos(new BlockPos(x, y, z)), this.absolutePos(new BlockPos(x + length, y + height, z + width)));
         return BlockPos.MutableBlockPos.betweenClosedStream(bounds);

--- a/testframework/src/main/java/net/neoforged/testframework/impl/reg/RegistrationHelperImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/reg/RegistrationHelperImpl.java
@@ -141,7 +141,7 @@ public class RegistrationHelperImpl implements RegistrationHelper {
         return entityTypes;
     }
 
-    private final DeferredRegistrar<AttachmentType<?>, DeferredAttachmentTypes> attachments = new DeferredRegistrar<>((namespace, reg) -> new DeferredAttachmentTypes(namespace));
+    private final DeferredRegistrar<AttachmentType<?, ?>, DeferredAttachmentTypes> attachments = new DeferredRegistrar<>((namespace, reg) -> new DeferredAttachmentTypes(namespace));
 
     @Override
     public DeferredAttachmentTypes attachments() {

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredAttachmentTypes.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredAttachmentTypes.java
@@ -11,16 +11,16 @@ import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 
-public class DeferredAttachmentTypes extends DeferredRegister<AttachmentType<?>> {
+public class DeferredAttachmentTypes extends DeferredRegister<AttachmentType<?, ?>> {
     public DeferredAttachmentTypes(String namespace) {
         super(NeoForgeRegistries.Keys.ATTACHMENT_TYPES, namespace);
     }
 
-    public <T> AttachmentType<T> registerSimpleAttachment(String name, Supplier<T> defaultValue) {
+    public <T> AttachmentType<Object, T> registerSimpleAttachment(String name, Supplier<T> defaultValue) {
         return register(name, defaultValue, UnaryOperator.identity());
     }
 
-    public <T> AttachmentType<T> register(String name, Supplier<T> defaultValue, UnaryOperator<AttachmentType.Builder<T>> factory) {
+    public <T> AttachmentType<Object, T> register(String name, Supplier<T> defaultValue, UnaryOperator<AttachmentType.Builder<Object, T>> factory) {
         final var attach = factory.apply(AttachmentType.builder(defaultValue)).build();
         register(name, () -> attach);
         return attach;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -112,7 +112,7 @@ public class AttachmentTests {
         }
 
         var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
-                .register("chunk_mutable_int", () -> AttachmentType.serializable(chunk -> new ChunkMutableInt((LevelChunk) chunk, 0)).build());
+                .register("chunk_mutable_int", () -> AttachmentType.serializable(LevelChunk.class, chunk -> new ChunkMutableInt(chunk, 0)).build());
 
         NeoForge.EVENT_BUS.addListener((RegisterCommandsEvent event) -> {
             event.getDispatcher()

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -5,12 +5,23 @@
 
 package net.neoforged.neoforge.debug.attachment;
 
+import static net.minecraft.commands.Commands.literal;
+
+import com.mojang.brigadier.Command;
 import io.netty.buffer.Unpooled;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.nbt.IntTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.chunk.LevelChunk;
 import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.common.util.INBTSerializable;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.ItemStackHandler;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
@@ -62,6 +73,73 @@ public class AttachmentTests {
 
             helper.assertTrue(ItemStack.matches(stack, readStack), "ItemStack did not sync correctly with NBT");
             helper.assertTrue(ItemStack.matches(Items.DIAMOND.getDefaultInstance(), readStack.getData(attachmentType).getStackInSlot(0)), "ItemStack handler did not sync the contained item");
+
+            helper.succeed();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Ensures that chunk attachments can capture a reference to the containing LevelChunk.")
+    static void chunkAttachmentReferenceTest(DynamicTest test, RegistrationHelper reg) {
+        class ChunkMutableInt implements INBTSerializable<IntTag> {
+            private final LevelChunk chunk;
+            private int value;
+
+            public ChunkMutableInt(LevelChunk chunk, int value) {
+                this.chunk = chunk;
+                this.value = value;
+            }
+
+            public int getValue() {
+                return value;
+            }
+
+            public void setValue(int value) {
+                this.value = value;
+                chunk.setUnsaved(true);
+            }
+
+            @Override
+            public IntTag serializeNBT() {
+                return IntTag.valueOf(value);
+            }
+
+            @Override
+            public void deserializeNBT(IntTag nbt) {
+                this.value = nbt.getAsInt();
+            }
+        }
+
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("chunk_mutable_int", () -> AttachmentType.serializable(chunk -> new ChunkMutableInt((LevelChunk) chunk, 0)).build());
+
+        NeoForge.EVENT_BUS.addListener((RegisterCommandsEvent event) -> {
+            event.getDispatcher()
+                    .register(literal(test.id())
+                            .then(literal("print_and_increment")
+                                    .requires(source -> source.hasPermission(Commands.LEVEL_OWNERS))
+                                    .executes(ctx -> {
+                                        var chunk = ctx.getSource().getLevel().getChunkAt(BlockPos.containing(ctx.getSource().getPosition()));
+                                        var attachment = chunk.getData(attachmentType);
+                                        attachment.setValue(attachment.getValue() + 1);
+                                        ctx.getSource().sendSuccess(() -> Component.literal("New attachment value: " + attachment.getValue()), false);
+                                        return Command.SINGLE_SUCCESS;
+                                    })));
+        });
+
+        test.onGameTest(helper -> {
+            var player = helper.makeOpMockPlayer(Commands.LEVEL_OWNERS);
+            var pos = helper.absolutePos(BlockPos.ZERO);
+            player.setPos(pos.getCenter());
+
+            helper.getLevel().getServer().getCommands().performPrefixedCommand(player.createCommandSourceStack(), test.id() + " print_and_increment");
+            helper.assertTrue(((LevelChunk) helper.getLevel().getChunk(pos)).getData(attachmentType).getValue() == 1,
+                    "Chunk attachment value should have been 1");
+
+            helper.getLevel().getServer().getCommands().performPrefixedCommand(player.createCommandSourceStack(), test.id() + " print_and_increment");
+            helper.assertTrue(((LevelChunk) helper.getLevel().getChunk(pos)).getData(attachmentType).getValue() == 2,
+                    "Chunk attachment value should have been 2");
 
             helper.succeed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/chat/CommandTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/chat/CommandTests.java
@@ -5,17 +5,14 @@
 
 package net.neoforged.neoforge.debug.chat;
 
-import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.ParsedCommandNode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
-import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
@@ -58,27 +55,7 @@ public class CommandTests {
         });
 
         test.onGameTest(helper -> {
-            final Player player = new Player(helper.getLevel(), BlockPos.ZERO, 0.0F, new GameProfile(UUID.randomUUID(), "test-mock-player")) {
-                @Override
-                public boolean isSpectator() {
-                    return false;
-                }
-
-                @Override
-                public boolean isCreative() {
-                    return false;
-                }
-
-                @Override
-                public boolean isLocalPlayer() {
-                    return true;
-                }
-
-                @Override
-                protected int getPermissionLevel() {
-                    return Commands.LEVEL_GAMEMASTERS;
-                }
-            };
+            final Player player = helper.makeOpMockPlayer(Commands.LEVEL_GAMEMASTERS);
             helper.startSequence()
                     .thenExecute(() -> helper.getLevel().getServer().getCommands().performPrefixedCommand(player.createCommandSourceStack(), "/attribute"))
                     .thenExecuteAfter(5, () -> helper.assertLivingEntityHasMobEffect(player, MobEffects.BLINDNESS, 2))


### PR DESCRIPTION
Different take to the same problem as #462: allowing attachments to capture an instance of their holder. This time, we introduce a generic for the holder type instead of requiring a cast.

Unfortunately, this approach only allows attachments that receive a `BlockEntity`, `Entity`, `ItemStack`, `LevelChunk` or `Level` instance (or a common superclass like `Object`). If you want a `Player`-specific attachment for example, you still need to cast to `Player`! This makes me think that the #462 approach is preferable.