### PR TITLE
Simplify LevelRenderer visible block entity patch

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -194,7 +194,7 @@
                  } else if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
                      flag = sectionrenderdispatcher$rendersection.isDirtyFromPlayer();
                  }
-@@ -2585,7 +_,33 @@
+@@ -2585,7 +_,30 @@
          this.viewArea.setDirty(p_109502_, p_109503_, p_109504_, p_109505_);
      }
  
@@ -206,14 +206,11 @@
 +        return this.ticks;
 +    }
 +
-+    private final List<SectionRenderDispatcher.RenderSection> visibleSectionsView = java.util.Collections.unmodifiableList(visibleSections);
-+    public List<SectionRenderDispatcher.RenderSection> getVisibleSections() {
-+        return visibleSectionsView;
-+    }
-+
-+    private final Set<BlockEntity> globalBlockEntitiesView = java.util.Collections.unmodifiableSet(globalBlockEntities);
-+    public Set<BlockEntity> getGlobalBlockEntities() {
-+        return globalBlockEntitiesView;
++    public void iterateVisibleBlockEntities(java.util.function.Consumer<BlockEntity> blockEntityConsumer) {
++        for (var chunkInfo : this.visibleSections) {
++            chunkInfo.getCompiled().getRenderableBlockEntities().forEach(blockEntityConsumer);
++        }
++        this.globalBlockEntities.forEach(blockEntityConsumer);
 +    }
 +
 +    /**

--- a/src/main/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
@@ -41,15 +41,7 @@ public final class BlockEntityRenderBoundsDebugRenderer {
         Vec3 camera = event.getCamera().getPosition();
         VertexConsumer consumer = Minecraft.getInstance().renderBuffers().bufferSource().getBuffer(RenderType.lines());
 
-        for (SectionRenderDispatcher.RenderSection section : levelRenderer.getVisibleSections()) {
-            for (BlockEntity be : section.getCompiled().getRenderableBlockEntities()) {
-                drawRenderBoundingBox(poseStack, consumer, camera, be);
-            }
-        }
-
-        for (BlockEntity be : levelRenderer.getGlobalBlockEntities()) {
-            drawRenderBoundingBox(poseStack, consumer, camera, be);
-        }
+        levelRenderer.iterateVisibleBlockEntities(be -> drawRenderBoundingBox(poseStack, consumer, camera, be));
     }
 
     private static void drawRenderBoundingBox(PoseStack poseStack, VertexConsumer consumer, Vec3 camera, BlockEntity be) {

--- a/src/main/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
@@ -13,7 +13,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
-import net.minecraft.client.renderer.chunk.SectionRenderDispatcher;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;


### PR DESCRIPTION
This PR simplifies the `LevelRenderer` hook added in https://github.com/neoforged/NeoForge/pull/327. The new hook does not expose implementation details of vanilla's chunk renderer, and thus allows for chunk renderer optimization mods to be completely compatible with code that depends on it. As a side effect, it also simplifies the loops in `BlockEntityRenderBoundsDebugRenderer` a bit.