### PR TITLE
Extensible VertexFormatElement.Usage

### DIFF
--- a/patches/com/mojang/blaze3d/vertex/BufferBuilder.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/BufferBuilder.java.patch
@@ -1,6 +1,6 @@
 --- a/com/mojang/blaze3d/vertex/BufferBuilder.java
 +++ b/com/mojang/blaze3d/vertex/BufferBuilder.java
-@@ -495,4 +_,14 @@
+@@ -495,4 +_,22 @@
              this.sorting = p_277855_;
          }
      }
@@ -13,5 +13,13 @@
 +        this.buffer.position(0);
 +        this.vertices += buffer.limit() / this.format.getVertexSize();
 +        this.nextElementByte += buffer.limit();
++    }
++
++    public ByteBuffer getBuffer() {
++        return this.buffer;
++    }
++
++    public int getNextElementByte() {
++        return this.nextElementByte;
 +    }
  }

--- a/patches/com/mojang/blaze3d/vertex/BufferBuilder.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/BufferBuilder.java.patch
@@ -1,6 +1,6 @@
 --- a/com/mojang/blaze3d/vertex/BufferBuilder.java
 +++ b/com/mojang/blaze3d/vertex/BufferBuilder.java
-@@ -495,4 +_,22 @@
+@@ -495,4 +_,14 @@
              this.sorting = p_277855_;
          }
      }
@@ -13,13 +13,5 @@
 +        this.buffer.position(0);
 +        this.vertices += buffer.limit() / this.format.getVertexSize();
 +        this.nextElementByte += buffer.limit();
-+    }
-+
-+    public ByteBuffer getBuffer() {
-+        return this.buffer;
-+    }
-+
-+    public int getNextElementByte() {
-+        return this.nextElementByte;
 +    }
  }

--- a/patches/com/mojang/blaze3d/vertex/VertexFormatElement.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/VertexFormatElement.java.patch
@@ -11,3 +11,23 @@
      @OnlyIn(Dist.CLIENT)
      public static enum Type {
          FLOAT(4, "Float", 5126),
+@@ -127,7 +_,7 @@
+     }
+ 
+     @OnlyIn(Dist.CLIENT)
+-    public static enum Usage {
++    public static enum Usage implements net.neoforged.neoforge.common.IExtensibleEnum {
+         POSITION("Position", (p_167043_, p_167044_, p_167045_, p_167046_, p_167047_, p_167048_) -> {
+             GlStateManager._enableVertexAttribArray(p_167048_);
+             GlStateManager._vertexAttribPointer(p_167048_, p_167043_, p_167044_, false, p_167045_, p_167046_);
+@@ -188,6 +_,10 @@
+         @OnlyIn(Dist.CLIENT)
+         public interface SetupState {
+             void setupBufferState(int p_167053_, int p_167054_, int p_167055_, long p_167056_, int p_167057_, int p_167058_);
++        }
++
++        public static Usage create(String name, String usageName, SetupState setupState, ClearState clearState) {
++            throw new IllegalArgumentException("Enum not extended");
+         }
+     }
+ }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -539,3 +539,5 @@ private-f net.minecraft.world.level.storage.loot.LootPool bonusRolls # bonusRoll
 public net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket KNOWN_TYPES
 public net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket KNOWN_TYPES
 public net.minecraft.server.network.ServerConfigurationPacketListenerImpl finishCurrentTask(Lnet/minecraft/server/network/ConfigurationTask$Type;)V
+public com.mojang.blaze3d.vertex.VertexFormatElement$Usage$SetupState
+public com.mojang.blaze3d.vertex.VertexFormatElement$Usage$ClearState

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/RenderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/RenderTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.client;
+
+import com.google.common.collect.ImmutableMap;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormatElement;
+import com.mojang.logging.LogUtils;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import org.slf4j.Logger;
+
+@ForEachTest(side = Dist.CLIENT, groups = { "client.render", "render" })
+public class RenderTests {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final VertexFormatElement.Usage TEST_USAGE = VertexFormatElement.Usage.create("TEST", "Test",
+            (p_167053_, p_167054_, p_167055_, p_167056_, p_167057_, p_167058_) -> LOGGER.info("Setup Test Vertex Attribute"),
+            (p_167050_, p_167051_) -> LOGGER.info("Clear Test Vertex Attribute"));
+    private static final VertexFormatElement TEST_ELEMENT = new VertexFormatElement(0, VertexFormatElement.Type.BYTE, TEST_USAGE, 4);
+    private static final VertexFormat TEST_FORMAT = new VertexFormat(
+            ImmutableMap.<String, VertexFormatElement>builder()
+                    .put("TEST", TEST_ELEMENT)
+                    .build());
+
+    @TestHolder(description = { "Tests if custom VertexFormatElement.Usage was created and attached to VertexFormatElement", "Prints in console on setup and clear state of custom VertexFormatElement.Usage" }, enabledByDefault = true)
+    static void setupClearVertexFormatElement(final DynamicTest test) {
+        TEST_FORMAT.setupBufferState();
+        TEST_FORMAT.clearBufferState();
+    }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/RenderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/RenderTests.java
@@ -8,28 +8,43 @@ package net.neoforged.neoforge.debug.client;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
-import com.mojang.logging.LogUtils;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
-import org.slf4j.Logger;
 
 @ForEachTest(side = Dist.CLIENT, groups = { "client.render", "render" })
 public class RenderTests {
-    private static final Logger LOGGER = LogUtils.getLogger();
-    private static final VertexFormatElement.Usage TEST_USAGE = VertexFormatElement.Usage.create("TEST", "Test",
-            (p_167053_, p_167054_, p_167055_, p_167056_, p_167057_, p_167058_) -> LOGGER.info("Setup Test Vertex Attribute"),
-            (p_167050_, p_167051_) -> LOGGER.info("Clear Test Vertex Attribute"));
-    private static final VertexFormatElement TEST_ELEMENT = new VertexFormatElement(0, VertexFormatElement.Type.BYTE, TEST_USAGE, 4);
-    private static final VertexFormat TEST_FORMAT = new VertexFormat(
-            ImmutableMap.<String, VertexFormatElement>builder()
-                    .put("TEST", TEST_ELEMENT)
-                    .build());
-
-    @TestHolder(description = { "Tests if custom VertexFormatElement.Usage was created and attached to VertexFormatElement", "Prints in console on setup and clear state of custom VertexFormatElement.Usage" }, enabledByDefault = true)
+    @TestHolder(description = { "Tests if custom VertexFormatElement.Usage setup and clear callbacks were called" }, enabledByDefault = true)
     static void setupClearVertexFormatElement(final DynamicTest test) {
-        TEST_FORMAT.setupBufferState();
-        TEST_FORMAT.clearBufferState();
+        test.framework().modEventBus().addListener(RenderLevelStageEvent.RegisterStageEvent.class, event -> {
+            var state = new AtomicInteger();
+            var usage = VertexFormatElement.Usage.create("TEST", "Test",
+                    (size, type, stride, offset, uvIndex, index) -> state.incrementAndGet(),
+                    (uvIndex, index) -> state.decrementAndGet());
+            var element = new VertexFormatElement(0, VertexFormatElement.Type.BYTE, usage, 4);
+            var format = new VertexFormat(
+                    ImmutableMap.<String, VertexFormatElement>builder()
+                            .put("TEST", element)
+                            .build());
+
+            format.setupBufferState();
+
+            if (state.get() != 1) {
+                test.fail("VertexFormatElement.Usage setup state callback was not called");
+                return;
+            }
+
+            format.clearBufferState();
+
+            if (state.get() != 0) {
+                test.fail("VertexFormatElement.Usage clear state callback was not called");
+                return;
+            }
+
+            test.pass();
+        });
     }
 }


### PR DESCRIPTION
This is useful for creating custom setup & clear state after binding vertex buffer without any hacks. Right now you are limited to already defined usages, so you cannot do stuff like glVertexAttribDivisor when binding vertex buffer that is very useful for binding matrix4x4 as vertex attribute for instanced rendering stuff.
Also I have added getters for ByteBuffer and nextElementByte to BufferBuilder, so that we can extend BufferBuilder and modify internal buffer more easily without AT, for example now you can create method for supplying Matrix4f and easily put it to internal ByteBuffer.