### PR TITLE
Fix EntityRenderersEvent.AddLayers casting when it shouldn't

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
@@ -160,7 +160,8 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
         }
 
         /**
-         * Returns an entity renderer for the given entity type.
+         * Returns an entity renderer for the given entity type. Note that the returned renderer may not be a
+         * {@link LivingEntityRenderer}.
          *
          * @param entityType the entity type to return a renderer for
          * @param <T>        the type of entity the renderer is for
@@ -169,7 +170,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
          */
         @Nullable
         @SuppressWarnings("unchecked")
-        public <T extends LivingEntity, R extends LivingEntityRenderer<T, ? extends EntityModel<T>>> R getRenderer(EntityType<? extends T> entityType) {
+        public <T extends LivingEntity, R extends EntityRenderer<T>> R getRenderer(EntityType<? extends T> entityType) {
             return (R) renderers.get(entityType);
         }
 

--- a/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.SkullModel;
 import net.minecraft.client.model.SkullModelBase;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -155,7 +154,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
          */
         @Nullable
         @SuppressWarnings("unchecked")
-        public <R extends LivingEntityRenderer<? extends Player, ? extends EntityModel<? extends Player>>> R getSkin(PlayerSkin.Model skinModel) {
+        public <R extends EntityRenderer<? extends Player>> R getSkin(PlayerSkin.Model skinModel) {
             return (R) skinMap.get(skinModel);
         }
 


### PR DESCRIPTION
Fixes https://github.com/MinecraftForge/MinecraftForge/issues/9683, the backing maps only store `EntityRenderer` so we shouldn't cast blindly.