### PR TITLE
Reduce patcher fuzziness to reduce misaligned patches

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -197,10 +197,10 @@ tasks.withType(Javadoc.class).configureEach {
 
 tasks.withType(GenerateModuleMetadata).configureEach { enabled = false }
 
-// Raise patcher fuzziness quality to 80% (50% default is too low)
+// Raise patcher fuzziness quality to 95% (50% default is too low)
 import net.neoforged.gradle.platform.runtime.runtime.tasks.ApplyPatches
 tasks.withType(ApplyPatches).configureEach {
-    minimalFuzzingQuality = 0.8F
+    minimalFuzzingQuality = 0.95F
 }
 
 configurations {

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -197,6 +197,12 @@ tasks.withType(Javadoc.class).configureEach {
 
 tasks.withType(GenerateModuleMetadata).configureEach { enabled = false }
 
+// Raise patcher fuzziness quality to 80% (50% default is too low)
+import net.neoforged.gradle.platform.runtime.runtime.tasks.ApplyPatches
+tasks.withType(ApplyPatches).configureEach {
+    minimalFuzzingQuality = 0.8F
+}
+
 configurations {
     forValidation {
         canBeConsumed = true


### PR DESCRIPTION
Misaligned patches can take weeks or months to catch after an update, whereas trivial patch rejects can be fixed in a matter of seconds. Especially now that the patches are in mojmap. As such, this PR is expected to slightly increase the porting work, but vastly reduce the amount of porting bugs due to misaligned patches.