### PR TITLE
send full dataslot value on neo<->neo connections

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -234,6 +_,10 @@
+         }
+ 
+         private void broadcastDataValue(AbstractContainerMenu p_143455_, int p_143456_, int p_143457_) {
++            if (ServerPlayer.this.connection.isConnected(net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload.ID)) {
++                ServerPlayer.this.connection.send(new net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload(p_143455_.containerId, p_143456_, p_143457_));
++                return;
++            }
+             ServerPlayer.this.connection.send(new ClientboundContainerSetDataPacket(p_143455_.containerId, p_143456_, p_143457_));
+         }
+     };
 @@ -594,6 +_,7 @@
      @Override
      public void die(DamageSource p_9035_) {

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -12,6 +12,7 @@ import net.neoforged.neoforge.network.event.RegisterPayloadHandlerEvent;
 import net.neoforged.neoforge.network.handlers.ClientPayloadHandler;
 import net.neoforged.neoforge.network.handlers.ServerPayloadHandler;
 import net.neoforged.neoforge.network.payload.AdvancedAddEntityPayload;
+import net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
 import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
@@ -84,6 +85,9 @@ public class NetworkInitialization {
                         handlers -> handlers.client(ClientPayloadHandler.getInstance()::handle))
                 .play(RegistryDataMapSyncPayload.ID,
                         RegistryDataMapSyncPayload::decode,
-                        handlers -> handlers.client(ClientRegistryManager::handleDataMapSync));
+                        handlers -> handlers.client(ClientRegistryManager::handleDataMapSync))
+                .play(AdvancedContainerSetDataPayload.ID,
+                        AdvancedContainerSetDataPayload::new,
+                        handlers -> handlers.client(ClientPayloadHandler.getInstance()::handle));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -31,6 +31,7 @@ import net.neoforged.neoforge.network.ConfigSync;
 import net.neoforged.neoforge.network.handling.ConfigurationPayloadContext;
 import net.neoforged.neoforge.network.handling.PlayPayloadContext;
 import net.neoforged.neoforge.network.payload.AdvancedAddEntityPayload;
+import net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
 import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
@@ -152,5 +153,8 @@ public class ClientPayloadHandler {
             context.packetHandler().disconnect(Component.translatable("neoforge.network.aux_light_data.failed", msg.pos(), e.getMessage()));
             return null;
         });
+    }
+    public void handle(AdvancedContainerSetDataPayload msg, PlayPayloadContext context) {
+        context.packetHandler().handle(msg.toVanillaPacket());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -154,6 +154,7 @@ public class ClientPayloadHandler {
             return null;
         });
     }
+
     public void handle(AdvancedContainerSetDataPayload msg, PlayPayloadContext context) {
         context.packetHandler().handle(msg.toVanillaPacket());
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
@@ -15,15 +15,14 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * A custom payload that updates the full dataslot value instead of just the short value
  *
- * @param containerId  The containerId for the container.
- * @param dataId       The id for the dataslot.
- * @param value        The value for the dataslot.
+ * @param containerId The containerId for the container.
+ * @param dataId      The id for the dataslot.
+ * @param value       The value for the dataslot.
  */
 @ApiStatus.Internal
 public record AdvancedContainerSetDataPayload(int containerId, int dataId, int value) implements CustomPacketPayload {
 
     public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_set_data");
-
     public AdvancedContainerSetDataPayload(FriendlyByteBuf buffer) {
         this(buffer.readByte(), buffer.readShort(), buffer.readVarInt());
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
@@ -16,8 +16,8 @@ import org.jetbrains.annotations.ApiStatus;
  * A custom payload that updates the full dataslot value instead of just the short value
  *
  * @param containerId The containerId for the container.
- * @param dataId      The id for the dataslot.
- * @param value       The value for the dataslot.
+ * @param dataId      The ID of the dataslot.
+ * @param value       The value of the dataslot.
  */
 @ApiStatus.Internal
 public record AdvancedContainerSetDataPayload(int containerId, int dataId, int value) implements CustomPacketPayload {

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.payload;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.game.ClientboundContainerSetDataPacket;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A custom payload that updates the full dataslot value instead of just the short value
+ *
+ * @param containerId  The containerId for the container.
+ * @param dataId       The id for the dataslot.
+ * @param value        The value for the dataslot.
+ */
+@ApiStatus.Internal
+public record AdvancedContainerSetDataPayload(int containerId, int dataId, int value) implements CustomPacketPayload {
+
+    public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_set_data");
+
+    public AdvancedContainerSetDataPayload(FriendlyByteBuf buffer) {
+        this(buffer.readByte(), buffer.readShort(), buffer.readVarInt());
+    }
+
+    @Override
+    public void write(FriendlyByteBuf buffer) {
+        buffer.writeByte(containerId);
+        buffer.writeShort(dataId);
+        buffer.writeVarInt(value);
+    }
+
+    @Override
+    public ResourceLocation id() {
+        return ID;
+    }
+
+    public ClientboundContainerSetDataPacket toVanillaPacket() {
+        return new ClientboundContainerSetDataPacket(containerId, dataId, value);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public record AdvancedContainerSetDataPayload(int containerId, int dataId, int value) implements CustomPacketPayload {
 
-    public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_set_data");
+    public static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_container_set_data");
     public AdvancedContainerSetDataPayload(FriendlyByteBuf buffer) {
         this(buffer.readByte(), buffer.readShort(), buffer.readVarInt());
     }

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -718,17 +718,7 @@ public class NetworkRegistry {
      * @return True if the connection is a vanilla connection, false otherwise.
      */
     public boolean isVanillaConnection(Connection connection) {
-        return isVanillaConnection(connection.channel());
-    }
-
-    /**
-     * Indicates if the given connection is a vanilla connection.
-     *
-     * @param channel The channel to check.
-     * @return True if the connection is a vanilla connection, false otherwise.
-     */
-    public boolean isVanillaConnection(Channel channel) {
-        return channel.attr(ATTRIBUTE_IS_MODDED_CONNECTION).get() == Boolean.FALSE;
+        return connection.channel().attr(ATTRIBUTE_IS_MODDED_CONNECTION).get() == Boolean.FALSE;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -720,6 +720,7 @@ public class NetworkRegistry {
     public boolean isVanillaConnection(Connection connection) {
         return isVanillaConnection(connection.channel());
     }
+
     /**
      * Indicates if the given connection is a vanilla connection.
      *

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.network.registration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.mojang.logging.LogUtils;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AttributeKey;
 import java.util.ArrayList;
@@ -717,7 +718,16 @@ public class NetworkRegistry {
      * @return True if the connection is a vanilla connection, false otherwise.
      */
     public boolean isVanillaConnection(Connection connection) {
-        return connection.channel().attr(ATTRIBUTE_IS_MODDED_CONNECTION).get() == Boolean.FALSE;
+        return isVanillaConnection(connection.channel());
+    }
+    /**
+     * Indicates if the given connection is a vanilla connection.
+     *
+     * @param channel The channel to check.
+     * @return True if the connection is a vanilla connection, false otherwise.
+     */
+    public boolean isVanillaConnection(Channel channel) {
+        return channel.attr(ATTRIBUTE_IS_MODDED_CONNECTION).get() == Boolean.FALSE;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.network.registration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.mojang.logging.LogUtils;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AttributeKey;
 import java.util.ArrayList;


### PR DESCRIPTION
## The Problem
Dataslots send only the short value over the network, this is enough for all vanilla use cases, however some modders want to synchronize higher values using dataslots. The problem is also annoying to catch as some modders don't test their full functionality on a dedicated servers and only there the information is lost. Some modders made their own helpers to have 2 dataslots and use bitmanipulation to set a single integer. That's needlessly complex.

## Solution
Send the full 32bit integer of a dataslot over the network on neo<->neo connections, so that modders don't have to use multiple dataslots for a piece of data and to prevent/fix synchronization errors in mods

## Testing
I've verified that this PR works on an integrated server and on a dedicated neo server with a neo and vanilla client.