### PR TITLE
Remove `alwaysSetupTerrainOffThread`

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -185,15 +185,6 @@
          float f = this.level.effects().getCloudHeight();
          if (!Float.isNaN(f)) {
              RenderSystem.disableCull();
-@@ -2072,7 +_,7 @@
-                 boolean flag = false;
-                 if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.NEARBY) {
-                     BlockPos blockpos1 = sectionrenderdispatcher$rendersection.getOrigin().offset(8, 8, 8);
--                    flag = blockpos1.distSqr(blockpos) < 768.0 || sectionrenderdispatcher$rendersection.isDirtyFromPlayer();
-+                    flag = !net.neoforged.neoforge.common.NeoForgeConfig.CLIENT.alwaysSetupTerrainOffThread.get() && (blockpos1.distSqr(blockpos) < 768.0D || sectionrenderdispatcher$rendersection.isDirtyFromPlayer()); // the target is the else block below, so invert the forge addition to get there early
-                 } else if (this.minecraft.options.prioritizeChunkUpdates().get() == PrioritizeChunkUpdates.PLAYER_AFFECTED) {
-                     flag = sectionrenderdispatcher$rendersection.isDirtyFromPlayer();
-                 }
 @@ -2585,7 +_,32 @@
          this.viewArea.setDirty(p_109502_, p_109503_, p_109504_, p_109505_);
      }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeConfig.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeConfig.java
@@ -80,8 +80,6 @@ public class NeoForgeConfig {
      * Client specific configuration - only loaded clientside from neoforge-client.toml
      */
     public static class Client {
-        public final BooleanValue alwaysSetupTerrainOffThread;
-
         public final BooleanValue experimentalForgeLightPipelineEnabled;
 
         public final BooleanValue showLoadWarnings;
@@ -94,13 +92,6 @@ public class NeoForgeConfig {
         Client(ModConfigSpec.Builder builder) {
             builder.comment("Client only settings, mostly things related to rendering")
                     .push("client");
-
-            alwaysSetupTerrainOffThread = builder
-                    .comment("Enable NeoForge to queue all chunk updates to the Chunk Update thread.",
-                            "May increase FPS significantly, but may also cause weird rendering lag.",
-                            "Not recommended for computers without a significant number of cores available.")
-                    .translation("neoforge.configgui.alwaysSetupTerrainOffThread")
-                    .define("alwaysSetupTerrainOffThread", false);
 
             experimentalForgeLightPipelineEnabled = builder
                     .comment("EXPERIMENTAL: Enable the NeoForge block rendering pipeline - fixes the lighting of custom models.")


### PR DESCRIPTION
This config option has been redundant since 1.18 as vanilla added the same feature.