### PR TITLE
Make it possible to add reload listeners between vanilla reload listeners

### DIFF
--- a/patches/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/net/minecraft/server/ReloadableServerResources.java.patch
@@ -10,18 +10,12 @@
      }
  
      public ServerFunctionLibrary getFunctionLibrary() {
-@@ -80,8 +_,13 @@
-         Executor p_249601_
+@@ -81,7 +_,7 @@
      ) {
          ReloadableServerResources reloadableserverresources = new ReloadableServerResources(p_251163_, p_250212_, p_249301_, p_251126_);
-+        List<PreparableReloadListener> listeners = new java.util.ArrayList<>(reloadableserverresources.listeners());
-+        listeners.addAll(net.neoforged.neoforge.event.EventHooks.onResourceReload(reloadableserverresources, p_251163_));
-+        listeners.forEach(rl -> {
-+            if (rl instanceof net.neoforged.neoforge.resource.ContextAwareReloadListener srl) srl.injectContext(reloadableserverresources.context, reloadableserverresources.registryAccess);
-+        });
          return SimpleReloadInstance.create(
 -                p_248588_, reloadableserverresources.listeners(), p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()
-+                p_248588_, listeners, p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()
++                p_248588_, net.neoforged.neoforge.event.EventHooks.onResourceReload(reloadableserverresources, p_251163_), p_249136_, p_249601_, DATA_RELOAD_INITIAL_TASK, LOGGER.isDebugEnabled()
              )
              .done()
              .whenComplete(

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -27,6 +27,7 @@ import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.common.util.FakePlayerFactory;
 import net.neoforged.neoforge.common.util.LogicalSidedProvider;
 import net.neoforged.neoforge.event.AddReloadListenerEvent;
+import net.neoforged.neoforge.event.AddReloadListenerEvent.VanillaReloadListenerTarget;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
@@ -152,7 +153,7 @@ public class NeoForgeEventHandler {
     public void onResourceReload(AddReloadListenerEvent event) {
         INSTANCE = new LootModifierManager();
         event.addListener(INSTANCE);
-        event.addListener(DATA_MAPS = new DataMapLoader(event.getConditionContext(), event.getRegistryAccess()));
+        event.addListenerBefore(VanillaReloadListenerTarget.RECIPES, DATA_MAPS = new DataMapLoader(event.getConditionContext(), event.getRegistryAccess()));
     }
 
     static LootModifierManager getLootModifierManager() {

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -161,6 +161,7 @@ import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.event.level.PistonEvent;
 import net.neoforged.neoforge.event.level.SaplingGrowTreeEvent;
 import net.neoforged.neoforge.event.level.SleepFinishedTimeEvent;
+import net.neoforged.neoforge.resource.ContextAwareReloadListener;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -714,7 +715,13 @@ public class EventHooks {
     public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, RegistryAccess registryAccess) {
         AddReloadListenerEvent event = new AddReloadListenerEvent(serverResources, registryAccess);
         NeoForge.EVENT_BUS.post(event);
-        return event.getListeners();
+        List<PreparableReloadListener> listeners = event.getListeners();
+        listeners.forEach(listener -> {
+            if (listener instanceof ContextAwareReloadListener contextAwareListener) {
+                contextAwareListener.injectContext(serverResources.getConditionContext(), serverResources.getRegistryAccess());
+            }
+        });
+        return listeners;
     }
 
     public static void onCommandRegister(CommandDispatcher<CommandSourceStack> dispatcher, Commands.CommandSelection environment, CommandBuildContext context) {


### PR DESCRIPTION
Simplifies the patch in ReloadabeServerResources and makes it possible to add reload listeners between vanilla listeners. One use case for this is to be able to move data maps to loading just before recipes so that mods can make use of loaded data for recipes.