### PR TITLE
[1.20.4] Fix GUI far plane calculation to match vanilla

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -74,7 +74,7 @@
              posestack.pushPose();
              posestack.setIdentity();
 -            posestack.translate(0.0F, 0.0F, -11000.0F);
-+            posestack.translate(0.0D, 0.0D, 1000F - net.neoforged.neoforge.client.ClientHooks.getGuiFarPlane());
++            posestack.translate(0.0D, 0.0D, 10000F - net.neoforged.neoforge.client.ClientHooks.getGuiFarPlane());
              RenderSystem.applyModelViewMatrix();
              Lighting.setupFor3DItems();
              GuiGraphics guigraphics = new GuiGraphics(this.minecraft, this.renderBuffers.bufferSource());

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -233,10 +233,10 @@ public class ClientHooks {
     }
 
     public static float getGuiFarPlane() {
-        // 1000 units for the overlay background,
+        // 11000 units for the overlay background,
         // and 10000 units for each layered Screen,
 
-        return 1000.0F + 10000.0F * (1 + guiLayers.size());
+        return 11000.0F + 10000.0F * (1 + guiLayers.size());
     }
 
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, EquipmentSlot slot, String type) {
@@ -376,7 +376,7 @@ public class ClientHooks {
         guiLayers.forEach(layer -> {
             // Prevent the background layers from thinking the mouse is over their controls and showing them as highlighted.
             drawScreenInternal(layer, guiGraphics, Integer.MAX_VALUE, Integer.MAX_VALUE, partialTick);
-            guiGraphics.pose().translate(0, 0, 2000);
+            guiGraphics.pose().translate(0, 0, 10000);
         });
         drawScreenInternal(screen, guiGraphics, mouseX, mouseY, partialTick);
         guiGraphics.pose().popPose();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
@@ -67,10 +67,9 @@ public class GuiTests {
         }
 
         @Override
-        public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
-            this.renderTransparentBackground(graphics);
+        public void renderBackground(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+            super.renderBackground(graphics, mouseX, mouseY, partialTicks);
             graphics.drawString(this.font, this.title, this.width / 2, 15, 0xFFFFFF);
-            super.render(graphics, mouseX, mouseY, partialTicks);
         }
 
         @Override


### PR DESCRIPTION
This PR fixes the screen-layer-aware GUI far plane calculation to fully match the vanilla GUI far plane again and adjusts the layer rendering the actually make use of the increased per-layer depth.

This fixes the VanillaTweaks "No Spyglass Overlay" resource pack not working on NeoForge.
It is worth noting though that, while it fixes this RP in an almost-vanilla environment (i.e. only NeoForge installed), there's no guarantee that it will work when other mods are involved as they can trivially insert a custom HUD component under the spy glass overlay and offset its depth such that the shader's detection doesn't work anymore or even breaks other HUD components. There is nothing NeoForge can do about this other than entirely removing a very valuable feature, which is not a viable solution, especially considering mods can achieve the RP's effect in a trivial and clean way as well.

The test mod used to test screen layering was also adjusted to match how screens are now supposed to be drawn and was used to test that layering to absurd levels still works fine.

Fixes #445