### PR TITLE
Fix fluid rendering logic still using vanilla overlay texture in one place

### DIFF
--- a/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
@@ -81,15 +81,16 @@
 -                    this.vertex(p_234372_, d5, d2 + (double)f45, d6, f37, f38, f39, f32, f34, j);
 -                    this.vertex(p_234372_, d5, d2 + (double)f17, d6, f37, f38, f39, f32, f35, j);
 -                    this.vertex(p_234372_, d3, d2 + (double)f17, d4, f37, f38, f39, f53, f35, j);
-+                    this.vertex(p_234372_, d3, d2 + (double)f44, d4, f37, f38, f39, alpha, f53, f33, j);
-+                    this.vertex(p_234372_, d5, d2 + (double)f45, d6, f37, f38, f39, alpha, f32, f34, j);
-+                    this.vertex(p_234372_, d5, d2 + (double)f17, d6, f37, f38, f39, alpha, f32, f35, j);
-+                    this.vertex(p_234372_, d3, d2 + (double)f17, d4, f37, f38, f39, alpha, f53, f35, j);
-                     if (textureatlassprite2 != this.waterOverlay) {
+-                    if (textureatlassprite2 != this.waterOverlay) {
 -                        this.vertex(p_234372_, d3, d2 + (double)f17, d4, f37, f38, f39, f53, f35, j);
 -                        this.vertex(p_234372_, d5, d2 + (double)f17, d6, f37, f38, f39, f32, f35, j);
 -                        this.vertex(p_234372_, d5, d2 + (double)f45, d6, f37, f38, f39, f32, f34, j);
 -                        this.vertex(p_234372_, d3, d2 + (double)f44, d4, f37, f38, f39, f53, f33, j);
++                    this.vertex(p_234372_, d3, d2 + (double)f44, d4, f37, f38, f39, alpha, f53, f33, j);
++                    this.vertex(p_234372_, d5, d2 + (double)f45, d6, f37, f38, f39, alpha, f32, f34, j);
++                    this.vertex(p_234372_, d5, d2 + (double)f17, d6, f37, f38, f39, alpha, f32, f35, j);
++                    this.vertex(p_234372_, d3, d2 + (double)f17, d4, f37, f38, f39, alpha, f53, f35, j);
++                    if (textureatlassprite2 != atextureatlassprite[2]) {
 +                        this.vertex(p_234372_, d3, d2 + (double)f17, d4, f37, f38, f39, alpha, f53, f35, j);
 +                        this.vertex(p_234372_, d5, d2 + (double)f17, d6, f37, f38, f39, alpha, f32, f35, j);
 +                        this.vertex(p_234372_, d5, d2 + (double)f45, d6, f37, f38, f39, alpha, f32, f34, j);


### PR DESCRIPTION
Theoretically fixes #511 - looks like a simple oversight where the `this.waterOverlay` reference was not changed to use our sprite array. This change should be correct, as it matches the corresponding patch earlier in the method.