### PR TITLE
Make chunk sections only be considered all air if filled with Blocks.AIR only

### DIFF
--- a/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
@@ -5,7 +5,7 @@
          FluidState fluidstate = blockstate.getFluidState();
          FluidState fluidstate1 = p_62995_.getFluidState();
 -        if (!blockstate.isAir()) {
-+        if (!blockstate.isEmpty()) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
++        if (!blockstate.isEmpty()) { // NEO: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
              --this.nonEmptyBlockCount;
              if (blockstate.isRandomlyTicking()) {
                  --this.tickingBlockCount;
@@ -14,7 +14,7 @@
          }
  
 -        if (!p_62995_.isAir()) {
-+        if (!p_62995_.isEmpty()) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
++        if (!p_62995_.isEmpty()) { // NEO: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
              ++this.nonEmptyBlockCount;
              if (p_62995_.isRandomlyTicking()) {
                  ++this.tickingBlockCount;

--- a/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
@@ -18,3 +18,12 @@
              ++this.nonEmptyBlockCount;
              if (p_62995_.isRandomlyTicking()) {
                  ++this.tickingBlockCount;
+@@ -114,7 +_,7 @@
+ 
+             public void accept(BlockState p_204444_, int p_204445_) {
+                 FluidState fluidstate = p_204444_.getFluidState();
+-                if (!p_204444_.isAir()) {
++                if (!p_204444_.isEmpty()) { // Neo: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
+                     this.nonEmptyBlockCount += p_204445_;
+                     if (p_204444_.isRandomlyTicking()) {
+                         this.tickingBlockCount += p_204445_;

--- a/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
@@ -5,7 +5,7 @@
          FluidState fluidstate = blockstate.getFluidState();
          FluidState fluidstate1 = p_62995_.getFluidState();
 -        if (!blockstate.isAir()) {
-+        if (!blockstate.isEmpty()) { // NEO: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
++        if (!blockstate.isEmpty()) { // Neo: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
              --this.nonEmptyBlockCount;
              if (blockstate.isRandomlyTicking()) {
                  --this.tickingBlockCount;
@@ -14,7 +14,7 @@
          }
  
 -        if (!p_62995_.isAir()) {
-+        if (!p_62995_.isEmpty()) { // NEO: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
++        if (!p_62995_.isEmpty()) { // Neo: Fix MC-232360 for modded blocks (Makes modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections)
              ++this.nonEmptyBlockCount;
              if (p_62995_.isRandomlyTicking()) {
                  ++this.tickingBlockCount;

--- a/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
@@ -5,7 +5,7 @@
          FluidState fluidstate = blockstate.getFluidState();
          FluidState fluidstate1 = p_62995_.getFluidState();
 -        if (!blockstate.isAir()) {
-+        if (!blockstate.is(Blocks.AIR)) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
++        if (!blockstate.isEmpty()) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
              --this.nonEmptyBlockCount;
              if (blockstate.isRandomlyTicking()) {
                  --this.tickingBlockCount;
@@ -14,7 +14,7 @@
          }
  
 -        if (!p_62995_.isAir()) {
-+        if (!p_62995_.is(Blocks.AIR)) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
++        if (!p_62995_.isEmpty()) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
              ++this.nonEmptyBlockCount;
              if (p_62995_.isRandomlyTicking()) {
                  ++this.tickingBlockCount;

--- a/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunkSection.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/level/chunk/LevelChunkSection.java
++++ b/net/minecraft/world/level/chunk/LevelChunkSection.java
+@@ -65,7 +_,7 @@
+ 
+         FluidState fluidstate = blockstate.getFluidState();
+         FluidState fluidstate1 = p_62995_.getFluidState();
+-        if (!blockstate.isAir()) {
++        if (!blockstate.is(Blocks.AIR)) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
+             --this.nonEmptyBlockCount;
+             if (blockstate.isRandomlyTicking()) {
+                 --this.tickingBlockCount;
+@@ -76,7 +_,7 @@
+             --this.tickingFluidCount;
+         }
+ 
+-        if (!p_62995_.isAir()) {
++        if (!p_62995_.is(Blocks.AIR)) { // NEO: Patched to make modded isAir blocks not be replaced with Blocks.AIR in all-air chunk sections
+             ++this.nonEmptyBlockCount;
+             if (p_62995_.isRandomlyTicking()) {
+                 ++this.tickingBlockCount;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -947,4 +947,14 @@ public interface IBlockExtension {
     default PushReaction getPistonPushReaction(BlockState state) {
         return null;
     }
+
+    /**
+     * Return true if the state is able to be replaced with Blocks.AIR in chunk sections that is entirely made of blocks that return true for isEmpty
+     *
+     * @param state  The current state
+     * @return True if the block should be allowed to be optimized away into Blocks.AIR
+     */
+    default boolean isEmpty(BlockState state) {
+        return state.is(Blocks.AIR) || state.is(Blocks.CAVE_AIR) || state.is(Blocks.VOID_AIR);
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -951,7 +951,7 @@ public interface IBlockExtension {
     /**
      * Return true if the state is able to be replaced with Blocks.AIR in chunk sections that is entirely made of blocks that return true for isEmpty
      *
-     * @param state  The current state
+     * @param state The current state
      * @return True if the block should be allowed to be optimized away into Blocks.AIR
      */
     default boolean isEmpty(BlockState state) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -721,4 +721,13 @@ public interface IBlockStateExtension {
     default BlockState getAppearance(BlockAndTintGetter level, BlockPos pos, Direction side, @Nullable BlockState queryState, @Nullable BlockPos queryPos) {
         return self().getBlock().getAppearance(self(), level, pos, side, queryState, queryPos);
     }
+
+    /**
+     * Return true if the state is able to be replaced with Blocks.AIR in chunk sections that is entirely made of blocks that return true for isEmpty
+     *
+     * @return True if the block should be allowed to be optimized away into Blocks.AIR
+     */
+    default boolean isEmpty() {
+        return self().getBlock().isEmpty(self());
+    }
 }


### PR DESCRIPTION
A small PR to adjust how LevelChunkSection determines if it is entirely Air or not. 

## The problem this solves:

If you have a chunk section (16x16x16) filled with Cave Air or a modded block with isAir set to true, LevelChunkSection will return true for hasOnlyAir(). This will cause getBlockState to always return Blocks.AIR despite people setting other kinds of air blocks in the chunk. This only happens when the entire chunk section has blocks whose isAir is true. Thus leading to confusion from players or modders who were so sure they placed a different air block in the chunk section before mining out the rest of it. 

It also makes it tougher for modders who has a modded isAir block with behaviors. If they fill a large area with that block, most of that block will be converted automatically to Blocks.AIR. This PR aims to make the hasOnlyAir be true if the chunk section is entirely vanilla air blocks and nothing else. Allowing modded air blocks to not get converted to Blocks.AIR while preserving the vanilla behavior for vanilla blocks. This then would match the expected and resultant behavior being done in the game.

In the code, many of the LevelChunkSection hasOnlyAir calls keeps making the assumption that if that method is true, the spot must be Blocks.AIR. Multiple places makes this assumption. Not good for mods.

## Why not replace LevelChunkSection's hasOnlyAir to be hasOnlyEmpy or isEmpty?

Would increase patch size significantly. Figured keeping it small would be more ideal.
![image](https://github.com/neoforged/NeoForge/assets/40846040/fc146d19-f23e-4afd-8547-0bf2e6c49f48)

## Why not add isEmpty to block and blockstate and check that in LevelChunkSection?

~~Realistically, this would be a useless method. If a modder made a block, then there's some behavior attached to the block or it is acting as some sort of marker. If we let modder mark it as isEmpty, suddenly, that block is replaced with Blocks.AIR in certain chunk sections and the modder's goal with the block is lost. I cannot see any realistic purpose for marking a modded block as isEmpty and having it spontaneously turn into Blocks.AIR. Might as well just use Blocks.AIR in the first place.~~

isEmpty is now a method added to IBlockExtension and IBlockStateExtension and returns true for AIR, CAVE_AIR, and VOID_AIR by default. Modded isAir blocks will not return true by default unless they override the method and explicitly return true.

## Why not a `c:air` or `c:airlike` tag?

Many mods are already doing the isAir check thinking it handles everything they need. Adding a tag would require every single one of those mods to go in their code and replace all their isAir checks with a tag check. Seems like uptake would be incredibly slow. By doing this patch instead, their isAir check would keep working out of the box and mods adding air-like blocks can mark their blocks as isAir true without fear of being converted to Blocks.AIR.

## What performance impact will this have? Any changes to vanilla worldgen?

Edit: latest changes will have zero impact changes to vanilla blocks. There should be no changes at all to vanilla’s behavior with vanilla blocks. Only modded air blocks will be affected

The only isAir blocks in vanilla are AIR, CAVE_AIR, and VOID_AIR:

- AIR is used everywhere. It's the main default block

- CAVE_AIR is used only in ravines in Overworld and Nether, caves in Nether, and in underground structures/features such as Mineshafts, Dungeons, and Strongholds.

- VOID_AIR is used only for positions outside of the world's build limits. Essentially, it is only when outside the chunk's height ranges. In the case of the Nether, from y = 128 to y = 256, AIR is placed. Above y= 256, VOID_AIR is place.

Before change, what Nether roof has.
![image](https://github.com/neoforged/NeoForge/assets/40846040/485a7271-c208-4668-8cda-94df1fb77430)
![image](https://github.com/neoforged/NeoForge/assets/40846040/76a9345d-e840-46f9-9d9d-eab6df3b3344)

After change, what Nether roof has:
![image](https://github.com/neoforged/NeoForge/assets/40846040/7d988777-fc15-4d58-a93c-e6ed4af70c6e)

So even with this change, nothing changed with the Nether roof so no change to vanilla behavior with vanilla blocks when double checking the Nether.

Hopefully this helps