### PR TITLE
[1.20.1] Unbreak the MC-176559 fix

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -93,7 +93,7 @@
     private boolean m_105281_(BlockPos p_105282_) {
        ItemStack itemstack = this.f_105189_.f_91074_.m_21205_();
 -      return p_105282_.equals(this.f_105191_) && ItemStack.m_150942_(itemstack, this.f_105192_);
-+      return p_105282_.equals(this.f_105191_) && ItemStack.m_150942_(itemstack, this.f_105192_) && !f_105192_.shouldCauseBlockBreakReset(itemstack);
++      return p_105282_.equals(this.f_105191_) && !f_105192_.shouldCauseBlockBreakReset(itemstack);
     }
  
     private void m_105297_() {


### PR DESCRIPTION
Backport of https://github.com/neoforged/NeoForge/pull/145 to 1.20.1.

Co-authored-by: Thomas Kain <kain.tommy@gmail.com>
