### PR TITLE
add `CalculateTurnPlayerValuesEvent`

### DIFF
--- a/patches/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/net/minecraft/client/MouseHandler.java.patch
@@ -65,23 +65,19 @@
                      if (this.minecraft.player.isSpectator()) {
                          if (this.minecraft.gui.getSpectatorGui().isMenuActive()) {
                              this.minecraft.gui.getSpectatorGui().onMouseScrolled(-k);
-@@ -235,12 +_,17 @@
+@@ -235,12 +_,13 @@
          double d1 = d0 - this.lastMouseEventTime;
          this.lastMouseEventTime = d0;
          if (this.isMouseGrabbed() && this.minecraft.isWindowActive()) {
 -            double d4 = this.minecraft.options.sensitivity().get() * 0.6F + 0.2F;
-+            double mouseSensitivity = this.minecraft.options.sensitivity().get();
-+            boolean cinematicCameraEnabled = this.minecraft.options.smoothCamera;
-+            final net.neoforged.neoforge.client.event.CalculateTurnPlayerValuesEvent event = net.neoforged.neoforge.client.ClientHooks.getTurnPlayerValues(mouseSensitivity, cinematicCameraEnabled);
-+            mouseSensitivity = event.getMouseSensitivity();
-+            cinematicCameraEnabled = event.getCinematicCameraEnabled();
-+            double d4 = mouseSensitivity * 0.6F + 0.2F;
++            final net.neoforged.neoforge.client.event.CalculateTurnPlayerValuesEvent event = net.neoforged.neoforge.client.ClientHooks.getTurnPlayerValues(this.minecraft.options.sensitivity().get(), this.minecraft.options.smoothCamera);
++            double d4 = event.getMouseSensitivity() * 0.6F + 0.2F;
              double d5 = d4 * d4 * d4;
              double d6 = d5 * 8.0;
              double d2;
              double d3;
 -            if (this.minecraft.options.smoothCamera) {
-+            if (cinematicCameraEnabled) {
++            if (event.getCinematicCameraEnabled()) {
                  double d7 = this.smoothTurnX.getNewDeltaValue(this.accumulatedDX * d6, d1 * d6);
                  double d8 = this.smoothTurnY.getNewDeltaValue(this.accumulatedDY * d6, d1 * d6);
                  d2 = d7;

--- a/patches/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/net/minecraft/client/MouseHandler.java.patch
@@ -65,6 +65,26 @@
                      if (this.minecraft.player.isSpectator()) {
                          if (this.minecraft.gui.getSpectatorGui().isMenuActive()) {
                              this.minecraft.gui.getSpectatorGui().onMouseScrolled(-k);
+@@ -235,12 +_,17 @@
+         double d1 = d0 - this.lastMouseEventTime;
+         this.lastMouseEventTime = d0;
+         if (this.isMouseGrabbed() && this.minecraft.isWindowActive()) {
+-            double d4 = this.minecraft.options.sensitivity().get() * 0.6F + 0.2F;
++            double mouseSensitivity = this.minecraft.options.sensitivity().get();
++            boolean cinematicCameraEnabled = this.minecraft.options.smoothCamera;
++            final net.neoforged.neoforge.client.event.CalculateTurnPlayerValuesEvent event = net.neoforged.neoforge.client.ClientHooks.getTurnPlayerValues(mouseSensitivity, cinematicCameraEnabled);
++            mouseSensitivity = event.getMouseSensitivity();
++            cinematicCameraEnabled = event.getCinematicCameraEnabled();
++            double d4 = mouseSensitivity * 0.6F + 0.2F;
+             double d5 = d4 * d4 * d4;
+             double d6 = d5 * 8.0;
+             double d2;
+             double d3;
+-            if (this.minecraft.options.smoothCamera) {
++            if (cinematicCameraEnabled) {
+                 double d7 = this.smoothTurnX.getNewDeltaValue(this.accumulatedDX * d6, d1 * d6);
+                 double d8 = this.smoothTurnY.getNewDeltaValue(this.accumulatedDY * d6, d1 * d6);
+                 d2 = d7;
 @@ -292,6 +_,14 @@
  
      public double ypos() {

--- a/patches/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/net/minecraft/client/MouseHandler.java.patch
@@ -70,7 +70,7 @@
          this.lastMouseEventTime = d0;
          if (this.isMouseGrabbed() && this.minecraft.isWindowActive()) {
 -            double d4 = this.minecraft.options.sensitivity().get() * 0.6F + 0.2F;
-+            final net.neoforged.neoforge.client.event.CalculateTurnPlayerValuesEvent event = net.neoforged.neoforge.client.ClientHooks.getTurnPlayerValues(this.minecraft.options.sensitivity().get(), this.minecraft.options.smoothCamera);
++            var event = net.neoforged.neoforge.client.ClientHooks.getTurnPlayerValues(this.minecraft.options.sensitivity().get(), this.minecraft.options.smoothCamera);
 +            double d4 = event.getMouseSensitivity() * 0.6F + 0.2F;
              double d5 = d4 * d4 * d4;
              double d6 = d5 * 8.0;

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -130,7 +130,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.neoforge.client.event.CalculateTurnPlayerValuesEvent;
+import net.neoforged.neoforge.client.event.CalculatePlayerTurnEvent;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.ClientChatReceivedEvent;
 import net.neoforged.neoforge.client.event.ClientPauseUpdatedEvent;
@@ -343,8 +343,8 @@ public class ClientHooks {
         return event.getFOV();
     }
 
-    public static CalculateTurnPlayerValuesEvent getTurnPlayerValues(double mouseSensitivity, boolean cinematicCameraEnabled) {
-        var event = new CalculateTurnPlayerValuesEvent(mouseSensitivity, cinematicCameraEnabled);
+    public static CalculatePlayerTurnEvent getTurnPlayerValues(double mouseSensitivity, boolean cinematicCameraEnabled) {
+        var event = new CalculatePlayerTurnEvent(mouseSensitivity, cinematicCameraEnabled);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -130,6 +130,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.event.CalculateTurnPlayerValuesEvent;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.ClientChatReceivedEvent;
 import net.neoforged.neoforge.client.event.ClientPauseUpdatedEvent;
@@ -340,6 +341,12 @@ public class ClientHooks {
         ViewportEvent.ComputeFov event = new ViewportEvent.ComputeFov(renderer, camera, partialTick, fov, usedConfiguredFov);
         NeoForge.EVENT_BUS.post(event);
         return event.getFOV();
+    }
+
+    public static CalculateTurnPlayerValuesEvent getTurnPlayerValues(double mouseSensitivity, boolean cinematicCameraEnabled) {
+        var event = new CalculateTurnPlayerValuesEvent(mouseSensitivity, cinematicCameraEnabled);
+        NeoForge.EVENT_BUS.post(event);
+        return event;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
@@ -33,7 +33,7 @@ public class CalculatePlayerTurnEvent extends Event {
     }
 
     /**
-     * @return the raw {@linkplain Options#sensitivity() mouse sensitivity} value
+     * Returns the raw {@linkplain Options#sensitivity() mouse sensitivity} value
      */
     public double getMouseSensitivity() {
         return mouseSensitivity;
@@ -49,7 +49,7 @@ public class CalculatePlayerTurnEvent extends Event {
     }
 
     /**
-     * @return the raw {@linkplain Options#smoothCamera cinematic camera} value
+     * Returns the raw {@linkplain Options#smoothCamera cinematic camera} value
      */
     public boolean getCinematicCameraEnabled() {
         return cinematicCameraEnabled;

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
@@ -21,13 +21,13 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class CalculateTurnPlayerValuesEvent extends Event {
+public class CalculatePlayerTurnEvent extends Event {
 
     private double mouseSensitivity;
     private boolean cinematicCameraEnabled;
 
     @ApiStatus.Internal
-    public CalculateTurnPlayerValuesEvent(double mouseSensitivity, boolean cinematicCameraEnabled) {
+    public CalculatePlayerTurnEvent(double mouseSensitivity, boolean cinematicCameraEnabled) {
         setMouseSensitivity(mouseSensitivity);
         setCinematicCameraEnabled(cinematicCameraEnabled);
     }

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculateTurnPlayerValuesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculateTurnPlayerValuesEvent.java
@@ -1,0 +1,62 @@
+package net.neoforged.neoforge.client.event;
+
+import net.minecraft.client.MouseHandler;
+import net.minecraft.client.Options;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Fired in {@linkplain MouseHandler#turnPlayer() MouseHandler#turnPlayer()} when retrieving the values of {@linkplain Options#sensitivity() mouse sensitivity} and {@linkplain Options#smoothCamera cinematic camera}, prior to running calculations on these values.
+ * 
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class CalculateTurnPlayerValuesEvent extends Event {
+
+    private double mouseSensitivity;
+    private boolean cinematicCameraEnabled;
+
+    @ApiStatus.Internal
+    public CalculateTurnPlayerValuesEvent(double mouseSensitivity, boolean cinematicCameraEnabled) {
+        setMouseSensitivity(mouseSensitivity);
+        setCinematicCameraEnabled(cinematicCameraEnabled);
+    }
+
+    /**
+     * @return the raw {@linkplain Options#sensitivity() mouse sensitivity} value
+     */
+    public double getMouseSensitivity() {
+        return mouseSensitivity;
+    }
+
+    /**
+     * Sets the {@linkplain Options#sensitivity() mouse sensitivity} value.
+     * 
+     * @param mouseSensitivity the new {@linkplain Options#sensitivity() mouse sensitivity} value
+     */
+    public void setMouseSensitivity(double mouseSensitivity) {
+        this.mouseSensitivity = mouseSensitivity;
+    }
+
+    /**
+     * @return the raw {@linkplain Options#smoothCamera cinematic camera} value
+     */
+    public boolean getCinematicCameraEnabled() {
+        return cinematicCameraEnabled;
+    }
+
+    /**
+     * Sets the {@linkplain Options#smoothCamera cinematic camera} value.
+     *
+     * @param cinematicCameraEnabled the new {@linkplain Options#smoothCamera cinematic camera} value
+     */
+    public void setCinematicCameraEnabled(boolean cinematicCameraEnabled) {
+        this.cinematicCameraEnabled = cinematicCameraEnabled;
+    }
+
+}

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculateTurnPlayerValuesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculateTurnPlayerValuesEvent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client.event;
 
 import net.minecraft.client.MouseHandler;


### PR DESCRIPTION
This PR adds an event called `CalculateTurnPlayerValuesEvent` which allows hooking the mouse sensitivity values and cinematic camera values from the game options when running `turnPlayer`, which is responsible for rotating the camera in response to mouse movement.