### PR TITLE
Set `IS_RUNNING_IN_IDE` to true in userdev

### DIFF
--- a/patches/net/minecraft/SharedConstants.java.patch
+++ b/patches/net/minecraft/SharedConstants.java.patch
@@ -1,5 +1,15 @@
 --- a/net/minecraft/SharedConstants.java
 +++ b/net/minecraft/SharedConstants.java
+@@ -122,7 +_,8 @@
+     public static final long MAXIMUM_TICK_TIME_NANOS = Duration.ofMillis(300L).toNanos();
+     public static final boolean USE_WORKFLOWS_HOOKS = false;
+     public static boolean CHECK_DATA_FIXER_SCHEMA = true;
+-    public static boolean IS_RUNNING_IN_IDE;
++    public static boolean IS_RUNNING_IN_IDE = !net.neoforged.fml.loading.FMLLoader.isProduction();
++    public static final boolean IS_RUNNING_WITH_JDWP = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().stream().anyMatch(str -> str.startsWith("-agentlib:jdwp"));
+     public static Set<TypeReference> DATA_FIX_TYPES_TO_OPTIMIZE = Set.of();
+     public static final int WORLD_RESOLUTION = 16;
+     public static final int MAX_CHAT_LENGTH = 256;
 @@ -204,6 +_,7 @@
      }
  

--- a/patches/net/minecraft/Util.java.patch
+++ b/patches/net/minecraft/Util.java.patch
@@ -7,7 +7,7 @@
 -            LOGGER.error("No data fixer registered for {}", p_137553_);
 -            if (SharedConstants.IS_RUNNING_IN_IDE) {
 +            LOGGER.debug("No data fixer registered for {}", p_137553_);
-+            if (false) {
++            if (SharedConstants.IS_RUNNING_IN_IDE && false) {
                  throw illegalargumentexception;
              }
          }

--- a/patches/net/minecraft/Util.java.patch
+++ b/patches/net/minecraft/Util.java.patch
@@ -1,11 +1,37 @@
 --- a/net/minecraft/Util.java
 +++ b/net/minecraft/Util.java
-@@ -261,7 +_,7 @@
+@@ -261,8 +_,8 @@
                  .getSchema(DataFixUtils.makeKey(SharedConstants.getCurrentVersion().getDataVersion().getVersion()))
                  .getChoiceType(p_137552_, p_137553_);
          } catch (IllegalArgumentException illegalargumentexception) {
 -            LOGGER.error("No data fixer registered for {}", p_137553_);
+-            if (SharedConstants.IS_RUNNING_IN_IDE) {
 +            LOGGER.debug("No data fixer registered for {}", p_137553_);
-             if (SharedConstants.IS_RUNNING_IN_IDE) {
++            if (false) {
                  throw illegalargumentexception;
              }
+         }
+@@ -438,20 +_,20 @@
+ 
+     public static void logAndPauseIfInIde(String p_143786_) {
+         LOGGER.error(p_143786_);
+-        if (SharedConstants.IS_RUNNING_IN_IDE) {
++        if (SharedConstants.IS_RUNNING_WITH_JDWP) {
+             doPause(p_143786_);
+         }
+     }
+ 
+     public static void logAndPauseIfInIde(String p_200891_, Throwable p_200892_) {
+         LOGGER.error(p_200891_, p_200892_);
+-        if (SharedConstants.IS_RUNNING_IN_IDE) {
++        if (SharedConstants.IS_RUNNING_WITH_JDWP) {
+             doPause(p_200891_);
+         }
+     }
+ 
+     public static <T extends Throwable> T pauseInIde(T p_137571_) {
+-        if (SharedConstants.IS_RUNNING_IN_IDE) {
++        if (SharedConstants.IS_RUNNING_WITH_JDWP) {
+             LOGGER.error("Trying to throw a fatal exception, pausing in IDE", p_137571_);
+             doPause(p_137571_.getMessage());
+         }

--- a/patches/net/minecraft/client/GameNarrator.java.patch
+++ b/patches/net/minecraft/client/GameNarrator.java.patch
@@ -5,7 +5,7 @@
  
      private void logNarratedMessage(String p_168788_) {
 -        if (SharedConstants.IS_RUNNING_IN_IDE) {
-+        if (false) {
++        if (SharedConstants.IS_RUNNING_IN_IDE && false) {
              LOGGER.debug("Narrating: {}", p_168788_.replaceAll("\n", "\\\\n"));
          }
      }

--- a/patches/net/minecraft/client/GameNarrator.java.patch
+++ b/patches/net/minecraft/client/GameNarrator.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/GameNarrator.java
++++ b/net/minecraft/client/GameNarrator.java
+@@ -59,7 +_,7 @@
+     }
+ 
+     private void logNarratedMessage(String p_168788_) {
+-        if (SharedConstants.IS_RUNNING_IN_IDE) {
++        if (false) {
+             LOGGER.debug("Narrating: {}", p_168788_.replaceAll("\n", "\\\\n"));
+         }
+     }

--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -79,7 +79,7 @@
 -                        if (SharedConstants.IS_RUNNING_IN_IDE) {
 +            net.neoforged.fml.loading.ImmediateWindowHandler.<LoadingOverlay>loadingOverlay(
 +                () -> this, () -> reloadinstance, p_299779_ -> Util.ifElse(p_299779_, p_299772_ -> this.rollbackResourcePacks(p_299772_, minecraft$gameloadcookie), () -> {
-+                        if (false) {
++                        if (SharedConstants.IS_RUNNING_IN_IDE && false) {
                              this.selfTest();
                          }
          

--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -76,9 +76,10 @@
          this.setOverlay(
 -            new LoadingOverlay(
 -                this, reloadinstance, p_299779_ -> Util.ifElse(p_299779_, p_299772_ -> this.rollbackResourcePacks(p_299772_, minecraft$gameloadcookie), () -> {
+-                        if (SharedConstants.IS_RUNNING_IN_IDE) {
 +            net.neoforged.fml.loading.ImmediateWindowHandler.<LoadingOverlay>loadingOverlay(
 +                () -> this, () -> reloadinstance, p_299779_ -> Util.ifElse(p_299779_, p_299772_ -> this.rollbackResourcePacks(p_299772_, minecraft$gameloadcookie), () -> {
-                         if (SharedConstants.IS_RUNNING_IN_IDE) {
++                        if (false) {
                              this.selfTest();
                          }
          

--- a/patches/net/minecraft/server/Bootstrap.java.patch
+++ b/patches/net/minecraft/server/Bootstrap.java.patch
@@ -9,7 +9,12 @@
                      wrapStreams();
                      bootstrapDuration.set(Duration.between(instant, Instant.now()).toMillis());
                  }
-@@ -121,7 +_,6 @@
+@@ -117,11 +_,11 @@
+     public static void validate() {
+         checkBootstrapCalled(() -> "validate");
+         if (SharedConstants.IS_RUNNING_IN_IDE) {
++            if (false) // Neo: this can be very annoying
+             getMissingTranslations().forEach(p_179915_ -> LOGGER.error("Missing translations: {}", p_179915_));
              Commands.validate();
          }
  

--- a/patches/net/minecraft/server/Bootstrap.java.patch
+++ b/patches/net/minecraft/server/Bootstrap.java.patch
@@ -9,12 +9,7 @@
                      wrapStreams();
                      bootstrapDuration.set(Duration.between(instant, Instant.now()).toMillis());
                  }
-@@ -117,11 +_,11 @@
-     public static void validate() {
-         checkBootstrapCalled(() -> "validate");
-         if (SharedConstants.IS_RUNNING_IN_IDE) {
-+            if (false) // Neo: this can be very annoying
-             getMissingTranslations().forEach(p_179915_ -> LOGGER.error("Missing translations: {}", p_179915_));
+@@ -121,7 +_,6 @@
              Commands.validate();
          }
  

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -17,7 +17,7 @@
          this.isFireResistant = p_41383_.isFireResistant;
          this.requiredFeatures = p_41383_.requiredFeatures;
 -        if (SharedConstants.IS_RUNNING_IN_IDE) {
-+        if (false) {
++        if (SharedConstants.IS_RUNNING_IN_IDE && false) {
              String s = this.getClass().getSimpleName();
              if (!s.endsWith("Item")) {
                  LOGGER.error("Item classes should end with Item and {} doesn't.", s);

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -12,7 +12,14 @@
      protected static final UUID BASE_ATTACK_DAMAGE_UUID = UUID.fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
      protected static final UUID BASE_ATTACK_SPEED_UUID = UUID.fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3");
      public static final int MAX_STACK_SIZE = 64;
-@@ -98,6 +_,8 @@
+@@ -92,12 +_,14 @@
+         this.foodProperties = p_41383_.foodProperties;
+         this.isFireResistant = p_41383_.isFireResistant;
+         this.requiredFeatures = p_41383_.requiredFeatures;
+-        if (SharedConstants.IS_RUNNING_IN_IDE) {
++        if (false) {
+             String s = this.getClass().getSimpleName();
+             if (!s.endsWith("Item")) {
                  LOGGER.error("Item classes should end with Item and {} doesn't.", s);
              }
          }

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -20,7 +20,7 @@
          this.stateDefinition = builder.create(Block::defaultBlockState, BlockState::new);
          this.registerDefaultState(this.stateDefinition.any());
 -        if (SharedConstants.IS_RUNNING_IN_IDE) {
-+        if (false) {
++        if (SharedConstants.IS_RUNNING_IN_IDE && false) {
              String s = this.getClass().getSimpleName();
              if (!s.endsWith("Block")) {
                  LOGGER.error("Block classes should end with Block and {} doesn't.", s);

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -15,7 +15,14 @@
      private static final LoadingCache<VoxelShape, Boolean> SHAPE_FULL_BLOCK_CACHE = CacheBuilder.newBuilder()
          .maximumSize(512L)
          .weakKeys()
-@@ -193,6 +_,7 @@
+@@ -187,12 +_,13 @@
+         this.createBlockStateDefinition(builder);
+         this.stateDefinition = builder.create(Block::defaultBlockState, BlockState::new);
+         this.registerDefaultState(this.stateDefinition.any());
+-        if (SharedConstants.IS_RUNNING_IN_IDE) {
++        if (false) {
+             String s = this.getClass().getSimpleName();
+             if (!s.endsWith("Block")) {
                  LOGGER.error("Block classes should end with Block and {} doesn't.", s);
              }
          }


### PR DESCRIPTION
To avoid this causing more pain, some of the “bad” uses of the field are patched out. The `pauseIfInIde` methods use a second constant that detects for JDWP being present.