### PR TITLE
Move config screen event registration to an event

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ConfigScreenHandler.java
+++ b/src/main/java/net/neoforged/neoforge/client/ConfigScreenHandler.java
@@ -5,18 +5,55 @@
 
 package net.neoforged.neoforge.client;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.neoforged.fml.IExtensionPoint;
 import net.neoforged.fml.ModList;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.client.event.RegisterConfigScreenEvent;
 import net.neoforged.neoforgespi.language.IModInfo;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 public class ConfigScreenHandler {
+    private static final Map<String, IConfigScreenFactory> factories = new HashMap<>();
+
+    /**
+     * Retrieves the config screen factory for a mod, if present.
+     */
+    @Nullable
+    public static IConfigScreenFactory getScreenFactory(String modid) {
+        var ret = factories.get(modid);
+        if (ret != null) {
+            return ret;
+        }
+
+        // support legacy system
+        return ModList.get().getModContainerById(modid)
+                .flatMap(mc -> mc.getCustomExtension(ConfigScreenFactory.class))
+                .map(f -> (IConfigScreenFactory) f.screenFunction()::apply)
+                .orElse(null);
+    }
+
+    @ApiStatus.Internal
+    public static void init() {
+        ModLoader.get().postEvent(new RegisterConfigScreenEvent(factories));
+    }
+
+    @Deprecated(forRemoval = true, since = "1.20.4")
     public record ConfigScreenFactory(BiFunction<Minecraft, Screen, Screen> screenFunction) implements IExtensionPoint<ConfigScreenFactory> {}
 
+    @Deprecated(forRemoval = true, since = "1.20.4")
     public static Optional<BiFunction<Minecraft, Screen, Screen>> getScreenFactoryFor(IModInfo selectedMod) {
+        var factory = factories.get(selectedMod.getModId());
+        if (factory != null) {
+            return Optional.of(factory::createScreen);
+        }
+
         return ModList.get().getModContainerById(selectedMod.getModId()).flatMap(mc -> mc.getCustomExtension(ConfigScreenFactory.class).map(ConfigScreenFactory::screenFunction));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/IConfigScreenFactory.java
+++ b/src/main/java/net/neoforged/neoforge/client/IConfigScreenFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.neoforged.neoforge.client.event.RegisterConfigScreenEvent;
+
+/**
+ * Factory for mod-provided config screens accessed via NeoForge's mod list menu.
+ * Register to {@link RegisterConfigScreenEvent}.
+ */
+public interface IConfigScreenFactory {
+    /**
+     * Creates a config screen.
+     * Setting the screen back to the provided {@code modListScreen} will return the user to the mod list menu.
+     */
+    Screen createScreen(Minecraft minecraft, Screen modListScreen);
+}

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterConfigScreenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterConfigScreenEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import java.util.Map;
+import java.util.Objects;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.neoforge.client.IConfigScreenFactory;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Event to register {@link IConfigScreenFactory} instances for mods.
+ */
+public class RegisterConfigScreenEvent extends Event implements IModBusEvent {
+    private final Map<String, IConfigScreenFactory> factories;
+
+    @ApiStatus.Internal
+    public RegisterConfigScreenEvent(Map<String, IConfigScreenFactory> factories) {
+        this.factories = factories;
+    }
+
+    /**
+     * Registers a config screen factory for the given mod.
+     *
+     * @param modid   the mod id
+     * @param factory the factory
+     */
+    public void register(String modid, IConfigScreenFactory factory) {
+        Objects.requireNonNull(modid, "modid may not be null");
+        Objects.requireNonNull(factory, "factory may not be null");
+
+        if (factories.putIfAbsent(modid, factory) != null) {
+            throw new IllegalArgumentException("A config screen factory for mod " + modid + " is already registered");
+        }
+    }
+
+    /**
+     * Registers a config screen factory for the given mod.
+     *
+     * @param container the mod container
+     * @param factory   the factory
+     */
+    public void register(ModContainer container, IConfigScreenFactory factory) {
+        register(container.getModId(), factory);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -294,7 +294,11 @@ public class ModListScreen extends Screen {
     private void displayModConfig() {
         if (selected == null) return;
         try {
-            ConfigScreenHandler.getScreenFactoryFor(selected.getInfo()).map(f -> f.apply(this.minecraft, this)).ifPresent(newScreen -> this.minecraft.setScreen(newScreen));
+            var factory = ConfigScreenHandler.getScreenFactory(selected.getInfo().getModId());
+            if (factory != null) {
+                var newScreen = factory.createScreen(this.minecraft, this);
+                this.minecraft.setScreen(newScreen);
+            }
         } catch (final Exception e) {
             LOGGER.error("There was a critical issue trying to build the config GUI for {}", selected.getInfo().getModId(), e);
         }
@@ -373,7 +377,7 @@ public class ModListScreen extends Screen {
             return;
         }
         IModInfo selectedMod = selected.getInfo();
-        this.configButton.active = ConfigScreenHandler.getScreenFactoryFor(selectedMod).isPresent();
+        this.configButton.active = ConfigScreenHandler.getScreenFactory(selectedMod.getModId()) != null;
         List<String> lines = new ArrayList<>();
         VersionChecker.CheckResult vercheck = VersionChecker.getResult(selectedMod);
 


### PR DESCRIPTION
So that we can deprecate the FML extension point system for removal.