### PR TITLE
Fix custom baked quad generators producing tinted quads by default

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/obj/ObjMaterialLibrary.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/obj/ObjMaterialLibrary.java
@@ -103,7 +103,7 @@ public class ObjMaterialLibrary {
         public float transparency = 0.0f;
 
         // non-standard
-        public int diffuseTintIndex = 0;
+        public int diffuseTintIndex = -1;
 
         public Material(String name) {
             this.name = name;

--- a/src/main/java/net/neoforged/neoforge/client/model/pipeline/QuadBakingVertexConsumer.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/pipeline/QuadBakingVertexConsumer.java
@@ -38,7 +38,7 @@ public class QuadBakingVertexConsumer implements VertexConsumer {
     int vertexIndex = 0;
     private int[] quadData = new int[QUAD_DATA_SIZE];
 
-    private int tintIndex;
+    private int tintIndex = -1;
     private Direction direction = Direction.DOWN;
     private TextureAtlasSprite sprite = UnitTextureAtlasSprite.INSTANCE;
     private boolean shade;


### PR DESCRIPTION
The `QuadBakingVertexConsumer` stores a `tintIndex` field but does not initialize it by default, which means that the default index is 0. Minecraft considers this to be a tinted quad, as the sentinel value for not having a tint index is -1. Also, this is inconsistent with much of the rest of the model system, which tends to not tint quads unless explicitly specified.

This seems unintended, and a breaking changes period is the perfect time to correct it.