### PR TITLE
[1.20.4] Fix inventoryTick and deprecate onArmorTick

### DIFF
--- a/patches/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/net/minecraft/world/entity/player/Inventory.java.patch
@@ -19,7 +19,19 @@
              if (p_36049_.hasTag()) {
                  itemstack.setTag(p_36049_.getTag().copy());
              }
-@@ -237,6 +_,7 @@
+@@ -230,13 +_,18 @@
+     }
+ 
+     public void tick() {
++        int slot = 0;
+         for(NonNullList<ItemStack> nonnulllist : this.compartments) {
+             for(int i = 0; i < nonnulllist.size(); ++i) {
+                 if (!nonnulllist.get(i).isEmpty()) {
+-                    nonnulllist.get(i).inventoryTick(this.player.level(), this.player, i, this.selected == i);
++                    // Neo: Fix the slot param to be the global index instead of the per-compartment index.
++                    // Neo: Fix the selected param to only be true for hotbar slots.
++                    nonnulllist.get(i).inventoryTick(this.player.level(), this.player, slot, this.selected == slot);
++                    slot++;
                  }
              }
          }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -280,7 +280,10 @@ public interface IItemExtension {
 
     /**
      * Called to tick armor in the armor slot. Override to do something
+     * 
+     * @deprecated Use {@link Item#inventoryTick(ItemStack, Level, Entity, int, boolean)} by checking that the slot argument is an armor slot. Armor slots are 36, 37, 38 and 39.
      */
+    @Deprecated(forRemoval = true, since = "1.20.4")
     default void onArmorTick(ItemStack stack, Level level, Player player) {}
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -272,7 +272,10 @@ public interface IItemStackExtension {
 
     /**
      * Called to tick armor in the armor slot. Override to do something
+     * 
+     * @deprecated Use {@link Item#inventoryTick(ItemStack, Level, Entity, int, boolean)} by checking that the slot argument is an armor slot. Armor slots are 36, 37, 38 and 39.
      */
+    @Deprecated(forRemoval = true, since = "1.20.4")
     default void onArmorTick(Level level, Player player) {
         self().getItem().onArmorTick(self(), level, player);
     }


### PR DESCRIPTION
This PR follows up on https://github.com/neoforged/NeoForge/pull/21 by deprecating the stale method `onArmorTick` and fixing the values of the parameters in `inventoryTick`.

Since there appears to be a lot of discussion on how best to solve the inventory tick problem, this is the minimal set of changes to restore current functionality to the best position.

I do believe that adding a more contextual version of `inventoryTick` with an arbitrary context object would benefit users in the long term, but that will need significant design work.