### PR TITLE
[1.20.1] Fix being unable to cancel deleting a world

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
@@ -20,7 +20,7 @@
                 this.m_170323_();
              }
  
-+            if (this.f_101693_.f_91080_ instanceof ProgressScreen) // Neo - fix MC-251068
++            if (this.f_101693_.f_91080_ instanceof ProgressScreen || this.f_101693_.f_91080_ instanceof ConfirmScreen) // Neo - fix MC-251068
              this.f_101693_.m_91152_(this.f_101694_);
           }, Component.m_237115_("selectWorld.deleteQuestion"), Component.m_237110_("selectWorld.deleteWarning", this.f_101695_.m_78361_()), Component.m_237115_("selectWorld.deleteButton"), CommonComponents.f_130656_));
        }


### PR DESCRIPTION
Backport of #408 to 1.20.1. See that PR for more information.