### PR TITLE
Add splash manager and splash registration event

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -35,6 +35,15 @@
          this.resourcePackRepository.reload();
          this.options.loadSelectedResourcePacks(this.resourcePackRepository);
          this.languageManager = new LanguageManager(this.options.languageCode);
+@@ -504,7 +_,7 @@
+         this.commandHistory = new CommandHistory(path);
+         this.soundManager = new SoundManager(this.options);
+         this.resourceManager.registerReloadListener(this.soundManager);
+-        this.splashManager = new SplashManager(this.user);
++        this.splashManager = new net.neoforged.neoforge.client.resources.NeoSplashManager(this.user); // Neo: Use our custom splash manager
+         this.resourceManager.registerReloadListener(this.splashManager);
+         this.musicManager = new MusicManager(this);
+         this.fontManager = new FontManager(this.textureManager);
 @@ -560,10 +_,13 @@
          this.gameRenderer = new GameRenderer(this, this.entityRenderDispatcher.getItemInHandRenderer(), this.resourceManager, this.renderBuffers);
          this.resourceManager.registerReloadListener(this.gameRenderer.createReloadListener());

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterSplashProvidersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterSplashProvidersEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.neoforge.client.resources.NeoSplashManager.ISplashProvider;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Allows users to register custom {@link SplashProvider splash providers}.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
+ *
+ * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class RegisterSplashProvidersEvent extends Event implements IModBusEvent {
+    private final Map<ResourceLocation, ISplashProvider> providers;
+    private final List<ISplashProvider> orderedProviders;
+
+    @ApiStatus.Internal
+    public RegisterSplashProvidersEvent(Map<ResourceLocation, ISplashProvider> providers, List<ISplashProvider> orderedProviders) {
+        this.providers = providers;
+        this.orderedProviders = orderedProviders;
+    }
+
+    /**
+     * Registers a splash provider.
+     *
+     * @param id       The ID of the splash provider.
+     * @param provider The splash provider.
+     */
+    public void register(@NotNull ResourceLocation id, @NotNull ISplashProvider provider) {
+        Preconditions.checkArgument(!providers.containsKey(id), "Provider already registered: " + id);
+
+        providers.put(id, provider);
+        orderedProviders.add(provider);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterSplashProvidersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterSplashProvidersEvent.java
@@ -6,6 +6,8 @@
 package net.neoforged.neoforge.client.event;
 
 import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -14,9 +16,6 @@ import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.neoforge.client.resources.NeoSplashManager.ISplashProvider;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Allows users to register custom {@link SplashProvider splash providers}.

--- a/src/main/java/net/neoforged/neoforge/client/resources/NeoSplashManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/resources/NeoSplashManager.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.resources;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.logging.LogUtils;
+import net.minecraft.client.User;
+import net.minecraft.client.gui.components.SplashRenderer;
+import net.minecraft.client.resources.SplashManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.client.event.RegisterSplashProvidersEvent;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+import java.util.*;
+
+/**
+ * An implementation of {@link SplashManager} which supports custom splashes via {@link RegisterSplashProvidersEvent}.
+ */
+public class NeoSplashManager extends SplashManager {
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private final ImmutableList<ISplashProvider> providers;
+
+    public NeoSplashManager(final User user) {
+        super(user);
+
+        // TODO: we don't actually use namedProviders but we're gathering that information anyway to avoid another breaking change in the future.
+        var namedProviders = new HashMap<ResourceLocation, ISplashProvider>();
+        var orderedProviders = new ArrayList<ISplashProvider>();
+        preRegisterVanillaProviders(namedProviders, orderedProviders);
+        var event = new RegisterSplashProvidersEvent(namedProviders, orderedProviders);
+        ModLoader.get().postEventWrapContainerInModOrder(event);
+        providers = ImmutableList.copyOf(orderedProviders);
+    }
+
+    private static void preRegisterVanillaProviders(
+        HashMap<ResourceLocation, ISplashProvider> namedProviders,
+        List<ISplashProvider> orderedProviders) {
+        for (var entry : VanillaSplash.values()) {
+            namedProviders.put(entry.id(), entry.provider());
+            orderedProviders.add(entry.provider());
+        }
+    }
+
+    @Nullable
+    @Override
+    public SplashRenderer getSplash() {
+        final var calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        final var context = new SelectionContext(calendar, RANDOM, user, splashes.size());
+
+        // Ask mods if there's a specific splash which can be displayed.
+        for (final var provider : providers) {
+            final var splash = provider.getSplash(context);
+
+            if (splash != null) {
+                return splash;
+            }
+        }
+
+        // If the random splash pool has nothing in it, there's nothing to render.
+        if (splashes.isEmpty()) {
+            return null;
+        }
+
+        // Get a random splash from the pool
+        return new SplashRenderer(splashes.get(RANDOM.nextInt(splashes.size())));
+    }
+
+    /**
+     * An interface which can be used to provide splashes
+     */
+    @FunctionalInterface
+    public interface ISplashProvider
+    {
+        /**
+         * Gets the splash to render, or null if there is no splash to render.
+         *
+         * @param context A collection of external properties for splash selection.
+         *
+         * @return A {@link SplashRenderer splash renderer} used to render splashes.
+         */
+        @Nullable
+        public SplashRenderer getSplash(SelectionContext context);
+    }
+
+    /**
+     * A record containing external properties used in the selection of a {@link SplashRenderer splash renderer}.
+     *
+     * @param calendar         The calendar representing the current date, for time-based splashes.
+     * @param randomSource     The random source, for random chance splashes.
+     * @param user             The user, for user-specific splashes, or {@code null} if no user could be loaded.
+     * @param sizeOfRandomPool The size of the random splash pool, or 0 if there are none.
+     */
+    public record SelectionContext(
+        Calendar calendar,
+        RandomSource randomSource,
+        @Nullable
+        User user,
+        int sizeOfRandomPool) { }
+
+    // The vanilla splashes, including the logic in which they trigger.
+    private enum VanillaSplash {
+        CHRISTMAS("christmas", (context) ->
+            context.calendar().get(Calendar.MONTH) + 1 == 12 && context.calendar().get(Calendar.DAY_OF_MONTH) == 24
+                ? SplashRenderer.CHRISTMAS
+                : null),
+        NEW_YEAR("new_year", (context) ->
+            context.calendar().get(Calendar.MONTH) + 1 == 1 && context.calendar().get(Calendar.DAY_OF_MONTH) == 1
+                ? SplashRenderer.NEW_YEAR
+                : null),
+        HALLOWEEN("halloween", (context) ->
+            context.calendar().get(Calendar.MONTH) + 1 == 10 && context.calendar().get(Calendar.DAY_OF_MONTH) == 31
+                ? SplashRenderer.HALLOWEEN
+                : null),
+        USERNAME_IS_YOU("username_is_you", (context) ->
+            context.user() != null && context.randomSource().nextInt(context.sizeOfRandomPool()) == 42
+                ? new SplashRenderer(context.user().getName().toUpperCase(Locale.ROOT) + " IS YOU")
+                : null);
+
+        private final ResourceLocation id;
+        private final ISplashProvider provider;
+
+        VanillaSplash(String id, ISplashProvider provider) {
+            this.id = new ResourceLocation("minecraft", id);
+            this.provider = provider;
+        }
+
+        public ResourceLocation id() {
+            return id;
+        }
+
+        public ISplashProvider provider() {
+            return provider;
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/resources/NeoSplashManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/resources/NeoSplashManager.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.client.resources;
 
 import com.google.common.collect.ImmutableList;
-import com.mojang.logging.LogUtils;
 import net.minecraft.client.User;
 import net.minecraft.client.gui.components.SplashRenderer;
 import net.minecraft.client.resources.SplashManager;
@@ -15,17 +14,18 @@ import net.minecraft.util.RandomSource;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.client.event.RegisterSplashProvidersEvent;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * An implementation of {@link SplashManager} which supports custom splashes via {@link RegisterSplashProvidersEvent}.
  */
 public class NeoSplashManager extends SplashManager {
-
-    private static final Logger LOGGER = LogUtils.getLogger();
-
     private final ImmutableList<ISplashProvider> providers;
 
     public NeoSplashManager(final User user) {

--- a/src/main/java/net/neoforged/neoforge/client/resources/NeoSplashManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/resources/NeoSplashManager.java
@@ -6,6 +6,12 @@
 package net.neoforged.neoforge.client.resources;
 
 import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import net.minecraft.client.User;
 import net.minecraft.client.gui.components.SplashRenderer;
 import net.minecraft.client.resources.SplashManager;
@@ -14,13 +20,6 @@ import net.minecraft.util.RandomSource;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.client.event.RegisterSplashProvidersEvent;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
 
 /**
  * An implementation of {@link SplashManager} which supports custom splashes via {@link RegisterSplashProvidersEvent}.
@@ -41,8 +40,8 @@ public class NeoSplashManager extends SplashManager {
     }
 
     private static void preRegisterVanillaProviders(
-        HashMap<ResourceLocation, ISplashProvider> namedProviders,
-        List<ISplashProvider> orderedProviders) {
+            HashMap<ResourceLocation, ISplashProvider> namedProviders,
+            List<ISplashProvider> orderedProviders) {
         for (var entry : VanillaSplash.values()) {
             namedProviders.put(entry.id(), entry.provider());
             orderedProviders.add(entry.provider());
@@ -78,8 +77,7 @@ public class NeoSplashManager extends SplashManager {
      * An interface which can be used to provide splashes
      */
     @FunctionalInterface
-    public interface ISplashProvider
-    {
+    public interface ISplashProvider {
         /**
          * Gets the splash to render, or null if there is no splash to render.
          *
@@ -100,28 +98,23 @@ public class NeoSplashManager extends SplashManager {
      * @param sizeOfRandomPool The size of the random splash pool, or 0 if there are none.
      */
     public record SelectionContext(
-        Calendar calendar,
-        RandomSource randomSource,
-        @Nullable
-        User user,
-        int sizeOfRandomPool) { }
+            Calendar calendar,
+            RandomSource randomSource,
+            @Nullable User user,
+            int sizeOfRandomPool) {}
 
     // The vanilla splashes, including the logic in which they trigger.
     private enum VanillaSplash {
-        CHRISTMAS("christmas", (context) ->
-            context.calendar().get(Calendar.MONTH) + 1 == 12 && context.calendar().get(Calendar.DAY_OF_MONTH) == 24
+        CHRISTMAS("christmas", (context) -> context.calendar().get(Calendar.MONTH) + 1 == 12 && context.calendar().get(Calendar.DAY_OF_MONTH) == 24
                 ? SplashRenderer.CHRISTMAS
                 : null),
-        NEW_YEAR("new_year", (context) ->
-            context.calendar().get(Calendar.MONTH) + 1 == 1 && context.calendar().get(Calendar.DAY_OF_MONTH) == 1
+        NEW_YEAR("new_year", (context) -> context.calendar().get(Calendar.MONTH) + 1 == 1 && context.calendar().get(Calendar.DAY_OF_MONTH) == 1
                 ? SplashRenderer.NEW_YEAR
                 : null),
-        HALLOWEEN("halloween", (context) ->
-            context.calendar().get(Calendar.MONTH) + 1 == 10 && context.calendar().get(Calendar.DAY_OF_MONTH) == 31
+        HALLOWEEN("halloween", (context) -> context.calendar().get(Calendar.MONTH) + 1 == 10 && context.calendar().get(Calendar.DAY_OF_MONTH) == 31
                 ? SplashRenderer.HALLOWEEN
                 : null),
-        USERNAME_IS_YOU("username_is_you", (context) ->
-            context.user() != null && context.randomSource().nextInt(context.sizeOfRandomPool()) == 42
+        USERNAME_IS_YOU("username_is_you", (context) -> context.user() != null && context.randomSource().nextInt(context.sizeOfRandomPool()) == 42
                 ? new SplashRenderer(context.user().getName().toUpperCase(Locale.ROOT) + " IS YOU")
                 : null);
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -120,6 +120,9 @@ public net.minecraft.client.particle.ParticleEngine register(Lnet/minecraft/core
 public net.minecraft.client.particle.ParticleEngine register(Lnet/minecraft/core/particles/ParticleType;Lnet/minecraft/client/particle/ParticleProvider$Sprite;)V # register
 public net.minecraft.client.particle.ParticleEngine$SpriteParticleRegistration
 public net.minecraft.client.player.LocalPlayer getPermissionLevel()I # getPermissionLevel
+protected net.minecraft.client.resources.SplashManager RANDOM
+protected net.minecraft.client.resources.SplashManager splashes
+protected net.minecraft.client.resources.SplashManager user
 public net.minecraft.client.renderer.GameRenderer loadEffect(Lnet/minecraft/resources/ResourceLocation;)V # loadEffect
 public net.minecraft.client.renderer.LevelRenderer shouldShowEntityOutlines()Z # shouldShowEntityOutlines
 protected-f net.minecraft.client.renderer.RenderStateShard setupState # setupState


### PR DESCRIPTION
This is a work in progress, in order to gauge interest in managing splashes centrally in NeoForge.

It's often the case that modders would like to add custom splashes to the title screen, except that doing so generally means using a mixin, or completely overwriting the splash pool with a custom resource pack. In order to alleviate that, I've started working on a system to overhaul the vanilla splash manager in such a way that mods can add their own splashes without conflicts. This implementation isn't complete, and it's missing tests, but some preliminary testing does indeed show that it works:
<details>
<summary>Screenshots of custom splashes and date/time specific splashes</summary>

![Screenshot_20240117_232614](https://github.com/neoforged/NeoForge/assets/21000186/5565060d-eeaf-4c5e-9a84-1ab81fca11c3)
![Screenshot_20240117_232216](https://github.com/neoforged/NeoForge/assets/21000186/25033b30-5efa-49db-b012-b93d4cf940fa)
</details>

If there's interest in a system like this, there are some open questions I have:
- Should this system be data-driven?
  - If so, how should it be structured?
    - A single `assets/modid/splashes.json`?
    - A directory of json files, a la `assets/modid/splashes/christmas.json`?
  - Should it use `neoforge:conditions`, or dispatch on some sort of `type` field, like recipes?
  - How do we handle backwards-compatibility with the vanilla format?
- How should we handle ordering between mods and vanilla?
  - If ModA and ModB both add a date/time-specific entry which overlap, which one do we pick?

There's likely way more questions that need to be answered, but I can't think of anything obvious right now :sweat_smile: 