### PR TITLE
Create AttachmentHolder map lazily

### DIFF
--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -114,12 +114,12 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
      */
     public static <H extends AttachmentHolder> boolean areAttachmentsCompatible(H first, H second) {
         // Confirm both maps are present or not present
-        if(first.attachments == second.attachments) {
+        if (first.attachments == second.attachments) {
             return true;
         }
         // If either of the maps are not present, then only one attachment holder has a populated map.
         // They are not compatible.
-        if(first.attachments == null || second.attachments == null) {
+        if (first.attachments == null || second.attachments == null) {
             return false;
         }
         for (var entry : first.attachments.entrySet()) {

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -113,19 +113,13 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
      * @return {@code true} if the attachments are compatible, {@code false} otherwise
      */
     public static <H extends AttachmentHolder> boolean areAttachmentsCompatible(H first, H second) {
-        // Confirm both maps are present or not present
-        if (first.attachments == second.attachments) {
-            return true;
-        }
-        // If either of the maps are not present, then only one attachment holder has a populated map.
-        // They are not compatible.
-        if (first.attachments == null || second.attachments == null) {
-            return false;
-        }
-        for (var entry : first.attachments.entrySet()) {
+        Map<AttachmentType<?>, Object> firstAttachments = first.attachments != null ? first.attachments : Map.of();
+        Map<AttachmentType<?>, Object> secondAttachments = second.attachments != null ? second.attachments : Map.of();
+
+        for (var entry : firstAttachments.entrySet()) {
             AttachmentType<Object> type = (AttachmentType<Object>) entry.getKey();
             if (type.serializer != null) {
-                var otherData = second.attachments.get(type);
+                var otherData = secondAttachments.get(type);
                 if (otherData == null)
                     // TODO: cache serialization of default value?
                     otherData = type.defaultValueSupplier.get();
@@ -133,10 +127,10 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
                     return false;
             }
         }
-        for (var entry : second.attachments.entrySet()) {
+        for (var entry : secondAttachments.entrySet()) {
             AttachmentType<Object> type = (AttachmentType<Object>) entry.getKey();
             if (type.serializer != null) {
-                var data = first.attachments.get(type);
+                var data = firstAttachments.get(type);
                 if (data != null)
                     continue; // already checked in the first loop
                 data = type.defaultValueSupplier.get();

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -41,7 +41,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
      */
     final Map<AttachmentType<?>, Object> getAttachmentMap() {
         if (attachments == null) {
-            attachments = new IdentityHashMap<>();
+            attachments = new IdentityHashMap<>(4);
         }
         return attachments;
     }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -39,7 +39,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
     /**
      * Create the attachment map if it does not yet exist, or return the current map.
      */
-    Map<AttachmentType<?>, Object> getAttachmentMap() {
+    final Map<AttachmentType<?>, Object> getAttachmentMap() {
         if (attachments == null) {
             attachments = new IdentityHashMap<>();
         }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
@@ -79,12 +79,15 @@ public final class AttachmentInternals {
      * Copy some attachments to another holder.
      */
     private static <H extends AttachmentHolder> void copyAttachments(H from, H to, Predicate<AttachmentType<?>> filter) {
+        if (from.attachments == null) {
+            return;
+        }
         for (var entry : from.attachments.entrySet()) {
             AttachmentType<?> type = entry.getKey();
             @SuppressWarnings("unchecked")
             var serializer = (IAttachmentSerializer<Tag, Object>) type.serializer;
             if (serializer != null && filter.test(type)) {
-                to.attachments.put(type, serializer.read(serializer.write(entry.getValue())));
+                to.getAttachmentMap().put(type, serializer.read(serializer.write(entry.getValue())));
             }
         }
     }


### PR DESCRIPTION
The backing `IdentityHashMap` here can allocate several hundred bytes worth of heap space, which multiplies to a huge amount if there are many `AttachmentHolder` objects in memory. An example is hundreds of thousands of `ItemStack` instances stored by recipes.

To avoid this, we should not create the map until an attachment is actually registered or deserialized.