### PR TITLE
[1.20.1] Suppress update checking

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -8,7 +8,7 @@ license="LGPL v2.1"
     modId="forge"
     # We use the global forge version
     version="${global.forgeVersion}"
-    updateJSONURL="https://maven.neoforged.net/releases/net/neoforged/forge/promotions_slim.json"
+    #updateJSONURL="https://maven.neoforged.net/releases/net/neoforged/forge/promotions_slim.json"
     displayName="NeoForge"
     credits="Anyone who has contributed on Github and supports our development"
     authors="The NeoForged Team"


### PR DESCRIPTION
Backport of https://github.com/neoforged/NeoForge/pull/242 to 1.20.1, since we still don't have a working update checker, and it creates noise in the log.