### PR TITLE
Add various helpers to FluidStack similar to those in ItemStack and BlockState

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -257,6 +257,7 @@ public class FluidStack {
      * @return A copy of this FluidStack
      */
     public FluidStack copy() {
+        //TODO - 1.20.5: Mirror vanilla's ItemStack#copy method and return the empty instance if this is empty
         return new FluidStack(getFluid(), amount, tag);
     }
 
@@ -264,6 +265,9 @@ public class FluidStack {
      * @return A copy of this FluidStack
      */
     public FluidStack copyWithAmount(int amount) {
+        if (isEmpty() || amount <= 0) {
+            return EMPTY;
+        }
         return new FluidStack(getFluid(), amount, tag);
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -8,13 +8,16 @@ package net.neoforged.neoforge.fluids;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.Optional;
+import java.util.stream.Stream;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
@@ -49,6 +52,7 @@ public class FluidStack {
 
     private boolean isEmpty;
     private int amount;
+    @Nullable
     private CompoundTag tag;
     private final Fluid fluid;
 
@@ -143,6 +147,38 @@ public class FluidStack {
         return fluid;
     }
 
+    public final FluidType getFluidType() {
+        return getFluid().getFluidType();
+    }
+
+    public final Holder<Fluid> getFluidHolder() {
+        return getFluid().builtInRegistryHolder();
+    }
+
+    public final boolean is(TagKey<Fluid> tag) {
+        return getFluidHolder().is(tag);
+    }
+
+    public final boolean is(Fluid fluid) {
+        return getFluid() == fluid;
+    }
+
+    public final boolean is(FluidType fluidType) {
+        return getFluidType() == fluidType;
+    }
+
+    public final boolean is(Holder<Fluid> holder) {
+        return is(holder.value());
+    }
+
+    public final boolean is(HolderSet<Fluid> holderSet) {
+        return holderSet.contains(getFluidHolder());
+    }
+
+    public final Stream<TagKey<Fluid>> getTags() {
+        return getFluidHolder().tags();
+    }
+
     public boolean isEmpty() {
         return isEmpty;
     }
@@ -173,6 +209,7 @@ public class FluidStack {
         return tag != null;
     }
 
+    @Nullable
     public CompoundTag getTag() {
         return tag;
     }
@@ -209,17 +246,24 @@ public class FluidStack {
     }
 
     public Component getDisplayName() {
-        return this.getFluid().getFluidType().getDescription(this);
+        return getFluidType().getDescription(this);
     }
 
     public String getTranslationKey() {
-        return this.getFluid().getFluidType().getDescriptionId(this);
+        return getFluidType().getDescriptionId(this);
     }
 
     /**
      * @return A copy of this FluidStack
      */
     public FluidStack copy() {
+        return new FluidStack(getFluid(), amount, tag);
+    }
+
+    /**
+     * @return A copy of this FluidStack
+     */
+    public FluidStack copyWithAmount(int amount) {
         return new FluidStack(getFluid(), amount, tag);
     }
 
@@ -231,7 +275,7 @@ public class FluidStack {
      * @return true if the Fluids (IDs and NBT Tags) are the same
      */
     public boolean isFluidEqual(FluidStack other) {
-        return getFluid() == other.getFluid() && isFluidStackTagEqual(other);
+        return is(other.getFluid()) && isFluidStackTagEqual(other);
     }
 
     private boolean isFluidStackTagEqual(FluidStack other) {

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidUtil.java
@@ -119,7 +119,7 @@ public class FluidUtil {
                         if (doFill) {
                             tryFluidTransfer(containerFluidHandler, fluidSource, maxAmount, true);
                             if (player != null) {
-                                SoundEvent soundevent = simulatedTransfer.getFluid().getFluidType().getSound(simulatedTransfer, SoundActions.BUCKET_FILL);
+                                SoundEvent soundevent = simulatedTransfer.getFluidType().getSound(simulatedTransfer, SoundActions.BUCKET_FILL);
 
                                 if (soundevent != null) {
                                     player.level().playSound(null, player.getX(), player.getY() + 0.5, player.getZ(), soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
@@ -166,7 +166,7 @@ public class FluidUtil {
                     }
 
                     if (doDrain && player != null) {
-                        SoundEvent soundevent = transfer.getFluid().getFluidType().getSound(transfer, SoundActions.BUCKET_EMPTY);
+                        SoundEvent soundevent = transfer.getFluidType().getSound(transfer, SoundActions.BUCKET_EMPTY);
 
                         if (soundevent != null) {
                             player.level().playSound(null, player.getX(), player.getY() + 0.5, player.getZ(), soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
@@ -490,7 +490,7 @@ public class FluidUtil {
         if (fluid.getFluidType().isVaporizedOnPlacement(level, pos, resource)) {
             FluidStack result = fluidSource.drain(resource, IFluidHandler.FluidAction.EXECUTE);
             if (!result.isEmpty()) {
-                result.getFluid().getFluidType().onVaporize(player, level, pos, result);
+                result.getFluidType().onVaporize(player, level, pos, result);
                 return true;
             }
         } else {
@@ -503,7 +503,7 @@ public class FluidUtil {
             }
             FluidStack result = tryFluidTransfer(handler, fluidSource, resource, true);
             if (!result.isEmpty()) {
-                SoundEvent soundevent = resource.getFluid().getFluidType().getSound(resource, SoundActions.BUCKET_EMPTY);
+                SoundEvent soundevent = resource.getFluidType().getSound(resource, SoundActions.BUCKET_EMPTY);
 
                 if (soundevent != null) {
                     level.playSound(player, pos, soundevent, SoundSource.BLOCKS, 1.0F, 1.0F);
@@ -553,16 +553,13 @@ public class FluidUtil {
      *         Returns empty itemStack if none of the enabled buckets can hold the fluid.
      */
     public static ItemStack getFilledBucket(FluidStack fluidStack) {
-        Fluid fluid = fluidStack.getFluid();
-
         if (!fluidStack.hasTag() || fluidStack.getTag().isEmpty()) {
-            if (fluid == Fluids.WATER) {
+            if (fluidStack.is(Fluids.WATER)) {
                 return new ItemStack(Items.WATER_BUCKET);
-            } else if (fluid == Fluids.LAVA) {
+            } else if (fluidStack.is(Fluids.LAVA)) {
                 return new ItemStack(Items.LAVA_BUCKET);
             }
         }
-
-        return fluid.getFluidType().getBucket(fluidStack);
+        return fluidStack.getFluidType().getBucket(fluidStack);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -88,9 +88,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
             int fillAmount = Math.min(capacity, resource.getAmount());
 
             if (doFill.execute()) {
-                FluidStack filled = resource.copy();
-                filled.setAmount(fillAmount);
-                setFluid(filled);
+                setFluid(resource.copyWithAmount(fillAmount));
             }
 
             return fillAmount;
@@ -131,8 +129,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
 
         final int drainAmount = Math.min(contained.getAmount(), maxDrain);
 
-        FluidStack drained = contained.copy();
-        drained.setAmount(drainAmount);
+        FluidStack drained = contained.copyWithAmount(drainAmount);
 
         if (action.execute()) {
             contained.shrink(drainAmount);

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -85,9 +85,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
             int fillAmount = Math.min(capacity, resource.getAmount());
             if (fillAmount == capacity) {
                 if (action.execute()) {
-                    FluidStack filled = resource.copy();
-                    filled.setAmount(fillAmount);
-                    setFluid(filled);
+                    setFluid(resource.copyWithAmount(fillAmount));
                 }
 
                 return fillAmount;

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/BlockWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/BlockWrapper.java
@@ -62,7 +62,7 @@ public class BlockWrapper extends VoidFluidHandler {
                 BlockState state = world.getBlockState(blockPos);
                 if (liquidContainer.canPlaceLiquid(null, world, blockPos, state, resource.getFluid())) {
                     if (action.execute()) {
-                        liquidContainer.placeLiquid(world, blockPos, state, resource.getFluid().getFluidType().getStateForPlacement(world, blockPos, resource));
+                        liquidContainer.placeLiquid(world, blockPos, state, resource.getFluidType().getStateForPlacement(world, blockPos, resource));
                     }
                     return FluidType.BUCKET_VOLUME;
                 }

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/BucketPickupHandlerWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/BucketPickupHandlerWrapper.java
@@ -70,7 +70,7 @@ public class BucketPickupHandlerWrapper implements IFluidHandler {
     public FluidStack drain(FluidStack resource, FluidAction action) {
         if (!resource.isEmpty() && FluidType.BUCKET_VOLUME <= resource.getAmount()) {
             FluidState fluidState = world.getFluidState(blockPos);
-            if (!fluidState.isEmpty() && resource.getFluid() == fluidState.getType()) {
+            if (!fluidState.isEmpty() && resource.is(fluidState.getType())) {
                 if (action.execute()) {
                     ItemStack itemStack = bucketPickupHandler.pickupBlock(player, world, blockPos, world.getBlockState(blockPos));
                     if (itemStack != ItemStack.EMPTY && itemStack.getItem() instanceof BucketItem bucket) {

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/CauldronWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/CauldronWrapper.java
@@ -84,7 +84,7 @@ public class CauldronWrapper implements IFluidHandler {
 
         BlockState state = level.getBlockState(pos);
         CauldronFluidContent currentContent = getContent(state);
-        if (currentContent.fluid != Fluids.EMPTY && currentContent.fluid != resource.getFluid()) {
+        if (currentContent.fluid != Fluids.EMPTY && !resource.is(currentContent.fluid)) {
             // Fluid mismatch
             return 0;
         }
@@ -110,7 +110,7 @@ public class CauldronWrapper implements IFluidHandler {
         }
 
         BlockState state = level.getBlockState(pos);
-        if (getContent(state).fluid == resource.getFluid() && !resource.hasTag()) {
+        if (resource.is(getContent(state).fluid) && !resource.hasTag()) {
             return drain(state, resource.getAmount(), action);
         } else {
             return FluidStack.EMPTY;

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/FluidBlockWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/FluidBlockWrapper.java
@@ -47,7 +47,7 @@ public class FluidBlockWrapper implements IFluidHandler {
 
     @Override
     public boolean isFluidValid(int tank, FluidStack stack) {
-        return stack.getFluid() == fluidBlock.getFluid();
+        return stack.is(fluidBlock.getFluid());
     }
 
     @Override
@@ -57,7 +57,7 @@ public class FluidBlockWrapper implements IFluidHandler {
 
     @Override
     public FluidStack drain(FluidStack resource, FluidAction action) {
-        if (!resource.isEmpty() && fluidBlock.canDrain(world, blockPos) && resource.getFluid() == fluidBlock.getFluid()) {
+        if (!resource.isEmpty() && fluidBlock.canDrain(world, blockPos) && resource.is(fluidBlock.getFluid())) {
             FluidStack simulatedDrained = fluidBlock.drain(world, blockPos, FluidAction.SIMULATE);
             if (simulatedDrained.getAmount() <= resource.getAmount() && resource.isFluidEqual(simulatedDrained)) {
                 if (action.execute()) {

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -34,10 +34,10 @@ public class FluidBucketWrapper implements IFluidHandlerItem {
     }
 
     public boolean canFillFluidType(FluidStack fluid) {
-        if (fluid.getFluid() == Fluids.WATER || fluid.getFluid() == Fluids.LAVA) {
+        if (fluid.is(Fluids.WATER) || fluid.is(Fluids.LAVA)) {
             return true;
         }
-        return !fluid.getFluid().getFluidType().getBucket(fluid).isEmpty();
+        return !fluid.getFluidType().getBucket(fluid).isEmpty();
     }
 
     public FluidStack getFluid() {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/FluidUtilTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/FluidUtilTest.java
@@ -131,7 +131,7 @@ public class FluidUtilTest {
     }
 
     private static void checkFluidStack(FluidStack stack, Fluid fluid, int amount) {
-        if (stack.getFluid() != fluid)
+        if (!stack.is(fluid))
             throw new AssertionError("Expected fluid " + BuiltInRegistries.FLUID.getKey(fluid) + ", got: " + BuiltInRegistries.FLUID.getKey(stack.getFluid()));
         if (stack.getAmount() != amount)
             throw new AssertionError("Expected amount " + amount + ", got: " + stack.getAmount());

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -72,7 +72,7 @@ public class CustomFluidContainerTest {
                 if (fluidStack.isEmpty()) {
                     name.set(name.get() + " (empty)");
                 } else {
-                    name.set(name.get() + " (" + fluidStack.getFluid().getFluidType().getDescription().getString() + ")");
+                    name.set(name.get() + " (" + fluidStack.getFluidType().getDescription().getString() + ")");
                 }
             });
             return Component.literal(name.get());


### PR DESCRIPTION
Finally got annoyed enough at this to make a PR, but adds methods for fluidstack that are equivalents to the following ItemStack/BlockState methods for accessing the wrapped Item/Block
- `getItemHolder`/`getBlockHolder` -> `getFluidHolder`
- `is(...)` -> `is(...)`
- `getTags()` -> `getTags()`
- `copyWithCount(int)`/`N/A` -> `copyWithAmount(int)`

Additionally I added a helper to get the fluid type of the fluid for the fluid stack, and properly marked the NBT for the fluidstack as nullable given it was not explicitly annotated as nullable and https://github.com/neoforged/NeoForge/commit/8952c96456cf811bc0a76f643c4ae6314bc29617 made them display as notnull