### PR TITLE
[1.20.4] Properly log exceptions in the vanilla network stack

### DIFF
--- a/patches/net/minecraft/network/Connection.java.patch
+++ b/patches/net/minecraft/network/Connection.java.patch
@@ -16,6 +16,14 @@
      }
  
      @Override
+@@ -135,6 +_,7 @@
+                     this.disconnect(Component.translatable("disconnect.timeout"));
+                 } else {
+                     Component component = Component.translatable("disconnect.genericReason", "Internal Exception: " + p_129534_);
++                    LOGGER.error("Exception caught in connection", p_129534_); // Neo: Always log critical network exceptions
+                     if (flag) {
+                         LOGGER.debug("Failed to sent packet", p_129534_);
+                         if (this.getSending() == PacketFlow.CLIENTBOUND) {
 @@ -380,7 +_,7 @@
          if (this.address == null) {
              return "local";

--- a/patches/net/minecraft/network/PacketEncoder.java.patch
+++ b/patches/net/minecraft/network/PacketEncoder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/PacketEncoder.java
++++ b/net/minecraft/network/PacketEncoder.java
+@@ -46,7 +_,7 @@
+ 
+                     JvmProfiler.INSTANCE.onPacketSent(codecdata.protocol(), i, p_130545_.channel().remoteAddress(), k);
+                 } catch (Throwable throwable) {
+-                    LOGGER.error("Error receiving packet {}", i, throwable);
++                    LOGGER.error("Error sending packet {}", i, throwable); // Neo: fix flipped log message
+                     if (p_130546_.isSkippable()) {
+                         throw new SkipPacketException(throwable);
+                     }


### PR DESCRIPTION
This PR adds improved exception logging to the vanilla network stack to make debugging issues with network packets significantly easier. Any exception happening during the part of sending or receiving a packet that happens in the Netty pipeline is caught by this logging, including ones happen during error handling (referred to as "double fault" in the error handler) but excluding `TimeoutException`s and ones wrapped in `SkipPacketException` (used by a few non-critical packets and does not cause a disconnect). The only caveat is that, under certain circumstances, an error during `Packet#write()` will be logged twice because `PacketEncoder#encode()` also does error logging. This should only be the case when a packet isn't handled by NeoForge's `GenericPacketSplitter` (in my testing this is currently the case for packets which are part of a bundle), any other case should (silently at first) error in the splitter and then bubble up to the logging added in this PR.

Additionaly, a tiny patch to the `PacketEncoder` is included, fixing the confusingly "flipped" log message in case of an error during writing.

This effectively absorbs Mrbysco's Spit It Out mod into NeoForge, which was discussed with him beforehand on [Discord](https://discord.com/channels/313125603924639766/852298000042164244/1196294655927660544).