### PR TITLE
Add a data map for vibration frequencies

### DIFF
--- a/patches/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
+++ b/patches/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java
++++ b/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java
+@@ -48,6 +_,8 @@
+         GameEvent.RESONATE_14,
+         GameEvent.RESONATE_15
+     };
++    /** @deprecated Neo: use the {@link net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps#VIBRATION_FREQUENCIES data map} instead. */
++    @Deprecated
+     ToIntFunction<GameEvent> VIBRATION_FREQUENCY_FOR_EVENT = Util.make(new Object2IntOpenHashMap<>(), p_297981_ -> {
+         p_297981_.defaultReturnValue(0);
+         p_297981_.put(GameEvent.STEP, 1);
+@@ -101,7 +_,8 @@
+     VibrationSystem.User getVibrationUser();
+ 
+     static int getGameEventFrequency(GameEvent p_281355_) {
+-        return VIBRATION_FREQUENCY_FOR_EVENT.applyAsInt(p_281355_);
++        var data = p_281355_.builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.VIBRATION_FREQUENCIES);
++        return data == null ? 0 : data.frequency();
+     }
+ 
+     static GameEvent getResonanceEventByFrequency(int p_282105_) {

--- a/patches/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
+++ b/patches/net/minecraft/world/level/gameevent/vibrations/VibrationSystem.java.patch
@@ -9,13 +9,14 @@
      ToIntFunction<GameEvent> VIBRATION_FREQUENCY_FOR_EVENT = Util.make(new Object2IntOpenHashMap<>(), p_297981_ -> {
          p_297981_.defaultReturnValue(0);
          p_297981_.put(GameEvent.STEP, 1);
-@@ -101,7 +_,8 @@
+@@ -101,7 +_,9 @@
      VibrationSystem.User getVibrationUser();
  
      static int getGameEventFrequency(GameEvent p_281355_) {
 -        return VIBRATION_FREQUENCY_FOR_EVENT.applyAsInt(p_281355_);
 +        var data = p_281355_.builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.VIBRATION_FREQUENCIES);
-+        return data == null ? 0 : data.frequency();
++        // TODO 1.20.5 - remove fallback
++        return data == null ? VIBRATION_FREQUENCY_FOR_EVENT.applyAsInt(p_281355_) : data.frequency();
      }
  
      static GameEvent getResonanceEventByFrequency(int p_282105_) {

--- a/src/generated/resources/data/neoforge/data_maps/game_event/vibration_frequencies.json
+++ b/src/generated/resources/data/neoforge/data_maps/game_event/vibration_frequencies.json
@@ -1,0 +1,169 @@
+{
+  "values": {
+    "minecraft:block_activate": {
+      "frequency": 10
+    },
+    "minecraft:block_attach": {
+      "frequency": 10
+    },
+    "minecraft:block_change": {
+      "frequency": 11
+    },
+    "minecraft:block_close": {
+      "frequency": 9
+    },
+    "minecraft:block_deactivate": {
+      "frequency": 9
+    },
+    "minecraft:block_destroy": {
+      "frequency": 12
+    },
+    "minecraft:block_detach": {
+      "frequency": 9
+    },
+    "minecraft:block_open": {
+      "frequency": 10
+    },
+    "minecraft:block_place": {
+      "frequency": 13
+    },
+    "minecraft:container_close": {
+      "frequency": 9
+    },
+    "minecraft:container_open": {
+      "frequency": 10
+    },
+    "minecraft:drink": {
+      "frequency": 8
+    },
+    "minecraft:eat": {
+      "frequency": 8
+    },
+    "minecraft:elytra_glide": {
+      "frequency": 4
+    },
+    "minecraft:entity_action": {
+      "frequency": 4
+    },
+    "minecraft:entity_damage": {
+      "frequency": 7
+    },
+    "minecraft:entity_die": {
+      "frequency": 15
+    },
+    "minecraft:entity_dismount": {
+      "frequency": 5
+    },
+    "minecraft:entity_interact": {
+      "frequency": 6
+    },
+    "minecraft:entity_mount": {
+      "frequency": 6
+    },
+    "minecraft:entity_place": {
+      "frequency": 14
+    },
+    "minecraft:equip": {
+      "frequency": 5
+    },
+    "minecraft:explode": {
+      "frequency": 15
+    },
+    "minecraft:flap": {
+      "frequency": 1
+    },
+    "minecraft:fluid_pickup": {
+      "frequency": 12
+    },
+    "minecraft:fluid_place": {
+      "frequency": 13
+    },
+    "minecraft:hit_ground": {
+      "frequency": 2
+    },
+    "minecraft:instrument_play": {
+      "frequency": 3
+    },
+    "minecraft:item_interact_finish": {
+      "frequency": 3
+    },
+    "minecraft:lightning_strike": {
+      "frequency": 14
+    },
+    "minecraft:note_block_play": {
+      "frequency": 10
+    },
+    "minecraft:prime_fuse": {
+      "frequency": 10
+    },
+    "minecraft:projectile_land": {
+      "frequency": 2
+    },
+    "minecraft:projectile_shoot": {
+      "frequency": 3
+    },
+    "minecraft:resonate_1": {
+      "frequency": 1
+    },
+    "minecraft:resonate_10": {
+      "frequency": 10
+    },
+    "minecraft:resonate_11": {
+      "frequency": 11
+    },
+    "minecraft:resonate_12": {
+      "frequency": 12
+    },
+    "minecraft:resonate_13": {
+      "frequency": 13
+    },
+    "minecraft:resonate_14": {
+      "frequency": 14
+    },
+    "minecraft:resonate_15": {
+      "frequency": 15
+    },
+    "minecraft:resonate_2": {
+      "frequency": 2
+    },
+    "minecraft:resonate_3": {
+      "frequency": 3
+    },
+    "minecraft:resonate_4": {
+      "frequency": 4
+    },
+    "minecraft:resonate_5": {
+      "frequency": 5
+    },
+    "minecraft:resonate_6": {
+      "frequency": 6
+    },
+    "minecraft:resonate_7": {
+      "frequency": 7
+    },
+    "minecraft:resonate_8": {
+      "frequency": 8
+    },
+    "minecraft:resonate_9": {
+      "frequency": 9
+    },
+    "minecraft:shear": {
+      "frequency": 6
+    },
+    "minecraft:splash": {
+      "frequency": 2
+    },
+    "minecraft:step": {
+      "frequency": 1
+    },
+    "minecraft:swim": {
+      "frequency": 1
+    },
+    "minecraft:teleport": {
+      "frequency": 14
+    },
+    "minecraft:unequip": {
+      "frequency": 4
+    }
+  }
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeDataMapsProvider.java
@@ -5,13 +5,17 @@
 
 package net.neoforged.neoforge.common.data.internal;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.gameevent.vibrations.VibrationSystem;
 import net.neoforged.neoforge.common.data.DataMapProvider;
 import net.neoforged.neoforge.registries.datamaps.builtin.Compostable;
 import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
+import net.neoforged.neoforge.registries.datamaps.builtin.VibrationFrequency;
 
 public class NeoForgeDataMapsProvider extends DataMapProvider {
     public NeoForgeDataMapsProvider(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> lookupProvider) {
@@ -22,5 +26,9 @@ public class NeoForgeDataMapsProvider extends DataMapProvider {
     protected void gather() {
         final var compostables = builder(NeoForgeDataMaps.COMPOSTABLES);
         ComposterBlock.COMPOSTABLES.forEach((item, chance) -> compostables.add(item.asItem().builtInRegistryHolder(), new Compostable(chance), false));
+
+        final var vibrationFrequencies = builder(NeoForgeDataMaps.VIBRATION_FREQUENCIES);
+        ((Object2IntMap<GameEvent>) VibrationSystem.VIBRATION_FREQUENCY_FOR_EVENT)
+                .forEach((event, frequency) -> vibrationFrequencies.add(event.builtInRegistryHolder(), new VibrationFrequency(frequency), false));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/NeoForgeDataMaps.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/NeoForgeDataMaps.java
@@ -9,6 +9,8 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.gameevent.vibrations.VibrationSystem;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.registries.datamaps.DataMapType;
@@ -34,6 +36,19 @@ public class NeoForgeDataMaps {
     public static final DataMapType<Item, Compostable> COMPOSTABLES = DataMapType.builder(
             id("compostables"), Registries.ITEM, Compostable.CODEC).synced(Compostable.CHANCE_CODEC, false).build();
 
+    /**
+     * The {@linkplain GameEvent} data map that replaces {@link VibrationSystem#VIBRATION_FREQUENCY_FOR_EVENT}.
+     * <p>
+     * The location of this data map is {@code neoforge/data_maps/game_event/vibration_frequencies.json}, and the values are objects with 1 field:
+     * <ul>
+     * <li>{@code frequency}, an integer between {@code 1} and {@code 15} (inclusive) - the vibration frequency of the game event</li>
+     * </ul>
+     *
+     * The use of an integer as the value is also possible, though discouraged in case more options are added in the future.
+     */
+    public static final DataMapType<GameEvent, VibrationFrequency> VIBRATION_FREQUENCIES = DataMapType.builder(
+            id("vibration_frequencies"), Registries.GAME_EVENT, VibrationFrequency.CODEC).synced(VibrationFrequency.FREQUENCY_CODEC, false).build();
+
     private static ResourceLocation id(final String name) {
         return new ResourceLocation(NeoForgeVersion.MOD_ID, name);
     }
@@ -41,5 +56,6 @@ public class NeoForgeDataMaps {
     @SubscribeEvent
     private static void register(final RegisterDataMapTypesEvent event) {
         event.register(COMPOSTABLES);
+        event.register(VIBRATION_FREQUENCIES);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/VibrationFrequency.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/builtin/VibrationFrequency.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.registries.datamaps.builtin;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.util.ExtraCodecs;
+
+/**
+ * Data map value for {@linkplain NeoForgeDataMaps#VIBRATION_FREQUENCIES vibration frequencies}.
+ *
+ * @param frequency the vibration frequency of the game event
+ */
+public record VibrationFrequency(int frequency) {
+    public static final Codec<VibrationFrequency> FREQUENCY_CODEC = Codec.intRange(1, 15)
+            .xmap(VibrationFrequency::new, VibrationFrequency::frequency);
+    public static final Codec<VibrationFrequency> CODEC = ExtraCodecs.withAlternative(
+            RecordCodecBuilder.create(in -> in.group(
+                    Codec.intRange(1, 15).fieldOf("frequency").forGetter(VibrationFrequency::frequency)).apply(in, VibrationFrequency::new)),
+            FREQUENCY_CODEC);
+}


### PR DESCRIPTION
Replace the vibration frequency vanilla map by a data map so that mods can add their own game events with an associated frequency. The path of the data map is `neoforge/data_maps/game_event/vibration_frequencies.json`