### PR TITLE
Removed shrink of U and V by 16 in UnitTextureAtlasSprite

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/textures/UnitTextureAtlasSprite.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/UnitTextureAtlasSprite.java
@@ -27,11 +27,11 @@ public class UnitTextureAtlasSprite extends TextureAtlasSprite {
 
     @Override
     public float getU(float u) {
-        return u / 16;
+        return u;
     }
 
     @Override
     public float getV(float v) {
-        return v / 16;
+        return v;
     }
 }


### PR DESCRIPTION
After 1.20.1 it seems Mojang changed some TextureAtlasSprite code and handling of sprites and removed shrinking/scaling of U and V coordinates by 16. So right now baked OBJ models with Neo Renderable API will have wrong UV coords.
TextureAtlasSprite code comparison:
![image](https://github.com/neoforged/NeoForge/assets/6237881/8b5a02da-f5dd-40b6-a588-0f3261f80893)
