### PR TITLE
[1.20.1] Fix CME in ModelDataManager

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/minecraftforge/client/model/data/ModelDataManager.java
@@ -46,7 +46,7 @@ public class ModelDataManager
     public void requestRefresh(@NotNull BlockEntity blockEntity)
     {
         Preconditions.checkNotNull(blockEntity, "Block entity must not be null");
-        needModelDataRefresh.computeIfAbsent(new ChunkPos(blockEntity.getBlockPos()), $ -> Collections.synchronizedSet(new HashSet<>()))
+        needModelDataRefresh.computeIfAbsent(new ChunkPos(blockEntity.getBlockPos()), $ -> Collections.newSetFromMap(new ConcurrentHashMap<>()))
                             .add(blockEntity.getBlockPos());
     }
 


### PR DESCRIPTION
We fixed this alongside the model data manager redesign in https://github.com/neoforged/NeoForge/pull/433, however, we should also patch it in 1.20.1 to prevent rare crashes. The least invasive solution is to just use a concurrent set to store the positions to update.