### PR TITLE
Add a simple hook to allow custom fluid rendering

### DIFF
--- a/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -59,6 +59,15 @@
                      );
              }
          } catch (Throwable throwable) {
+@@ -90,7 +_,7 @@
+ 
+     public void renderLiquid(BlockPos p_234364_, BlockAndTintGetter p_234365_, VertexConsumer p_234366_, BlockState p_234367_, FluidState p_234368_) {
+         try {
+-            this.liquidBlockRenderer.tesselate(p_234365_, p_234364_, p_234366_, p_234367_, p_234368_);
++            net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(p_234368_).renderFluid(p_234368_, p_234365_, p_234364_, p_234366_, p_234367_, this.liquidBlockRenderer);
+         } catch (Throwable throwable) {
+             CrashReport crashreport = CrashReport.forThrowable(throwable, "Tesselating liquid in world");
+             CrashReportCategory crashreportcategory = crashreport.addCategory("Block being tesselated");
 @@ -107,7 +_,11 @@
          return this.blockModelShaper.getBlockModel(p_110911_);
      }

--- a/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -63,7 +63,7 @@
  
      public void renderLiquid(BlockPos p_234364_, BlockAndTintGetter p_234365_, VertexConsumer p_234366_, BlockState p_234367_, FluidState p_234368_) {
          try {
-+            if (net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(p_234368_).renderFluid(p_234368_, p_234365_, p_234364_, p_234366_, p_234367_, this.liquidBlockRenderer)) return;
++            if (net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(p_234368_).renderFluid(p_234368_, p_234365_, p_234364_, p_234366_, p_234367_)) return;
              this.liquidBlockRenderer.tesselate(p_234365_, p_234364_, p_234366_, p_234367_, p_234368_);
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Tesselating liquid in world");
@@ -109,3 +109,13 @@
              }
          }
      }
+@@ -140,5 +_,9 @@
+     @Override
+     public void onResourceManagerReload(ResourceManager p_110909_) {
+         this.liquidBlockRenderer.setupSprites();
++    }
++
++    public LiquidBlockRenderer getLiquidBlockRenderer() {
++        return this.liquidBlockRenderer;
+     }
+ }

--- a/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/block/BlockRenderDispatcher.java.patch
@@ -59,15 +59,14 @@
                      );
              }
          } catch (Throwable throwable) {
-@@ -90,7 +_,7 @@
+@@ -90,6 +_,7 @@
  
      public void renderLiquid(BlockPos p_234364_, BlockAndTintGetter p_234365_, VertexConsumer p_234366_, BlockState p_234367_, FluidState p_234368_) {
          try {
--            this.liquidBlockRenderer.tesselate(p_234365_, p_234364_, p_234366_, p_234367_, p_234368_);
-+            net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(p_234368_).renderFluid(p_234368_, p_234365_, p_234364_, p_234366_, p_234367_, this.liquidBlockRenderer);
++            if (net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(p_234368_).renderFluid(p_234368_, p_234365_, p_234364_, p_234366_, p_234367_, this.liquidBlockRenderer)) return;
+             this.liquidBlockRenderer.tesselate(p_234365_, p_234364_, p_234366_, p_234367_, p_234368_);
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Tesselating liquid in world");
-             CrashReportCategory crashreportcategory = crashreport.addCategory("Block being tesselated");
 @@ -107,7 +_,11 @@
          return this.blockModelShaper.getBlockModel(p_110911_);
      }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
@@ -14,7 +14,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.ScreenEffectRenderer;
-import net.minecraft.client.renderer.block.LiquidBlockRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.BlockAndTintGetter;
@@ -345,10 +344,9 @@ public interface IClientFluidTypeExtensions {
      * @param pos             the position of the fluid
      * @param vertexConsumer  the vertex consumer to emit quads to
      * @param blockState      the blockstate at the position of the fluid
-     * @param vanillaRenderer the vanilla fluid renderer object
      * @return true if vanilla fluid rendering should be skipped
      */
-    default boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
+    default boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState) {
         return false;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
@@ -334,9 +334,8 @@ public interface IClientFluidTypeExtensions {
     }
 
     /**
-     * Called to tessellate a fluid during chunk meshing. The default implementation just calls the vanilla
-     * fluid renderer, but mods are free to replace the logic with their own (and optionally call super to
-     * augment the vanilla logic).
+     * Called to allow rendering custom quads for a fluid during chunk meshing. You may replace the fluid
+     * rendering entirely, or return false to allow vanilla's fluid rendering to also run.
      *
      * <p>Note: this method will be called once for every fluid block during chunk meshing, so any logic
      * here needs to be performant.
@@ -347,8 +346,9 @@ public interface IClientFluidTypeExtensions {
      * @param vertexConsumer  the vertex consumer to emit quads to
      * @param blockState      the blockstate at the position of the fluid
      * @param vanillaRenderer the vanilla fluid renderer object
+     * @return true if vanilla fluid rendering should be skipped
      */
-    default void renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
-        vanillaRenderer.tesselate(getter, pos, vertexConsumer, blockState, fluidState);
+    default boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
+        return false;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
@@ -339,11 +339,11 @@ public interface IClientFluidTypeExtensions {
      * <p>Note: this method will be called once for every fluid block during chunk meshing, so any logic
      * here needs to be performant.
      *
-     * @param fluidState      the state of the fluid
-     * @param getter          the getter the fluid can be obtained from
-     * @param pos             the position of the fluid
-     * @param vertexConsumer  the vertex consumer to emit quads to
-     * @param blockState      the blockstate at the position of the fluid
+     * @param fluidState     the state of the fluid
+     * @param getter         the getter the fluid can be obtained from
+     * @param pos            the position of the fluid
+     * @param vertexConsumer the vertex consumer to emit quads to
+     * @param blockState     the blockstate at the position of the fluid
      * @return true if vanilla fluid rendering should be skipped
      */
     default boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState) {

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
@@ -8,14 +8,18 @@ package net.neoforged.neoforge.client.extensions.common;
 import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.vertex.PoseStack;
 import java.util.function.Consumer;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.ScreenEffectRenderer;
+import net.minecraft.client.renderer.block.LiquidBlockRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
@@ -328,5 +332,24 @@ public interface IClientFluidTypeExtensions {
      */
     default ResourceLocation getOverlayTexture(FluidStack stack) {
         return this.getOverlayTexture();
+    }
+
+    /**
+     * Called to tessellate a fluid during chunk meshing. The default implementation just calls the vanilla
+     * fluid renderer, but mods are free to replace the logic with their own (and optionally call super to
+     * augment the vanilla logic).
+     *
+     * <p>Note: this method will be called once for every fluid block during chunk meshing, so any logic
+     * here needs to be performant.
+     *
+     * @param fluidState  the state of the fluid
+     * @param getter      the getter the fluid can be obtained from
+     * @param pos         the position of the fluid
+     * @param vertexConsumer the vertex consumer to emit quads to
+     * @param blockState the blockstate at the position of the fluid
+     * @param vanillaRenderer the vanilla fluid renderer object
+     */
+    default void renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
+        vanillaRenderer.tesselate(getter, pos, vertexConsumer, blockState, fluidState);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
@@ -7,9 +7,8 @@ package net.neoforged.neoforge.client.extensions.common;
 
 import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.vertex.PoseStack;
-import java.util.function.Consumer;
-
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import java.util.function.Consumer;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -342,11 +341,11 @@ public interface IClientFluidTypeExtensions {
      * <p>Note: this method will be called once for every fluid block during chunk meshing, so any logic
      * here needs to be performant.
      *
-     * @param fluidState  the state of the fluid
-     * @param getter      the getter the fluid can be obtained from
-     * @param pos         the position of the fluid
-     * @param vertexConsumer the vertex consumer to emit quads to
-     * @param blockState the blockstate at the position of the fluid
+     * @param fluidState      the state of the fluid
+     * @param getter          the getter the fluid can be obtained from
+     * @param pos             the position of the fluid
+     * @param vertexConsumer  the vertex consumer to emit quads to
+     * @param blockState      the blockstate at the position of the fluid
      * @param vanillaRenderer the vanilla fluid renderer object
      */
     default void renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
@@ -9,12 +9,16 @@ import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.LiquidBlockRenderer;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -24,9 +28,11 @@ import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
@@ -37,6 +43,7 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.neoforged.neoforge.client.model.pipeline.VertexConsumerWrapper;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.fluids.BaseFlowingFluid;
@@ -136,6 +143,20 @@ public class FluidTypeTest {
                     RenderSystem.setShaderFogStart(nearDistance);
                     RenderSystem.setShaderFogEnd(farDistance);
                     RenderSystem.setShaderFogShape(shape);
+                }
+
+                @Override
+                public void renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
+                    // Flip RGB to BGR *only* for fluid blocks rendered at Y 100
+                    if (pos.getY() == 100) {
+                        vertexConsumer = new VertexConsumerWrapper(vertexConsumer) {
+                            @Override
+                            public VertexConsumer color(int r, int g, int b, int a) {
+                                return super.color(b, g, r, a);
+                            }
+                        };
+                    }
+                    IClientFluidTypeExtensions.super.renderFluid(fluidState, getter, pos, vertexConsumer, blockState, vanillaRenderer);
                 }
             });
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
@@ -145,7 +145,7 @@ public class FluidTypeTest {
                 }
 
                 @Override
-                public boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
+                public boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState) {
                     // Flip RGB to BGR *only* for fluid blocks rendered at Y 100
                     if (pos.getY() == 100) {
                         vertexConsumer = new VertexConsumerWrapper(vertexConsumer) {
@@ -156,7 +156,7 @@ public class FluidTypeTest {
                         };
                     }
                     // Replace vanilla fluid rendering
-                    vanillaRenderer.tesselate(getter, pos, vertexConsumer, blockState, fluidState);
+                    Minecraft.getInstance().getBlockRenderer().getLiquidBlockRenderer().tesselate(getter, pos, vertexConsumer, blockState, fluidState);
                     return true;
                 }
             });

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
@@ -16,7 +16,6 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.block.LiquidBlockRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleTypes;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
@@ -145,7 +145,7 @@ public class FluidTypeTest {
                 }
 
                 @Override
-                public void renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
+                public boolean renderFluid(FluidState fluidState, BlockAndTintGetter getter, BlockPos pos, VertexConsumer vertexConsumer, BlockState blockState, LiquidBlockRenderer vanillaRenderer) {
                     // Flip RGB to BGR *only* for fluid blocks rendered at Y 100
                     if (pos.getY() == 100) {
                         vertexConsumer = new VertexConsumerWrapper(vertexConsumer) {
@@ -155,7 +155,9 @@ public class FluidTypeTest {
                             }
                         };
                     }
-                    IClientFluidTypeExtensions.super.renderFluid(fluidState, getter, pos, vertexConsumer, blockState, vanillaRenderer);
+                    // Replace vanilla fluid rendering
+                    vanillaRenderer.tesselate(getter, pos, vertexConsumer, blockState, fluidState);
+                    return true;
                 }
             });
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
@@ -7,10 +7,9 @@ package net.neoforged.neoforge.oldtest.fluid;
 
 import com.mojang.blaze3d.shaders.FogShape;
 import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;


### PR DESCRIPTION
This essentially allows mods to augment the `LiquidBlockRenderer#tesselate` call with their own rendering, or replace it entirely if desired. The fluid state, block state, position, etc. are all provided as context.

As a test, the fluid type test mod now switches RGB to BGR on its fluid blocks when they are rendered at Y 100 (making them appear yellow).