### PR TITLE
Prevent helmet overlay rendering when spyglass is being used

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
@@ -145,7 +145,7 @@ public class ExtendedGui extends Gui {
     void renderHelmet(float partialTick, GuiGraphics guiGraphics) {
         ItemStack itemstack = this.minecraft.player.getInventory().getArmor(3);
 
-        if (this.minecraft.options.getCameraType().isFirstPerson() && !itemstack.isEmpty()) {
+        if (this.minecraft.options.getCameraType().isFirstPerson() && !itemstack.isEmpty() && !this.minecraft.player.isScoping()) {
             Item item = itemstack.getItem();
             if (item == Blocks.CARVED_PUMPKIN.asItem()) {
                 renderTextureOverlay(guiGraphics, PUMPKIN_BLUR_LOCATION, 1.0F);


### PR DESCRIPTION
This PR fixes #601 by preventing helmet overlay rendering (e.g., the carved pumpkin overlay) when the player is using a spyglass (which renders the spyglass scope overlay). This matches the vanilla behavior by matching a missing check from `Gui#render` to `ExtendedGui#renderHelmet`.

Tested by wearing a carved pumpkin on one's head (not IRL) and using a spyglass.