### PR TITLE
Fire LivingConversionEvent Pre and Post properly for Husk, Tadpole, Mushroom, and Skeleton conversions

### DIFF
--- a/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
+++ b/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
@@ -18,7 +18,7 @@
              this.shear(SoundSource.PLAYERS);
              this.gameEvent(GameEvent.SHEAR, p_28941_);
              if (!this.level().isClientSide) {
-@@ -164,7 +_,16 @@
+@@ -164,11 +_,22 @@
      }
  
      @Override
@@ -34,7 +34,13 @@
 +    private java.util.List<ItemStack> shearInternal(SoundSource p_28924_) {
          this.level().playSound(null, this, SoundEvents.MOOSHROOM_SHEAR, p_28924_, 1.0F, 1.0F);
          if (!this.level().isClientSide()) {
++            if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.COW, (timer) -> {})) return java.util.Collections.emptyList();
              Cow cow = EntityType.COW.create(this.level());
+             if (cow != null) {
++                net.neoforged.neoforge.event.EventHooks.onLivingConvert(this, cow);
+                 ((ServerLevel)this.level()).sendParticles(ParticleTypes.EXPLOSION, this.getX(), this.getY(0.5), this.getZ(), 1, 0.0, 0.0, 0.0, 0.0);
+                 this.discard();
+                 cow.moveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
 @@ -186,14 +_,14 @@
                  cow.setInvulnerable(this.isInvulnerable());
                  this.level().addFreshEntity(cow);

--- a/patches/net/minecraft/world/entity/animal/frog/Tadpole.java.patch
+++ b/patches/net/minecraft/world/entity/animal/frog/Tadpole.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/entity/animal/frog/Tadpole.java
++++ b/net/minecraft/world/entity/animal/frog/Tadpole.java
+@@ -226,8 +_,10 @@
+     private void ageUp() {
+         Level $$1 = this.level();
+         if ($$1 instanceof ServerLevel serverlevel) {
++            if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.FROG, (timer) -> {})) return;
+             Frog frog = EntityType.FROG.create(this.level());
+             if (frog != null) {
++                net.neoforged.neoforge.event.EventHooks.onLivingConvert(this, frog);
+                 frog.moveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
+                 frog.finalizeSpawn(serverlevel, this.level().getCurrentDifficultyAt(frog.blockPosition()), MobSpawnType.CONVERSION, null, null);
+                 frog.setNoAi(this.isNoAi());

--- a/patches/net/minecraft/world/entity/monster/Husk.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Husk.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/entity/monster/Husk.java
++++ b/net/minecraft/world/entity/monster/Husk.java
+@@ -72,6 +_,7 @@
+ 
+     @Override
+     protected void doUnderWaterConversion() {
++        if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.ZOMBIE, (timer) -> this.conversionTime = timer)) return;
+         this.convertToZombieType(EntityType.ZOMBIE);
+         if (!this.isSilent()) {
+             this.level().levelEvent(null, 1041, this.blockPosition(), 0);

--- a/patches/net/minecraft/world/entity/monster/Skeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Skeleton.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/world/entity/monster/Skeleton.java
 +++ b/net/minecraft/world/entity/monster/Skeleton.java
-@@ -9,6 +_,7 @@
- import net.minecraft.world.damagesource.DamageSource;
- import net.minecraft.world.entity.Entity;
- import net.minecraft.world.entity.EntityType;
-+import net.minecraft.world.entity.LivingEntity;
- import net.minecraft.world.item.Items;
- import net.minecraft.world.level.Level;
- 
 @@ -86,7 +_,9 @@
      }
  

--- a/patches/net/minecraft/world/entity/monster/Skeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Skeleton.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/world/entity/monster/Skeleton.java
++++ b/net/minecraft/world/entity/monster/Skeleton.java
+@@ -9,6 +_,7 @@
+ import net.minecraft.world.damagesource.DamageSource;
+ import net.minecraft.world.entity.Entity;
+ import net.minecraft.world.entity.EntityType;
++import net.minecraft.world.entity.LivingEntity;
+ import net.minecraft.world.item.Items;
+ import net.minecraft.world.level.Level;
+ 
+@@ -86,7 +_,9 @@
+     }
+ 
+     protected void doFreezeConversion() {
+-        this.convertTo(EntityType.STRAY, true);
++        if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.STRAY, (timer) -> this.conversionTime = timer)) return;
++        Stray stray = this.convertTo(EntityType.STRAY, true);
++        if (stray != null) net.neoforged.neoforge.event.EventHooks.onLivingConvert(this, stray);
+         if (!this.isSilent()) {
+             this.level().levelEvent(null, 1048, this.blockPosition(), 0);
+         }

--- a/patches/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -1,14 +1,13 @@
 --- a/net/minecraft/world/entity/monster/Zombie.java
 +++ b/net/minecraft/world/entity/monster/Zombie.java
-@@ -203,7 +_,7 @@
-         if (!this.level().isClientSide && this.isAlive() && !this.isNoAi()) {
-             if (this.isUnderWaterConverting()) {
-                 --this.conversionTime;
--                if (this.conversionTime < 0) {
-+                if (this.conversionTime < 0 && net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.DROWNED, (timer) -> this.conversionTime = timer)) {
-                     this.doUnderWaterConversion();
-                 }
-             } else if (this.convertsInWater()) {
+@@ -254,6 +_,7 @@
+     }
+ 
+     protected void doUnderWaterConversion() {
++        if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.DROWNED, (timer) -> this.conversionTime = timer)) return;
+         this.convertToZombieType(EntityType.DROWNED);
+         if (!this.isSilent()) {
+             this.level().levelEvent(null, 1040, this.blockPosition(), 0);
 @@ -265,6 +_,7 @@
          if (zombie != null) {
              zombie.handleAttributes(zombie.level().getCurrentDifficultyAt(zombie.blockPosition()).getSpecialMultiplier());

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -298,6 +298,7 @@ protected net.minecraft.world.entity.projectile.Projectile <init>(Lnet/minecraft
 private-f net.minecraft.world.entity.raid.Raid$RaiderType VALUES # VALUES
 public net.minecraft.world.entity.schedule.Activity <init>(Ljava/lang/String;)V # constructor
 protected net.minecraft.world.entity.vehicle.VehicleEntity getDropItem()Lnet/minecraft/world/item/Item; # getDropItem - make VehicleEntity implementable
+protected net.minecraft.world.entity.monster.Zombie conversionTime
 public net.minecraft.world.inventory.AnvilMenu repairItemCountCost # repairItemCountCost
 public net.minecraft.world.inventory.MenuType <init>(Lnet/minecraft/world/inventory/MenuType$MenuSupplier;Lnet/minecraft/world/flag/FeatureFlagSet;)V # constructor
 public net.minecraft.world.inventory.MenuType$MenuSupplier


### PR DESCRIPTION
Fixes https://github.com/neoforged/NeoForge/issues/505

Husks turn into Zombies when they drown once. Then after some time, the Zombie drowns into Drowned. The conversion is not Husk to Drowned. It's Husk -> Zombie -> Drowned.

Added patch to fire pre and post for Skeleton turning into Strays in Powder Snow

Handles Tadpole to growing up into Frogs

And handles Mooshroom sheared into Cows too