### PR TITLE
Expose what entity types have renderers to the AddLayer event

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
@@ -159,6 +159,13 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
         }
 
         /**
+         * {@return the set of entity types which have a renderer}
+         */
+        public Set<EntityType<?>> getEntityTypes() {
+            return renderers.keySet();
+        }
+
+        /**
          * Returns an entity renderer for the given entity type. Note that the returned renderer may not be a
          * {@link LivingEntityRenderer}.
          *

--- a/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/EntityRenderersEvent.java
@@ -25,7 +25,6 @@ import net.minecraft.client.renderer.entity.player.PlayerRenderer;
 import net.minecraft.client.resources.PlayerSkin;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.SkullBlock;
 import net.minecraft.world.level.block.SkullBlock.Type;
@@ -176,7 +175,7 @@ public abstract class EntityRenderersEvent extends Event implements IModBusEvent
          */
         @Nullable
         @SuppressWarnings("unchecked")
-        public <T extends LivingEntity, R extends EntityRenderer<T>> R getRenderer(EntityType<? extends T> entityType) {
+        public <T extends Entity, R extends EntityRenderer<T>> R getRenderer(EntityType<? extends T> entityType) {
             return (R) renderers.get(entityType);
         }
 


### PR DESCRIPTION
Partial follow-up to #510 in that this looses the bounds on the input generic to `AddLayer#getRenderer` to allow getting the renderer for non living entity types, which in of itself I don't believe is necessarily super useful as I believe only `LivingEntityRenderer`'s have layers, but it simplifies and removes some unchecked casts when using the second part of this PR which is exposing the list of entity types to listeners of the event similar to how the list of player skins is exposed.

My use case is that I add a few custom layers to entity's with a corresponding vanilla layer so that I can do some extra handling for some of my custom armor and such. Currently I query `Minecraft.getInstance().getEntityRenderDispatcher().renderers` for the list of entity types as the event is fired just after the variable is set, but it would be a lot cleaner to be able to do something along the lines of:
```java
for (EntityType<?> entityType : event.getEntityTypes()) {
    EntityRenderer<?> renderer = event.getRenderer(entityType);
    if (renderer instanceof LivingEntityRenderer) {
        ...
    }
}
```