### PR TITLE
[1.20.4] Provide preliminary atlas stitch results in ModelEvent.ModifyBakingResult

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -40,7 +40,7 @@
                      )
              );
 +        p_252136_.popPush("forge_modify_baking_result");
-+        net.neoforged.neoforge.client.ClientHooks.onModifyBakingResult(p_248945_.getBakedTopLevelModels(), p_248945_);
++        net.neoforged.neoforge.client.ClientHooks.onModifyBakingResult(p_248945_.getBakedTopLevelModels(), p_250646_, p_248945_);
          p_252136_.popPush("dispatch");
          Map<ResourceLocation, BakedModel> map = p_248945_.getBakedTopLevelModels();
          BakedModel bakedmodel = map.get(ModelBakery.MISSING_MODEL_LOCATION);

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -79,6 +79,7 @@ import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.atlas.SpriteSourceType;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.client.resources.model.AtlasSet;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.ModelBakery;
@@ -425,8 +426,8 @@ public class ClientHooks {
         return event;
     }
 
-    public static void onModifyBakingResult(Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery) {
-        ModLoader.get().postEvent(new ModelEvent.ModifyBakingResult(models, modelBakery));
+    public static void onModifyBakingResult(Map<ResourceLocation, BakedModel> models, Map<ResourceLocation, AtlasSet.StitchResult> stitchResults, ModelBakery modelBakery) {
+        ModLoader.get().postEvent(new ModelEvent.ModifyBakingResult(models, Collections.unmodifiableMap(stitchResults), modelBakery));
     }
 
     public static void onModelBake(ModelManager modelManager, Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery) {

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -427,7 +427,16 @@ public class ClientHooks {
     }
 
     public static void onModifyBakingResult(Map<ResourceLocation, BakedModel> models, Map<ResourceLocation, AtlasSet.StitchResult> stitchResults, ModelBakery modelBakery) {
-        ModLoader.get().postEvent(new ModelEvent.ModifyBakingResult(models, Collections.unmodifiableMap(stitchResults), modelBakery));
+        Function<Material, TextureAtlasSprite> textureGetter = material -> {
+            AtlasSet.StitchResult stitchResult = stitchResults.get(material.atlasLocation());
+            TextureAtlasSprite sprite = stitchResult.getSprite(material.texture());
+            if (sprite != null) {
+                return sprite;
+            }
+            LOGGER.warn("Failed to retrieve texture '{}' from atlas '{}'", material.texture(), material.atlasLocation(), new Throwable());
+            return stitchResult.missing();
+        };
+        ModLoader.get().postEvent(new ModelEvent.ModifyBakingResult(models, textureGetter, modelBakery));
     }
 
     public static void onModelBake(ModelManager modelManager, Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery) {

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.client.event;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import java.util.Set;
+import net.minecraft.client.resources.model.AtlasSet;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelManager;
@@ -44,11 +45,13 @@ public abstract class ModelEvent extends Event {
      */
     public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
         private final Map<ResourceLocation, BakedModel> models;
+        private final Map<ResourceLocation, AtlasSet.StitchResult> stitchResults;
         private final ModelBakery modelBakery;
 
         @ApiStatus.Internal
-        public ModifyBakingResult(Map<ResourceLocation, BakedModel> models, ModelBakery modelBakery) {
+        public ModifyBakingResult(Map<ResourceLocation, BakedModel> models, Map<ResourceLocation, AtlasSet.StitchResult> stitchResults, ModelBakery modelBakery) {
             this.models = models;
+            this.stitchResults = stitchResults;
             this.modelBakery = modelBakery;
         }
 
@@ -57,6 +60,15 @@ public abstract class ModelEvent extends Event {
          */
         public Map<ResourceLocation, BakedModel> getModels() {
             return models;
+        }
+
+        /**
+         * {@return an unmodifiable view of the preliminary atlas stitch results}
+         * @apiNote Looking up sprites from an {@link AtlasSet.StitchResult} does not handle missing sprites automatically,
+         * the fallback to the missing sprite must be implemented manually
+         */
+        public Map<ResourceLocation, AtlasSet.StitchResult> getAtlasStitchResults() {
+            return stitchResults;
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -8,8 +8,10 @@ package net.neoforged.neoforge.client.event;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import java.util.Set;
-import net.minecraft.client.resources.model.AtlasSet;
+import java.util.function.Function;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.Material;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.resources.ResourceLocation;
@@ -45,13 +47,13 @@ public abstract class ModelEvent extends Event {
      */
     public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
         private final Map<ResourceLocation, BakedModel> models;
-        private final Map<ResourceLocation, AtlasSet.StitchResult> stitchResults;
+        private final Function<Material, TextureAtlasSprite> textureGetter;
         private final ModelBakery modelBakery;
 
         @ApiStatus.Internal
-        public ModifyBakingResult(Map<ResourceLocation, BakedModel> models, Map<ResourceLocation, AtlasSet.StitchResult> stitchResults, ModelBakery modelBakery) {
+        public ModifyBakingResult(Map<ResourceLocation, BakedModel> models, Function<Material, TextureAtlasSprite> textureGetter, ModelBakery modelBakery) {
             this.models = models;
-            this.stitchResults = stitchResults;
+            this.textureGetter = textureGetter;
             this.modelBakery = modelBakery;
         }
 
@@ -63,13 +65,14 @@ public abstract class ModelEvent extends Event {
         }
 
         /**
-         * {@return an unmodifiable view of the preliminary atlas stitch results}
-         * 
-         * @apiNote Looking up sprites from an {@link AtlasSet.StitchResult} does not handle missing sprites automatically,
-         *          the fallback to the missing sprite must be implemented manually
+         * Returns a lookup function to retrieve {@link TextureAtlasSprite}s by name from any of the atlases handled by
+         * the {@link ModelManager}. See {@link ModelManager#VANILLA_ATLASES} for the atlases accessible through the
+         * returned function
+         *
+         * @return a function to lookup sprites from an atlas by name
          */
-        public Map<ResourceLocation, AtlasSet.StitchResult> getPreliminaryStitchResults() {
-            return stitchResults;
+        public Function<Material, TextureAtlasSprite> getTextureGetter() {
+            return textureGetter;
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -68,7 +68,7 @@ public abstract class ModelEvent extends Event {
          * @apiNote Looking up sprites from an {@link AtlasSet.StitchResult} does not handle missing sprites automatically,
          *          the fallback to the missing sprite must be implemented manually
          */
-        public Map<ResourceLocation, AtlasSet.StitchResult> getAtlasStitchResults() {
+        public Map<ResourceLocation, AtlasSet.StitchResult> getPreliminaryStitchResults() {
             return stitchResults;
         }
 

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -64,8 +64,9 @@ public abstract class ModelEvent extends Event {
 
         /**
          * {@return an unmodifiable view of the preliminary atlas stitch results}
+         * 
          * @apiNote Looking up sprites from an {@link AtlasSet.StitchResult} does not handle missing sprites automatically,
-         * the fallback to the missing sprite must be implemented manually
+         *          the fallback to the missing sprite must be implemented manually
          */
         public Map<ResourceLocation, AtlasSet.StitchResult> getAtlasStitchResults() {
             return stitchResults;


### PR DESCRIPTION
This PR adds an accessor for the preliminary atlas stitch results (`Map<ResourceLocation, AtlasSet.StitchResult>`) to `ModelEvent.ModifyBakingResult` to allow retrieving sprites in said event.

In my specific use case I need to capture a sprite while wrapping a baked model to dynamically build quads with it at a later time.
Another use case would be dynamically baking models which cannot use geometry loaders.