### PR TITLE
Update and re-run tests datagen

### DIFF
--- a/tests/src/generated/resources/assets/neotests_custom_spawn_logic/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_custom_spawn_logic/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "entity.neotests_custom_spawn_logic.adapted_spawn": "Adapted complex spawn egg",
+  "entity.neotests_custom_spawn_logic.complex_spawn": "Custom complex spawn egg",
+  "entity.neotests_custom_spawn_logic.simple_spawn": "Simple spawn egg"
+}

--- a/tests/src/generated/resources/assets/neotests_snow_boots/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_snow_boots/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "item.neotests_snow_boots.snow_boots": "Snow Boots"
+}

--- a/tests/src/generated/resources/data/neotests_dmg_type_tests/damage_type/test.json
+++ b/tests/src/generated/resources/data/neotests_dmg_type_tests/damage_type/test.json
@@ -1,0 +1,7 @@
+{
+  "death_message_type": "test:msgtype",
+  "effects": "test:effects",
+  "exhaustion": 0.0,
+  "message_id": "test_mod",
+  "scaling": "test:scaling"
+}

--- a/tests/src/generated/resources/data/test/damage_type/test.json
+++ b/tests/src/generated/resources/data/test/damage_type/test.json
@@ -1,7 +1,0 @@
-{
-    "exhaustion": 0.0,
-    "message_id": "test_mod",
-    "scaling": "test:scaling",
-    "effects": "test:effects",
-    "death_message_type": "test:msgtype"
-}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/damagesource/DamageTypeTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/damagesource/DamageTypeTests.java
@@ -5,8 +5,10 @@
 
 package net.neoforged.neoforge.debug.damagesource;
 
+import java.util.Set;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistrySetBuilder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.chat.Component;
@@ -30,6 +32,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.damagesource.IDeathMessageProvider;
 import net.neoforged.neoforge.common.damagesource.IScalingFunction;
+import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -58,12 +61,12 @@ public class DamageTypeTests {
     public static final DamageScaling SCALING = DamageScaling.create("TEST_SCALING", "test:scaling", SCALE_FUNC);
     public static final DeathMessageType MSGTYPE = DeathMessageType.create("TEST_MSGTYPE", "test:msgtype", MSG_PROVIDER);
 
-    public static final ResourceKey<DamageType> TEST_DMG_TYPE = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation("test", "test"));
-
     @GameTest
     @EmptyTemplate
     @TestHolder(description = "Tests if custom damage types function as expected")
     static void dmgTypeTests(final DynamicTest test, final RegistrationHelper reg) {
+        ResourceKey<DamageType> TEST_DMG_TYPE = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(reg.modId(), "test"));
+
         Holder<Item> customSword = reg.registrar(Registries.ITEM).register("custom_damage_sword", () -> new Item(new Item.Properties()) {
             @Override
             public boolean onLeftClickEntity(ItemStack stack, Player player, Entity entity) {
@@ -73,6 +76,17 @@ public class DamageTypeTests {
                 return true;
             }
         });
+
+        RegistrySetBuilder registrySetBuilder = new RegistrySetBuilder();
+        registrySetBuilder.add(Registries.DAMAGE_TYPE, bootstrap -> {
+            bootstrap.register(TEST_DMG_TYPE, new DamageType("test_mod", SCALING, 0.0f, EFFECTS, MSGTYPE));
+        });
+
+        reg.addProvider(event -> new DatapackBuiltinEntriesProvider(
+                event.getGenerator().getPackOutput(),
+                event.getLookupProvider(),
+                registrySetBuilder,
+                Set.of(reg.modId())));
 
         test.onGameTest(helper -> {
             Skeleton target = helper.spawnWithNoFreeWill(EntityType.SKELETON, 1, 1, 1);


### PR DESCRIPTION
Fixes the damage type not being generated, and re-run to account for lang updates in other tests.