### PR TITLE
[1.20.4] Fix ModListScreen link detection

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -207,7 +207,7 @@ public class ModListScreen extends Screen {
             if (!isMouseOver(mouseX, mouseY))
                 return null;
 
-            double offset = (mouseY - top) + border + scrollDistance + 1;
+            double offset = (mouseY - top - PADDING - border) + scrollDistance;
             if (logoPath != null) {
                 offset -= 50;
             }
@@ -215,12 +215,12 @@ public class ModListScreen extends Screen {
                 return null;
 
             int lineIdx = (int) (offset / font.lineHeight);
-            if (lineIdx >= lines.size() || lineIdx < 1)
+            if (lineIdx >= lines.size() || lineIdx < 0)
                 return null;
 
-            FormattedCharSequence line = lines.get(lineIdx - 1);
+            FormattedCharSequence line = lines.get(lineIdx);
             if (line != null) {
-                return font.getSplitter().componentStyleAtWidth(line, mouseX - left - border);
+                return font.getSplitter().componentStyleAtWidth(line, mouseX - left - border - 1);
             }
             return null;
         }


### PR DESCRIPTION
This PR fixes the calculation used to find the style of the hovered text line in the `ModListScreen`.

Fixes #538