### PR TITLE
Improve withAlternative support for MapCodecCodecs

### DIFF
--- a/patches/net/minecraft/advancements/Advancement.java.patch
+++ b/patches/net/minecraft/advancements/Advancement.java.patch
@@ -4,7 +4,7 @@
          ),
          Advancement::validate
      );
-+    public static final Codec<Optional<net.neoforged.neoforge.common.conditions.WithConditions<Advancement>>> CONDITIONAL_ADVANCEMENT_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.createConditionalCodecWithConditions(CODEC);
++    public static final Codec<Optional<net.neoforged.neoforge.common.conditions.WithConditions<Advancement>>> CONDITIONAL_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.createConditionalCodecWithConditions(CODEC);
  
      public Advancement(
          Optional<ResourceLocation> p_300893_,

--- a/patches/net/minecraft/advancements/Advancement.java.patch
+++ b/patches/net/minecraft/advancements/Advancement.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/advancements/Advancement.java
 +++ b/net/minecraft/advancements/Advancement.java
+@@ -54,6 +_,7 @@
+         ),
+         Advancement::validate
+     );
++    public static final Codec<Optional<net.neoforged.neoforge.common.conditions.WithConditions<Advancement>>> CONDITIONAL_ADVANCEMENT_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.createConditionalCodecWithConditions(CODEC);
+ 
+     public Advancement(
+         Optional<ResourceLocation> p_300893_,
 @@ -113,7 +_,7 @@
          });
      }

--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -33,12 +33,12 @@
                          throw new IllegalStateException("Duplicate recipe " + p_312039_);
                      } else {
 -                        list.add(DataProvider.saveStable(p_254020_, Recipe.CODEC, p_312254_, RecipeProvider.this.recipePathProvider.json(p_312039_)));
-+                        list.add(DataProvider.saveStable(p_254020_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_RECIPE_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, conditions)), RecipeProvider.this.recipePathProvider.json(p_312039_)));
++                        list.add(DataProvider.saveStable(p_254020_, Recipe.CONDITIONAL_RECIPE_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, conditions)), RecipeProvider.this.recipePathProvider.json(p_312039_)));
                          if (p_311794_ != null) {
                              list.add(
                                  DataProvider.saveStable(
 -                                    p_254020_, Advancement.CODEC, p_311794_.value(), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
-+                                    p_254020_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), conditions)), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
++                                    p_254020_, Advancement.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), conditions)), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
                                  )
                              );
                          }
@@ -56,7 +56,7 @@
 +    }
 +
 +    protected CompletableFuture<?> buildAdvancement(CachedOutput p_253674_, AdvancementHolder p_301116_, net.neoforged.neoforge.common.conditions.ICondition... conditions) {
-+        return DataProvider.saveStable(p_253674_, net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_301116_.value(), conditions)), this.advancementPathProvider.json(p_301116_.id()));
++        return DataProvider.saveStable(p_253674_, Advancement.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_301116_.value(), conditions)), this.advancementPathProvider.json(p_301116_.id()));
      }
  
      protected abstract void buildRecipes(RecipeOutput p_301172_);

--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -33,12 +33,12 @@
                          throw new IllegalStateException("Duplicate recipe " + p_312039_);
                      } else {
 -                        list.add(DataProvider.saveStable(p_254020_, Recipe.CODEC, p_312254_, RecipeProvider.this.recipePathProvider.json(p_312039_)));
-+                        list.add(DataProvider.saveStable(p_254020_, Recipe.CONDITIONAL_RECIPE_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, conditions)), RecipeProvider.this.recipePathProvider.json(p_312039_)));
++                        list.add(DataProvider.saveStable(p_254020_, Recipe.CONDITIONAL_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, conditions)), RecipeProvider.this.recipePathProvider.json(p_312039_)));
                          if (p_311794_ != null) {
                              list.add(
                                  DataProvider.saveStable(
 -                                    p_254020_, Advancement.CODEC, p_311794_.value(), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
-+                                    p_254020_, Advancement.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), conditions)), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
++                                    p_254020_, Advancement.CONDITIONAL_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), conditions)), RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
                                  )
                              );
                          }
@@ -56,7 +56,7 @@
 +    }
 +
 +    protected CompletableFuture<?> buildAdvancement(CachedOutput p_253674_, AdvancementHolder p_301116_, net.neoforged.neoforge.common.conditions.ICondition... conditions) {
-+        return DataProvider.saveStable(p_253674_, Advancement.CONDITIONAL_ADVANCEMENT_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_301116_.value(), conditions)), this.advancementPathProvider.json(p_301116_.id()));
++        return DataProvider.saveStable(p_253674_, Advancement.CONDITIONAL_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_301116_.value(), conditions)), this.advancementPathProvider.json(p_301116_.id()));
      }
  
      protected abstract void buildRecipes(RecipeOutput p_301172_);

--- a/patches/net/minecraft/server/ServerAdvancementManager.java.patch
+++ b/patches/net/minecraft/server/ServerAdvancementManager.java.patch
@@ -5,7 +5,7 @@
          p_136034_.forEach((p_311532_, p_311533_) -> {
              try {
 -                Advancement advancement = Util.getOrThrow(Advancement.CODEC.parse(JsonOps.INSTANCE, p_311533_), JsonParseException::new);
-+                Advancement advancement = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_ADVANCEMENT_CODEC, registryAccess == null ? com.mojang.serialization.JsonOps.INSTANCE : net.neoforged.neoforge.common.conditions.ConditionalOps.create(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registryAccess), conditionContext), p_311533_).orElse(null);
++                Advancement advancement = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(Advancement.CONDITIONAL_ADVANCEMENT_CODEC, registryAccess == null ? com.mojang.serialization.JsonOps.INSTANCE : net.neoforged.neoforge.common.conditions.ConditionalOps.create(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registryAccess), conditionContext), p_311533_).orElse(null);
 +                if (advancement == null) {
 +                    LOGGER.debug("Skipping loading advancement {} as its conditions were not met", p_311532_);
 +                    return;

--- a/patches/net/minecraft/server/ServerAdvancementManager.java.patch
+++ b/patches/net/minecraft/server/ServerAdvancementManager.java.patch
@@ -5,7 +5,7 @@
          p_136034_.forEach((p_311532_, p_311533_) -> {
              try {
 -                Advancement advancement = Util.getOrThrow(Advancement.CODEC.parse(JsonOps.INSTANCE, p_311533_), JsonParseException::new);
-+                Advancement advancement = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(Advancement.CONDITIONAL_ADVANCEMENT_CODEC, registryAccess == null ? com.mojang.serialization.JsonOps.INSTANCE : net.neoforged.neoforge.common.conditions.ConditionalOps.create(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registryAccess), conditionContext), p_311533_).orElse(null);
++                Advancement advancement = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(Advancement.CONDITIONAL_CODEC, registryAccess == null ? com.mojang.serialization.JsonOps.INSTANCE : net.neoforged.neoforge.common.conditions.ConditionalOps.create(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registryAccess), conditionContext), p_311533_).orElse(null);
 +                if (advancement == null) {
 +                    LOGGER.debug("Skipping loading advancement {} as its conditions were not met", p_311532_);
 +                    return;

--- a/patches/net/minecraft/world/item/crafting/Recipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Recipe.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/world/item/crafting/Recipe.java
 +++ b/net/minecraft/world/item/crafting/Recipe.java
+@@ -12,6 +_,7 @@
+ 
+ public interface Recipe<C extends Container> {
+     Codec<Recipe<?>> CODEC = BuiltInRegistries.RECIPE_SERIALIZER.byNameCodec().dispatch(Recipe::getSerializer, RecipeSerializer::codec);
++    Codec<java.util.Optional<net.neoforged.neoforge.common.conditions.WithConditions<Recipe<?>>>> CONDITIONAL_RECIPE_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.createConditionalCodecWithConditions(CODEC);
+ 
+     boolean matches(C p_44002_, Level p_44003_);
+ 
 @@ -25,9 +_,9 @@
          NonNullList<ItemStack> nonnulllist = NonNullList.withSize(p_44004_.getContainerSize(), ItemStack.EMPTY);
  

--- a/patches/net/minecraft/world/item/crafting/Recipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Recipe.java.patch
@@ -4,7 +4,7 @@
  
  public interface Recipe<C extends Container> {
      Codec<Recipe<?>> CODEC = BuiltInRegistries.RECIPE_SERIALIZER.byNameCodec().dispatch(Recipe::getSerializer, RecipeSerializer::codec);
-+    Codec<java.util.Optional<net.neoforged.neoforge.common.conditions.WithConditions<Recipe<?>>>> CONDITIONAL_RECIPE_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.createConditionalCodecWithConditions(CODEC);
++    Codec<java.util.Optional<net.neoforged.neoforge.common.conditions.WithConditions<Recipe<?>>>> CONDITIONAL_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.createConditionalCodecWithConditions(CODEC);
  
      boolean matches(C p_44002_, Level p_44003_);
  

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -33,7 +33,7 @@
 +    }
 +
 +    public static Optional<RecipeHolder<?>> fromJson(ResourceLocation p_44046_, JsonObject p_44047_, com.mojang.serialization.DynamicOps<com.google.gson.JsonElement> jsonElementOps) {
-+        Optional<? extends Recipe<?>> recipe = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(Recipe.CONDITIONAL_RECIPE_CODEC, jsonElementOps, p_44047_);
++        Optional<? extends Recipe<?>> recipe = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(Recipe.CONDITIONAL_CODEC, jsonElementOps, p_44047_);
 +        return recipe.map(r -> new RecipeHolder<>(p_44046_, r));
      }
  

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -33,7 +33,7 @@
 +    }
 +
 +    public static Optional<RecipeHolder<?>> fromJson(ResourceLocation p_44046_, JsonObject p_44047_, com.mojang.serialization.DynamicOps<com.google.gson.JsonElement> jsonElementOps) {
-+        Optional<? extends Recipe<?>> recipe = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(net.neoforged.neoforge.common.util.NeoForgeExtraCodecs.CONDITIONAL_RECIPE_CODEC, jsonElementOps, p_44047_);
++        Optional<? extends Recipe<?>> recipe = net.neoforged.neoforge.common.conditions.ICondition.getWithWithConditionsCodec(Recipe.CONDITIONAL_RECIPE_CODEC, jsonElementOps, p_44047_);
 +        return recipe.map(r -> new RecipeHolder<>(p_44046_, r));
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -109,14 +109,10 @@ public class NeoForgeExtraCodecs {
      * the first codec and then the second codec for decoding, <b>but only the first for encoding</b>.
      * <p>
      * Unlike vanilla, this alternative codec also tries to encode with the second codec if the first encode fails.
-     * <p>
-     * This codec will also try to keep the resulting codec to a MapCodecCodec if both inputs are MapCodecCodecs.
+     * 
+     * @see #withAlternative(MapCodec, MapCodec) for keeping {@link com.mojang.serialization.MapCodec MapCodecs} as MapCodecs.
      */
     public static <T> Codec<T> withAlternative(final Codec<T> codec, final Codec<T> alternative) {
-        if (codec instanceof MapCodec.MapCodecCodec<T> mCodec && alternative instanceof MapCodec.MapCodecCodec<T> mAlternative) {
-            //If both codecs are MapCodecCodecs then return it as a MapCodecCodec to allow for cleaner support in dispatch codecs
-            return withAlternative(mCodec.codec(), mAlternative.codec()).codec();
-        }
         return new AlternativeCodec<>(codec, alternative);
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -21,11 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import net.minecraft.advancements.Advancement;
 import net.minecraft.util.ExtraCodecs;
-import net.minecraft.world.item.crafting.Recipe;
-import net.neoforged.neoforge.common.conditions.ConditionalOps;
-import net.neoforged.neoforge.common.conditions.WithConditions;
 
 /**
  * {@link Codec}-related helper functions that are not in {@link ExtraCodecs}, but useful to NeoForge and other mods.
@@ -33,10 +29,6 @@ import net.neoforged.neoforge.common.conditions.WithConditions;
  * @see ExtraCodecs
  */
 public class NeoForgeExtraCodecs {
-    //Lazily initialize these codecs so that loading NeoForgeExtraCodecs in things like JUnit don't cause cascading class loading of things that
-    // can't be initialized properly such as registries
-    public static final Codec<Optional<WithConditions<Recipe<?>>>> CONDITIONAL_RECIPE_CODEC = ExtraCodecs.lazyInitializedCodec(() -> ConditionalOps.createConditionalCodecWithConditions(Recipe.CODEC));
-    public static final Codec<Optional<WithConditions<Advancement>>> CONDITIONAL_ADVANCEMENT_CODEC = ExtraCodecs.lazyInitializedCodec(() -> ConditionalOps.createConditionalCodecWithConditions(Advancement.CODEC));
 
     public static <T> MapCodec<T> aliasedFieldOf(final Codec<T> codec, final String... names) {
         if (names.length == 0)

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -166,12 +166,12 @@ public class NeoForgeExtraCodecs {
         }
     }
 
-    private static class AlternativeMapCodec<TYPE> extends MapCodec<TYPE> {
+    private static class AlternativeMapCodec<T> extends MapCodec<T> {
 
-        private final MapCodec<TYPE> codec;
-        private final MapCodec<TYPE> alternative;
+        private final MapCodec<T> codec;
+        private final MapCodec<T> alternative;
 
-        private AlternativeMapCodec(MapCodec<TYPE> codec, MapCodec<TYPE> alternative) {
+        private AlternativeMapCodec(MapCodec<T> codec, MapCodec<T> alternative) {
             this.codec = codec;
             this.alternative = alternative;
         }
@@ -182,8 +182,8 @@ public class NeoForgeExtraCodecs {
         }
 
         @Override
-        public <T> DataResult<TYPE> decode(DynamicOps<T> ops, MapLike<T> input) {
-            DataResult<TYPE> result = codec.decode(ops, input);
+        public <T1> DataResult<T> decode(DynamicOps<T1> ops, MapLike<T1> input) {
+            DataResult<T> result = codec.decode(ops, input);
             if (result.error().isEmpty()) {
                 return result;
             }
@@ -191,9 +191,9 @@ public class NeoForgeExtraCodecs {
         }
 
         @Override
-        public <T> RecordBuilder<T> encode(TYPE input, DynamicOps<T> ops, RecordBuilder<T> prefix) {
+        public <T1> RecordBuilder<T1> encode(T input, DynamicOps<T1> ops, RecordBuilder<T1> prefix) {
             //Build it to see if there is an error
-            DataResult<T> result = codec.encode(input, ops, prefix).build(ops.empty());
+            DataResult<T1> result = codec.encode(input, ops, prefix).build(ops.empty());
             if (result.error().isEmpty()) {
                 //But then we even if there isn't we have to encode it again so that we can actually allow the building to apply
                 // as our earlier build consumes the result


### PR DESCRIPTION
Added another variation of `NeoForgeExtraCodecs#withAlternative` for dealing with `MapCodec`s to make it possible to keep `MapCodecCodec`s as `MapCodecCodec`s, and be supported with mojang's special casing for `MapCodecCodec`s in things like dispatch codecs. My use case of this is having alternative codecs for serializing a recipe but needing it to stay as a `MapCodecCodec` so that it is inlined rather than wrapped in a pointless `"value" : { }` block.

I am leaving `NeoForgeExtraCodecs#mapWithAlternative` alone as I presume the use case via `aliasedFieldOf` was tested and it is a decent method for mirroring vanilla's `ExtraCodecs#withAlternative` but for `MapCodec`s.

I am also moving the two codecs at the top of `NeoForgeExtraCodecs` to their corresponding classes to not cause accidental 
 cascading class loading of a bunch of things including registries, which then would cause class initialization errors in things like JUnit.