### PR TITLE
fixed inventoryTick patch

### DIFF
--- a/patches/net/minecraft/world/entity/player/Inventory.java.patch
+++ b/patches/net/minecraft/world/entity/player/Inventory.java.patch
@@ -31,8 +31,8 @@
 +                    // Neo: Fix the slot param to be the global index instead of the per-compartment index.
 +                    // Neo: Fix the selected param to only be true for hotbar slots.
 +                    nonnulllist.get(i).inventoryTick(this.player.level(), this.player, slot, this.selected == slot);
-+                    slot++;
                  }
++                slot++;
              }
          }
 +        armor.forEach(e -> e.onArmorTick(player.level(), player));


### PR DESCRIPTION
When https://github.com/neoforged/NeoForge/pull/549 was merged, nobody seemed to notice that the slot incrementer only accounted for filled slots, breaking any and all inventory ticking logic. This PR puts it in the right spot so it works as intended. 