### PR TITLE
Compostables as data maps

### DIFF
--- a/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -9,7 +9,7 @@
      public static final Object2FloatMap<ItemLike> COMPOSTABLES = new Object2FloatOpenHashMap<>();
      private static final int AABB_SIDE_THICKNESS = 2;
      private static final VoxelShape OUTER_SHAPE = Shapes.block();
-@@ -226,14 +_,24 @@
+@@ -226,13 +_,22 @@
          if (p_51978_.getValue(LEVEL) == 7) {
              p_51979_.scheduleTick(p_51980_, p_51978_.getBlock(), 20);
          }
@@ -29,59 +29,46 @@
          int i = p_51949_.getValue(LEVEL);
          ItemStack itemstack = p_51952_.getItemInHand(p_51953_);
 -        if (i < 8 && COMPOSTABLES.containsKey(itemstack.getItem())) {
--            if (i < 7 && !p_51950_.isClientSide) {
-+        var compostable = getValue(itemstack);
-+        if (i < 8 && compostable != null) {
-+            if (i <= MAX_LEVEL - compostable.amount() && !p_51950_.isClientSide) {
++        if (i < 8 && getValue(itemstack) > 0) {
+             if (i < 7 && !p_51950_.isClientSide) {
                  BlockState blockstate = addItem(p_51952_, p_51949_, p_51950_, p_51951_, itemstack);
                  p_51950_.levelEvent(1500, p_51951_, p_51949_ != blockstate ? 1 : 0);
-                 p_51952_.awardStat(Stats.ITEM_USED.get(itemstack.getItem()));
-@@ -253,7 +_,8 @@
+@@ -253,7 +_,7 @@
  
      public static BlockState insertItem(Entity p_270919_, BlockState p_270087_, ServerLevel p_270284_, ItemStack p_270253_, BlockPos p_270678_) {
          int i = p_270087_.getValue(LEVEL);
 -        if (i < 7 && COMPOSTABLES.containsKey(p_270253_.getItem())) {
-+        var compostable = getValue(p_270253_);
-+        if (compostable != null && i <= MAX_LEVEL - compostable.amount()) {
++        if (i < 7 && getValue(p_270253_) > 0) {
              BlockState blockstate = addItem(p_270919_, p_270087_, p_270284_, p_270678_, p_270253_);
              p_270253_.shrink(1);
              return blockstate;
-@@ -284,11 +_,12 @@
+@@ -284,7 +_,7 @@
  
      static BlockState addItem(@Nullable Entity p_270464_, BlockState p_270603_, LevelAccessor p_270151_, BlockPos p_270547_, ItemStack p_270354_) {
          int i = p_270603_.getValue(LEVEL);
 -        float f = COMPOSTABLES.getFloat(p_270354_.getItem());
-+        var compostable = getValue(p_270354_);
-+        float f = compostable == null ? 0f : compostable.chance();
++        float f = getValue(p_270354_);
          if ((i != 0 || !(f > 0.0F)) && !(p_270151_.getRandom().nextDouble() < (double)f)) {
              return p_270603_;
          } else {
--            int j = i + 1;
-+            int j = i + compostable.amount();
-             BlockState blockstate = p_270603_.setValue(LEVEL, Integer.valueOf(j));
-             p_270151_.setBlock(p_270547_, blockstate, 3);
-             p_270151_.gameEvent(GameEvent.BLOCK_CHANGE, p_270547_, GameEvent.Context.of(p_270464_, blockstate));
-@@ -384,7 +_,8 @@
+@@ -384,7 +_,7 @@
  
          @Override
          public boolean canPlaceItemThroughFace(int p_52028_, ItemStack p_52029_, @Nullable Direction p_52030_) {
 -            return !this.changed && p_52030_ == Direction.UP && ComposterBlock.COMPOSTABLES.containsKey(p_52029_.getItem());
-+            var value = getValue(p_52029_);
-+            return !this.changed && p_52030_ == Direction.UP && value != null && value.amount() <= MAX_LEVEL - state.getValue(LEVEL);
++            return !this.changed && p_52030_ == Direction.UP && getValue(p_52029_) > 0f;
          }
  
          @Override
-@@ -442,5 +_,13 @@
+@@ -442,5 +_,11 @@
              ComposterBlock.empty(null, this.state, this.level, this.pos);
              this.changed = true;
          }
 +    }
 +
-+    @org.jetbrains.annotations.Nullable
-+    public static net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable getValue(ItemStack item) {
++    public static float getValue(ItemStack item) {
 +        var value = item.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
-+        if (value != null) return value;
-+        float chance = COMPOSTABLES.getFloat(item.getItem());
-+        return chance > 0 ? new net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable(chance, 1) : null;
++        if (value != null) return value.chance();
++        return COMPOSTABLES.getFloat(item.getItem());
      }
  }

--- a/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -4,7 +4,7 @@
      public static final int MIN_LEVEL = 0;
      public static final int MAX_LEVEL = 7;
      public static final IntegerProperty LEVEL = BlockStateProperties.LEVEL_COMPOSTER;
-+    /** @deprecated Neo: Use the {@link net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable compostable} data map instead, as this field will be ignored starting with 1.20.5. */
++    /** @deprecated Neo: Use the {@link net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps#COMPOSTABLES compostable} data map instead, as this field will be ignored starting with 1.20.5. */
 +    @Deprecated
      public static final Object2FloatMap<ItemLike> COMPOSTABLES = new Object2FloatOpenHashMap<>();
      private static final int AABB_SIDE_THICKNESS = 2;
@@ -67,7 +67,7 @@
 +    }
 +
 +    public static float getValue(ItemStack item) {
-+        var value = item.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        var value = item.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.COMPOSTABLES);
 +        if (value != null) return value.chance();
 +        return COMPOSTABLES.getFloat(item.getItem());
      }

--- a/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -1,6 +1,15 @@
 --- a/net/minecraft/world/level/block/ComposterBlock.java
 +++ b/net/minecraft/world/level/block/ComposterBlock.java
-@@ -226,6 +_,15 @@
+@@ -47,6 +_,8 @@
+     public static final int MIN_LEVEL = 0;
+     public static final int MAX_LEVEL = 7;
+     public static final IntegerProperty LEVEL = BlockStateProperties.LEVEL_COMPOSTER;
++    /** @deprecated Neo: Use the {@link net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable compostable} data map instead, as this field is ignored. */
++    @Deprecated
+     public static final Object2FloatMap<ItemLike> COMPOSTABLES = new Object2FloatOpenHashMap<>();
+     private static final int AABB_SIDE_THICKNESS = 2;
+     private static final VoxelShape OUTER_SHAPE = Shapes.block();
+@@ -226,14 +_,24 @@
          if (p_51978_.getValue(LEVEL) == 7) {
              p_51979_.scheduleTick(p_51980_, p_51978_.getBlock(), 20);
          }
@@ -16,3 +25,49 @@
      }
  
      @Override
+     public InteractionResult use(BlockState p_51949_, Level p_51950_, BlockPos p_51951_, Player p_51952_, InteractionHand p_51953_, BlockHitResult p_51954_) {
+         int i = p_51949_.getValue(LEVEL);
+         ItemStack itemstack = p_51952_.getItemInHand(p_51953_);
+-        if (i < 8 && COMPOSTABLES.containsKey(itemstack.getItem())) {
+-            if (i < 7 && !p_51950_.isClientSide) {
++        var compostable = itemstack.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        if (i < 8 && compostable != null) {
++            if (i <= MAX_LEVEL - compostable.amount() && !p_51950_.isClientSide) {
+                 BlockState blockstate = addItem(p_51952_, p_51949_, p_51950_, p_51951_, itemstack);
+                 p_51950_.levelEvent(1500, p_51951_, p_51949_ != blockstate ? 1 : 0);
+                 p_51952_.awardStat(Stats.ITEM_USED.get(itemstack.getItem()));
+@@ -253,7 +_,8 @@
+ 
+     public static BlockState insertItem(Entity p_270919_, BlockState p_270087_, ServerLevel p_270284_, ItemStack p_270253_, BlockPos p_270678_) {
+         int i = p_270087_.getValue(LEVEL);
+-        if (i < 7 && COMPOSTABLES.containsKey(p_270253_.getItem())) {
++        var compostable = p_270253_.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        if (compostable != null && i <= MAX_LEVEL - compostable.amount()) {
+             BlockState blockstate = addItem(p_270919_, p_270087_, p_270284_, p_270678_, p_270253_);
+             p_270253_.shrink(1);
+             return blockstate;
+@@ -284,11 +_,12 @@
+ 
+     static BlockState addItem(@Nullable Entity p_270464_, BlockState p_270603_, LevelAccessor p_270151_, BlockPos p_270547_, ItemStack p_270354_) {
+         int i = p_270603_.getValue(LEVEL);
+-        float f = COMPOSTABLES.getFloat(p_270354_.getItem());
++        var compostable = p_270354_.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        float f = compostable == null ? 0f : compostable.chance();
+         if ((i != 0 || !(f > 0.0F)) && !(p_270151_.getRandom().nextDouble() < (double)f)) {
+             return p_270603_;
+         } else {
+-            int j = i + 1;
++            int j = i + compostable.amount();
+             BlockState blockstate = p_270603_.setValue(LEVEL, Integer.valueOf(j));
+             p_270151_.setBlock(p_270547_, blockstate, 3);
+             p_270151_.gameEvent(GameEvent.BLOCK_CHANGE, p_270547_, GameEvent.Context.of(p_270464_, blockstate));
+@@ -384,7 +_,8 @@
+ 
+         @Override
+         public boolean canPlaceItemThroughFace(int p_52028_, ItemStack p_52029_, @Nullable Direction p_52030_) {
+-            return !this.changed && p_52030_ == Direction.UP && ComposterBlock.COMPOSTABLES.containsKey(p_52029_.getItem());
++            var value = p_52029_.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++            return !this.changed && p_52030_ == Direction.UP && value != null && value.amount() <= MAX_LEVEL - state.getValue(LEVEL);
+         }
+ 
+         @Override

--- a/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -4,7 +4,7 @@
      public static final int MIN_LEVEL = 0;
      public static final int MAX_LEVEL = 7;
      public static final IntegerProperty LEVEL = BlockStateProperties.LEVEL_COMPOSTER;
-+    /** @deprecated Neo: Use the {@link net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable compostable} data map instead, as this field is ignored. */
++    /** @deprecated Neo: Use the {@link net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable compostable} data map instead, as this field will be ignored starting with 1.20.5. */
 +    @Deprecated
      public static final Object2FloatMap<ItemLike> COMPOSTABLES = new Object2FloatOpenHashMap<>();
      private static final int AABB_SIDE_THICKNESS = 2;
@@ -30,7 +30,7 @@
          ItemStack itemstack = p_51952_.getItemInHand(p_51953_);
 -        if (i < 8 && COMPOSTABLES.containsKey(itemstack.getItem())) {
 -            if (i < 7 && !p_51950_.isClientSide) {
-+        var compostable = itemstack.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        var compostable = getValue(itemstack);
 +        if (i < 8 && compostable != null) {
 +            if (i <= MAX_LEVEL - compostable.amount() && !p_51950_.isClientSide) {
                  BlockState blockstate = addItem(p_51952_, p_51949_, p_51950_, p_51951_, itemstack);
@@ -41,7 +41,7 @@
      public static BlockState insertItem(Entity p_270919_, BlockState p_270087_, ServerLevel p_270284_, ItemStack p_270253_, BlockPos p_270678_) {
          int i = p_270087_.getValue(LEVEL);
 -        if (i < 7 && COMPOSTABLES.containsKey(p_270253_.getItem())) {
-+        var compostable = p_270253_.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        var compostable = getValue(p_270253_);
 +        if (compostable != null && i <= MAX_LEVEL - compostable.amount()) {
              BlockState blockstate = addItem(p_270919_, p_270087_, p_270284_, p_270678_, p_270253_);
              p_270253_.shrink(1);
@@ -51,7 +51,7 @@
      static BlockState addItem(@Nullable Entity p_270464_, BlockState p_270603_, LevelAccessor p_270151_, BlockPos p_270547_, ItemStack p_270354_) {
          int i = p_270603_.getValue(LEVEL);
 -        float f = COMPOSTABLES.getFloat(p_270354_.getItem());
-+        var compostable = p_270354_.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        var compostable = getValue(p_270354_);
 +        float f = compostable == null ? 0f : compostable.chance();
          if ((i != 0 || !(f > 0.0F)) && !(p_270151_.getRandom().nextDouble() < (double)f)) {
              return p_270603_;
@@ -66,8 +66,22 @@
          @Override
          public boolean canPlaceItemThroughFace(int p_52028_, ItemStack p_52029_, @Nullable Direction p_52030_) {
 -            return !this.changed && p_52030_ == Direction.UP && ComposterBlock.COMPOSTABLES.containsKey(p_52029_.getItem());
-+            var value = p_52029_.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++            var value = getValue(p_52029_);
 +            return !this.changed && p_52030_ == Direction.UP && value != null && value.amount() <= MAX_LEVEL - state.getValue(LEVEL);
          }
  
          @Override
+@@ -442,5 +_,13 @@
+             ComposterBlock.empty(null, this.state, this.level, this.pos);
+             this.changed = true;
+         }
++    }
++
++    @org.jetbrains.annotations.Nullable
++    public static net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable getValue(ItemStack item) {
++        var value = item.getItemHolder().getData(net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.COMPOSTABLES);
++        if (value != null) return value;
++        float chance = COMPOSTABLES.getFloat(item.getItem());
++        return chance > 0 ? new net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps.Compostable(chance, 1) : null;
+     }
+ }

--- a/src/generated/resources/data/neoforge/data_maps/item/compostables.json
+++ b/src/generated/resources/data/neoforge/data_maps/item/compostables.json
@@ -1,0 +1,307 @@
+{
+  "values": {
+    "minecraft:acacia_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:acacia_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:allium": {
+      "chance": 0.65
+    },
+    "minecraft:apple": {
+      "chance": 0.65
+    },
+    "minecraft:azalea": {
+      "chance": 0.65
+    },
+    "minecraft:azalea_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:azure_bluet": {
+      "chance": 0.65
+    },
+    "minecraft:baked_potato": {
+      "chance": 0.85
+    },
+    "minecraft:beetroot": {
+      "chance": 0.65
+    },
+    "minecraft:beetroot_seeds": {
+      "chance": 0.3
+    },
+    "minecraft:big_dripleaf": {
+      "chance": 0.65
+    },
+    "minecraft:birch_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:birch_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:blue_orchid": {
+      "chance": 0.65
+    },
+    "minecraft:bread": {
+      "chance": 0.85
+    },
+    "minecraft:brown_mushroom": {
+      "chance": 0.65
+    },
+    "minecraft:brown_mushroom_block": {
+      "chance": 0.85
+    },
+    "minecraft:cactus": {
+      "chance": 0.5
+    },
+    "minecraft:cake": {
+      "chance": 1.0
+    },
+    "minecraft:carrot": {
+      "chance": 0.65
+    },
+    "minecraft:carved_pumpkin": {
+      "chance": 0.65
+    },
+    "minecraft:cherry_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:cherry_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:cocoa_beans": {
+      "chance": 0.65
+    },
+    "minecraft:cookie": {
+      "chance": 0.85
+    },
+    "minecraft:cornflower": {
+      "chance": 0.65
+    },
+    "minecraft:crimson_fungus": {
+      "chance": 0.65
+    },
+    "minecraft:crimson_roots": {
+      "chance": 0.65
+    },
+    "minecraft:dandelion": {
+      "chance": 0.65
+    },
+    "minecraft:dark_oak_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:dark_oak_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:dried_kelp": {
+      "chance": 0.3
+    },
+    "minecraft:dried_kelp_block": {
+      "chance": 0.5
+    },
+    "minecraft:fern": {
+      "chance": 0.65
+    },
+    "minecraft:flowering_azalea": {
+      "chance": 0.85
+    },
+    "minecraft:flowering_azalea_leaves": {
+      "chance": 0.5
+    },
+    "minecraft:glow_berries": {
+      "chance": 0.3
+    },
+    "minecraft:glow_lichen": {
+      "chance": 0.5
+    },
+    "minecraft:hanging_roots": {
+      "chance": 0.3
+    },
+    "minecraft:hay_block": {
+      "chance": 0.85
+    },
+    "minecraft:jungle_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:jungle_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:kelp": {
+      "chance": 0.3
+    },
+    "minecraft:large_fern": {
+      "chance": 0.65
+    },
+    "minecraft:lilac": {
+      "chance": 0.65
+    },
+    "minecraft:lily_of_the_valley": {
+      "chance": 0.65
+    },
+    "minecraft:lily_pad": {
+      "chance": 0.65
+    },
+    "minecraft:mangrove_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:mangrove_propagule": {
+      "chance": 0.3
+    },
+    "minecraft:mangrove_roots": {
+      "chance": 0.3
+    },
+    "minecraft:melon": {
+      "chance": 0.65
+    },
+    "minecraft:melon_seeds": {
+      "chance": 0.3
+    },
+    "minecraft:melon_slice": {
+      "chance": 0.5
+    },
+    "minecraft:moss_block": {
+      "chance": 0.65
+    },
+    "minecraft:moss_carpet": {
+      "chance": 0.3
+    },
+    "minecraft:mushroom_stem": {
+      "chance": 0.65
+    },
+    "minecraft:nether_sprouts": {
+      "chance": 0.5
+    },
+    "minecraft:nether_wart": {
+      "chance": 0.65
+    },
+    "minecraft:nether_wart_block": {
+      "chance": 0.85
+    },
+    "minecraft:oak_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:oak_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:orange_tulip": {
+      "chance": 0.65
+    },
+    "minecraft:oxeye_daisy": {
+      "chance": 0.65
+    },
+    "minecraft:peony": {
+      "chance": 0.65
+    },
+    "minecraft:pink_petals": {
+      "chance": 0.3
+    },
+    "minecraft:pink_tulip": {
+      "chance": 0.65
+    },
+    "minecraft:pitcher_plant": {
+      "chance": 0.85
+    },
+    "minecraft:pitcher_pod": {
+      "chance": 0.3
+    },
+    "minecraft:poppy": {
+      "chance": 0.65
+    },
+    "minecraft:potato": {
+      "chance": 0.65
+    },
+    "minecraft:pumpkin": {
+      "chance": 0.65
+    },
+    "minecraft:pumpkin_pie": {
+      "chance": 1.0
+    },
+    "minecraft:pumpkin_seeds": {
+      "chance": 0.3
+    },
+    "minecraft:red_mushroom": {
+      "chance": 0.65
+    },
+    "minecraft:red_mushroom_block": {
+      "chance": 0.85
+    },
+    "minecraft:red_tulip": {
+      "chance": 0.65
+    },
+    "minecraft:rose_bush": {
+      "chance": 0.65
+    },
+    "minecraft:sea_pickle": {
+      "chance": 0.65
+    },
+    "minecraft:seagrass": {
+      "chance": 0.3
+    },
+    "minecraft:short_grass": {
+      "chance": 0.3
+    },
+    "minecraft:shroomlight": {
+      "chance": 0.65
+    },
+    "minecraft:small_dripleaf": {
+      "chance": 0.3
+    },
+    "minecraft:spore_blossom": {
+      "chance": 0.65
+    },
+    "minecraft:spruce_leaves": {
+      "chance": 0.3
+    },
+    "minecraft:spruce_sapling": {
+      "chance": 0.3
+    },
+    "minecraft:sugar_cane": {
+      "chance": 0.5
+    },
+    "minecraft:sunflower": {
+      "chance": 0.65
+    },
+    "minecraft:sweet_berries": {
+      "chance": 0.3
+    },
+    "minecraft:tall_grass": {
+      "chance": 0.5
+    },
+    "minecraft:torchflower": {
+      "chance": 0.85
+    },
+    "minecraft:torchflower_seeds": {
+      "chance": 0.3
+    },
+    "minecraft:twisting_vines": {
+      "chance": 0.5
+    },
+    "minecraft:vine": {
+      "chance": 0.5
+    },
+    "minecraft:warped_fungus": {
+      "chance": 0.65
+    },
+    "minecraft:warped_roots": {
+      "chance": 0.65
+    },
+    "minecraft:warped_wart_block": {
+      "chance": 0.85
+    },
+    "minecraft:weeping_vines": {
+      "chance": 0.5
+    },
+    "minecraft:wheat": {
+      "chance": 0.65
+    },
+    "minecraft:wheat_seeds": {
+      "chance": 0.3
+    },
+    "minecraft:white_tulip": {
+      "chance": 0.65
+    },
+    "minecraft:wither_rose": {
+      "chance": 0.65
+    }
+  }
+}

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -153,7 +153,7 @@ import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.NeoForgeRegistriesSetup;
 import net.neoforged.neoforge.registries.RegisterEvent;
-import net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps;
+import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
 import net.neoforged.neoforge.registries.holdersets.AndHolderSet;
 import net.neoforged.neoforge.registries.holdersets.AnyHolderSet;
 import net.neoforged.neoforge.registries.holdersets.HolderSetType;

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -113,6 +113,7 @@ import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.common.data.NeoForgeDamageTypeTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeBiomeTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeBlockTagsProvider;
+import net.neoforged.neoforge.common.data.internal.NeoForgeDataMapsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeEntityTypeTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeFluidTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeItemTagsProvider;
@@ -152,6 +153,7 @@ import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.NeoForgeRegistriesSetup;
 import net.neoforged.neoforge.registries.RegisterEvent;
+import net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps;
 import net.neoforged.neoforge.registries.holdersets.AndHolderSet;
 import net.neoforged.neoforge.registries.holdersets.AnyHolderSet;
 import net.neoforged.neoforge.registries.holdersets.HolderSetType;
@@ -605,6 +607,8 @@ public class NeoForgeMod {
         NeoForge.EVENT_BUS.addListener(CapabilityHooks::invalidateCapsOnChunkUnload);
         NeoForge.EVENT_BUS.addListener(CapabilityHooks::cleanCapabilityListenerReferencesOnTick);
 
+        modEventBus.register(NeoForgeDataMaps.class);
+
         if (isPRBuild(container.getModInfo().getVersion().toString())) {
             isPRBuild = true;
             ModLoader.get().addWarning(new ModLoadingWarning(
@@ -644,6 +648,7 @@ public class NeoForgeMod {
         gen.addProvider(event.includeServer(), new NeoForgeBiomeTagsProvider(packOutput, lookupProvider, existingFileHelper));
         gen.addProvider(event.includeServer(), new NeoForgeDamageTypeTagsProvider(packOutput, lookupProvider, existingFileHelper));
         gen.addProvider(event.includeServer(), new NeoForgeRegistryOrderReportProvider(packOutput));
+        gen.addProvider(event.includeServer(), new NeoForgeDataMapsProvider(packOutput, lookupProvider));
 
         gen.addProvider(event.includeClient(), new NeoForgeSpriteSourceProvider(packOutput, lookupProvider, existingFileHelper));
         gen.addProvider(event.includeClient(), new VanillaSoundDefinitionsProvider(packOutput, existingFileHelper));

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
@@ -20,6 +20,6 @@ public class NeoForgeDataMapsProvider extends DataMapProvider {
     @Override
     protected void gather() {
         final var compostables = builder(NeoForgeDataMaps.COMPOSTABLES);
-        ComposterBlock.COMPOSTABLES.forEach((item, chance) -> compostables.add(item.asItem().builtInRegistryHolder(), new NeoForgeDataMaps.Compostable(chance, 1), false));
+        ComposterBlock.COMPOSTABLES.forEach((item, chance) -> compostables.add(item.asItem().builtInRegistryHolder(), new NeoForgeDataMaps.Compostable(chance), false));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.data.internal;
+
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.level.block.ComposterBlock;
+import net.neoforged.neoforge.common.data.DataMapProvider;
+import net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps;
+
+public class NeoForgeDataMapsProvider extends DataMapProvider {
+    public NeoForgeDataMapsProvider(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> lookupProvider) {
+        super(packOutput, lookupProvider);
+    }
+
+    @Override
+    protected void gather() {
+        final var compostables = builder(NeoForgeDataMaps.COMPOSTABLES);
+        ComposterBlock.COMPOSTABLES.forEach((item, chance) -> compostables.add(item.asItem().builtInRegistryHolder(), new NeoForgeDataMaps.Compostable(chance, 1), false));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
@@ -10,7 +10,8 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.world.level.block.ComposterBlock;
 import net.neoforged.neoforge.common.data.DataMapProvider;
-import net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps;
+import net.neoforged.neoforge.registries.datamaps.builtin.Compostable;
+import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
 
 public class NeoForgeDataMapsProvider extends DataMapProvider {
     public NeoForgeDataMapsProvider(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> lookupProvider) {
@@ -20,6 +21,6 @@ public class NeoForgeDataMapsProvider extends DataMapProvider {
     @Override
     protected void gather() {
         final var compostables = builder(NeoForgeDataMaps.COMPOSTABLES);
-        ComposterBlock.COMPOSTABLES.forEach((item, chance) -> compostables.add(item.asItem().builtInRegistryHolder(), new NeoForgeDataMaps.Compostable(chance), false));
+        ComposterBlock.COMPOSTABLES.forEach((item, chance) -> compostables.add(item.asItem().builtInRegistryHolder(), new Compostable(chance), false));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/NeoForgeDataMaps.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/NeoForgeDataMaps.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.registries.datamaps;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.ComposterBlock;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+
+/**
+ * Holds all {@link DataMapType data maps} provided by NeoForge.
+ * <p>
+ * These data maps are usually replacements for vanilla in-code maps, and are optionally
+ * synced so that mods can use them on the client side.
+ */
+public class NeoForgeDataMaps {
+    /**
+     * The {@linkplain Item} data map that replaces {@link ComposterBlock#COMPOSTABLES}.
+     * <p>
+     * The location of this data map is {@code neoforge/data_maps/item/compostables.json}, and the values are objects with 2 fields:
+     * <ul>
+     * <li>{@code chance}, a float between 0 and 1 (inclusive) - the chance that the item will add levels to the composter when composted</li>
+     * <li>{@code amount}, an optional integer between 1 and 7 (inclusive) - how many levels a successful compost should add to the composter</li>
+     * </ul>
+     */
+    public static final DataMapType<Item, Compostable> COMPOSTABLES = DataMapType.builder(
+            id("compostables"), Registries.ITEM, Compostable.CODEC).synced(Compostable.CODEC, false).build();
+
+    /**
+     * Data map value for {@linkplain #COMPOSTABLES compostables}.
+     *
+     * @param chance the chance that a compost is successful
+     * @param amount the levels to add to the composter
+     */
+    public record Compostable(float chance, int amount) {
+        public static final Codec<Compostable> CODEC = RecordCodecBuilder.create(in -> in.group(
+                Codec.floatRange(0f, 1f).fieldOf("chance").forGetter(Compostable::chance),
+                ExtraCodecs.strictOptionalField(ExtraCodecs.intRange(1, 7), "amount", 1).forGetter(Compostable::amount)).apply(in, Compostable::new));
+    }
+
+    private static ResourceLocation id(final String name) {
+        return new ResourceLocation(NeoForgeVersion.MOD_ID, name);
+    }
+
+    @SubscribeEvent
+    private static void register(final RegisterDataMapTypesEvent event) {
+        event.register(COMPOSTABLES);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/NeoForgeDataMaps.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/NeoForgeDataMaps.java
@@ -25,25 +25,28 @@ public class NeoForgeDataMaps {
     /**
      * The {@linkplain Item} data map that replaces {@link ComposterBlock#COMPOSTABLES}.
      * <p>
-     * The location of this data map is {@code neoforge/data_maps/item/compostables.json}, and the values are objects with 2 fields:
+     * The location of this data map is {@code neoforge/data_maps/item/compostables.json}, and the values are objects with 1 field:
      * <ul>
      * <li>{@code chance}, a float between 0 and 1 (inclusive) - the chance that the item will add levels to the composter when composted</li>
-     * <li>{@code amount}, an optional integer between 1 and 7 (inclusive) - how many levels a successful compost should add to the composter</li>
      * </ul>
+     *
+     * The use of a float as the value is also possible, though discouraged in case more options are added in the future.
      */
     public static final DataMapType<Item, Compostable> COMPOSTABLES = DataMapType.builder(
-            id("compostables"), Registries.ITEM, Compostable.CODEC).synced(Compostable.CODEC, false).build();
+            id("compostables"), Registries.ITEM, Compostable.CODEC).synced(Compostable.CHANCE_CODEC, false).build();
 
     /**
      * Data map value for {@linkplain #COMPOSTABLES compostables}.
      *
      * @param chance the chance that a compost is successful
-     * @param amount the levels to add to the composter
      */
-    public record Compostable(float chance, int amount) {
-        public static final Codec<Compostable> CODEC = RecordCodecBuilder.create(in -> in.group(
-                Codec.floatRange(0f, 1f).fieldOf("chance").forGetter(Compostable::chance),
-                ExtraCodecs.strictOptionalField(ExtraCodecs.intRange(1, 7), "amount", 1).forGetter(Compostable::amount)).apply(in, Compostable::new));
+    public record Compostable(float chance) {
+        public static final Codec<Compostable> CHANCE_CODEC = Codec.floatRange(0f, 1f)
+                .xmap(Compostable::new, Compostable::chance);
+        public static final Codec<Compostable> CODEC = ExtraCodecs.withAlternative(
+                RecordCodecBuilder.create(in -> in.group(
+                        Codec.floatRange(0f, 1f).fieldOf("chance").forGetter(Compostable::chance)).apply(in, Compostable::new)),
+                CHANCE_CODEC);
     }
 
     private static ResourceLocation id(final String name) {

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/Compostable.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/Compostable.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.registries.datamaps.builtin;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.ExtraCodecs;
+
+/**
+ * Data map value for {@linkplain NeoForgeDataMaps#COMPOSTABLES compostables}.
+ *
+ * @param chance the chance that a compost is successful
+ */
+public record Compostable(float chance) {
+    public static final Codec<Compostable> CHANCE_CODEC = Codec.floatRange(0f, 1f)
+            .xmap(Compostable::new, Compostable::chance);
+    public static final Codec<Compostable> CODEC = ExtraCodecs.withAlternative(
+            RecordCodecBuilder.create(in -> in.group(
+                    Codec.floatRange(0f, 1f).fieldOf("chance").forGetter(Compostable::chance)).apply(in, Compostable::new)),
+            CHANCE_CODEC);
+}

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/NeoForgeDataMaps.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/NeoForgeDataMaps.java
@@ -3,17 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-package net.neoforged.neoforge.registries.datamaps;
+package net.neoforged.neoforge.registries.datamaps.builtin;
 
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.ComposterBlock;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.registries.datamaps.DataMapType;
+import net.neoforged.neoforge.registries.datamaps.RegisterDataMapTypesEvent;
 
 /**
  * Holds all {@link DataMapType data maps} provided by NeoForge.
@@ -34,20 +33,6 @@ public class NeoForgeDataMaps {
      */
     public static final DataMapType<Item, Compostable> COMPOSTABLES = DataMapType.builder(
             id("compostables"), Registries.ITEM, Compostable.CODEC).synced(Compostable.CHANCE_CODEC, false).build();
-
-    /**
-     * Data map value for {@linkplain #COMPOSTABLES compostables}.
-     *
-     * @param chance the chance that a compost is successful
-     */
-    public record Compostable(float chance) {
-        public static final Codec<Compostable> CHANCE_CODEC = Codec.floatRange(0f, 1f)
-                .xmap(Compostable::new, Compostable::chance);
-        public static final Codec<Compostable> CODEC = ExtraCodecs.withAlternative(
-                RecordCodecBuilder.create(in -> in.group(
-                        Codec.floatRange(0f, 1f).fieldOf("chance").forGetter(Compostable::chance)).apply(in, Compostable::new)),
-                CHANCE_CODEC);
-    }
 
     private static ResourceLocation id(final String name) {
         return new ResourceLocation(NeoForgeVersion.MOD_ID, name);

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.registries.datamaps.builtin;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/tests/src/generated/resources/data/neoforge/data_maps/item/compostables.json
+++ b/tests/src/generated/resources/data/neoforge/data_maps/item/compostables.json
@@ -1,0 +1,12 @@
+{
+  "values": {
+    "#minecraft:compasses": {
+      "amount": 2,
+      "chance": 1.0
+    },
+    "minecraft:activator_rail": {
+      "amount": 6,
+      "chance": 1.0
+    }
+  }
+}

--- a/tests/src/generated/resources/data/neoforge/data_maps/item/compostables.json
+++ b/tests/src/generated/resources/data/neoforge/data_maps/item/compostables.json
@@ -1,11 +1,6 @@
 {
   "values": {
     "#minecraft:compasses": {
-      "amount": 2,
-      "chance": 1.0
-    },
-    "minecraft:activator_rail": {
-      "amount": 6,
       "chance": 1.0
     }
   }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -306,7 +306,8 @@ public class DataMapTests {
                 // Activator rail gives 6 level so it should be impossible to insert it in a composter with 2 filled already
                 .thenExecute(player -> helper.useBlock(
                         new BlockPos(1, 1, 1), player, Items.ACTIVATOR_RAIL.getDefaultInstance()))
-                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2)));
+                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2))
+                .thenSucceed());
     }
 
     public record SomeObject(

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -39,8 +39,9 @@ import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueMerger;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueRemover;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueRemover.Default;
-import net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps;
 import net.neoforged.neoforge.registries.datamaps.RegisterDataMapTypesEvent;
+import net.neoforged.neoforge.registries.datamaps.builtin.Compostable;
+import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -293,7 +294,7 @@ public class DataMapTests {
             @Override
             protected void gather() {
                 builder(NeoForgeDataMaps.COMPOSTABLES)
-                        .add(ItemTags.COMPASSES, new NeoForgeDataMaps.Compostable(1f), false);
+                        .add(ItemTags.COMPASSES, new Compostable(1f), false);
             }
         });
         test.onGameTest(helper -> helper.startSequence(helper::makeMockPlayer)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -300,7 +300,7 @@ public class DataMapTests {
                 .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.COMPOSTER))
                 .thenExecute(player -> helper.useBlock(
                         new BlockPos(1, 1, 1), player, Items.COMPASS.getDefaultInstance()))
-                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2))
+                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 1))
                 .thenSucceed());
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -293,19 +293,13 @@ public class DataMapTests {
             @Override
             protected void gather() {
                 builder(NeoForgeDataMaps.COMPOSTABLES)
-                        .add(ItemTags.COMPASSES, new NeoForgeDataMaps.Compostable(1f, 2), false)
-                        .add(Items.ACTIVATOR_RAIL.builtInRegistryHolder(), new NeoForgeDataMaps.Compostable(1f, 6), false);
+                        .add(ItemTags.COMPASSES, new NeoForgeDataMaps.Compostable(1f), false);
             }
         });
         test.onGameTest(helper -> helper.startSequence(helper::makeMockPlayer)
                 .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.COMPOSTER))
                 .thenExecute(player -> helper.useBlock(
                         new BlockPos(1, 1, 1), player, Items.COMPASS.getDefaultInstance()))
-                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2))
-
-                // Activator rail gives 6 level so it should be impossible to insert it in a composter with 2 filled already
-                .thenExecute(player -> helper.useBlock(
-                        new BlockPos(1, 1, 1), player, Items.ACTIVATOR_RAIL.getDefaultInstance()))
                 .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2))
                 .thenSucceed());
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
@@ -28,6 +29,8 @@ import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ComposterBlock;
 import net.neoforged.neoforge.common.data.DataMapProvider;
 import net.neoforged.neoforge.event.entity.living.LivingDamageEvent;
 import net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent;
@@ -36,6 +39,7 @@ import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueMerger;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueRemover;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueRemover.Default;
+import net.neoforged.neoforge.registries.datamaps.NeoForgeDataMaps;
 import net.neoforged.neoforge.registries.datamaps.RegisterDataMapTypesEvent;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
@@ -279,6 +283,30 @@ public class DataMapTests {
             helper.assertTrue(player.totalExperience == 130, "Player didn't receive experience");
             helper.succeed();
         });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if custom compostables work")
+    static void compostablesMapTest(final DynamicTest test, final RegistrationHelper reg) {
+        reg.addProvider(event -> new DataMapProvider(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
+            @Override
+            protected void gather() {
+                builder(NeoForgeDataMaps.COMPOSTABLES)
+                        .add(ItemTags.COMPASSES, new NeoForgeDataMaps.Compostable(1f, 2), false)
+                        .add(Items.ACTIVATOR_RAIL.builtInRegistryHolder(), new NeoForgeDataMaps.Compostable(1f, 6), false);
+            }
+        });
+        test.onGameTest(helper -> helper.startSequence(helper::makeMockPlayer)
+                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.COMPOSTER))
+                .thenExecute(player -> helper.useBlock(
+                        new BlockPos(1, 1, 1), player, Items.COMPASS.getDefaultInstance()))
+                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2))
+
+                // Activator rail gives 6 level so it should be impossible to insert it in a composter with 2 filled already
+                .thenExecute(player -> helper.useBlock(
+                        new BlockPos(1, 1, 1), player, Items.ACTIVATOR_RAIL.getDefaultInstance()))
+                .thenExecute(() -> helper.assertBlockProperty(new BlockPos(1, 1, 1), ComposterBlock.LEVEL, 2)));
     }
 
     public record SomeObject(


### PR DESCRIPTION
Adds compostables as a data map that has an object with 1 key as value: `chance`: [0, 1] float.  
The type is a record and serializes as an object for future expansion.

The vanilla map will be ignored starting with 1.20.5, and a data map file for its values is generated through neo's datagen (we already have to re-run datagen every version because we replace recipes).  

The data map is *optionally* synced so that mods can use it on the client if they want to. Vanilla clients do not use the value on the client.

Fixes #495.