### PR TITLE
Have Watchdog print the full stacktraces when doing a thread dump

### DIFF
--- a/patches/net/minecraft/server/dedicated/ServerWatchdog.java.patch
+++ b/patches/net/minecraft/server/dedicated/ServerWatchdog.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/dedicated/ServerWatchdog.java
 +++ b/net/minecraft/server/dedicated/ServerWatchdog.java
-@@ -48,7 +_,7 @@
+@@ -48,14 +_,14 @@
                  ThreadMXBean threadmxbean = ManagementFactory.getThreadMXBean();
                  ThreadInfo[] athreadinfo = threadmxbean.dumpAllThreads(true, true);
                  StringBuilder stringbuilder = new StringBuilder();
@@ -9,3 +9,11 @@
  
                  for(ThreadInfo threadinfo : athreadinfo) {
                      if (threadinfo.getThreadId() == this.server.getRunningThread().getId()) {
+                         error.setStackTrace(threadinfo.getStackTrace());
+                     }
+ 
+-                    stringbuilder.append(threadinfo);
++                    stringbuilder.append(net.neoforged.neoforge.logging.ThreadInfoUtil.getEntireStacktrace(threadinfo));
+                     stringbuilder.append("\n");
+                 }
+ 

--- a/src/main/java/net/neoforged/neoforge/logging/ThreadInfoUtil.java
+++ b/src/main/java/net/neoforged/neoforge/logging/ThreadInfoUtil.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.logging;
+
+import java.lang.management.LockInfo;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+
+public class ThreadInfoUtil {
+
+    public static String getEntireStacktrace(ThreadInfo threadInfo) {
+        StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
+                (threadInfo.isDaemon() ? " daemon" : "") +
+                " prio=" + threadInfo.getPriority() +
+                " Id=" + threadInfo.getThreadId() + " " +
+                threadInfo.getThreadState());
+
+        if (threadInfo.getLockName() != null) {
+            sb.append(" on ").append(threadInfo.getLockName());
+        }
+
+        if (threadInfo.getLockOwnerName() != null) {
+            sb.append(" owned by \"").append(threadInfo.getLockOwnerName())
+                    .append("\" Id=").append(threadInfo.getLockOwnerId());
+        }
+
+        if (threadInfo.isSuspended()) {
+            sb.append(" (suspended)");
+        }
+
+        if (threadInfo.isInNative()) {
+            sb.append(" (in native)");
+        }
+
+        sb.append('\n');
+
+        StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+        for (int i = 0; i < stackTraceElements.length; i++) {
+            StackTraceElement ste = stackTraceElements[i];
+            sb.append("\tat ").append(ste.toString());
+            sb.append('\n');
+            if (i == 0 && threadInfo.getLockInfo() != null) {
+                Thread.State ts = threadInfo.getThreadState();
+                switch (ts) {
+                    case BLOCKED -> {
+                        sb.append("\t-  blocked on ").append(threadInfo.getLockInfo());
+                        sb.append('\n');
+                    }
+                    case WAITING, TIMED_WAITING -> {
+                        sb.append("\t-  waiting on ").append(threadInfo.getLockInfo());
+                        sb.append('\n');
+                    }
+                    default -> {}
+                }
+            }
+
+            for (MonitorInfo mi : threadInfo.getLockedMonitors()) {
+                if (mi.getLockedStackDepth() == i) {
+                    sb.append("\t-  locked ").append(mi);
+                    sb.append('\n');
+                }
+            }
+        }
+
+        LockInfo[] locks = threadInfo.getLockedSynchronizers();
+        if (locks.length > 0) {
+            sb.append("\n\tNumber of locked synchronizers = ").append(locks.length);
+            sb.append('\n');
+            for (LockInfo li : locks) {
+                sb.append("\t- ").append(li);
+                sb.append('\n');
+            }
+        }
+
+        sb.append('\n');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
This PR is literally just my FullStack Watchdog mod handed off to NeoForge.
https://legacy.curseforge.com/minecraft/mc-mods/fullstack-watchdog

Left side is vanilla watchdog thread dump. Right side is with this change
![image](https://github.com/neoforged/NeoForge/assets/40846040/ab117d7f-76cb-4c52-894d-40c265476758)

The issue is ThreadInfo's toString method has a hardcoded limit of 8. Yes 8.
![image](https://github.com/neoforged/NeoForge/assets/40846040/20cd9322-b54c-40c5-9761-3d66d9d69dc7)

This PR adds a helper method to turn ThreadInfo into a string but without that limit. The method is a copy of the toString method but allows the loop to run to the end of the strackTrace. Could be useful for other mods to use if they are printing out ThreadInfo too.