### PR TITLE
Simplify shear patches and fix some differences compared to vanilla

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -532,7 +532,7 @@
      public void setMaxUpStep(float p_275672_) {
          this.maxUpStep = p_275672_;
      }
-@@ -3419,6 +_,119 @@
+@@ -3419,6 +_,120 @@
      public boolean mayInteract(Level p_146843_, BlockPos p_146844_) {
          return true;
      }
@@ -548,13 +548,14 @@
 +    public boolean canUpdate() {
 +        return this.canUpdate;
 +    }
++    @Nullable
 +    private java.util.Collection<ItemEntity> captureDrops = null;
 +    @Override
 +    public java.util.Collection<ItemEntity> captureDrops() {
 +        return captureDrops;
 +    }
 +    @Override
-+    public java.util.Collection<ItemEntity> captureDrops(java.util.Collection<ItemEntity> value) {
++    public java.util.Collection<ItemEntity> captureDrops(@Nullable java.util.Collection<ItemEntity> value) {
 +        java.util.Collection<ItemEntity> ret = captureDrops;
 +        this.captureDrops = value;
 +        return ret;

--- a/patches/net/minecraft/world/entity/Shearable.java.patch
+++ b/patches/net/minecraft/world/entity/Shearable.java.patch
@@ -1,15 +1,24 @@
 --- a/net/minecraft/world/entity/Shearable.java
 +++ b/net/minecraft/world/entity/Shearable.java
-@@ -2,8 +_,11 @@
+@@ -2,8 +_,20 @@
  
  import net.minecraft.sounds.SoundSource;
  
 -public interface Shearable {
-+@Deprecated // Forge: Use IShearable
++/**
++ * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable} instead.
++ */
++@Deprecated
 +public interface Shearable extends net.neoforged.neoforge.common.IShearable {
-+    @Deprecated // Forge: Use IShearable
++    /**
++     * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable#onSheared(net.minecraft.world.entity.player.Player, net.minecraft.world.item.ItemStack, net.minecraft.world.level.Level, net.minecraft.core.BlockPos, int)} instead.
++     */
++    @Deprecated
      void shear(SoundSource p_21749_);
  
-+    @Deprecated // Forge: Use IShearable
++    /**
++     * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable#isShearable(net.minecraft.world.item.ItemStack, net.minecraft.world.level.Level, net.minecraft.core.BlockPos)} instead.
++     */
++    @Deprecated
      boolean readyForShearing();
  }

--- a/patches/net/minecraft/world/entity/Shearable.java.patch
+++ b/patches/net/minecraft/world/entity/Shearable.java.patch
@@ -4,8 +4,9 @@
  
  import net.minecraft.sounds.SoundSource;
  
+-public interface Shearable {
 +@Deprecated // Forge: Use IShearable
- public interface Shearable {
++public interface Shearable extends net.neoforged.neoforge.common.IShearable {
 +    @Deprecated // Forge: Use IShearable
      void shear(SoundSource p_21749_);
  

--- a/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
+++ b/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/world/entity/animal/MushroomCow.java
 +++ b/net/minecraft/world/entity/animal/MushroomCow.java
-@@ -42,7 +_,7 @@
- import net.minecraft.world.level.block.state.BlockState;
- import net.minecraft.world.level.gameevent.GameEvent;
- 
--public class MushroomCow extends Cow implements Shearable, VariantHolder<MushroomCow.MushroomType> {
-+public class MushroomCow extends Cow implements Shearable, net.neoforged.neoforge.common.IShearable {
-     private static final EntityDataAccessor<String> DATA_TYPE = SynchedEntityData.defineId(MushroomCow.class, EntityDataSerializers.STRING);
-     private static final int MUTATE_CHANCE = 1024;
-     private static final String TAG_STEW_EFFECTS = "stew_effects";
 @@ -108,7 +_,7 @@
  
              this.playSound(soundevent, 1.0F, 1.0F);
@@ -18,57 +9,28 @@
              this.shear(SoundSource.PLAYERS);
              this.gameEvent(GameEvent.SHEAR, p_28941_);
              if (!this.level().isClientSide) {
-@@ -164,11 +_,22 @@
-     }
- 
-     @Override
-+    public java.util.List<ItemStack> onSheared(@org.jetbrains.annotations.Nullable Player player, @org.jetbrains.annotations.NotNull ItemStack item, Level world, BlockPos pos, int fortune) {
-+        this.gameEvent(GameEvent.SHEAR, player);
-+        return shearInternal(player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS);
-+    }
-+
+@@ -167,8 +_,10 @@
      public void shear(SoundSource p_28924_) {
-+        shearInternal(p_28924_).forEach(s -> this.level().addFreshEntity(new ItemEntity(this.level(), this.getX(), this.getY(1.0D), this.getZ(), s)));
-+    }
-+
-+    private java.util.List<ItemStack> shearInternal(SoundSource p_28924_) {
          this.level().playSound(null, this, SoundEvents.MOOSHROOM_SHEAR, p_28924_, 1.0F, 1.0F);
          if (!this.level().isClientSide()) {
-+            if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.COW, (timer) -> {})) return java.util.Collections.emptyList();
++            if (!net.neoforged.neoforge.event.EventHooks.canLivingConvert(this, EntityType.COW, (timer) -> {})) return;
              Cow cow = EntityType.COW.create(this.level());
              if (cow != null) {
 +                net.neoforged.neoforge.event.EventHooks.onLivingConvert(this, cow);
                  ((ServerLevel)this.level()).sendParticles(ParticleTypes.EXPLOSION, this.getX(), this.getY(0.5), this.getZ(), 1, 0.0, 0.0, 0.0, 0.0);
                  this.discard();
                  cow.moveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
-@@ -186,14 +_,14 @@
-                 cow.setInvulnerable(this.isInvulnerable());
+@@ -187,10 +_,9 @@
                  this.level().addFreshEntity(cow);
  
-+                java.util.List<ItemStack> items = new java.util.ArrayList<>();
                  for(int i = 0; i < 5; ++i) {
 -                    this.level()
 -                        .addFreshEntity(
 -                            new ItemEntity(this.level(), this.getX(), this.getY(1.0), this.getZ(), new ItemStack(this.getVariant().blockState.getBlock()))
 -                        );
-+                    items.add(new ItemStack(this.getVariant().blockState.getBlock()));
++                    //Neo: Change from addFreshEntity to spawnAtLocation to ensure captureDrops can capture this, we also need to unset the default pickup delay from the item
++                    ItemEntity item = spawnAtLocation(new ItemStack(this.getVariant().blockState.getBlock()), getBbHeight());
++                    if (item != null) item.setNoPickUpDelay();
                  }
-+                return items;
              }
          }
-+        return java.util.Collections.emptyList();
-     }
- 
-     @Override
-@@ -261,6 +_,11 @@
-         }
- 
-         return mushroomcow$mushroomtype2;
-+    }
-+
-+    @Override
-+    public boolean isShearable(@org.jetbrains.annotations.NotNull ItemStack item, Level world, BlockPos pos) {
-+        return readyForShearing();
-     }
- 
-     public static enum MushroomType implements StringRepresentable {

--- a/patches/net/minecraft/world/entity/animal/Sheep.java.patch
+++ b/patches/net/minecraft/world/entity/animal/Sheep.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/world/entity/animal/Sheep.java
 +++ b/net/minecraft/world/entity/animal/Sheep.java
-@@ -65,7 +_,7 @@
- import net.minecraft.world.level.storage.loot.BuiltInLootTables;
- import org.joml.Vector3f;
- 
--public class Sheep extends Animal implements Shearable {
-+public class Sheep extends Animal implements Shearable, net.neoforged.neoforge.common.IShearable {
-     private static final int EAT_ANIMATION_TICKS = 40;
-     private static final EntityDataAccessor<Byte> DATA_WOOL_ID = SynchedEntityData.defineId(Sheep.class, EntityDataSerializers.BYTE);
-     private static final Map<DyeColor, ItemLike> ITEM_BY_DYE = Util.make(Maps.newEnumMap(DyeColor.class), p_29841_ -> {
 @@ -206,7 +_,7 @@
      @Override
      public InteractionResult mobInteract(Player p_29853_, InteractionHand p_29854_) {
@@ -18,33 +9,3 @@
              if (!this.level().isClientSide && this.readyForShearing()) {
                  this.shear(SoundSource.PLAYERS);
                  this.gameEvent(GameEvent.SHEAR, p_29853_);
-@@ -380,6 +_,29 @@
-     @Override
-     protected float getStandingEyeHeight(Pose p_29850_, EntityDimensions p_29851_) {
-         return 0.95F * p_29851_.height;
-+    }
-+
-+    @Override
-+    public boolean isShearable(@org.jetbrains.annotations.NotNull ItemStack item, Level world, BlockPos pos) {
-+        return readyForShearing();
-+    }
-+
-+    @org.jetbrains.annotations.NotNull
-+    @Override
-+    public java.util.List<ItemStack> onSheared(@Nullable Player player, @org.jetbrains.annotations.NotNull ItemStack item, Level world, BlockPos pos, int fortune) {
-+        world.playSound(null, this, SoundEvents.SHEEP_SHEAR, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 1.0F, 1.0F);
-+        this.gameEvent(GameEvent.SHEAR, player);
-+        if (!world.isClientSide) {
-+            this.setSheared(true);
-+            int i = 1 + this.random.nextInt(3);
-+
-+            java.util.List<ItemStack> items = new java.util.ArrayList<>();
-+            for (int j = 0; j < i; ++j) {
-+                items.add(new ItemStack(ITEM_BY_DYE.get(this.getColor())));
-+            }
-+            return items;
-+        }
-+        return java.util.Collections.emptyList();
-     }
- 
-     @Override

--- a/patches/net/minecraft/world/entity/animal/SnowGolem.java.patch
+++ b/patches/net/minecraft/world/entity/animal/SnowGolem.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/world/entity/animal/SnowGolem.java
 +++ b/net/minecraft/world/entity/animal/SnowGolem.java
-@@ -40,7 +_,7 @@
- import net.minecraft.world.level.gameevent.GameEvent;
- import net.minecraft.world.phys.Vec3;
- 
--public class SnowGolem extends AbstractGolem implements Shearable, RangedAttackMob {
-+public class SnowGolem extends AbstractGolem implements Shearable, RangedAttackMob, net.neoforged.neoforge.common.IShearable {
-     private static final EntityDataAccessor<Byte> DATA_PUMPKIN_ID = SynchedEntityData.defineId(SnowGolem.class, EntityDataSerializers.BYTE);
-     private static final byte PUMPKIN_FLAG = 16;
-     private static final float EYE_HEIGHT = 1.7F;
 @@ -95,7 +_,7 @@
                  this.hurt(this.damageSources().onFire(), 1.0F);
              }
@@ -27,26 +18,3 @@
              this.shear(SoundSource.PLAYERS);
              this.gameEvent(GameEvent.SHEAR, p_29920_);
              if (!this.level().isClientSide) {
-@@ -196,5 +_,22 @@
-     @Override
-     public Vec3 getLeashOffset() {
-         return new Vec3(0.0, (double)(0.75F * this.getEyeHeight()), (double)(this.getBbWidth() * 0.4F));
-+    }
-+
-+    @Override
-+    public boolean isShearable(@org.jetbrains.annotations.NotNull ItemStack item, Level world, BlockPos pos) {
-+        return readyForShearing();
-+    }
-+
-+    @org.jetbrains.annotations.NotNull
-+    @Override
-+    public java.util.List<ItemStack> onSheared(@Nullable Player player, @org.jetbrains.annotations.NotNull ItemStack item, Level world, BlockPos pos, int fortune) {
-+        world.playSound(null, this, SoundEvents.SNOW_GOLEM_SHEAR, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS, 1.0F, 1.0F);
-+        this.gameEvent(GameEvent.SHEAR, player);
-+        if (!world.isClientSide()) {
-+            setPumpkin(false);
-+            return java.util.Collections.singletonList(new ItemStack(Items.CARVED_PUMPKIN));
-+        }
-+        return java.util.Collections.emptyList();
-     }
- }

--- a/patches/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/net/minecraft/world/item/ShearsItem.java.patch
@@ -9,9 +9,9 @@
 +            if (entity.level().isClientSide) return InteractionResult.CONSUME;
 +            BlockPos pos = entity.blockPosition();
 +            if (target.isShearable(stack, entity.level(), pos)) {
-+                java.util.List<ItemStack> drops = target.onSheared(player, stack, entity.level(), pos, stack.getEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_FORTUNE));
++                target.onSheared(player, stack, entity.level(), pos, stack.getEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_FORTUNE))
++                      .forEach(drop -> target.spawnShearedDrop(entity.level(), pos, drop));
 +                entity.gameEvent(GameEvent.SHEAR, player);
-+                drops.forEach(drop -> target.spawnShearedDrop(entity.level(), pos, drop));
 +                stack.hurtAndBreak(1, player, e -> e.broadcastBreakEvent(hand));
 +            }
 +            return InteractionResult.SUCCESS;

--- a/patches/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/net/minecraft/world/item/ShearsItem.java.patch
@@ -1,26 +1,22 @@
 --- a/net/minecraft/world/item/ShearsItem.java
 +++ b/net/minecraft/world/item/ShearsItem.java
-@@ -59,6 +_,31 @@
+@@ -59,6 +_,27 @@
      }
  
      @Override
-+    public net.minecraft.world.InteractionResult interactLivingEntity(ItemStack stack, net.minecraft.world.entity.player.Player playerIn, LivingEntity entity, net.minecraft.world.InteractionHand hand) {
++    public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity entity, net.minecraft.world.InteractionHand hand) {
 +        if (entity instanceof net.neoforged.neoforge.common.IShearable target) {
-+            if (entity.level().isClientSide) return net.minecraft.world.InteractionResult.SUCCESS;
-+            BlockPos pos = BlockPos.containing(entity.position());
++            if (entity.level().isClientSide) return InteractionResult.CONSUME;
++            BlockPos pos = entity.blockPosition();
 +            if (target.isShearable(stack, entity.level(), pos)) {
-+                java.util.List<ItemStack> drops = target.onSheared(playerIn, stack, entity.level(), pos,
-+                          net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_FORTUNE, stack));
-+                java.util.Random rand = new java.util.Random();
-+                drops.forEach(d -> {
-+                    net.minecraft.world.entity.item.ItemEntity ent = entity.spawnAtLocation(d, 1.0F);
-+                    ent.setDeltaMovement(ent.getDeltaMovement().add((double)((rand.nextFloat() - rand.nextFloat()) * 0.1F), (double)(rand.nextFloat() * 0.05F), (double)((rand.nextFloat() - rand.nextFloat()) * 0.1F)));
-+                });
-+                stack.hurtAndBreak(1, playerIn, e -> e.broadcastBreakEvent(hand));
++                java.util.List<ItemStack> drops = target.onSheared(player, stack, entity.level(), pos, stack.getEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_FORTUNE));
++                entity.gameEvent(GameEvent.SHEAR, player);
++                drops.forEach(target::spawnShearedDrop);
++                stack.hurtAndBreak(1, player, e -> e.broadcastBreakEvent(hand));
 +            }
-+            return net.minecraft.world.InteractionResult.SUCCESS;
++            return InteractionResult.SUCCESS;
 +        }
-+        return net.minecraft.world.InteractionResult.PASS;
++        return InteractionResult.PASS;
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/net/minecraft/world/item/ShearsItem.java.patch
@@ -11,7 +11,7 @@
 +            if (target.isShearable(stack, entity.level(), pos)) {
 +                java.util.List<ItemStack> drops = target.onSheared(player, stack, entity.level(), pos, stack.getEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_FORTUNE));
 +                entity.gameEvent(GameEvent.SHEAR, player);
-+                drops.forEach(target::spawnShearedDrop);
++                drops.forEach(drop -> target.spawnShearedDrop(entity.level(), pos, drop));
 +                stack.hurtAndBreak(1, player, e -> e.broadcastBreakEvent(hand));
 +            }
 +            return InteractionResult.SUCCESS;

--- a/src/main/java/net/neoforged/neoforge/common/IShearable.java
+++ b/src/main/java/net/neoforged/neoforge/common/IShearable.java
@@ -49,9 +49,7 @@ public interface IShearable {
      * The object should perform all actions related to being sheared,
      * except for dropping of the items, and removal of the block.
      * As those are handled by ItemShears itself.
-     *
-     * Returns a list of items that resulted from the shearing process.
-     *
+     * <p>
      * For entities, they should trust there internal location information
      * over the values passed into this function.
      *
@@ -59,7 +57,7 @@ public interface IShearable {
      * @param level   The current level.
      * @param pos     If this is a block, the block's position in level.
      * @param fortune The fortune level of the shears being used.
-     * @return A List containing all items from this shearing. May be empty.
+     * @return A List containing all items that resulted from the shearing process. May be empty.
      */
     default List<ItemStack> onSheared(@Nullable Player player, ItemStack item, Level level, BlockPos pos, int fortune) {
         if (this instanceof LivingEntity entity && this instanceof Shearable shearable) {
@@ -75,10 +73,14 @@ public interface IShearable {
 
     /**
      * Performs the logic used to drop a shear result into the world at the correct position and with the proper movement.
+     * <br>
+     * For entities, they should trust there internal location information over the values passed into this function.
      *
-     * @param drop The ItemStack to drop
+     * @param level The current level.
+     * @param pos   If this is a block, the block's position in level.
+     * @param drop  The ItemStack to drop.
      */
-    default void spawnShearedDrop(ItemStack drop) {
+    default void spawnShearedDrop(Level level, BlockPos pos, ItemStack drop) {
         if (this instanceof SnowGolem golem) {
             golem.spawnAtLocation(drop, 1.7F);
         } else if (this instanceof MushroomCow cow) {
@@ -94,6 +96,8 @@ public interface IShearable {
                         (entity.getRandom().nextFloat() * 0.05F),
                         ((entity.getRandom().nextFloat() - entity.getRandom().nextFloat()) * 0.1F)));
             }
+        } else {
+            level.addFreshEntity(new ItemEntity(level, pos.getX(), pos.getY(), pos.getZ(), drop));
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/IShearable.java
+++ b/src/main/java/net/neoforged/neoforge/common/IShearable.java
@@ -50,8 +50,7 @@ public interface IShearable {
      * except for dropping of the items, and removal of the block.
      * As those are handled by ItemShears itself.
      * <p>
-     * For entities, they should trust there internal location information
-     * over the values passed into this function.
+     * For entities, they should trust their internal location information over the values passed into this function.
      *
      * @param item    The ItemStack that is being used, may be empty.
      * @param level   The current level.
@@ -74,7 +73,7 @@ public interface IShearable {
     /**
      * Performs the logic used to drop a shear result into the world at the correct position and with the proper movement.
      * <br>
-     * For entities, they should trust there internal location information over the values passed into this function.
+     * For entities, they should trust their internal location information over the values passed into this function.
      *
      * @param level The current level.
      * @param pos   If this is a block, the block's position in level.
@@ -84,7 +83,7 @@ public interface IShearable {
         if (this instanceof SnowGolem golem) {
             golem.spawnAtLocation(drop, 1.7F);
         } else if (this instanceof MushroomCow cow) {
-            //Note: Vanilla uses addFreshEntity instead of spawnAtLocation for spawning mooshrooms drops
+            // Note: Vanilla uses addFreshEntity instead of spawnAtLocation for spawning mooshrooms drops
             // In case a mod is capturing drops for the entity we instead do it the same way we patch in MushroomCow#shear
             ItemEntity itemEntity = cow.spawnAtLocation(drop, cow.getBbHeight());
             if (itemEntity != null) itemEntity.setNoPickUpDelay();


### PR DESCRIPTION
Cleanup:
- Reduce patch complexity for redirecting shearing of vanilla entities from the entity to the shears item
- Added the nullable annotation to captureDrops as it is nullable and this then removes the nullability warning from our uses
- Made `Shearable` extend our `IShearable` so that we don't have to have patches in the different entities adding our interface and add a default implementations to query the methods on `Shearable` to remove the need for implementation patches in vanilla implementors
- Use our `Entity#captureDrops` system to prevent items from `Shearable#shear` being dropped and call `Shearable#shear` as a default implementation for `IShearable#onSheared` (this required a small patch to mooshrooms so that the spawned items could actually be captured)
- Removed a few no longer necessary FQNs from the patch in `ShearsItem`
- Fire `GameEvent.SHEAR` from `ShearsItem` rather than where we were patching it in for `onSheared` to be more consistent with how vanilla calls it
- Use the already existing block pos for the entity's position
- Simplify check to use the method we forward to for getting the fortune level

Fixed differences compared to how vanilla has things:
- Fixed us accidentally patching out the `VariantHolder` interface on `MushroomCow`
- Probably doesn't matter but uses the entity's random instead of creating a new random each time
- Spawn sheared drops for snow golems and mooshrooms at the correct height offset and without any random motion applied
- Drops from shearing mooshrooms don't have a pickup delay in vanilla (and now we don't have one either)
- Switched from returning `SUCCESS` to returning `CONSUME` on the client which is what vanilla calls

Minor differences that still exist compared to vanilla but I don't think are worth fixing:
- Shearing snow golems and mooshrooms causes the sound to be played on both the server and the client, but as it is passed with `null` the sound will be synced to the player regardless so we are just causing the sound to play once instead of twice.
- I don't believe this is relevant because `ClientLevel#gameEvent` is a NO-OP so the fact we skip calling it shouldn't matter, but for snow golems and mooshrooms the GameEvent is called on the client level in vanilla

Future work?:
- Make `IShearable` more of a proper extension to `Shearable` rather than the weird relationship the two classes currently have
- Remove the passed in `fortune` parameter from `IShearable#onSheared` as if it is needed it can be easily gotten from the passed in stack