### PR TITLE
Make sure empty model data is not inserted into manager

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -119,11 +119,21 @@ public abstract sealed class ModelDataManager permits ModelDataManager.Active, M
                 Long2ObjectMap<ModelData> data = modelDataCache.computeIfAbsent(section, $ -> new Long2ObjectOpenHashMap<>());
                 for (BlockPos pos : needUpdate) {
                     BlockEntity toUpdate = level.getBlockEntity(pos);
+                    ModelData newData = ModelData.EMPTY;
+                    // Query the BE for new model data if it exists
                     if (toUpdate != null && !toUpdate.isRemoved()) {
-                        data.put(pos.asLong(), toUpdate.getModelData());
+                        newData = toUpdate.getModelData();
+                    }
+                    // Make sure we don't bother storing empty data in the map
+                    if (newData != ModelData.EMPTY) {
+                        data.put(pos.asLong(), newData);
                     } else {
                         data.remove(pos.asLong());
                     }
+                }
+                // Remove the map completely if it's now empty
+                if (data.isEmpty()) {
+                    modelDataCache.remove(section);
                 }
             }
         }


### PR DESCRIPTION
This PR cleans up the model data manager a bit by making sure it doesn't insert empty model data. I noticed this issue while working on Embeddium, and it seems to affect all three iterations of the model data manager (pre-1.19, 1.19-1.20, and the latest refactor just merged). Now, we only bother storing model data if it's non-empty and also delete the map if it shrinks to zero entries.