### PR TITLE
Bump MixinExtras to 0.3.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ unsafe_version=0.2.+
 typetools_version=0.6.3
 nashorn_core_version=15.3
 lwjgl_glfw_version=3.3.2
-mixin_extras_version=0.3.3
+mixin_extras_version=0.3.5
 
 jupiter_api_version=5.7.0
 vintage_engine_version=5.+


### PR DESCRIPTION
The previous minor behaviour change is now gated behind a new annotation. I don't know of anyone who relied on the old behaviour on neoforge, but this will restore it until they manually update. In future this will be done for all breaking changes, though I'm hoping there won't be any more.
Also includes another minor fix.