### PR TITLE
[1.20.1] Remove redundant getResource call in DelegatingPackResources

### DIFF
--- a/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
+++ b/src/main/java/net/minecraftforge/resource/DelegatingPackResources.java
@@ -103,7 +103,7 @@ public class DelegatingPackResources extends AbstractPackResources
         {
             IoSupplier<InputStream> ioSupplier = pack.getResource(type, location);
             if (ioSupplier != null)
-                return pack.getResource(type, location);
+                return ioSupplier;
         }
 
         return null;


### PR DESCRIPTION
Backport of #149 to 1.20.1.