### PR TITLE
Add system for conditional pack overlays

### DIFF
--- a/patches/net/minecraft/server/packs/OverlayMetadataSection.java.patch
+++ b/patches/net/minecraft/server/packs/OverlayMetadataSection.java.patch
@@ -1,0 +1,33 @@
+--- a/net/minecraft/server/packs/OverlayMetadataSection.java
++++ b/net/minecraft/server/packs/OverlayMetadataSection.java
+@@ -28,18 +_,28 @@
+         return this.overlays.stream().filter(p_296207_ -> p_296207_.isApplicable(p_296262_)).map(OverlayMetadataSection.OverlayEntry::overlay).toList();
+     }
+ 
+-    public static record OverlayEntry(InclusiveRange<Integer> format, String overlay) {
++    public static record OverlayEntry(InclusiveRange<Integer> format, String overlay, List<net.neoforged.neoforge.common.conditions.ICondition> conditions) {
++        public OverlayEntry(InclusiveRange<Integer> format, String overlay) {
++            this(format, overlay, List.of());
++        }
++
+         static final Codec<OverlayMetadataSection.OverlayEntry> CODEC = RecordCodecBuilder.create(
+             p_295923_ -> p_295923_.group(
+                         InclusiveRange.codec(Codec.INT).fieldOf("formats").forGetter(OverlayMetadataSection.OverlayEntry::format),
+                         ExtraCodecs.validate(Codec.STRING, OverlayMetadataSection::validateOverlayDir)
+                             .fieldOf("directory")
+-                            .forGetter(OverlayMetadataSection.OverlayEntry::overlay)
++                            .forGetter(OverlayMetadataSection.OverlayEntry::overlay),
++                        net.neoforged.neoforge.common.conditions.ICondition.LIST_CODEC.optionalFieldOf(net.neoforged.neoforge.common.conditions.ConditionalOps.DEFAULT_CONDITIONS_KEY, List.of()).forGetter(OverlayMetadataSection.OverlayEntry::conditions)
+                     )
+                     .apply(p_295923_, OverlayMetadataSection.OverlayEntry::new)
+         );
+ 
+         public boolean isApplicable(int p_295083_) {
++            for (var condition : this.conditions) {
++                if (!condition.test(net.neoforged.neoforge.common.conditions.ICondition.IContext.EMPTY)) {
++                    return false;
++                }
++            }
+             return this.format.isValueInRange(p_295083_);
+         }
+     }

--- a/patches/net/minecraft/server/packs/OverlayMetadataSection.java.patch
+++ b/patches/net/minecraft/server/packs/OverlayMetadataSection.java.patch
@@ -1,33 +1,11 @@
 --- a/net/minecraft/server/packs/OverlayMetadataSection.java
 +++ b/net/minecraft/server/packs/OverlayMetadataSection.java
-@@ -28,18 +_,28 @@
-         return this.overlays.stream().filter(p_296207_ -> p_296207_.isApplicable(p_296262_)).map(OverlayMetadataSection.OverlayEntry::overlay).toList();
-     }
- 
--    public static record OverlayEntry(InclusiveRange<Integer> format, String overlay) {
-+    public static record OverlayEntry(InclusiveRange<Integer> format, String overlay, List<net.neoforged.neoforge.common.conditions.ICondition> conditions) {
-+        public OverlayEntry(InclusiveRange<Integer> format, String overlay) {
-+            this(format, overlay, List.of());
-+        }
-+
-         static final Codec<OverlayMetadataSection.OverlayEntry> CODEC = RecordCodecBuilder.create(
-             p_295923_ -> p_295923_.group(
-                         InclusiveRange.codec(Codec.INT).fieldOf("formats").forGetter(OverlayMetadataSection.OverlayEntry::format),
-                         ExtraCodecs.validate(Codec.STRING, OverlayMetadataSection::validateOverlayDir)
-                             .fieldOf("directory")
--                            .forGetter(OverlayMetadataSection.OverlayEntry::overlay)
-+                            .forGetter(OverlayMetadataSection.OverlayEntry::overlay),
-+                        net.neoforged.neoforge.common.conditions.ICondition.LIST_CODEC.optionalFieldOf(net.neoforged.neoforge.common.conditions.ConditionalOps.DEFAULT_CONDITIONS_KEY, List.of()).forGetter(OverlayMetadataSection.OverlayEntry::conditions)
-                     )
-                     .apply(p_295923_, OverlayMetadataSection.OverlayEntry::new)
-         );
- 
-         public boolean isApplicable(int p_295083_) {
-+            for (var condition : this.conditions) {
-+                if (!condition.test(net.neoforged.neoforge.common.conditions.ICondition.IContext.EMPTY)) {
-+                    return false;
-+                }
-+            }
-             return this.format.isValueInRange(p_295083_);
-         }
-     }
+@@ -13,7 +_,7 @@
+ public record OverlayMetadataSection(List<OverlayMetadataSection.OverlayEntry> overlays) {
+     private static final Pattern DIR_VALIDATOR = Pattern.compile("[-_a-zA-Z0-9.]+");
+     private static final Codec<OverlayMetadataSection> CODEC = RecordCodecBuilder.create(
+-        p_294898_ -> p_294898_.group(OverlayMetadataSection.OverlayEntry.CODEC.listOf().fieldOf("entries").forGetter(OverlayMetadataSection::overlays))
++        p_294898_ -> p_294898_.group(net.neoforged.neoforge.common.conditions.ConditionalOps.decodeListWithElementConditions(OverlayMetadataSection.OverlayEntry.CODEC).fieldOf("entries").forGetter(OverlayMetadataSection::overlays))
+                 .apply(p_294898_, OverlayMetadataSection::new)
+     );
+     public static final MetadataSectionType<OverlayMetadataSection> TYPE = MetadataSectionType.fromCodec("overlays", CODEC);

--- a/src/main/java/net/neoforged/neoforge/common/data/GeneratingOverlayMetadataSection.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/GeneratingOverlayMetadataSection.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.common.data;
 
 import com.mojang.serialization.Codec;

--- a/src/main/java/net/neoforged/neoforge/common/data/GeneratingOverlayMetadataSection.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/GeneratingOverlayMetadataSection.java
@@ -1,0 +1,21 @@
+package net.neoforged.neoforge.common.data;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import net.minecraft.server.packs.OverlayMetadataSection;
+import net.minecraft.server.packs.metadata.MetadataSectionType;
+import net.neoforged.neoforge.common.conditions.ConditionalOps;
+import net.neoforged.neoforge.common.conditions.WithConditions;
+import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
+
+/**
+ * Can be used in place of {@link OverlayMetadataSection} during datagen if you wish to generate conditions.
+ */
+public record GeneratingOverlayMetadataSection(List<WithConditions<OverlayMetadataSection.OverlayEntry>> overlays) {
+    private static final Codec<GeneratingOverlayMetadataSection> CODEC = RecordCodecBuilder.create(i -> i.group(
+            NeoForgeExtraCodecs.listWithOptionalElements(
+                    ConditionalOps.createConditionalCodecWithConditions(OverlayMetadataSection.OverlayEntry.CODEC)).fieldOf("entries").forGetter(GeneratingOverlayMetadataSection::overlays))
+            .apply(i, GeneratingOverlayMetadataSection::new));
+    public static final MetadataSectionType<GeneratingOverlayMetadataSection> TYPE = MetadataSectionType.fromCodec("overlays", CODEC);
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -267,6 +267,7 @@ public net.minecraft.server.network.ServerLoginPacketListenerImpl authenticatedP
 public net.minecraft.server.packs.FilePackResources <init>(Ljava/lang/String;Lnet/minecraft/server/packs/FilePackResources$SharedZipFileAccess;ZLjava/lang/String;)V # constructor
 public net.minecraft.server.packs.FilePackResources$SharedZipFileAccess
 public net.minecraft.server.packs.FilePackResources$SharedZipFileAccess <init>(Ljava/io/File;)V # constructor
+public net.minecraft.server.packs.OverlayMetadataSection$OverlayEntry CODEC # CODEC
 public net.minecraft.server.packs.repository.BuiltInPackSource fixedResources(Lnet/minecraft/server/packs/PackResources;)Lnet/minecraft/server/packs/repository/Pack$ResourcesSupplier; # fixedResources
 public net.minecraft.server.packs.repository.ServerPacksSource createVanillaPackSource()Lnet/minecraft/server/packs/VanillaPackResources; # createVanillaPackSource
 public net.minecraft.server.packs.repository.Pack getDeclaredPackVersions(Ljava/lang/String;Lnet/minecraft/server/packs/metadata/pack/PackMetadataSection;)Lnet/minecraft/util/InclusiveRange; # getDeclaredPackVersions

--- a/tests/src/generated/resources/pack.mcmeta
+++ b/tests/src/generated/resources/pack.mcmeta
@@ -7,6 +7,32 @@
           0,
           2147483647
         ]
+      },
+      {
+        "neoforge:conditions": [
+          {
+            "type": "neoforge:mod_loaded",
+            "modid": "neoforge"
+          }
+        ],
+        "directory": "conditional_overlays_enabled",
+        "formats": [
+          0,
+          2147483647
+        ]
+      },
+      {
+        "neoforge:conditions": [
+          {
+            "type": "neoforge:mod_loaded",
+            "modid": "does_not_exist"
+          }
+        ],
+        "directory": "conditional_overlays_enabled",
+        "formats": [
+          0,
+          2147483647
+        ]
       }
     ]
   },

--- a/tests/src/main/java/net/neoforged/neoforge/debug/resources/OverlayTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/resources/OverlayTests.java
@@ -30,4 +30,19 @@ public class OverlayTests {
             helper.succeed();
         });
     }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if conditions work for pack overlays")
+    static void conditionalOverlay(final DynamicTest test) {
+        var enabledKey = TagKey.create(Registries.BLOCK, new ResourceLocation("conditional_overlays_test", "overlay_enabled"));
+        var disabledKey = TagKey.create(Registries.BLOCK, new ResourceLocation("conditional_overlays_test", "overlay_disabled"));
+        test.onGameTest(helper -> {
+            helper.assertTrue(Blocks.DIAMOND_BLOCK.defaultBlockState().is(enabledKey), "Enabled overlay was not applied");
+            helper.assertFalse(Blocks.COBBLESTONE.defaultBlockState().is(enabledKey), "File under enabled overlay was applied");
+            helper.assertFalse(Blocks.DIAMOND_BLOCK.defaultBlockState().is(disabledKey), "Disabled overlay was applied");
+            helper.assertTrue(Blocks.COBBLESTONE.defaultBlockState().is(disabledKey), "File under disabled overlay was not applied");
+            helper.succeed();
+        });
+    }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
@@ -116,6 +116,7 @@ import net.neoforged.neoforge.client.model.generators.MultiPartBlockStateBuilder
 import net.neoforged.neoforge.client.model.generators.VariantBlockStateBuilder;
 import net.neoforged.neoforge.common.conditions.IConditionBuilder;
 import net.neoforged.neoforge.common.conditions.ModLoadedCondition;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.DifferenceIngredient;
 import net.neoforged.neoforge.common.crafting.IntersectionIngredient;
@@ -124,6 +125,7 @@ import net.neoforged.neoforge.common.data.AdvancementProvider;
 import net.neoforged.neoforge.common.data.BlockTagsProvider;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import net.neoforged.neoforge.common.data.GeneratingOverlayMetadataSection;
 import net.neoforged.neoforge.common.data.LanguageProvider;
 import net.neoforged.neoforge.common.data.ParticleDescriptionProvider;
 import net.neoforged.neoforge.common.data.SoundDefinition;
@@ -161,10 +163,10 @@ public class DataGeneratorTest {
         CompletableFuture<HolderLookup.Provider> lookupProvider = event.getLookupProvider();
 
         gen.addProvider(true, new PackMetadataGenerator(packOutput)
-                .add(OverlayMetadataSection.TYPE, new OverlayMetadataSection(List.of(
-                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "pack_overlays_test"),
-                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "conditional_overlays_enabled", List.of(new ModLoadedCondition("neoforge"))),
-                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "conditional_overlays_enabled", List.of(new ModLoadedCondition("does_not_exist"))))))
+                .add(GeneratingOverlayMetadataSection.TYPE, new GeneratingOverlayMetadataSection(List.of(
+                        new WithConditions<>(new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "pack_overlays_test")),
+                        new WithConditions<>(new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "conditional_overlays_enabled"), new ModLoadedCondition("neoforge")),
+                        new WithConditions<>(new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "conditional_overlays_enabled"), new ModLoadedCondition("does_not_exist")))))
                 .add(PackMetadataSection.TYPE, new PackMetadataSection(
                         Component.literal("NeoForge tests resource pack"),
                         DetectedVersion.BUILT_IN.getPackVersion(PackType.CLIENT_RESOURCES),

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
@@ -115,6 +115,7 @@ import net.neoforged.neoforge.client.model.generators.ModelFile.UncheckedModelFi
 import net.neoforged.neoforge.client.model.generators.MultiPartBlockStateBuilder;
 import net.neoforged.neoforge.client.model.generators.VariantBlockStateBuilder;
 import net.neoforged.neoforge.common.conditions.IConditionBuilder;
+import net.neoforged.neoforge.common.conditions.ModLoadedCondition;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.DifferenceIngredient;
 import net.neoforged.neoforge.common.crafting.IntersectionIngredient;
@@ -161,7 +162,9 @@ public class DataGeneratorTest {
 
         gen.addProvider(true, new PackMetadataGenerator(packOutput)
                 .add(OverlayMetadataSection.TYPE, new OverlayMetadataSection(List.of(
-                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "pack_overlays_test"))))
+                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "pack_overlays_test"),
+                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "conditional_overlays_enabled", List.of(new ModLoadedCondition("neoforge"))),
+                        new OverlayMetadataSection.OverlayEntry(new InclusiveRange<>(0, Integer.MAX_VALUE), "conditional_overlays_enabled", List.of(new ModLoadedCondition("does_not_exist"))))))
                 .add(PackMetadataSection.TYPE, new PackMetadataSection(
                         Component.literal("NeoForge tests resource pack"),
                         DetectedVersion.BUILT_IN.getPackVersion(PackType.CLIENT_RESOURCES),

--- a/tests/src/main/resources/conditional_overlays_disabled/data/conditional_overlays_test/tags/blocks/overlay_disabled.json
+++ b/tests/src/main/resources/conditional_overlays_disabled/data/conditional_overlays_test/tags/blocks/overlay_disabled.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:diamond_block"
+  ]
+}

--- a/tests/src/main/resources/conditional_overlays_enabled/data/conditional_overlays_test/tags/blocks/overlay_enabled.json
+++ b/tests/src/main/resources/conditional_overlays_enabled/data/conditional_overlays_test/tags/blocks/overlay_enabled.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:diamond_block"
+  ]
+}

--- a/tests/src/main/resources/data/conditional_overlays_test/tags/blocks/overlay_disabled.json
+++ b/tests/src/main/resources/data/conditional_overlays_test/tags/blocks/overlay_disabled.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:cobblestone"
+  ]
+}

--- a/tests/src/main/resources/data/conditional_overlays_test/tags/blocks/overlay_enabled.json
+++ b/tests/src/main/resources/data/conditional_overlays_test/tags/blocks/overlay_enabled.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:cobblestone"
+  ]
+}


### PR DESCRIPTION
The new pack overlay system allows resource or data packs to specify an "overlay" which is used to replace/add resources on certain pack format versions. This PR expands the overlay system with a "conditions" field, which allows mods to make *anything* conditional simply by placing it in a conditional pack overlay.

~~I implemented this by adding a "conditions" field to the overlay entry record; alternatively, I could have implemented this by instead making the list of overlays in the overlay metadata section use the conditional list codec - I avoided this because it makes datagen more painful.~~ By request, I switched this to a system that doesn't keep the conditions around. Datagen is now painful, but still possible.