### PR TITLE
Update formatter config to remove extraneous lines at the beginning and end of declarations

### DIFF
--- a/codeformat/formatter-config.xml
+++ b/codeformat/formatter-config.xml
@@ -57,7 +57,7 @@
         <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
-        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="-1"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
@@ -99,7 +99,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_if_empty"/>
-        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="-1"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
@@ -224,7 +224,7 @@
         <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
-        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="-1"/>
         <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
@@ -361,7 +361,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="-1"/>
         <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>

--- a/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
@@ -31,7 +31,6 @@ import net.minecraft.world.scores.Scoreboard;
  * overrides for {@link CommandSourceStack} so that the methods will run successfully client side
  */
 public class ClientCommandSourceStack extends CommandSourceStack {
-
     public ClientCommandSourceStack(CommandSource source, Vec3 position, Vec2 rotation, int permission, String plainTextName, Component displayName,
             Entity executing) {
         super(source, position, rotation, null, permission, plainTextName, displayName, null, executing);
@@ -134,5 +133,4 @@ public class ClientCommandSourceStack extends CommandSourceStack {
     public ServerLevel getLevel() {
         throw new UnsupportedOperationException("Attempted to get server level in client command");
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/ColorResolverManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/ColorResolverManager.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.ApiStatus;
  * Manager for custom {@link ColorResolver} instances, collected via {@link RegisterColorHandlersEvent.ColorResolvers}.
  */
 public final class ColorResolverManager {
-
     private static ImmutableList<ColorResolver> colorResolvers;
 
     @ApiStatus.Internal

--- a/src/main/java/net/neoforged/neoforge/client/IArmPoseTransformer.java
+++ b/src/main/java/net/neoforged/neoforge/client/IArmPoseTransformer.java
@@ -19,7 +19,6 @@ import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
  */
 @FunctionalInterface
 public interface IArmPoseTransformer {
-
     /**
      * This method should be used to apply all wanted transformations to the player when the ArmPose is active.
      * You can use {@link LivingEntity#getTicksUsingItem()} and {@link LivingEntity#getUseItemRemainingTicks()} for moving animations.
@@ -29,5 +28,4 @@ public interface IArmPoseTransformer {
      * @param arm    Arm to pose
      */
     void applyTransform(HumanoidModel<?> model, LivingEntity entity, HumanoidArm arm);
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/RenderTypeGroup.java
+++ b/src/main/java/net/neoforged/neoforge/client/RenderTypeGroup.java
@@ -16,7 +16,6 @@ import net.minecraft.client.renderer.RenderType;
 public record RenderTypeGroup(RenderType block, RenderType entity, RenderType entityFabulous) {
 
     public static RenderTypeGroup EMPTY = new RenderTypeGroup(null, null, null);
-
     public RenderTypeGroup {
         if ((block == null) != (entity == null) || (block == null) != (entityFabulous == null))
             throw new IllegalArgumentException("The render types in a group must either be all null, or all non-null.");

--- a/src/main/java/net/neoforged/neoforge/client/RenderTypeGroup.java
+++ b/src/main/java/net/neoforged/neoforge/client/RenderTypeGroup.java
@@ -14,8 +14,6 @@ import net.minecraft.client.renderer.RenderType;
  * be the same as {@code entity}.
  */
 public record RenderTypeGroup(RenderType block, RenderType entity, RenderType entityFabulous) {
-
-    public static RenderTypeGroup EMPTY = new RenderTypeGroup(null, null, null);
     public RenderTypeGroup {
         if ((block == null) != (entity == null) || (block == null) != (entityFabulous == null))
             throw new IllegalArgumentException("The render types in a group must either be all null, or all non-null.");
@@ -24,6 +22,8 @@ public record RenderTypeGroup(RenderType block, RenderType entity, RenderType en
     public RenderTypeGroup(RenderType block, RenderType entity) {
         this(block, entity, entity);
     }
+
+    public static RenderTypeGroup EMPTY = new RenderTypeGroup(null, null, null);
 
     /**
      * {@return true if this group has render types or not. It either has all, or none}

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class CalculatePlayerTurnEvent extends Event {
-
     private double mouseSensitivity;
     private boolean cinematicCameraEnabled;
 
@@ -63,5 +62,4 @@ public class CalculatePlayerTurnEvent extends Event {
     public void setCinematicCameraEnabled(boolean cinematicCameraEnabled) {
         this.cinematicCameraEnabled = cinematicCameraEnabled;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterColorHandlersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterColorHandlersEvent.java
@@ -130,7 +130,5 @@ public abstract class RegisterColorHandlersEvent extends Event implements IModBu
         public void register(ColorResolver resolver) {
             this.builder.add(resolver);
         }
-
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterItemDecorationsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterItemDecorationsEvent.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterItemDecorationsEvent extends Event implements IModBusEvent {
-
     private final Map<Item, List<IItemDecorator>> decorators;
 
     @ApiStatus.Internal

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterParticleProvidersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterParticleProvidersEvent.java
@@ -82,5 +82,4 @@ public class RegisterParticleProvidersEvent extends Event implements IModBusEven
     public <T extends ParticleOptions> void registerSpriteSet(ParticleType<T> type, ParticleEngine.SpriteParticleRegistration<T> registration) {
         particleEngine.register(type, registration);
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IAbstractWidgetExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IAbstractWidgetExtension.java
@@ -11,7 +11,6 @@ import net.minecraft.client.gui.components.AbstractWidget;
  * Extension interface for {@link AbstractWidget}.
  */
 public interface IAbstractWidgetExtension {
-
     private AbstractWidget self() {
         return (AbstractWidget) this;
     }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IMenuProviderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IMenuProviderExtension.java
@@ -9,7 +9,6 @@ package net.neoforged.neoforge.client.extensions;
  * Extension type for the {@link net.minecraft.world.MenuProvider} interface.
  */
 public interface IMenuProviderExtension {
-
     /**
      * {@return {@code true} if the existing container should be closed on the client side when opening a new one, {@code false} otherwise}
      * 

--- a/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
@@ -149,6 +149,5 @@ public class LoadingErrorScreen extends ErrorScreen {
                 }
             }
         }
-
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -390,7 +390,6 @@ public class ModListScreen extends Screen {
                 if (logo != null) {
 
                     return Pair.of(tm.register("modlogo", new DynamicTexture(logo) {
-
                         @Override
                         public void upload() {
                             this.bind();

--- a/src/main/java/net/neoforged/neoforge/client/gui/TitleScreenModUpdateIndicator.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/TitleScreenModUpdateIndicator.java
@@ -20,7 +20,6 @@ import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
 @OnlyIn(Dist.CLIENT)
 public class TitleScreenModUpdateIndicator extends Screen {
-
     private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(NeoForgeVersion.MOD_ID, "textures/gui/version_check_icons.png");
 
     private final Button modButton;
@@ -62,5 +61,4 @@ public class TitleScreenModUpdateIndicator extends Screen {
         titleScreenModUpdateIndicator.init();
         return titleScreenModUpdateIndicator;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/CompositeModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/CompositeModel.java
@@ -279,7 +279,6 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
                 return new Baked(isGui3d, isSideLit, isAmbientOcclusion, particle, transforms, overrides, childrenBuilder.build(), itemPassesBuilder.build());
             }
         }
-
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
@@ -42,7 +42,6 @@ public record ExtraFaceData(int color, int blockLight, int skyLight, boolean amb
                             Codec.intRange(0, 15).optionalFieldOf("sky_light", 0).forGetter(ExtraFaceData::skyLight),
                             Codec.BOOL.optionalFieldOf("ambient_occlusion", true).forGetter(ExtraFaceData::ambientOcclusion))
                     .apply(builder, ExtraFaceData::new));
-
     /**
      * Parses an ExtraFaceData from JSON
      * 

--- a/src/main/java/net/neoforged/neoforge/client/model/QuadTransformers.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/QuadTransformers.java
@@ -20,7 +20,6 @@ import org.joml.Vector4f;
  * @see IQuadTransformer
  */
 public final class QuadTransformers {
-
     private static final IQuadTransformer EMPTY = quad -> {};
     private static final IQuadTransformer[] EMISSIVE_TRANSFORMERS = Util.make(new IQuadTransformer[16], array -> {
         Arrays.setAll(array, i -> applyingLightmap(LightTexture.pack(i, i)));

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/BlockModelProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/BlockModelProvider.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.NotNull;
  * boilerplate constructor parameters.
  */
 public abstract class BlockModelProvider extends ModelProvider<BlockModelBuilder> {
-
     public BlockModelProvider(PackOutput output, String modid, ExistingFileHelper existingFileHelper) {
         super(output, modid, BLOCK_FOLDER, BlockModelBuilder::new, existingFileHelper);
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/BlockStateProvider.java
@@ -64,7 +64,6 @@ import org.jetbrains.annotations.VisibleForTesting;
  * blockstates and their referenced models can be provided in tandem.
  */
 public abstract class BlockStateProvider implements DataProvider {
-
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping().create();
 

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ConfiguredModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ConfiguredModel.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
  * {@link #builder()}.
  */
 public final class ConfiguredModel {
-
     /**
      * The default random weight of configured models, used by convenience
      * overloads.
@@ -171,7 +170,6 @@ public final class ConfiguredModel {
      *            will be returned upon completion.
      */
     public static class Builder<T> {
-
         private ModelFile model;
         @Nullable
         private final Function<ConfiguredModel[], T> callback;

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ItemModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ItemModelBuilder.java
@@ -23,7 +23,6 @@ import net.neoforged.neoforge.common.data.ExistingFileHelper;
  * {@link #override()}.
  */
 public class ItemModelBuilder extends ModelBuilder<ItemModelBuilder> {
-
     private static final List<ResourceKey<TrimMaterial>> VANILLA_TRIM_MATERIALS = List.of(TrimMaterials.QUARTZ, TrimMaterials.IRON, TrimMaterials.NETHERITE, TrimMaterials.REDSTONE, TrimMaterials.COPPER, TrimMaterials.GOLD, TrimMaterials.EMERALD, TrimMaterials.DIAMOND, TrimMaterials.LAPIS, TrimMaterials.AMETHYST);
     protected List<OverrideBuilder> overrides = new ArrayList<>();
 
@@ -68,7 +67,6 @@ public class ItemModelBuilder extends ModelBuilder<ItemModelBuilder> {
     }
 
     public class OverrideBuilder {
-
         private ModelFile model;
         private final Map<ResourceLocation, Float> predicates = new LinkedHashMap<>();
 
@@ -96,5 +94,4 @@ public class ItemModelBuilder extends ModelBuilder<ItemModelBuilder> {
             return ret;
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ItemModelProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ItemModelProvider.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
  * boilerplate constructor parameters.
  */
 public abstract class ItemModelProvider extends ModelProvider<ItemModelBuilder> {
-
     public ItemModelProvider(PackOutput output, String modid, ExistingFileHelper existingFileHelper) {
         super(output, modid, ITEM_FOLDER, ItemModelBuilder::new, existingFileHelper);
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ModelBuilder.java
@@ -51,7 +51,6 @@ import org.joml.Vector3f;
  * @param <T> Self type, for simpler chaining of methods.
  */
 public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
-
     @Nullable
     protected ModelFile parent;
     protected final Map<String, String> textures = new LinkedHashMap<>();
@@ -389,7 +388,6 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     public class ElementBuilder {
-
         private Vector3f from = new Vector3f();
         private Vector3f to = new Vector3f(16, 16, 16);
         private final Map<Direction, FaceBuilder> faces = new LinkedHashMap<>();
@@ -583,7 +581,6 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         }
 
         public class FaceBuilder {
-
             private Direction cullface;
             private int tintindex = -1;
             private String texture = MissingTextureAtlasSprite.getLocation().toString();
@@ -687,7 +684,6 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         }
 
         public class RotationBuilder {
-
             private Vector3f origin;
             private Direction.Axis axis;
             private float angle;
@@ -751,7 +747,6 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
     }
 
     public class TransformsBuilder {
-
         private final Map<ItemDisplayContext, TransformVecBuilder> transforms = new LinkedHashMap<>();
 
         /**
@@ -778,7 +773,6 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
         }
 
         public class TransformVecBuilder {
-
             private Vector3f rotation = new Vector3f(ItemTransform.Deserializer.DEFAULT_ROTATION);
             private Vector3f translation = new Vector3f(ItemTransform.Deserializer.DEFAULT_TRANSLATION);
             private Vector3f scale = new Vector3f(ItemTransform.Deserializer.DEFAULT_SCALE);

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ModelFile.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ModelFile.java
@@ -10,7 +10,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 public abstract class ModelFile {
-
     protected ResourceLocation location;
 
     protected ModelFile(ResourceLocation location) {
@@ -38,7 +37,6 @@ public abstract class ModelFile {
     }
 
     public static class UncheckedModelFile extends ModelFile {
-
         public UncheckedModelFile(String location) {
             this(new ResourceLocation(location));
         }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ModelProvider.java
@@ -24,7 +24,6 @@ import net.neoforged.neoforge.common.data.ExistingFileHelper.ResourceType;
 import org.jetbrains.annotations.VisibleForTesting;
 
 public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataProvider {
-
     public static final String BLOCK_FOLDER = "block";
     public static final String ITEM_FOLDER = "item";
 

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/MultiPartBlockStateBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/MultiPartBlockStateBuilder.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.properties.Property;
 
 public final class MultiPartBlockStateBuilder implements IGeneratedBlockState {
-
     private final List<PartBuilder> parts = new ArrayList<>();
     private final Block owner;
 

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/VariantBlockStateBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/VariantBlockStateBuilder.java
@@ -50,7 +50,6 @@ import org.jetbrains.annotations.Nullable;
  * @see BlockStateProvider
  */
 public class VariantBlockStateBuilder implements IGeneratedBlockState {
-
     private final Block owner;
     private final Map<PartialBlockstate, ConfiguredModelList> models = new LinkedHashMap<>();
     private final Set<BlockState> coveredStates = new HashSet<>();

--- a/src/main/java/net/neoforged/neoforge/client/model/geometry/IUnbakedGeometry.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/geometry/IUnbakedGeometry.java
@@ -33,9 +33,7 @@ public interface IUnbakedGeometry<T extends IUnbakedGeometry<T>> {
      * {@link IUnbakedGeometry#bake(IGeometryBakingContext, ModelBaker, Function, ModelState, ItemOverrides, ResourceLocation)}
      * via {@link BlockModel#resolveParents(Function)}
      */
-    default void resolveParents(Function<ResourceLocation, UnbakedModel> modelGetter, IGeometryBakingContext context) {
-
-    }
+    default void resolveParents(Function<ResourceLocation, UnbakedModel> modelGetter, IGeometryBakingContext context) {}
 
     /**
      * {@return a set of all the components whose visibility may be configured via {@link IGeometryBakingContext}}

--- a/src/main/java/net/neoforged/neoforge/client/model/pipeline/TransformingVertexPipeline.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/pipeline/TransformingVertexPipeline.java
@@ -36,5 +36,4 @@ public class TransformingVertexPipeline extends VertexConsumerWrapper {
         vec.normalize();
         return super.normal(vec.x(), vec.y(), vec.z());
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/renderable/BakedModelRenderable.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/renderable/BakedModelRenderable.java
@@ -79,7 +79,6 @@ public class BakedModelRenderable implements IRenderable<BakedModelRenderable.Co
 
         private static final Direction[] ALL_FACES_AND_NULL = Arrays.copyOf(Direction.values(), Direction.values().length + 1);
         private static final Vector4f WHITE = new Vector4f(1, 1, 1, 1);
-
         public Context(ModelData data) {
             this(null, ALL_FACES_AND_NULL, RandomSource.create(), 42, data, WHITE);
         }

--- a/src/main/java/net/neoforged/neoforge/client/util/DebuggingHelper.java
+++ b/src/main/java/net/neoforged/neoforge/client/util/DebuggingHelper.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public final class DebuggingHelper {
-
     private DebuggingHelper() {
         throw new IllegalStateException("Tried to create utility class!");
     }

--- a/src/main/java/net/neoforged/neoforge/common/BasicItemListing.java
+++ b/src/main/java/net/neoforged/neoforge/common/BasicItemListing.java
@@ -17,7 +17,6 @@ import net.minecraft.world.item.trading.MerchantOffer;
  * This class contains everything needed to make a MerchantOffer, the actual "trade" object shown in trading guis.
  */
 public class BasicItemListing implements ItemListing {
-
     protected final ItemStack price;
     protected final ItemStack price2;
     protected final ItemStack forSale;

--- a/src/main/java/net/neoforged/neoforge/common/CreativeModeTabRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/common/CreativeModeTabRegistry.java
@@ -231,5 +231,4 @@ public final class CreativeModeTabRegistry {
             edges.put(before, name);
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/IMinecartCollisionHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/IMinecartCollisionHandler.java
@@ -17,7 +17,6 @@ import net.minecraft.world.phys.AABB;
  * @author CovertJaguar
  */
 public interface IMinecartCollisionHandler {
-
     /**
      * This basically replaces the function of the same name in EntityMinecart.
      * Code in IMinecartHooks.applyEntityCollisionHook is still run.

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeConfig.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeConfig.java
@@ -68,7 +68,6 @@ public class NeoForgeConfig {
      * General configuration that doesn't need to be synchronized but needs to be available before server startup
      */
     public static class Common {
-
         Common(ModConfigSpec.Builder builder) {
             builder.comment("[DEPRECATED / NO EFFECT]: General configuration settings")
                     .push("general");

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -545,7 +545,6 @@ public class Tags {
     }
 
     public static class DamageTypes {
-
         /**
          * Damage types representing magic damage.
          */

--- a/src/main/java/net/neoforged/neoforge/common/UsernameCache.java
+++ b/src/main/java/net/neoforged/neoforge/common/UsernameCache.java
@@ -37,7 +37,6 @@ import org.jetbrains.annotations.Nullable;
  * the caches underlying map.
  */
 public final class UsernameCache {
-
     private static Map<UUID, String> map = new HashMap<>();
 
     private static final Path saveFile = FMLLoader.getGamePath().resolve("usernamecache.json");
@@ -158,7 +157,6 @@ public final class UsernameCache {
      * representation of the cache to disk
      */
     private static class SaveThread extends Thread {
-
         /** The data that will be saved to disk */
         private final String data;
 

--- a/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
@@ -21,7 +21,6 @@ import net.neoforged.neoforge.event.village.VillagerTradesEvent;
 import net.neoforged.neoforge.event.village.WandererTradesEvent;
 
 public class VillagerTradingManager {
-
     private static final Map<VillagerProfession, Int2ObjectMap<ItemListing[]>> VANILLA_TRADES = new HashMap<>();
     private static final Int2ObjectMap<ItemListing[]> WANDERER_TRADES = new Int2ObjectOpenHashMap<>();
 
@@ -71,5 +70,4 @@ public class VillagerTradingManager {
             VillagerTrades.TRADES.put(prof, newTrades);
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/common/brewing/BrewingRecipeRegistry.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
 public class BrewingRecipeRegistry {
-
     private static List<IBrewingRecipe> recipes = new ArrayList<IBrewingRecipe>();
 
     static {

--- a/src/main/java/net/neoforged/neoforge/common/brewing/IBrewingRecipe.java
+++ b/src/main/java/net/neoforged/neoforge/common/brewing/IBrewingRecipe.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.common.brewing;
 import net.minecraft.world.item.ItemStack;
 
 public interface IBrewingRecipe {
-
     /**
      * Returns true is the passed ItemStack is an input for this recipe. "Input"
      * being the item that goes in one of the three bottom slots of the brewing

--- a/src/main/java/net/neoforged/neoforge/common/brewing/VanillaBrewingRecipe.java
+++ b/src/main/java/net/neoforged/neoforge/common/brewing/VanillaBrewingRecipe.java
@@ -16,7 +16,6 @@ import net.minecraft.world.item.alchemy.PotionBrewing;
  * Most of the code was simply adapted from net.minecraft.tileentity.TileEntityBrewingStand
  */
 public class VanillaBrewingRecipe implements IBrewingRecipe {
-
     /**
      * Code adapted from TileEntityBrewingStand.isItemValidForSlot(int index, ItemStack stack)
      */

--- a/src/main/java/net/neoforged/neoforge/common/conditions/AndCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/AndCondition.java
@@ -11,7 +11,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.List;
 
 public record AndCondition(List<ICondition> children) implements ICondition {
-
     public static final Codec<AndCondition> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
@@ -23,7 +23,6 @@ import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
  * This allows getting the {@link ICondition.IContext} while decoding an entry from within a codec.
  */
 public class ConditionalOps<T> extends RegistryOps<T> {
-
     public static <T> ConditionalOps<T> create(RegistryOps<T> ops, ICondition.IContext context) {
         return new ConditionalOps<T>(ops, context);
     }

--- a/src/main/java/net/neoforged/neoforge/common/conditions/FalseCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/FalseCondition.java
@@ -9,7 +9,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 
 public final class FalseCondition implements ICondition {
-
     public static final FalseCondition INSTANCE = new FalseCondition();
 
     public static final Codec<FalseCondition> CODEC = MapCodec.unit(INSTANCE).stable().codec();

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ItemExistsCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ItemExistsCondition.java
@@ -11,7 +11,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 
 public class ItemExistsCondition implements ICondition {
-
     public static Codec<ItemExistsCondition> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ModLoadedCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ModLoadedCondition.java
@@ -10,7 +10,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.neoforged.fml.ModList;
 
 public record ModLoadedCondition(String modid) implements ICondition {
-
     public static Codec<ModLoadedCondition> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(

--- a/src/main/java/net/neoforged/neoforge/common/conditions/TrueCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/TrueCondition.java
@@ -9,7 +9,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 
 public final class TrueCondition implements ICondition {
-
     public static final TrueCondition INSTANCE = new TrueCondition();
 
     public static Codec<TrueCondition> CODEC = MapCodec.unit(INSTANCE).stable().codec();

--- a/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
 
 /** Ingredient that matches everything from the first ingredient that is not included in the second ingredient */
 public class DifferenceIngredient extends Ingredient {
-
     public static final Codec<DifferenceIngredient> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(
@@ -99,7 +98,6 @@ public class DifferenceIngredient extends Ingredient {
     }
 
     private record SubtractingValue(Value inner, Ingredient subtracted) implements Ingredient.Value {
-
         @Override
         public Collection<ItemStack> getItems() {
             final Collection<ItemStack> innerItems = new ArrayList<>(inner().getItems());

--- a/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
@@ -97,7 +97,6 @@ public class IntersectionIngredient extends Ingredient {
     }
 
     public record IntersectionValue(Value inner, List<Ingredient> other) implements Ingredient.Value {
-
         @Override
         public Collection<ItemStack> getItems() {
             final Collection<ItemStack> inner = new ArrayList<>(inner().getItems());

--- a/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
@@ -28,7 +28,6 @@ import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
  * match if the item's tags contain all of the elements of the provided one, while allowing for additional elements to exist.
  */
 public class NBTIngredient extends Ingredient {
-
     public static final Codec<NBTIngredient> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(

--- a/src/main/java/net/neoforged/neoforge/common/data/DatapackBuiltinEntriesProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/DatapackBuiltinEntriesProvider.java
@@ -19,7 +19,6 @@ import net.minecraft.data.registries.RegistryPatchGenerator;
  * object.
  */
 public class DatapackBuiltinEntriesProvider extends RegistriesDatapackGenerator {
-
     private final CompletableFuture<HolderLookup.Provider> fullRegistries;
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/data/ExistingFileHelper.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/ExistingFileHelper.java
@@ -43,9 +43,7 @@ import org.jetbrains.annotations.VisibleForTesting;
  * or mod resources via the {@code --existing-mod} argument.
  */
 public class ExistingFileHelper {
-
     public interface IResourceType {
-
         PackType getPackType();
 
         String getSuffix();
@@ -54,7 +52,6 @@ public class ExistingFileHelper {
     }
 
     public static class ResourceType implements IResourceType {
-
         final PackType packType;
         final String suffix, prefix;
 

--- a/src/main/java/net/neoforged/neoforge/common/data/NeoForgeDamageTypeTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/NeoForgeDamageTypeTagsProvider.java
@@ -17,7 +17,6 @@ import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.common.Tags;
 
 public final class NeoForgeDamageTypeTagsProvider extends DamageTypeTagsProvider {
-
     public NeoForgeDamageTypeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, ExistingFileHelper existingFileHelper) {
         super(output, lookupProvider, "neoforge", existingFileHelper);
     }

--- a/src/main/java/net/neoforged/neoforge/common/data/ParticleDescriptionProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/ParticleDescriptionProvider.java
@@ -67,7 +67,6 @@ import org.jetbrains.annotations.VisibleForTesting;
  * @see net.minecraft.client.particle.ParticleDescription
  */
 public abstract class ParticleDescriptionProvider implements DataProvider {
-
     private final PackOutput.PathProvider particlesPath;
     @VisibleForTesting
     protected final ExistingFileHelper fileHelper;
@@ -140,7 +139,6 @@ public abstract class ParticleDescriptionProvider implements DataProvider {
     protected void spriteSet(ParticleType<?> type, ResourceLocation baseName, int numOfTextures, boolean reverse) {
         Preconditions.checkArgument(numOfTextures > 0, "The number of textures to generate must be positive");
         this.spriteSet(type, () -> new Iterator<>() {
-
             private int counter = 0;
 
             @Override

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBiomeTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBiomeTagsProvider.java
@@ -18,7 +18,6 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 public final class NeoForgeBiomeTagsProvider extends BiomeTagsProvider {
-
     public NeoForgeBiomeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, ExistingFileHelper existingFileHelper) {
         super(output, lookupProvider, "neoforge", existingFileHelper);
     }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeEntityTypeTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeEntityTypeTagsProvider.java
@@ -14,7 +14,6 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 public class NeoForgeEntityTypeTagsProvider extends EntityTypeTagsProvider {
-
     public NeoForgeEntityTypeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, ExistingFileHelper existingFileHelper) {
         super(output, lookupProvider, "neoforge", existingFileHelper);
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IAdvancementBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IAdvancementBuilderExtension.java
@@ -14,7 +14,6 @@ import net.minecraft.server.packs.PackType;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 public interface IAdvancementBuilderExtension {
-
     private Advancement.Builder self() {
         return (Advancement.Builder) this;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBaseRailBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBaseRailBlockExtension.java
@@ -15,7 +15,6 @@ import net.minecraft.world.level.block.state.properties.RailShape;
 import org.jetbrains.annotations.Nullable;
 
 public interface IBaseRailBlockExtension {
-
     /**
      * Return true if the rail can make corners.
      * Used by placement logic.

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBucketPickupExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBucketPickupExtension.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.block.BucketPickup;
 import net.minecraft.world.level.block.state.BlockState;
 
 public interface IBucketPickupExtension {
-
     private BucketPickup self() {
         return (BucketPickup) this;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IClientCommonPacketListenerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IClientCommonPacketListenerExtension.java
@@ -22,7 +22,6 @@ import net.neoforged.neoforge.network.registration.NetworkRegistry;
  * </p>
  */
 public interface IClientCommonPacketListenerExtension {
-
     /**
      * {@return the ClientCommonPacketListener this extension is attached to}
      */

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension.java
@@ -16,7 +16,6 @@ import net.minecraft.world.scores.Scoreboard;
  * Additional methods for {@link CommandSourceStack} so that commands and arguments can access various things without directly referencing using server specific classes
  */
 public interface ICommandSourceStackExtension {
-
     private CommandSourceStack self() {
         return (CommandSourceStack) this;
     }
@@ -48,5 +47,4 @@ public interface ICommandSourceStackExtension {
     default Level getUnsidedLevel() {
         return self().getLevel();
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPacketFlowExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPacketFlowExtension.java
@@ -12,7 +12,6 @@ import net.neoforged.fml.LogicalSide;
  * Extension for {@link PacketFlow} to add some utility methods.
  */
 public interface IPacketFlowExtension {
-
     /**
      * {@return the {@link PacketFlow} this extension is applied to}
      */

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -20,7 +20,6 @@ import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.network.IContainerFactory;
 
 public interface IPlayerExtension {
-
     private Player self() {
         return (Player) this;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerListExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerListExtension.java
@@ -19,7 +19,6 @@ import net.minecraft.world.level.Level;
  * </p>
  */
 public interface IPlayerListExtension {
-
     /**
      * {@return the PlayerList instance that this extension is attached to}
      */

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IServerChunkCacheExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IServerChunkCacheExtension.java
@@ -18,7 +18,6 @@ import net.minecraft.world.entity.Entity;
  */
 @SuppressWarnings("resource")
 public interface IServerChunkCacheExtension {
-
     default ServerChunkCache self() {
         return (ServerChunkCache) this;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IServerCommonPacketListenerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IServerCommonPacketListenerExtension.java
@@ -24,7 +24,6 @@ import net.neoforged.neoforge.network.registration.NetworkRegistry;
  * </p>
  */
 public interface IServerCommonPacketListenerExtension {
-
     /**
      * {@return the {@link ServerCommonPacketListener} that the extensions is attached to}
      */

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IServerGamePacketListenerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IServerGamePacketListenerExtension.java
@@ -18,7 +18,6 @@ import net.minecraft.network.protocol.game.ServerGamePacketListener;
  * Extension class for {@link ServerGamePacketListener}
  */
 public interface IServerGamePacketListenerExtension extends IServerCommonPacketListenerExtension {
-
     /**
      * {@return the listener this extension is attached to}
      */

--- a/src/main/java/net/neoforged/neoforge/common/loot/CanToolPerformAction.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/CanToolPerformAction.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
  * This LootItemCondition "neoforge:can_tool_perform_action" can be used to check if a tool can perform a given ToolAction.
  */
 public class CanToolPerformAction implements LootItemCondition {
-
     public static Codec<CanToolPerformAction> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(

--- a/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
@@ -97,5 +97,4 @@ public class LootModifierManager extends SimpleJsonResourceReloadListener {
     public Collection<IGlobalLootModifier> getAllLootMods() {
         return registeredLootModifiers.values();
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockSnapshot.java
@@ -185,5 +185,4 @@ public class BlockSnapshot {
     public CompoundTag getTag() {
         return nbt;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/FriendlyByteBufUtil.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FriendlyByteBufUtil.java
@@ -13,7 +13,6 @@ import net.minecraft.network.FriendlyByteBuf;
  * Utility class for working with {@link FriendlyByteBuf}s.
  */
 public class FriendlyByteBufUtil {
-
     private FriendlyByteBufUtil() {
         throw new IllegalStateException("Tried to create utility class!");
     }

--- a/src/main/java/net/neoforged/neoforge/common/util/HexDumper.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/HexDumper.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBuf;
  * </PRE>
  */
 public class HexDumper {
-
     public static String dump(ByteBuf data) {
         int current = data.readerIndex();
         data.readerIndex(0);

--- a/src/main/java/net/neoforged/neoforge/common/util/ITeleporter.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/ITeleporter.java
@@ -83,5 +83,4 @@ public interface ITeleporter {
     default boolean playTeleportSound(ServerPlayer player, ServerLevel sourceWorld, ServerLevel destWorld) {
         return true;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/ItemStackMap.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/ItemStackMap.java
@@ -12,7 +12,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemStackLinkedSet;
 
 public class ItemStackMap {
-
     public static <V> Map<ItemStack, V> createTypeAndTagLinkedMap() {
         return new Object2ObjectLinkedOpenCustomHashMap<>(ItemStackLinkedSet.TYPE_AND_TAG);
     }

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -29,7 +29,6 @@ import net.minecraft.util.ExtraCodecs;
  * @see ExtraCodecs
  */
 public class NeoForgeExtraCodecs {
-
     public static <T> MapCodec<T> aliasedFieldOf(final Codec<T> codec, final String... names) {
         if (names.length == 0)
             throw new IllegalArgumentException("Must have at least one name!");
@@ -155,7 +154,6 @@ public class NeoForgeExtraCodecs {
     }
 
     private static class AlternativeMapCodec<T> extends MapCodec<T> {
-
         private final MapCodec<T> codec;
         private final MapCodec<T> alternative;
 

--- a/src/main/java/net/neoforged/neoforge/common/world/chunk/TicketController.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/chunk/TicketController.java
@@ -25,7 +25,6 @@ import net.minecraft.world.level.ForcedChunksSavedData;
  */
 @ParametersAreNonnullByDefault
 public record TicketController(ResourceLocation id, @Nullable LoadingValidationCallback callback) {
-
     public TicketController {
         Objects.requireNonNull(id, "id must not be null");
     }

--- a/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
@@ -102,7 +102,6 @@ public class GatherDataEvent extends Event implements IModBusEvent {
             this.reports = reports;
             this.validate = validate;
             this.flat = flat;
-
         }
 
         public Collection<Path> getInputs() {

--- a/src/main/java/net/neoforged/neoforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/neoforged/neoforge/energy/IEnergyStorage.java
@@ -58,5 +58,4 @@ public interface IEnergyStorage {
      * If this is false, then any calls to receiveEnergy will return 0.
      */
     boolean canReceive();
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/AnvilUpdateEvent.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
  * if the output is empty, and the event is not canceled, vanilla behavior will execute. <br>
  */
 public class AnvilUpdateEvent extends Event implements ICancellableEvent {
-
     private final ItemStack left;
     private final ItemStack right;
     private final String name;

--- a/src/main/java/net/neoforged/neoforge/event/BuildCreativeModeTabContentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/BuildCreativeModeTabContentsEvent.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
  * In vanilla, this is only fired on the logical client, but mods may request creative mode tab contents on the server.
  */
 public final class BuildCreativeModeTabContentsEvent extends Event implements IModBusEvent, CreativeModeTab.Output {
-
     private final CreativeModeTab tab;
     private final CreativeModeTab.ItemDisplayParameters parameters;
     private final MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility> entries;

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -161,7 +161,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class EventHooks {
-
     public static boolean onMultiBlockPlace(@Nullable Entity entity, List<BlockSnapshot> blockSnapshots, Direction direction) {
         BlockSnapshot snap = blockSnapshots.get(0);
         BlockState placedAgainst = snap.getLevel().getBlockState(snap.getPos().relative(direction.getOpposite()));

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/GetEnchantmentLevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/GetEnchantmentLevelEvent.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
  * It is not fired for interactions with NBT, which means these changes will not reflect in the item tooltip.
  */
 public class GetEnchantmentLevelEvent extends Event {
-
     protected final ItemStack stack;
     protected final Map<Enchantment, Integer> enchantments;
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityAttributeModificationEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityAttributeModificationEvent.java
@@ -57,5 +57,4 @@ public class EntityAttributeModificationEvent extends Event implements IModBusEv
     public List<EntityType<? extends LivingEntity>> getTypes() {
         return entityTypes;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
@@ -61,7 +61,6 @@ public abstract class EntityEvent extends Event {
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      **/
     public static class EnteringSection extends EntityEvent {
-
         private final long packedOldPos;
         private final long packedNewPos;
 
@@ -112,7 +111,6 @@ public abstract class EntityEvent extends Event {
         public boolean didChunkChange() {
             return SectionPos.x(packedOldPos) != SectionPos.x(packedNewPos) || SectionPos.z(packedOldPos) != SectionPos.z(packedNewPos);
         }
-
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityMountEvent.java
@@ -25,7 +25,6 @@ import net.neoforged.neoforge.common.NeoForge;
  */
 
 public class EntityMountEvent extends EntityEvent implements ICancellableEvent {
-
     private final Entity entityMounting;
     private final Entity entityBeingMounted;
     private final Level level;

--- a/src/main/java/net/neoforged/neoforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -173,5 +173,4 @@ public class SpawnPlacementRegisterEvent extends Event implements IModBusEvent {
             return compiledAndPredicate;
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/item/ItemExpireEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/item/ItemExpireEvent.java
@@ -15,7 +15,6 @@ import net.neoforged.bus.api.ICancellableEvent;
  * it will add more time to the entities life equal to extraLife.
  */
 public class ItemExpireEvent extends ItemEvent implements ICancellableEvent {
-
     private int extraLife;
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/item/ItemTossEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/item/ItemTossEvent.java
@@ -16,7 +16,6 @@ import net.neoforged.bus.api.ICancellableEvent;
  * removed from the inventory - and thus removed from the system.
  */
 public class ItemTossEvent extends ItemEvent implements ICancellableEvent {
-
     private final Player player;
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingSwapItemsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingSwapItemsEvent.java
@@ -12,7 +12,6 @@ import net.neoforged.bus.api.ICancellableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 public abstract class LivingSwapItemsEvent extends LivingEvent {
-
     @ApiStatus.Internal
     public LivingSwapItemsEvent(LivingEntity entity) {
         super(entity);

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LootingLevelEvent.java
@@ -10,7 +10,6 @@ import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.Nullable;
 
 public class LootingLevelEvent extends LivingEvent {
-
     @Nullable
     private final DamageSource damageSource;
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/MobSpawnEvent.java
@@ -409,5 +409,4 @@ public abstract class MobSpawnEvent extends EntityEvent {
             super(mob, level, mob.getX(), mob.getY(), mob.getZ());
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ShieldBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ShieldBlockEvent.java
@@ -75,5 +75,4 @@ public class ShieldBlockEvent extends LivingEvent implements ICancellableEvent {
     public void setShieldTakesDamage(boolean damage) {
         this.shieldTakesDamage = damage;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/AdvancementEvent.java
@@ -43,7 +43,6 @@ public abstract class AdvancementEvent extends PlayerEvent {
      * @see AdvancementProgress#isDone()
      */
     public static class AdvancementEarnEvent extends AdvancementEvent {
-
         public AdvancementEarnEvent(Player player, AdvancementHolder earned) {
             super(player, earned);
         }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/BonemealEvent.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
  */
 @Event.HasResult
 public class BonemealEvent extends PlayerEvent implements ICancellableEvent {
-
     private final Level level;
     private final BlockPos pos;
     private final BlockState block;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/FillBucketEvent.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
  */
 @Event.HasResult
 public class FillBucketEvent extends PlayerEvent implements ICancellableEvent {
-
     private final ItemStack current;
     private final Level level;
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -67,5 +67,4 @@ public class PlayerDestroyItemEvent extends PlayerEvent {
     public InteractionHand getHand() {
         return this.hand;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -248,7 +248,6 @@ public abstract class PlayerEvent extends LivingEvent {
      *
      */
     public static class StartTracking extends PlayerEvent {
-
         private final Entity target;
 
         public StartTracking(Player player, Entity target) {
@@ -269,7 +268,6 @@ public abstract class PlayerEvent extends LivingEvent {
      *
      */
     public static class StopTracking extends PlayerEvent {
-
         private final Entity target;
 
         public StopTracking(Player player, Entity target) {
@@ -467,7 +465,6 @@ public abstract class PlayerEvent extends LivingEvent {
         public boolean isEndConquered() {
             return this.endConquered;
         }
-
     }
 
     public static class PlayerChangedDimensionEvent extends PlayerEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInteractEvent.java
@@ -386,5 +386,4 @@ public abstract class PlayerInteractEvent extends PlayerEvent {
     public void setCancellationResult(InteractionResult result) {
         this.cancellationResult = result;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerNegotiationEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerNegotiationEvent.java
@@ -22,7 +22,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  */
 public class PlayerNegotiationEvent extends Event {
-
     private final Connection connection;
     private final GameProfile profile;
     private final List<Future<Void>> futures;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSleepInBedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSleepInBedEvent.java
@@ -47,5 +47,4 @@ public class PlayerSleepInBedEvent extends PlayerEvent {
     public Optional<BlockPos> getOptionalPos() {
         return pos;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
@@ -18,7 +18,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.
  */
 public abstract class PlayerXpEvent extends PlayerEvent {
-
     public PlayerXpEvent(Player player) {
         super(player);
     }
@@ -28,7 +27,6 @@ public abstract class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     public static class PickupXp extends PlayerXpEvent implements ICancellableEvent {
-
         private final ExperienceOrb orb;
 
         public PickupXp(Player player, ExperienceOrb orb) {
@@ -39,7 +37,6 @@ public abstract class PlayerXpEvent extends PlayerEvent {
         public ExperienceOrb getOrb() {
             return orb;
         }
-
     }
 
     /**
@@ -47,7 +44,6 @@ public abstract class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     public static class XpChange extends PlayerXpEvent implements ICancellableEvent {
-
         private int amount;
 
         public XpChange(Player player, int amount) {
@@ -62,7 +58,6 @@ public abstract class PlayerXpEvent extends PlayerEvent {
         public void setAmount(int amount) {
             this.amount = amount;
         }
-
     }
 
     /**
@@ -70,7 +65,6 @@ public abstract class PlayerXpEvent extends PlayerEvent {
      * It can be cancelled, and no further processing will be done.
      */
     public static class LevelChange extends PlayerXpEvent implements ICancellableEvent {
-
         private int levels;
 
         public LevelChange(Player player, int levels) {
@@ -85,7 +79,5 @@ public abstract class PlayerXpEvent extends PlayerEvent {
         public void setLevels(int levels) {
             this.levels = levels;
         }
-
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/SleepingLocationCheckEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/SleepingLocationCheckEvent.java
@@ -25,7 +25,6 @@ import net.neoforged.neoforge.event.entity.living.LivingEvent;
  */
 @HasResult
 public class SleepingLocationCheckEvent extends LivingEvent {
-
     private final BlockPos sleepingLocation;
 
     public SleepingLocationCheckEvent(LivingEntity player, BlockPos sleepingLocation) {

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -336,7 +336,6 @@ public abstract class BlockEvent extends Event {
      * This event is {@link ICancellableEvent}
      */
     public static class FarmlandTrampleEvent extends BlockEvent implements ICancellableEvent {
-
         private final Entity entity;
         private final float fallDistance;
 
@@ -353,7 +352,6 @@ public abstract class BlockEvent extends Event {
         public float getFallDistance() {
             return fallDistance;
         }
-
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/level/NoteBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/NoteBlockEvent.java
@@ -147,5 +147,4 @@ public abstract class NoteBlockEvent extends BlockEvent {
             return id < 12 ? LOW : id == 24 ? HIGH : MID;
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/level/PistonEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/PistonEvent.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.Nullable;
  * Base piston event, use {@link PistonEvent.Post} and {@link PistonEvent.Pre}
  */
 public abstract class PistonEvent extends BlockEvent {
-
     private final Direction direction;
     private final PistonMoveType moveType;
 
@@ -67,22 +66,18 @@ public abstract class PistonEvent extends BlockEvent {
      * Fires after the piston has moved and set surrounding states. This will not fire if {@link PistonEvent.Pre} is cancelled.
      */
     public static class Post extends PistonEvent {
-
         public Post(Level world, BlockPos pos, Direction direction, PistonMoveType moveType) {
             super(world, pos, direction, moveType);
         }
-
     }
 
     /**
      * Fires before the piston has updated block states. Cancellation prevents movement.
      */
     public static class Pre extends PistonEvent implements ICancellableEvent {
-
         public Pre(Level world, BlockPos pos, Direction direction, PistonMoveType moveType) {
             super(world, pos, direction, moveType);
         }
-
     }
 
     public static enum PistonMoveType {
@@ -94,5 +89,4 @@ public abstract class PistonEvent extends BlockEvent {
             this.isExtend = isExtend;
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/server/ServerAboutToStartEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/server/ServerAboutToStartEvent.java
@@ -17,7 +17,6 @@ import net.neoforged.fml.event.lifecycle.InterModProcessEvent;
  * @author cpw
  */
 public class ServerAboutToStartEvent extends ServerLifecycleEvent {
-
     public ServerAboutToStartEvent(MinecraftServer server) {
         super(server);
     }

--- a/src/main/java/net/neoforged/neoforge/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/server/ServerLifecycleEvent.java
@@ -9,7 +9,6 @@ import net.minecraft.server.MinecraftServer;
 import net.neoforged.bus.api.Event;
 
 public abstract class ServerLifecycleEvent extends Event {
-
     protected final MinecraftServer server;
 
     public ServerLifecycleEvent(MinecraftServer server) {

--- a/src/main/java/net/neoforged/neoforge/event/server/ServerStartedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/server/ServerStartedEvent.java
@@ -13,7 +13,6 @@ import net.minecraft.server.MinecraftServer;
  * @author cpw
  */
 public class ServerStartedEvent extends ServerLifecycleEvent {
-
     public ServerStartedEvent(final MinecraftServer server) {
         super(server);
     }

--- a/src/main/java/net/neoforged/neoforge/event/server/ServerStartingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/server/ServerStartingEvent.java
@@ -20,5 +20,4 @@ public class ServerStartingEvent extends ServerLifecycleEvent {
     public ServerStartingEvent(final MinecraftServer server) {
         super(server);
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/village/VillagerTradesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/VillagerTradesEvent.java
@@ -26,7 +26,6 @@ import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
  * To add trades to the merchant, simply add new trades to the list. {@link BasicItemListing} provides a default implementation.
  */
 public class VillagerTradesEvent extends Event {
-
     protected Int2ObjectMap<List<ItemListing>> trades;
     protected VillagerProfession type;
 
@@ -42,5 +41,4 @@ public class VillagerTradesEvent extends Event {
     public VillagerProfession getType() {
         return type;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/WandererTradesEvent.java
@@ -19,7 +19,6 @@ import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
  * To add trades to the merchant, simply add new trades to the list. {@link BasicItemListing} provides a default implementation.
  */
 public class WandererTradesEvent extends Event {
-
     protected List<ItemListing> generic;
     protected List<ItemListing> rare;
 

--- a/src/main/java/net/neoforged/neoforge/fluids/IFluidTank.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/IFluidTank.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.NotNull;
  * DO NOT ASSUME that these objects are used internally in all cases.
  */
 public interface IFluidTank {
-
     /**
      * @return FluidStack representing the fluid in the tank, null if the tank is empty.
      */
@@ -59,5 +58,4 @@ public interface IFluidTank {
      */
     @NotNull
     FluidStack drain(FluidStack resource, FluidAction action);
-
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/IFluidHandler.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/IFluidHandler.java
@@ -105,5 +105,4 @@ public interface IFluidHandler {
      */
     @NotNull
     FluidStack drain(int maxDrain, FluidAction action);
-
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -63,26 +63,22 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
 
     @Override
     public int getTanks() {
-
         return 1;
     }
 
     @NotNull
     @Override
     public FluidStack getFluidInTank(int tank) {
-
         return getFluid();
     }
 
     @Override
     public int getTankCapacity(int tank) {
-
         return capacity;
     }
 
     @Override
     public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-
         return true;
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -60,26 +60,22 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
 
     @Override
     public int getTanks() {
-
         return 1;
     }
 
     @NotNull
     @Override
     public FluidStack getFluidInTank(int tank) {
-
         return getFluid();
     }
 
     @Override
     public int getTankCapacity(int tank) {
-
         return capacity;
     }
 
     @Override
     public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-
         return true;
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidTank.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
  * @author King Lemming
  */
 public class FluidTank implements IFluidHandler, IFluidTank {
-
     protected Predicate<FluidStack> validator;
     @NotNull
     protected FluidStack fluid = FluidStack.EMPTY;
@@ -63,14 +62,12 @@ public class FluidTank implements IFluidHandler, IFluidTank {
     }
 
     public FluidTank readFromNBT(CompoundTag nbt) {
-
         FluidStack fluid = FluidStack.loadFluidStackFromNBT(nbt);
         setFluid(fluid);
         return this;
     }
 
     public CompoundTag writeToNBT(CompoundTag nbt) {
-
         fluid.writeToNBT(nbt);
 
         return nbt;
@@ -78,26 +75,22 @@ public class FluidTank implements IFluidHandler, IFluidTank {
 
     @Override
     public int getTanks() {
-
         return 1;
     }
 
     @NotNull
     @Override
     public FluidStack getFluidInTank(int tank) {
-
         return getFluid();
     }
 
     @Override
     public int getTankCapacity(int tank) {
-
         return getCapacity();
     }
 
     @Override
     public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-
         return isFluidValid(stack);
     }
 
@@ -160,9 +153,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         return stack;
     }
 
-    protected void onContentsChanged() {
-
-    }
+    protected void onContentsChanged() {}
 
     public void setFluid(FluidStack stack) {
         this.fluid = stack;
@@ -175,5 +166,4 @@ public class FluidTank implements IFluidHandler, IFluidTank {
     public int getSpace() {
         return Math.max(0, capacity - fluid.getAmount());
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
  * Swaps between empty bucket and filled bucket of the correct type.
  */
 public class FluidBucketWrapper implements IFluidHandlerItem {
-
     @NotNull
     protected ItemStack container;
 
@@ -65,26 +64,22 @@ public class FluidBucketWrapper implements IFluidHandlerItem {
 
     @Override
     public int getTanks() {
-
         return 1;
     }
 
     @NotNull
     @Override
     public FluidStack getFluidInTank(int tank) {
-
         return getFluid();
     }
 
     @Override
     public int getTankCapacity(int tank) {
-
         return FluidType.BUCKET_VOLUME;
     }
 
     @Override
     public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-
         return true;
     }
 

--- a/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
@@ -174,11 +174,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
             throw new RuntimeException("Slot " + slot + " not in valid range - [0," + stacks.size() + ")");
     }
 
-    protected void onLoad() {
+    protected void onLoad() {}
 
-    }
-
-    protected void onContentsChanged(int slot) {
-
-    }
+    protected void onContentsChanged(int slot) {}
 }

--- a/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java
@@ -51,9 +51,7 @@ public class SlotItemHandler extends Slot {
     }
 
     @Override
-    public void onQuickCraft(@NotNull ItemStack oldStackIn, @NotNull ItemStack newStackIn) {
-
-    }
+    public void onQuickCraft(@NotNull ItemStack oldStackIn, @NotNull ItemStack newStackIn) {}
 
     @Override
     public int getMaxStackSize() {

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/CombinedInvWrapper.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 
 // combines multiple IItemHandlerModifiable into one interface
 public class CombinedInvWrapper implements IItemHandlerModifiable {
-
     protected final IItemHandlerModifiable[] itemHandler; // the handlers
     protected final int[] baseIndex; // index-offsets of the different handlers
     protected final int slotCount; // number of total slots

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/InvWrapper.java
@@ -28,7 +28,6 @@ public class InvWrapper implements IItemHandlerModifiable {
         InvWrapper that = (InvWrapper) o;
 
         return getInv().equals(that.getInv());
-
     }
 
     @Override
@@ -115,7 +114,6 @@ public class InvWrapper implements IItemHandlerModifiable {
                 return ItemStack.EMPTY;
             }
         }
-
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/RangedWrapper.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
  * Shifting of slot indices is handled automatically for you.
  */
 public class RangedWrapper implements IItemHandlerModifiable {
-
     private final IItemHandlerModifiable compose;
     private final int minSlot;
     private final int maxSlot;
@@ -90,5 +89,4 @@ public class RangedWrapper implements IItemHandlerModifiable {
     private boolean checkSlot(int localSlot) {
         return localSlot + minSlot < maxSlot;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/RecipeWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/RecipeWrapper.java
@@ -11,7 +11,6 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
 
 public class RecipeWrapper implements Container {
-
     protected final IItemHandlerModifiable inv;
 
     public RecipeWrapper(IItemHandlerModifiable inv) {
@@ -101,5 +100,4 @@ public class RecipeWrapper implements Container {
 
     @Override
     public void stopOpen(Player player) {}
-
 }

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
 public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable {
-
     private final ItemStack stack;
 
     private CompoundTag cachedTag;

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/SidedInvWrapper.java
@@ -155,7 +155,6 @@ public class SidedInvWrapper implements IItemHandlerModifiable {
                 return ItemStack.EMPTY;
             }
         }
-
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
+++ b/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
@@ -24,7 +24,6 @@ import net.neoforged.neoforgespi.language.IModInfo;
 import org.apache.logging.log4j.Logger;
 
 public class CrashReportExtender {
-
     public static void extendSystemReport(final SystemReport systemReport) {
         for (final ISystemReportExtender call : CrashReportCallables.allCrashCallables()) {
             if (call.isActive()) {

--- a/src/main/java/net/neoforged/neoforge/logging/PacketDump.java
+++ b/src/main/java/net/neoforged/neoforge/logging/PacketDump.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.logging;
 import io.netty.buffer.ByteBuf;
 
 public class PacketDump {
-
     public static String getContentDump(ByteBuf buffer) {
         int currentLength = buffer.readableBytes();
         StringBuffer returnString = new StringBuffer((currentLength * 3) + // The
@@ -67,6 +66,5 @@ public class PacketDump {
         returnString.append("Length: " + currentLength);
 
         return returnString.toString();
-
     }
 }

--- a/src/main/java/net/neoforged/neoforge/logging/ThreadInfoUtil.java
+++ b/src/main/java/net/neoforged/neoforge/logging/ThreadInfoUtil.java
@@ -10,7 +10,6 @@ import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 
 public class ThreadInfoUtil {
-
     public static String getEntireStacktrace(ThreadInfo threadInfo) {
         StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
                 (threadInfo.isDaemon() ? " daemon" : "") +

--- a/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.ApiStatus;
 @Mod.EventBusSubscriber(modid = "neoforge", bus = Mod.EventBusSubscriber.Bus.MOD)
 @ApiStatus.Internal
 public class ConfigurationInitialization {
-
     @SubscribeEvent
     private static void configureModdedClient(OnGameConfigurationEvent event) {
         if (!event.getListener().isVanillaConnection()) {

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.ApiStatus;
 @Mod.EventBusSubscriber(modid = NeoForgeVersion.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 @ApiStatus.Internal
 public class NetworkInitialization {
-
     @SubscribeEvent
     private static void register(final RegisterPayloadHandlerEvent event) {
         final IPayloadRegistrar registrar = event.registrar(NeoForgeVersion.MOD_ID)

--- a/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
+++ b/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
@@ -83,7 +83,6 @@ public class PacketDistributor<T> {
     public static final PacketDistributor<LevelChunk> TRACKING_CHUNK = new PacketDistributor<>(PacketDistributor::trackingChunk, PacketFlow.CLIENTBOUND);
 
     public static final class TargetPoint {
-
         private final ServerPlayer excluded;
         private final double x;
         private final double y;
@@ -142,7 +141,6 @@ public class PacketDistributor<T> {
             TargetPoint tp = new TargetPoint(x, y, z, r2, dim);
             return () -> tp;
         }
-
     }
 
     /**
@@ -183,7 +181,6 @@ public class PacketDistributor<T> {
         public PacketFlow flow() {
             return distributor.flow;
         }
-
     }
 
     private final BiFunction<PacketDistributor<T>, T, Consumer<Packet<?>>> functor;

--- a/src/main/java/net/neoforged/neoforge/network/bundle/BundlePacketUtils.java
+++ b/src/main/java/net/neoforged/neoforge/network/bundle/BundlePacketUtils.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public class BundlePacketUtils {
-
     private BundlePacketUtils() {
         throw new IllegalStateException("Tried to create utility class!");
     }

--- a/src/main/java/net/neoforged/neoforge/network/bundle/PacketAndPayloadAcceptor.java
+++ b/src/main/java/net/neoforged/neoforge/network/bundle/PacketAndPayloadAcceptor.java
@@ -12,7 +12,6 @@ import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 
 public class PacketAndPayloadAcceptor<L extends ClientCommonPacketListener> {
-
     private final Consumer<Packet<? super L>> consumer;
 
     public PacketAndPayloadAcceptor(Consumer<Packet<? super L>> consumer) {

--- a/src/main/java/net/neoforged/neoforge/network/configuration/ICustomConfigurationTask.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/ICustomConfigurationTask.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  */
 public interface ICustomConfigurationTask extends ConfigurationTask {
-
     /**
      * Invoked when it is time for this configuration to run.
      *

--- a/src/main/java/net/neoforged/neoforge/network/connection/ConnectionUtils.java
+++ b/src/main/java/net/neoforged/neoforge/network/connection/ConnectionUtils.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.ApiStatus;
  * Utility class for storing and retrieving {@link Connection} objects from {@link ChannelHandlerContext} objects.
  */
 public class ConnectionUtils {
-
     private ConnectionUtils() {
         throw new IllegalStateException("Tried to create utility class!");
     }

--- a/src/main/java/net/neoforged/neoforge/network/event/OnGameConfigurationEvent.java
+++ b/src/main/java/net/neoforged/neoforge/network/event/OnGameConfigurationEvent.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.ApiStatus;
  * that should be run on the server to configure the client.
  */
 public class OnGameConfigurationEvent extends Event implements IModBusEvent {
-
     private final ServerConfigurationPacketListener listener;
 
     private final Queue<ICustomConfigurationTask> configurationTasks = new LinkedList<>();

--- a/src/main/java/net/neoforged/neoforge/network/event/RegisterPayloadHandlerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/network/event/RegisterPayloadHandlerEvent.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.ApiStatus;
  * </p>
  */
 public class RegisterPayloadHandlerEvent extends Event implements IModBusEvent {
-
     private final Function<String, IPayloadRegistrar> registrarFactory;
 
     @ApiStatus.Internal

--- a/src/main/java/net/neoforged/neoforge/network/filters/CommandTreeCleaner.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/CommandTreeCleaner.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 class CommandTreeCleaner {
-
     /**
      * Cleans the command tree starting at the given root node from any argument types that do not match the given predicate.
      * Any {@code ArgumentCommandNode}s that have an unmatched argument type will be stripped from the tree.
@@ -57,5 +56,4 @@ class CommandTreeCleaner {
             return builder.build();
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/network/filters/DynamicChannelHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/DynamicChannelHandler.java
@@ -16,6 +16,5 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public interface DynamicChannelHandler extends ChannelHandler {
-
     boolean isNecessary(Connection manager);
 }

--- a/src/main/java/net/neoforged/neoforge/network/filters/GenericPacketSplitter.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/GenericPacketSplitter.java
@@ -42,7 +42,6 @@ import org.jetbrains.annotations.ApiStatus;
 @Mod.EventBusSubscriber(modid = NeoForgeVersion.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 @ApiStatus.Internal
 public class GenericPacketSplitter extends MessageToMessageEncoder<Packet<?>> implements DynamicChannelHandler {
-
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final int MAX_PACKET_SIZE = CompressionDecoder.MAXIMUM_UNCOMPRESSED_LENGTH;

--- a/src/main/java/net/neoforged/neoforge/network/filters/NetworkFilters.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/NetworkFilters.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public class NetworkFilters {
-
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final Map<String, Function<Connection, DynamicChannelHandler>> instances = ImmutableMap.of(
@@ -57,5 +56,4 @@ public class NetworkFilters {
     }
 
     private NetworkFilters() {}
-
 }

--- a/src/main/java/net/neoforged/neoforge/network/filters/VanillaPacketFilter.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/VanillaPacketFilter.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
  * A filter for vanilla impl packets.
  */
 public abstract class VanillaPacketFilter extends MessageToMessageEncoder<Packet<?>> implements DynamicChannelHandler {
-
     protected final Map<Class<? extends Packet<?>>, BiConsumer<Packet<?>, List<? super Packet<?>>>> handlers;
 
     protected VanillaPacketFilter(Map<Class<? extends Packet<?>>, BiConsumer<Packet<?>, List<? super Packet<?>>>> handlers) {
@@ -53,5 +52,4 @@ public abstract class VanillaPacketFilter extends MessageToMessageEncoder<Packet
         BiConsumer<Packet<?>, List<? super Packet<?>>> consumer = handlers.getOrDefault(msg.getClass(), (pkt, list) -> list.add(pkt));
         consumer.accept(msg, out);
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -44,7 +44,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public class ClientPayloadHandler {
-
     private static final ClientPayloadHandler INSTANCE = new ClientPayloadHandler();
 
     public static ClientPayloadHandler getInstance() {

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ServerPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ServerPayloadHandler.java
@@ -14,7 +14,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public class ServerPayloadHandler {
-
     private static final ServerPayloadHandler INSTANCE = new ServerPayloadHandler();
 
     public static ServerPayloadHandler getInstance() {

--- a/src/main/java/net/neoforged/neoforge/network/handling/IConfigurationPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IConfigurationPayloadHandler.java
@@ -14,7 +14,6 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
  */
 @FunctionalInterface
 public interface IConfigurationPayloadHandler<T extends CustomPacketPayload> {
-
     /**
      * Invoked to handle the given payload in the given context.
      *

--- a/src/main/java/net/neoforged/neoforge/network/handling/IPacketHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IPacketHandler.java
@@ -14,7 +14,6 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
  * Allows for the handling of full packets from custom payloads
  */
 public interface IPacketHandler {
-
     /**
      * Invoked to handle the given packet.
      *

--- a/src/main/java/net/neoforged/neoforge/network/handling/IPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IPayloadHandler.java
@@ -14,7 +14,6 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
  */
 @FunctionalInterface
 public interface IPayloadHandler<T extends CustomPacketPayload> {
-
     /**
      * Invoked to handle the given payload in the given context.
      *

--- a/src/main/java/net/neoforged/neoforge/network/handling/IPlayPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IPlayPayloadHandler.java
@@ -14,7 +14,6 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
  */
 @FunctionalInterface
 public interface IPlayPayloadHandler<T extends CustomPacketPayload> {
-
     /**
      * Invoked to handle the given payload in the given context.
      *

--- a/src/main/java/net/neoforged/neoforge/network/handling/IReplyHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IReplyHandler.java
@@ -12,7 +12,6 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
  */
 @FunctionalInterface
 public interface IReplyHandler {
-
     /**
      * Sends the given payload back to the player.
      *

--- a/src/main/java/net/neoforged/neoforge/network/handling/ISynchronizedWorkHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ISynchronizedWorkHandler.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
  * Defines a replyHandler which can accept work that needs to be run synchronously, on the main thread of the game.
  */
 public interface ISynchronizedWorkHandler {
-
     /**
      * Executes a task on the main thread of the game.
      * <p>

--- a/src/main/java/net/neoforged/neoforge/network/handling/ITaskCompletedHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ITaskCompletedHandler.java
@@ -12,7 +12,6 @@ import net.minecraft.server.network.ConfigurationTask;
  */
 @FunctionalInterface
 public interface ITaskCompletedHandler {
-
     /**
      * Called when a task is completed.
      *

--- a/src/main/java/net/neoforged/neoforge/network/negotiation/NetworkComponentNegotiator.java
+++ b/src/main/java/net/neoforged/neoforge/network/negotiation/NetworkComponentNegotiator.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.VisibleForTesting;
  */
 @ApiStatus.Internal
 public class NetworkComponentNegotiator {
-
     /**
      * Negotiates the network components between the server and client.
      * <p>

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedAddEntityPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedAddEntityPayload.java
@@ -29,7 +29,6 @@ public record AdvancedAddEntityPayload(
      * The id of this payload.
      */
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_add_entity");
-
     public AdvancedAddEntityPayload(FriendlyByteBuf buf) {
         this(
                 buf.readVarInt(),

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
@@ -33,7 +33,6 @@ public record AdvancedOpenScreenPayload(
         byte[] additionalData) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_open_screen");
-
     public AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Component name, Consumer<FriendlyByteBuf> dataWriter) {
         this(windowId, menuType, name, FriendlyByteBufUtil.writeCustomData(dataWriter));
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AuxiliaryLightDataPayload.java
@@ -17,7 +17,6 @@ import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 public record AuxiliaryLightDataPayload(ChunkPos pos, Map<BlockPos, Byte> entries) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "auxiliary_light_data");
-
     public AuxiliaryLightDataPayload(FriendlyByteBuf buf) {
         this(buf.readChunkPos(), buf.readMap(FriendlyByteBuf::readBlockPos, FriendlyByteBuf::readByte));
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/ConfigFilePayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ConfigFilePayload.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.ApiStatus;
 public record ConfigFilePayload(byte[] contents, String fileName) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "config_file");
-
     public ConfigFilePayload(FriendlyByteBuf buf) {
         this(buf.readByteArray(), buf.readUtf());
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/FrozenRegistryPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/FrozenRegistryPayload.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
 public record FrozenRegistryPayload(ResourceLocation registryName, RegistrySnapshot snapshot) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "frozen_registry");
-
     public FrozenRegistryPayload(FriendlyByteBuf buf) {
         this(buf.readResourceLocation(), new RegistrySnapshot(buf));
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkComponent.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkComponent.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record ModdedNetworkComponent(ResourceLocation id, Optional<String> version) {
-
     public ModdedNetworkComponent(FriendlyByteBuf buf) {
         this(buf.readResourceLocation(), buf.readOptional(FriendlyByteBuf::readUtf));
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkPayload.java
@@ -24,7 +24,6 @@ public record ModdedNetworkPayload(Set<ModdedNetworkComponent> configuration, Se
 
     public static final ResourceLocation ID = new ResourceLocation("network");
     public static final FriendlyByteBuf.Reader<? extends CustomPacketPayload> READER = ModdedNetworkPayload::new;
-
     public ModdedNetworkPayload(FriendlyByteBuf buf) {
         this(buf.readCollection(HashSet::new, ModdedNetworkComponent::new), buf.readCollection(HashSet::new, ModdedNetworkComponent::new));
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryComponent.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryComponent.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record ModdedNetworkQueryComponent(ResourceLocation id, Optional<String> version, Optional<PacketFlow> flow, boolean optional) {
-
     public ModdedNetworkQueryComponent(FriendlyByteBuf buf) {
         this(
                 buf.readResourceLocation(),

--- a/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryPayload.java
@@ -24,7 +24,6 @@ public record ModdedNetworkQueryPayload(Set<ModdedNetworkQueryComponent> configu
 
     public static final ResourceLocation ID = new ResourceLocation("register");
     public static final FriendlyByteBuf.Reader<? extends CustomPacketPayload> READER = ModdedNetworkQueryPayload::new;
-
     public ModdedNetworkQueryPayload() {
         this(Set.of(), Set.of());
     }

--- a/src/main/java/net/neoforged/neoforge/network/registration/ConfigurationPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/ConfigurationPayloadHandler.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
  */
 @ApiStatus.Internal
 public final class ConfigurationPayloadHandler<T extends CustomPacketPayload> implements IConfigurationPayloadHandler<T> {
-
     @Nullable
     private final IConfigurationPayloadHandler<T> clientSide;
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/network/registration/IDirectionAwarePayloadHandlerBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/IDirectionAwarePayloadHandlerBuilder.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
  * @param <T> The type of handler.
  */
 public interface IDirectionAwarePayloadHandlerBuilder<P extends CustomPacketPayload, T> {
-
     /**
      * Sets the client side handler.
      *

--- a/src/main/java/net/neoforged/neoforge/network/registration/IPayloadRegistrar.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/IPayloadRegistrar.java
@@ -78,7 +78,6 @@ import net.neoforged.neoforge.network.handling.PlayPayloadContext;
  * </p>
  */
 public interface IPayloadRegistrar {
-
     /**
      * Registers a new payload type for the play phase.
      *

--- a/src/main/java/net/neoforged/neoforge/network/registration/ModdedPacketRegistrar.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/ModdedPacketRegistrar.java
@@ -22,7 +22,6 @@ import net.neoforged.neoforge.network.handling.IPlayPayloadHandler;
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 class ModdedPacketRegistrar implements IPayloadRegistrar {
-
     private final String modId;
     private final Map<ResourceLocation, ConfigurationRegistration<?>> configurationPayloads;
     private final Map<ResourceLocation, PlayRegistration<?>> playPayloads;

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkPayloadSetup.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkPayloadSetup.java
@@ -24,7 +24,6 @@ public record NetworkPayloadSetup(
         Map<ResourceLocation, NetworkChannel> configuration,
         Map<ResourceLocation, NetworkChannel> play,
         boolean vanilla) {
-
     /**
      * {@return An empty modded network.}
      */

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -76,7 +76,6 @@ import org.slf4j.Logger;
  */
 @ApiStatus.Internal
 public class NetworkRegistry {
-
     private static final Logger LOGGER = LogUtils.getLogger();
 
     private static final AttributeKey<NetworkPayloadSetup> ATTRIBUTE_PAYLOAD_SETUP = AttributeKey.valueOf("neoforge:payload_setup");
@@ -253,7 +252,6 @@ public class NetworkRegistry {
             LOGGER.error("Received a modded custom payload packet from a client that is not in the configuration or play phase. Not parsing packet.");
             throw new IllegalStateException("A client sent a packet while not in the configuration or play phase. Somebody changed the phases known to NeoForge!");
         }
-
     }
 
     /**
@@ -869,7 +867,6 @@ public class NetworkRegistry {
     @SuppressWarnings("resource")
     private record EventLoopSynchronizedWorkHandler<T>(
             ReentrantBlockableEventLoop<?> eventLoop, T payload) implements ISynchronizedWorkHandler {
-
         private static final Logger LOGGER = LogUtils.getLogger();
 
         /**
@@ -903,7 +900,6 @@ public class NetworkRegistry {
 
     @SuppressWarnings("unchecked")
     private record ServerPacketHandler(ServerCommonPacketListener listener) implements IPacketHandler {
-
         @Override
         public void handle(Packet<?> packet) {
             resolvePacketGenerics(packet, listener());
@@ -930,7 +926,6 @@ public class NetworkRegistry {
 
     @SuppressWarnings("unchecked")
     private record ClientPacketHandler(ClientCommonPacketListener listener) implements IPacketHandler {
-
         @Override
         public void handle(Packet<?> packet) {
             resolvePacketGenerics(packet, listener());
@@ -954,5 +949,4 @@ public class NetworkRegistry {
             }
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/network/registration/PlayPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/PlayPayloadHandler.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
  */
 @ApiStatus.Internal
 final class PlayPayloadHandler<T extends CustomPacketPayload> implements IPlayPayloadHandler<T> {
-
     @Nullable
     private final IPlayPayloadHandler<T> clientSide;
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/network/registration/RegistrationFailedException.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/RegistrationFailedException.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.ApiStatus;
  * </p>
  */
 public class RegistrationFailedException extends RuntimeException {
-
     private final ResourceLocation id;
     private final String namespace;
     private final Reason reason;
@@ -135,7 +134,6 @@ public class RegistrationFailedException extends RuntimeException {
      */
     @FunctionalInterface
     private interface ReasonFormatter {
-
         /**
          * Creates a nice error message for the given parameters.
          *

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredBlock.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredBlock.java
@@ -18,7 +18,6 @@ import net.minecraft.world.level.block.Block;
  * @param <T> The specific {@link Block} type.
  */
 public class DeferredBlock<T extends Block> extends DeferredHolder<Block, T> implements ItemLike {
-
     /**
      * Creates a new {@link DeferredHolder} targeting the {@link Block} with the specified name.
      *

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredItem.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredItem.java
@@ -17,7 +17,6 @@ import net.minecraft.world.level.ItemLike;
  * @param <T> The specific {@link Item} type.
  */
 public class DeferredItem<T extends Item> extends DeferredHolder<Item, T> implements ItemLike {
-
     /**
      * Creates a new {@link DeferredHolder} targeting the {@link Item} with the specified name.
      *

--- a/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
@@ -115,5 +115,4 @@ public interface IRegistryExtension<T> {
      * @param value the object whose existence to check for
      */
     boolean containsValue(T value);
-
 }

--- a/src/main/java/net/neoforged/neoforge/registries/NewRegistryEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NewRegistryEvent.java
@@ -73,5 +73,4 @@ public class NewRegistryEvent extends Event implements IModBusEvent {
 
         ((WritableRegistry) BuiltInRegistries.REGISTRY).register(registry.key(), registry, Lifecycle.stable());
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
@@ -233,5 +233,4 @@ public class ResourcePackLoader {
             return i2 - i1;
         };
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/server/LanguageHook.java
+++ b/src/main/java/net/neoforged/neoforge/server/LanguageHook.java
@@ -80,7 +80,6 @@ public class LanguageHook {
                 LOGGER.warn("Skipped language file: {}:{}", namespace, langFile, exception);
             }
         });
-
     }
 
     public static void loadForgeAndMCLangs() {

--- a/src/main/java/net/neoforged/neoforge/server/command/EntityCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/EntityCommand.java
@@ -121,5 +121,4 @@ class EntityCommand {
             }
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/server/command/ModListCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/ModListCommand.java
@@ -31,5 +31,4 @@ class ModListCommand {
                     return 0;
                 });
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/server/console/ConsoleCommandCompleter.java
+++ b/src/main/java/net/neoforged/neoforge/server/console/ConsoleCommandCompleter.java
@@ -63,5 +63,4 @@ final class ConsoleCommandCompleter implements Completer {
             logger.error("Failed to tab complete", e);
         }
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/server/console/TerminalHandler.java
+++ b/src/main/java/net/neoforged/neoforge/server/console/TerminalHandler.java
@@ -15,7 +15,6 @@ import org.jline.reader.UserInterruptException;
 import org.jline.terminal.Terminal;
 
 public final class TerminalHandler {
-
     private TerminalHandler() {}
 
     public static boolean handleCommands(DedicatedServer server) {
@@ -59,5 +58,4 @@ public final class TerminalHandler {
 
         return true;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/server/permission/events/PermissionGatherEvent.java
+++ b/src/main/java/net/neoforged/neoforge/server/permission/events/PermissionGatherEvent.java
@@ -29,7 +29,6 @@ import net.neoforged.neoforge.server.permission.nodes.PermissionNode;
  * <p><strong>Note:</strong> All PermissionNodes that you want to use, <strong>must</strong> be registered!</p>
  */
 public abstract class PermissionGatherEvent extends Event {
-
     /**
      * Used to register a new PermissionHandler, a server config value exists to choose which one to use.
      * <p>Note: Create a new instance when registering a PermissionHandler.

--- a/src/main/java/net/neoforged/neoforge/server/permission/nodes/PermissionType.java
+++ b/src/main/java/net/neoforged/neoforge/server/permission/nodes/PermissionType.java
@@ -48,5 +48,4 @@ public final class PermissionType<T> {
                 "typeToken=" + typeToken + ", " +
                 "typeName=" + typeName + ']';
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/server/timings/ObjectTimings.java
+++ b/src/main/java/net/neoforged/neoforge/server/timings/ObjectTimings.java
@@ -14,7 +14,6 @@ import java.lang.ref.WeakReference;
  * @param <T>
  */
 public class ObjectTimings<T> {
-
     private WeakReference<T> object;
 
     private int[] rawTimingData;

--- a/src/main/java/net/neoforged/neoforge/server/timings/TimeTracker.java
+++ b/src/main/java/net/neoforged/neoforge/server/timings/TimeTracker.java
@@ -20,7 +20,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
  * @param <T>
  */
 public class TimeTracker<T> {
-
     /**
      * A tracker for timing tile entity update
      */

--- a/testframework/src/main/java/net/neoforged/testframework/TestFramework.java
+++ b/testframework/src/main/java/net/neoforged/testframework/TestFramework.java
@@ -155,5 +155,4 @@ public interface TestFramework {
          */
         void addListener(TestListener listener);
     }
-
 }

--- a/testframework/src/main/java/net/neoforged/testframework/annotation/ForEachTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/annotation/ForEachTest.java
@@ -22,7 +22,6 @@ import net.neoforged.testframework.TestListener;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ForEachTest {
     ForEachTest DEFAULT = new ForEachTest() {
-
         @Override
         public Class<? extends Annotation> annotationType() {
             return ForEachTest.class;

--- a/testframework/src/main/java/net/neoforged/testframework/client/AbstractTestScreen.java
+++ b/testframework/src/main/java/net/neoforged/testframework/client/AbstractTestScreen.java
@@ -337,5 +337,4 @@ public abstract class AbstractTestScreen extends Screen {
             }
         }
     }
-
 }

--- a/testframework/src/main/java/net/neoforged/testframework/client/FrameworkClientImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/client/FrameworkClientImpl.java
@@ -63,7 +63,6 @@ public class FrameworkClientImpl implements FrameworkClient {
     }
 
     public static final class Factory implements FrameworkClient.Factory {
-
         @Override
         public FrameworkClient create(MutableTestFramework impl, ClientConfiguration clientConfiguration) {
             return new FrameworkClientImpl(impl, clientConfiguration);

--- a/testframework/src/main/java/net/neoforged/testframework/condition/TestEnabledLootCondition.java
+++ b/testframework/src/main/java/net/neoforged/testframework/condition/TestEnabledLootCondition.java
@@ -20,7 +20,6 @@ public record TestEnabledLootCondition(TestFramework framework, String testId) i
     public static final Codec<TestEnabledLootCondition> CODEC = RecordCodecBuilder.create(in -> in.group(
             MutableTestFramework.REFERENCE_CODEC.fieldOf("framework").forGetter(TestEnabledLootCondition::framework),
             Codec.STRING.fieldOf("test").forGetter(TestEnabledLootCondition::testId)).apply(in, TestEnabledLootCondition::new));
-
     public TestEnabledLootCondition(DynamicTest test) {
         this(test.framework(), test.id());
     }

--- a/testframework/src/main/java/net/neoforged/testframework/conf/ClientConfiguration.java
+++ b/testframework/src/main/java/net/neoforged/testframework/conf/ClientConfiguration.java
@@ -15,7 +15,6 @@ public record ClientConfiguration(int toggleOverlayKey, int openManagerKey) {
     public static Builder builder() {
         return new Builder();
     }
-
     public static final class Builder {
         private int toggleOverlayKey;
         private int openManagerKey;

--- a/testframework/src/main/java/net/neoforged/testframework/conf/FrameworkConfiguration.java
+++ b/testframework/src/main/java/net/neoforged/testframework/conf/FrameworkConfiguration.java
@@ -35,7 +35,6 @@ public record FrameworkConfiguration(
     public MutableTestFramework create() {
         return new TestFrameworkImpl(this);
     }
-
     public static final class Builder {
         private final ResourceLocation id;
         private final Collection<Feature> features = EnumSet.noneOf(Feature.class);

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -262,9 +262,7 @@ public class ExtendedGameTestHelper extends GameTestHelper {
     public void addEndListener(Consumer<Boolean> listener) {
         testInfo.addListener(new GameTestListener() {
             @Override
-            public void testStructureLoaded(GameTestInfo info) {
-
-            }
+            public void testStructureLoaded(GameTestInfo info) {}
 
             @Override
             public void testPassed(GameTestInfo info) {

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/GameTestPlayer.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/GameTestPlayer.java
@@ -65,9 +65,7 @@ public class GameTestPlayer extends ServerPlayer implements GameTestListener {
     }
 
     @Override
-    public void testStructureLoaded(GameTestInfo i) {
-
-    }
+    public void testStructureLoaded(GameTestInfo i) {}
 
     @Override
     public void testPassed(GameTestInfo i) {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/GameTestRegistration.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/GameTestRegistration.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class GameTestRegistration {
-
     public static final Method REGISTER_METHOD = LamdbaExceptionUtils.uncheck(() -> GameTestRegistration.class.getDeclaredMethod("register"));
 
     @GameTestGenerator
@@ -43,9 +42,7 @@ public final class GameTestRegistration {
                             rethrow(helper -> {
                                 ReflectionUtils.addListener(helper, new GameTestListener() {
                                     @Override
-                                    public void testStructureLoaded(GameTestInfo info) {
-
-                                    }
+                                    public void testStructureLoaded(GameTestInfo info) {}
 
                                     @Override
                                     public void testPassed(GameTestInfo info) {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/LoggerSetup.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/LoggerSetup.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 
 @ApiStatus.Internal
 public record LoggerSetup(MutableTestFramework framework) {
-
     /**
      * Set the {@link TestFramework#logger()} to only write to logs/tests/{@code id}.log, and to console.
      */

--- a/testframework/src/main/java/net/neoforged/testframework/impl/ReflectionUtils.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/ReflectionUtils.java
@@ -21,7 +21,6 @@ import net.minecraft.gametest.framework.GameTestListener;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public final class ReflectionUtils {
-
     public static <T> T getInstanceField(Object instance, String name) {
         try {
             final Field field = instance.getClass().getDeclaredField(name);

--- a/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
@@ -512,5 +512,4 @@ public class TestFrameworkImpl implements MutableTestFramework {
     public static String capitaliseWords(String string, String splitOn) {
         return Stream.of(string.split(splitOn)).map(StringUtils::capitalize).collect(Collectors.joining(" "));
     }
-
 }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/md/Table.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/md/Table.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 
 public final class Table {
-
     public static final String SEPARATOR = "|";
     public static final String WHITESPACE = " ";
     public static final String DEFAULT_TRIMMING_INDICATOR = "~";
@@ -31,7 +30,6 @@ public final class Table {
     }
 
     public static final class Builder {
-
         private List<TableRow<?>> rows = new ArrayList<>();
         private List<Alignment> alignments = new ArrayList<>();
         private boolean firstRowIsHeader = true;
@@ -250,5 +248,4 @@ public final class Table {
     public static String surroundWith(String value, String surrounding) {
         return surrounding + value + surrounding;
     }
-
 }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/md/TableRow.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/md/TableRow.java
@@ -10,7 +10,6 @@ import java.util.Iterator;
 import java.util.List;
 
 public class TableRow<T> {
-
     private final List<T> columns;
 
     public TableRow() {
@@ -49,5 +48,4 @@ public class TableRow<T> {
     public List<T> getColumns() {
         return columns;
     }
-
 }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeEnabledPayload.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeEnabledPayload.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 public record ChangeEnabledPayload(MutableTestFramework framework, String testId, boolean enabled) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation("neoforge", "tf_change_enabled");
-
     public void handle(PlayPayloadContext context) {
         switch (context.flow().getReceptionSide()) {
             case CLIENT -> {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeStatusPayload.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeStatusPayload.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 public record ChangeStatusPayload(MutableTestFramework framework, String testId, Test.Status status) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation("neoforge", "tf_change_status");
-
     @Override
     public void write(FriendlyByteBuf buf) {
         buf.writeUtf(testId);

--- a/testframework/src/main/java/net/neoforged/testframework/impl/packet/TestFrameworkPayloadInitialization.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/packet/TestFrameworkPayloadInitialization.java
@@ -14,10 +14,8 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public record TestFrameworkPayloadInitialization(MutableTestFramework framework) {
-
     @SubscribeEvent
     public void onNetworkSetup(final RegisterPayloadHandlerEvent event) {
-
         final IPayloadRegistrar registrar = event.registrar(NeoForgeVersion.MOD_ID);
 
         registrar.play(ChangeStatusPayload.ID, buf -> ChangeStatusPayload.decode(framework, buf), (payload, context) -> context.workHandler().submitAsync(() -> payload.handle(context)));

--- a/testframework/src/main/java/net/neoforged/testframework/impl/reg/RegistrationHelperImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/reg/RegistrationHelperImpl.java
@@ -43,7 +43,6 @@ import net.neoforged.testframework.registration.DeferredItems;
 import net.neoforged.testframework.registration.RegistrationHelper;
 
 public class RegistrationHelperImpl implements RegistrationHelper {
-
     public RegistrationHelperImpl(String modId) {
         this.modId = modId;
     }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/MethodBasedGameTestTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/MethodBasedGameTestTest.java
@@ -41,5 +41,4 @@ public class MethodBasedGameTestTest extends AbstractTest.Dynamic {
             }
         });
     }
-
 }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/MethodBasedTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/MethodBasedTest.java
@@ -41,5 +41,4 @@ public class MethodBasedTest extends AbstractTest.Dynamic {
             throw new RuntimeException("Encountered exception initiating method-based test: " + method, e);
         }
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEntityTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEntityTests.java
@@ -93,5 +93,4 @@ public class BlockEntityTests {
                 .thenExecuteAfter(5, () -> helper.assertTrue(((TestBlockEntity) helper.getBlockEntity(new BlockPos(1, 2, 1))).loaded, "BE wasn't loaded!"))
                 .thenSucceed());
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -30,7 +30,6 @@ import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 
 @ForEachTest(groups = { BlockTests.GROUP + ".event", "event" })
 public class BlockEventTests {
-
     @GameTest(template = TestsMod.TEMPLATE_3x3)
     @TestHolder(description = "Tests if the entity place event is fired")
     public static void entityPlacedEvent(final DynamicTest test) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
@@ -41,7 +41,6 @@ import net.neoforged.testframework.registration.RegistrationHelper;
 
 @ForEachTest(groups = BlockTests.GROUP + ".properties")
 public class BlockPropertyTests {
-
     @GameTest
     @TestHolder(description = "Adds a toggleable light source to test if level-sensitive light emission works")
     static void levelSensitiveLight(final DynamicTest test, final RegistrationHelper reg) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/chat/CommandTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/chat/CommandTests.java
@@ -37,7 +37,6 @@ import org.jetbrains.annotations.Nullable;
 
 @ForEachTest(groups = "chat.command")
 public class CommandTests {
-
     @GameTest
     @EmptyTemplate
     @TestHolder(description = { "Tests if the command event works", "Redirects /attribute with no arguments to effect" })
@@ -113,7 +112,6 @@ public class CommandTests {
     }
 
     public final static class ErrorCatchingStack extends CommandSourceStack {
-
         public static ErrorCatchingStack createCommandSourceStack(Player player, int perm) {
             return new ErrorCatchingStack(
                     player,

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
@@ -83,57 +83,39 @@ public class EntityTests {
     }
 
     public static final class CustomComplexSpawnEntity extends Entity implements IEntityWithComplexSpawn {
-
         public CustomComplexSpawnEntity(EntityType<?> type, Level level) {
             super(type, level);
         }
 
         @Override
-        protected void defineSynchedData() {
-
-        }
+        protected void defineSynchedData() {}
 
         @Override
-        protected void readAdditionalSaveData(@NotNull CompoundTag tag) {
-
-        }
+        protected void readAdditionalSaveData(@NotNull CompoundTag tag) {}
 
         @Override
-        protected void addAdditionalSaveData(@NotNull CompoundTag tag) {
-
-        }
+        protected void addAdditionalSaveData(@NotNull CompoundTag tag) {}
 
         @Override
-        public void writeSpawnData(FriendlyByteBuf buffer) {
-
-        }
+        public void writeSpawnData(FriendlyByteBuf buffer) {}
 
         @Override
-        public void readSpawnData(FriendlyByteBuf additionalData) {
-
-        }
+        public void readSpawnData(FriendlyByteBuf additionalData) {}
     }
 
     public static final class AdaptedSpawnEntity extends Entity {
-
         public AdaptedSpawnEntity(EntityType<?> type, Level level) {
             super(type, level);
         }
 
         @Override
-        protected void defineSynchedData() {
-
-        }
+        protected void defineSynchedData() {}
 
         @Override
-        protected void readAdditionalSaveData(@NotNull CompoundTag tag) {
-
-        }
+        protected void readAdditionalSaveData(@NotNull CompoundTag tag) {}
 
         @Override
-        protected void addAdditionalSaveData(@NotNull CompoundTag tag) {
-
-        }
+        protected void addAdditionalSaveData(@NotNull CompoundTag tag) {}
 
         @Override
         public void sendPairingData(ServerPlayer serverPlayer, Consumer<CustomPacketPayload> bundleBuilder) {
@@ -142,29 +124,21 @@ public class EntityTests {
     }
 
     public static final class SimpleEntity extends Entity {
-
         public SimpleEntity(EntityType<?> type, Level level) {
             super(type, level);
         }
 
         @Override
-        protected void defineSynchedData() {
-
-        }
+        protected void defineSynchedData() {}
 
         @Override
-        protected void readAdditionalSaveData(@NotNull CompoundTag tag) {
-
-        }
+        protected void readAdditionalSaveData(@NotNull CompoundTag tag) {}
 
         @Override
-        protected void addAdditionalSaveData(@NotNull CompoundTag tag) {
-
-        }
+        protected void addAdditionalSaveData(@NotNull CompoundTag tag) {}
     }
 
     public record CustomSyncPayload() implements CustomPacketPayload {
-
         private static final ResourceLocation ID = new ResourceLocation("test", "custom_sync_payload");
 
         public CustomSyncPayload(FriendlyByteBuf buf) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
@@ -96,7 +96,6 @@ public class PlayerEventTests {
                         Direction.UP))
                 .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DIRT, 1, 2, 1))
                 .thenSucceed());
-
     }
 
     @GameTest

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -125,7 +125,6 @@ public class ItemTests {
                 }).withRenderer(() -> PigRenderer::new).withLang("Test Pig spawn egg");
 
         final var egg = reg.items().register("test_spawn_egg", () -> new DeferredSpawnEggItem(testEntity, 0x0000FF, 0xFF0000, new Item.Properties()) {
-
             @Override
             public InteractionResult useOn(UseOnContext ctx) {
                 final var result = super.useOn(ctx);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
@@ -940,7 +940,6 @@ public class DataGeneratorTest {
     }
 
     private static class Advancements implements AdvancementProvider.AdvancementGenerator {
-
         @Override
         public void generate(HolderLookup.Provider registries, Consumer<AdvancementHolder> saver, ExistingFileHelper existingFileHelper) {
             var obtainDirt = Advancement.Builder.advancement()
@@ -1008,7 +1007,6 @@ public class DataGeneratorTest {
     }
 
     private static class ParticleDescriptions extends ParticleDescriptionProvider {
-
         public ParticleDescriptions(PackOutput output, ExistingFileHelper fileHelper) {
             super(output, fileHelper);
         }
@@ -1026,7 +1024,6 @@ public class DataGeneratorTest {
                     new ResourceLocation("splash_3"));
 
             this.spriteSet(ParticleTypes.ENCHANT, () -> new Iterator<>() {
-
                 private final ResourceLocation base = new ResourceLocation("sga");
                 private char suffix = 'a';
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredHolderTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredHolderTest.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Logger;
  */
 @Mod(DeferredHolderTest.MODID)
 public class DeferredHolderTest {
-
     static final String MODID = "deferred_holder_test";
 
     private static final boolean ENABLED = true;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/ManyMobEffectsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/ManyMobEffectsTest.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.Logger;
  */
 @Mod(ManyMobEffectsTest.MODID)
 public class ManyMobEffectsTest {
-
     static final String MODID = "many_mob_effects_test";
 
     private static final boolean ENABLED = true;
@@ -110,5 +109,4 @@ public class ManyMobEffectsTest {
             }
         }
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
@@ -25,7 +25,6 @@ import net.neoforged.neoforge.data.event.GatherDataEvent;
 
 @Mod(RemoveTagDatagenTest.MODID)
 public class RemoveTagDatagenTest {
-
     public static final String MODID = "remove_tag_datagen_test";
     public static final TagKey<Block> TEST_TAG = BlockTags.create(new ResourceLocation("test_tag"));
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomSignsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomSignsTest.java
@@ -92,7 +92,6 @@ public class CustomSignsTest {
     }
 
     public static class CustomStandingSignBlock extends StandingSignBlock {
-
         public CustomStandingSignBlock(Properties propertiesIn, WoodType woodTypeIn) {
             super(woodTypeIn, propertiesIn);
         }
@@ -104,7 +103,6 @@ public class CustomSignsTest {
     }
 
     public static class CustomWallSignBlock extends WallSignBlock {
-
         public CustomWallSignBlock(Properties propertiesIn, WoodType woodTypeIn) {
             super(woodTypeIn, propertiesIn);
         }
@@ -127,7 +125,6 @@ public class CustomSignsTest {
     }
 
     public static class CustomCeilingHangingSignBlock extends CeilingHangingSignBlock {
-
         public CustomCeilingHangingSignBlock(Properties propertiesIn, WoodType woodTypeIn) {
             super(woodTypeIn, propertiesIn);
         }
@@ -139,7 +136,6 @@ public class CustomSignsTest {
     }
 
     public static class CustomWallHangingSignBlock extends WallHangingSignBlock {
-
         public CustomWallHangingSignBlock(Properties propertiesIn, WoodType woodTypeIn) {
             super(woodTypeIn, propertiesIn);
         }
@@ -151,7 +147,6 @@ public class CustomSignsTest {
     }
 
     public static class CustomHangingSignBlockEntity extends HangingSignBlockEntity {
-
         public CustomHangingSignBlockEntity(BlockPos pos, BlockState state) {
             super(pos, state);
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/RedstoneSidedConnectivityTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/RedstoneSidedConnectivityTest.java
@@ -51,7 +51,6 @@ public class RedstoneSidedConnectivityTest {
     private static class EastRedstoneBlock extends Block {
         //This block visually connect to redstone dust only on the east side
         //if a furnace block is placed on top of it
-
         public EastRedstoneBlock() {
             super(Properties.of());
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/ScaffoldingTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/ScaffoldingTest.java
@@ -63,7 +63,6 @@ public class ScaffoldingTest {
     }
 
     static class ScaffoldingMethodTestBlock extends ScaffoldingBlock {
-
         public ScaffoldingMethodTestBlock(Properties properties) {
             super(properties);
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomColorResolverTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomColorResolverTest.java
@@ -41,7 +41,6 @@ public class CustomColorResolverTest {
 
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
     private static class ClientHandler {
-
         private static final ColorResolver COLOR_RESOLVER = (biome, x, z) -> biome.getPrecipitationAt(BlockPos.containing(x, 0, z)) == Biome.Precipitation.NONE ? 0xFF0000 : 0x0000FF;
 
         @SubscribeEvent

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomSpriteSourceTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomSpriteSourceTest.java
@@ -77,7 +77,6 @@ public class CustomSpriteSourceTest {
         }
 
         static final class CustomSpriteContents extends SpriteContents {
-
             public CustomSpriteContents(ResourceLocation name, FrameSize size, NativeImage image, ResourceMetadata metadata) {
                 super(name, size, image, metadata);
             }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CustomItemDisplayContextTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CustomItemDisplayContextTest.java
@@ -144,7 +144,6 @@ public class CustomItemDisplayContextTest {
     }
 
     public static class BlockStateModels extends BlockStateProvider {
-
         public BlockStateModels(PackOutput output, ExistingFileHelper exFileHelper) {
             super(output, MODID, exFileHelper);
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
@@ -92,13 +92,11 @@ public class MegaModelTest {
 
     @Mod.EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
     public static class ClientEvents {
-
         @SubscribeEvent
         public static void onModelBakingCompleted(ModelEvent.ModifyBakingResult event) {
             var name = new ModelResourceLocation(MOD_ID, REG_NAME, "");
             event.getModels().computeIfPresent(name, (n, m) -> new TransformingModelWrapper(m));
         }
-
     }
 
     private static class TestBlock extends Block implements EntityBlock {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/EntityRendererEventsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/EntityRendererEventsTest.java
@@ -109,9 +109,7 @@ public class EntityRendererEventsTest {
             }
 
             @Override
-            public void setupAnim(MyEntity p_102618_, float p_102619_, float p_102620_, float p_102621_, float p_102622_, float p_102623_) {
-
-            }
+            public void setupAnim(MyEntity p_102618_, float p_102619_, float p_102620_, float p_102621_, float p_102622_, float p_102623_) {}
 
             @Override
             public void renderToBuffer(PoseStack poseStack, VertexConsumer vertexConsumer, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
@@ -168,9 +166,7 @@ public class EntityRendererEventsTest {
         }
 
         @Override
-        public void setItemSlot(EquipmentSlot p_21036_, ItemStack p_21037_) {
-
-        }
+        public void setItemSlot(EquipmentSlot p_21036_, ItemStack p_21037_) {}
 
         @Override
         public HumanoidArm getMainArm() {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/NameplateRenderingEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/NameplateRenderingEventTest.java
@@ -23,7 +23,6 @@ public class NameplateRenderingEventTest {
 
     @SubscribeEvent
     public static void onNameplateRender(RenderNameTagEvent event) {
-
         if (!ENABLED) {
             return;
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/PartEntityTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/PartEntityTest.java
@@ -125,7 +125,6 @@ public class PartEntityTest {
             for (int i = 0; i < parts.length; ++i) {
                 parts[i].setId(i + packet.getId());
             }
-
         }
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ItemUseAnimationTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ItemUseAnimationTest.java
@@ -32,7 +32,6 @@ import net.neoforged.neoforge.registries.DeferredRegister;
  */
 @Mod(ItemUseAnimationTest.MOD_ID)
 public class ItemUseAnimationTest {
-
     public static final String MOD_ID = "item_use_animation_test";
 
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
@@ -50,7 +49,6 @@ public class ItemUseAnimationTest {
     }
 
     private static class ThingItem extends Item {
-
         public ThingItem(Item.Properties props) {
             super(props);
         }
@@ -63,7 +61,6 @@ public class ItemUseAnimationTest {
         @Override
         public void initializeClient(Consumer<IClientItemExtensions> consumer) {
             consumer.accept(new IClientItemExtensions() {
-
                 private static final HumanoidModel.ArmPose SWING_POSE = HumanoidModel.ArmPose.create("SWING", false, (model, entity, arm) -> {
                     if (arm == HumanoidArm.RIGHT) {
                         model.rightArm.xRot = (float) (Math.random() * Math.PI * 2);
@@ -101,5 +98,4 @@ public class ItemUseAnimationTest {
             });
         }
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/PlayerSpawnPhantomsEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/PlayerSpawnPhantomsEventTest.java
@@ -19,7 +19,6 @@ import net.neoforged.neoforge.event.entity.player.PlayerSpawnPhantomsEvent;
 @Mod("player_spawn_phantoms_event_test")
 @Mod.EventBusSubscriber()
 public class PlayerSpawnPhantomsEventTest {
-
     private static final boolean ENABLE = false;
 
     @SubscribeEvent
@@ -28,5 +27,4 @@ public class PlayerSpawnPhantomsEventTest {
         event.setPhantomsToSpawn(20);
         event.setResult(Event.Result.ALLOW);
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/TradeWithVillagerEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/TradeWithVillagerEventTest.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 @Mod("trade_with_villager_event_test")
 @Mod.EventBusSubscriber()
 public class TradeWithVillagerEventTest {
-
     private static final boolean ENABLE = true;
     private static final Logger LOGGER = LogUtils.getLogger();
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomElytraTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomElytraTest.java
@@ -62,7 +62,6 @@ public class CustomElytraTest {
     }
 
     public static class CustomElytra extends Item {
-
         public CustomElytra(Properties properties) {
             super(properties);
             DispenserBlock.registerBehavior(this, ArmorItem.DISPENSE_ITEM_BEHAVIOR);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -61,7 +61,6 @@ public class CustomFluidContainerTest {
      * A custom fluid container item with a capacity of a vanilla bucket which uses the FluidUtil functionalities to pickup and place fluids.
      */
     private static class CustomFluidContainer extends Item {
-
         public CustomFluidContainer(Properties properties) {
             super(properties);
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/HiddenTooltipPartsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/HiddenTooltipPartsTest.java
@@ -41,7 +41,6 @@ public class HiddenTooltipPartsTest {
     }
 
     static class TestItem extends Item {
-
         public TestItem(Properties properties) {
             super(properties);
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/RangedMobsUseModdedWeaponsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/RangedMobsUseModdedWeaponsTest.java
@@ -26,7 +26,6 @@ public class RangedMobsUseModdedWeaponsTest {
     // as well as replacing their usages of LivingEntity#isHolding(Item) with LivingEntity#isHolding(Predicate<ItemStack>)
     // Skeletons and Illusioners should be able to use the modded bow.
     // Piglins and Pillagers should be able to use the modded crossbow.
-
     public static final boolean ENABLE = true;
 
     public static final String MOD_ID = "ranged_mobs_use_modded_weapons_test";

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/ModMismatchTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/ModMismatchTest.java
@@ -67,7 +67,6 @@ public class ModMismatchTest implements IConfigurationPayloadHandler<ModMismatch
     }
 
     public record ModMismatchPayload() implements CustomPacketPayload {
-
         private static final ResourceLocation ID = new ResourceLocation(MOD_ID, "mod_mismatch");
 
         public ModMismatchPayload(FriendlyByteBuf buf) {
@@ -81,7 +80,5 @@ public class ModMismatchTest implements IConfigurationPayloadHandler<ModMismatch
         public ResourceLocation id() {
             return ID;
         }
-
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/RegistryCodecTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/RegistryCodecTest.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.Logger;
  */
 @Mod("registry_codec_test")
 public class RegistryCodecTest {
-
     private static final Logger LOGGER = LogManager.getLogger("Codec Registry Test");
 
     /**

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/BiomeModifierTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/BiomeModifierTest.java
@@ -129,7 +129,6 @@ public class BiomeModifierTest {
     }
 
     private static class BiomeModifiers extends DatapackBuiltinEntriesProvider {
-
         public BiomeModifiers(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
             super(output, registries, BUILDER, Set.of(MODID));
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/ForgeChunkManagerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/ForgeChunkManagerTest.java
@@ -75,7 +75,6 @@ public class ForgeChunkManagerTest {
     }
 
     private static class ChunkLoaderBlock extends Block {
-
         public ChunkLoaderBlock(Properties properties) {
             super(properties);
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/LoginPacketSplitTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/LoginPacketSplitTest.java
@@ -229,9 +229,7 @@ public class LoginPacketSplitTest {
         }
 
         @Override
-        public void close() {
-
-        }
+        public void close() {}
 
         public void putRoot(String path, JsonObject json) {
             final byte[] bytes = fromJson(json);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/StructureModifierTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/StructureModifierTest.java
@@ -84,7 +84,6 @@ generator.addProvider(event.includeServer(), structureModifierProvider);*/
             implements StructureModifier {
 
         private static final DeferredHolder<Codec<? extends StructureModifier>, Codec<? extends StructureModifier>> SERIALIZER = DeferredHolder.create(NeoForgeRegistries.Keys.STRUCTURE_MODIFIER_SERIALIZERS, ADD_SPAWNS_TO_STRUCTURE_RL);
-
         @Override
         public void modify(Holder<Structure> structure, Phase phase, Builder builder) {
             if (phase == Phase.ADD && this.structures.contains(structure)) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/WorldgenRegistryDesyncTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/WorldgenRegistryDesyncTest.java
@@ -16,7 +16,6 @@ import net.neoforged.neoforge.registries.DeferredRegister;
 
 @Mod("worldgen_registry_desync_test")
 public class WorldgenRegistryDesyncTest {
-
     public static final DeferredRegister<Feature<?>> FEATURES = DeferredRegister.create(Registries.FEATURE, "worldgen_registry_desync_test");
     public static final Holder<Feature<?>> dungeon = FEATURES.register("dungeon", () -> new MonsterRoomFeature(NoneFeatureConfiguration.CODEC));
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/item/IngredientInvalidationTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/item/IngredientInvalidationTest.java
@@ -62,5 +62,4 @@ public class IngredientInvalidationTest {
             }
         }*/
     }
-
 }

--- a/tests/src/main/java/net/neoforged/neoforge/unittest/ModConfigSpecTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/unittest/ModConfigSpecTest.java
@@ -152,7 +152,6 @@ public class ModConfigSpecTest {
     }
 
     private final static class TestResult {
-
         private final Stopwatch enabledWatch;
         private final Stopwatch disabledWatch;
 


### PR DESCRIPTION
Formatter was already set to 0, but setting it to -1 makes it remove the extra lines instead of allowing them.