### PR TITLE
[1.20.4] Move Attribute to head of registration order

### DIFF
--- a/src/generated/resources/reports/registry_order.json
+++ b/src/generated/resources/reports/registry_order.json
@@ -1,5 +1,6 @@
 {
   "order": [
+    "minecraft:attribute",
     "minecraft:game_event",
     "minecraft:sound_event",
     "minecraft:fluid",
@@ -20,7 +21,6 @@
     "minecraft:menu",
     "minecraft:recipe_type",
     "minecraft:recipe_serializer",
-    "minecraft:attribute",
     "minecraft:position_source_type",
     "minecraft:command_argument_type",
     "minecraft:stat_type",
@@ -69,6 +69,17 @@
     "minecraft:decorated_pot_patterns",
     "minecraft:creative_mode_tab",
     "minecraft:trigger_type",
-    "minecraft:number_format_type"
+    "minecraft:number_format_type",
+    "neoforge:attachment_types",
+    "neoforge:biome_modifier_serializers",
+    "neoforge:condition_codecs",
+    "neoforge:display_contexts",
+    "neoforge:entity_data_serializers",
+    "neoforge:fluid_type",
+    "neoforge:global_loot_modifier_serializers",
+    "neoforge:holder_set_type",
+    "neoforge:ingredient_serializer",
+    "neoforge:item_predicates",
+    "neoforge:structure_modifier_serializers"
   ]
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRegistryOrderReportProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRegistryOrderReportProvider.java
@@ -9,10 +9,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
+import net.neoforged.neoforge.registries.GameData;
 
 public final class NeoForgeRegistryOrderReportProvider implements DataProvider {
     private final PackOutput output;
@@ -26,7 +26,7 @@ public final class NeoForgeRegistryOrderReportProvider implements DataProvider {
         JsonObject json = new JsonObject();
 
         JsonArray array = new JsonArray();
-        BuiltInRegistries.getVanillaRegistrationOrder().forEach(name -> array.add(name.toString()));
+        GameData.getRegistrationOrder().forEach(name -> array.add(name.toString()));
         json.add("order", array);
 
         Path path = this.output.getOutputFolder(PackOutput.Target.REPORTS).resolve("registry_order.json");

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -34,10 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
-/**
- * INTERNAL ONLY
- * MODDERS SHOULD HAVE NO REASON TO USE THIS CLASS
- */
 @ApiStatus.Internal
 public class GameData {
     private static final Logger LOGGER = LogUtils.getLogger();

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -79,10 +79,7 @@ public class GameData {
     }
 
     public static void postRegisterEvents() {
-        Set<ResourceLocation> ordered = new LinkedHashSet<>();
-        ordered.add(Registries.ATTRIBUTE.location()); // Vanilla order is incorrect, both Item and MobEffect depend on Attribute at construction time.
-        ordered.addAll(BuiltInRegistries.getVanillaRegistrationOrder());
-        ordered.addAll(BuiltInRegistries.REGISTRY.keySet().stream().sorted(ResourceLocation::compareNamespaced).toList());
+        Set<ResourceLocation> ordered = GameData.getRegistrationOrder();
 
         RuntimeException aggregate = new RuntimeException();
         for (ResourceLocation rootRegistryName : ordered) {
@@ -112,5 +109,22 @@ public class GameData {
 
     static void fireRemapEvent(final Map<ResourceLocation, Map<ResourceLocation, IdMappingEvent.IdRemapping>> remaps, final boolean isFreezing) {
         NeoForge.EVENT_BUS.post(new IdMappingEvent(remaps, isFreezing));
+    }
+
+    /**
+     * Creates a {@link LinkedHashSet} containing the ordered list of registry names in the registration order.
+     * <p>
+     * The order is Attributes, then the remaining vanilla registries in vanilla order, then modded registries in alphabetical order.
+     * <p>
+     * Due to static init issues, this is not necessarily the order that vanilla objects are bootstrapped in.
+     * 
+     * @return A {@link LinkedHashSet} containing the registration order.
+     */
+    public static Set<ResourceLocation> getRegistrationOrder() {
+        Set<ResourceLocation> ordered = new LinkedHashSet<>();
+        ordered.add(Registries.ATTRIBUTE.location()); // Vanilla order is incorrect, both Item and MobEffect depend on Attribute at construction time.
+        ordered.addAll(BuiltInRegistries.getVanillaRegistrationOrder());
+        ordered.addAll(BuiltInRegistries.REGISTRY.keySet().stream().sorted(ResourceLocation::compareNamespaced).toList());
+        return ordered;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -16,6 +16,7 @@ import net.minecraft.core.IdMapper;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.SpawnPlacements;
@@ -78,8 +79,9 @@ public class GameData {
     }
 
     public static void postRegisterEvents() {
-        Set<ResourceLocation> ordered = new LinkedHashSet<>(BuiltInRegistries.getVanillaRegistrationOrder());
-        ordered.retainAll(RegistryManager.getVanillaRegistryKeys());
+        Set<ResourceLocation> ordered = new LinkedHashSet<>();
+        ordered.add(Registries.ATTRIBUTE.location()); // Vanilla order is incorrect, both Item and MobEffect depend on Attribute at construction time.
+        ordered.addAll(BuiltInRegistries.getVanillaRegistrationOrder());
         ordered.addAll(BuiltInRegistries.REGISTRY.keySet().stream().sorted(ResourceLocation::compareNamespaced).toList());
 
         RuntimeException aggregate = new RuntimeException();


### PR DESCRIPTION
## What
This PR moves registration of `Attribute`s to the head of the registration order.
## Why
The recent registry-order change (#558) switched the registration order to match vanilla, but vanilla's registration order has a bug that is hidden by their static-init shenanigans.  Certain `Item`s and `MobEffect`s depend on `Attribute`s at construction time, but currently `Attribute` registers after `Item`.  

Presumably at some point in the future vanilla will also realize this, but for now we get to fix it.  Currently this is causing crashes in mods expecting the "expected" vanilla behavior (Attributes being present during Item + MobEffect construction).