### PR TITLE
Fix LivingEntityUseItemEvent.Start patch

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -563,7 +563,7 @@
          ItemStack itemstack = this.getItemInHand(p_21159_);
          if (!itemstack.isEmpty() && !this.isUsingItem()) {
 +            int duration = net.neoforged.neoforge.event.EventHooks.onItemUseStart(this, itemstack, itemstack.getUseDuration());
-+            if (duration <= 0) return;
++            if (duration < 0) return; // Neo: Early return for negative values, as that indicates event cancellation.
              this.useItem = itemstack;
 -            this.useItemRemaining = itemstack.getUseDuration();
 +            this.useItemRemaining = duration;


### PR DESCRIPTION
Fixes the patch for `LivingEntityUseItemEvent.Start` checking `<= 0` for early return when the condition should be `< 0`.  Zero is a legal value used by vanilla, and in some cases can cause the `using_item` advancement criteria to not trigger.

Discovered by @coehlrich 