### PR TITLE
Minor Quality of Life additions to Attachments

### DIFF
--- a/patches/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -47,7 +47,7 @@
      }
  
      public boolean triggerEvent(int p_58889_, int p_58890_) {
-@@ -185,6 +_,20 @@
+@@ -185,6 +_,27 @@
  
      public BlockEntityType<?> getType() {
          return this.type;
@@ -65,6 +65,13 @@
 +    public final <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
 +        setChanged();
 +        return super.setData(type, data);
++    }
++
++    @Override
++    @Nullable
++    public final <T> T removeData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        setChanged();
++        return super.removeData(type);
      }
  
      @Deprecated

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -120,8 +120,8 @@
 +    private final net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager auxLightManager = new net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager(this);
 +
 +    @Override
-+    public boolean hasData() {
-+        return attachmentHolder.hasData();
++    public boolean hasAttachments() {
++        return attachmentHolder.hasAttachments();
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -111,13 +111,18 @@
          this.blockEntities.values().forEach(p_187988_ -> {
              Level level = this.level;
              if (level instanceof ServerLevel serverlevel) {
-@@ -646,6 +_,33 @@
+@@ -646,6 +_,45 @@
          return new LevelChunk.BoundTickingBlockEntity<>(p_156376_, p_156377_);
      }
  
 +    // FORGE START
 +    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
 +    private final net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager auxLightManager = new net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager(this);
++
++    @Override
++    public boolean hasData() {
++        return attachmentHolder.hasData();
++    }
 +
 +    @Override
 +    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
@@ -134,6 +139,13 @@
 +    public <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
 +        setUnsaved(true);
 +        return attachmentHolder.setData(type, data);
++    }
++
++    @Override
++    @Nullable
++    public <T> T removeData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        setUnsaved(true);
++        return attachmentHolder.removeData(type);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
@@ -40,8 +40,8 @@
 +                  LOGGER.error("Failed to write chunk attachments. An attachment has likely thrown an exception trying to write state. It will not persist. Report this to the mod author", exception);
 +             }
 +
-+             Tag lightTag = levelChunk.getAuxLightManager(chunkpos).serializeNBT();
-+             if (lightTag != null) compoundtag.put(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, lightTag);
++             net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager auxiliaryLightManager = levelChunk.getAuxLightManager(chunkpos);
++             if (auxiliaryLightManager.canSerialize()) compoundtag.put(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, auxiliaryLightManager.serializeNBT());
          }
  
          saveTicks(p_63455_, compoundtag, p_63456_.getTicksForSerialization());

--- a/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
@@ -40,8 +40,8 @@
 +                  LOGGER.error("Failed to write chunk attachments. An attachment has likely thrown an exception trying to write state. It will not persist. Report this to the mod author", exception);
 +             }
 +
-+             net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager auxiliaryLightManager = levelChunk.getAuxLightManager(chunkpos);
-+             if (auxiliaryLightManager.canSerialize()) compoundtag.put(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, auxiliaryLightManager.serializeNBT());
++             Tag lightTag = levelChunk.getAuxLightManager(chunkpos).serializeNBT();
++             if (lightTag != null) compoundtag.put(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, lightTag);
          }
  
          saveTicks(p_63455_, compoundtag, p_63456_.getTicksForSerialization());

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -39,7 +39,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
     @Nullable
     Map<AttachmentType<?>, Object> attachments = null;
     @Nullable
-    Map<AttachmentType<?>, Tag> defaultSerializations = null;
+    private Map<AttachmentType<?>, Tag> defaultSerializations = null;
 
     /**
      * Create the attachment map if it does not yet exist, or return the current map.

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -9,7 +9,6 @@ import com.mojang.logging.LogUtils;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
@@ -60,7 +59,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
     }
 
     @Override
-    public final boolean hasData() {
+    public final boolean hasAttachments() {
         return attachments != null && !attachments.isEmpty();
     }
 
@@ -111,10 +110,13 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
         CompoundTag tag = null;
         for (var entry : attachments.entrySet()) {
             var type = entry.getKey();
-            if (type.serializer != null && !(((Predicate<Object>) type.skipSerialization).test(entry.getValue()))) {
-                if (tag == null)
-                    tag = new CompoundTag();
-                tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(), ((IAttachmentSerializer<?, Object>) type.serializer).write(entry.getValue()));
+            if (type.serializer != null) {
+                Tag serialized = ((IAttachmentSerializer<?, Object>) type.serializer).write(entry.getValue());
+                if (serialized != null) {
+                    if (tag == null)
+                        tag = new CompoundTag();
+                    tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(), serialized);
+                }
             }
         }
         return tag;

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -9,6 +9,7 @@ import com.mojang.logging.LogUtils;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
@@ -128,15 +129,10 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
         CompoundTag tag = null;
         for (var entry : attachments.entrySet()) {
             var type = entry.getKey();
-            if (type.serializer != null) {
-                Tag serialized = ((IAttachmentSerializer<?, Object>) type.serializer).write(entry.getValue());
-                if (type.skipDefaultSerialization && serialized.equals(getDefaultSerialization(type))) {
-                    //Do not serialize attachments with the default value
-                    continue;
-                }
+            if (type.serializer != null && !(((Predicate<Object>) type.skipSerialization).test(entry.getValue()))) {
                 if (tag == null)
                     tag = new CompoundTag();
-                tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(), serialized);
+                tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(), ((IAttachmentSerializer<?, Object>) type.serializer).write(entry.getValue()));
             }
         }
         return tag;

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -39,8 +39,6 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
 
     @Nullable
     Map<AttachmentType<?>, Object> attachments = null;
-    @Nullable
-    private Map<AttachmentType<?>, Tag> defaultSerializations = null;
 
     /**
      * Create the attachment map if it does not yet exist, or return the current map.
@@ -99,22 +97,6 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
             return null;
         }
         return (T) attachments.remove(type);
-    }
-
-    @Nullable
-    private Tag getDefaultSerialization(AttachmentType<?> type) {
-        if (type.serializer == null) {
-            return null;
-        }
-        if (defaultSerializations == null) {
-            defaultSerializations = new IdentityHashMap<>(4);
-        }
-        Tag serialization = defaultSerializations.get(type);
-        if (serialization == null) {
-            serialization = ((IAttachmentSerializer<?, Object>) type.serializer).write(type.defaultValueSupplier.apply(getExposedHolder()));
-            defaultSerializations.put(type, serialization);
-        }
-        return serialization;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
@@ -87,7 +87,10 @@ public final class AttachmentInternals {
             @SuppressWarnings("unchecked")
             var serializer = (IAttachmentSerializer<Tag, Object>) type.serializer;
             if (serializer != null && filter.test(type)) {
-                to.getAttachmentMap().put(type, serializer.read(to.getExposedHolder(), serializer.write(entry.getValue())));
+                Tag serialized = serializer.write(entry.getValue());
+                if (serialized != null) {
+                    to.getAttachmentMap().put(type, serializer.read(to.getExposedHolder(), serialized));
+                }
             }
         }
     }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -131,7 +131,7 @@ public final class AttachmentType<T> {
             @Nullable
             @Override
             public S write(T attachment) {
-                return attachment.canSerialize() ? attachment.serializeNBT() : null;
+                return attachment.serializeNBT();
             }
         });
     }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -54,12 +54,14 @@ public final class AttachmentType<T> {
     final Function<IAttachmentHolder, T> defaultValueSupplier;
     @Nullable
     final IAttachmentSerializer<?, T> serializer;
+    final boolean skipDefaultSerialization;
     final boolean copyOnDeath;
     final IAttachmentComparator<T> comparator;
 
     private AttachmentType(Builder<T> builder) {
         this.defaultValueSupplier = builder.defaultValueSupplier;
         this.serializer = builder.serializer;
+        this.skipDefaultSerialization = builder.skipDefaultSerialization;
         this.copyOnDeath = builder.copyOnDeath;
         this.comparator = builder.comparator != null ? builder.comparator : defaultComparator(serializer);
     }
@@ -137,6 +139,7 @@ public final class AttachmentType<T> {
         private final Function<IAttachmentHolder, T> defaultValueSupplier;
         @Nullable
         private IAttachmentSerializer<?, T> serializer;
+        private boolean skipDefaultSerialization;
         private boolean copyOnDeath;
         @Nullable
         private IAttachmentComparator<T> comparator;
@@ -183,6 +186,16 @@ public final class AttachmentType<T> {
                     return codec.encodeStart(NbtOps.INSTANCE, attachment).result().get();
                 }
             });
+        }
+
+        /**
+         * Requests that this attachment is not serialized when it would have default serialization.
+         */
+        public Builder<T> skipDefaultSerialization() {
+            if (this.serializer == null)
+                throw new IllegalStateException("skipDefaultSerialization requires a serializer");
+            this.skipDefaultSerialization = true;
+            return this;
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -15,7 +15,7 @@ public interface IAttachmentHolder {
     /**
      * Returns {@code true} if there is any data attachments, {@code false} otherwise.
      */
-    boolean hasData();
+    boolean hasAttachments();
 
     /**
      * Returns {@code true} if there is a data attachment of the give type, {@code false} otherwise.

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -13,6 +13,11 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface IAttachmentHolder {
     /**
+     * Returns {@code true} if there is any data attachments, {@code false} otherwise.
+     */
+    boolean hasData();
+
+    /**
      * Returns {@code true} if there is a data attachment of the give type, {@code false} otherwise.
      */
     boolean hasData(AttachmentType<?> type);
@@ -55,5 +60,21 @@ public interface IAttachmentHolder {
      */
     default <T> @Nullable T setData(Supplier<AttachmentType<T>> type, T data) {
         return setData(type.get(), data);
+    }
+
+    /**
+     * Removes the data attachment of the given type.
+     *
+     * @return the previous value for that attachment type, if any, or {@code null} if there was none
+     */
+    <T> @Nullable T removeData(AttachmentType<T> type);
+
+    /**
+     * Removes the data attachment of the given type.
+     *
+     * @return the previous value for that attachment type, if any, or {@code null} if there was none
+     */
+    default <T> @Nullable T removeData(Supplier<AttachmentType<T>> type) {
+        return removeData(type.get());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentSerializer.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentSerializer.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.attachment;
 
 import net.minecraft.nbt.Tag;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Serializer for data attachments.
@@ -39,7 +40,8 @@ public interface IAttachmentSerializer<S extends Tag, T> {
     }
 
     /**
-     * Writes the attachment to NBT.
+     * Writes the attachment to NBT, or returns null if it is should not be serialized.
      */
+    @Nullable
     S write(T attachment);
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/INBTSerializable.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/INBTSerializable.java
@@ -15,4 +15,8 @@ public interface INBTSerializable<T extends Tag> {
     T serializeNBT();
 
     void deserializeNBT(T nbt);
+
+    default boolean canSerialize() {
+        return true;
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/INBTSerializable.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/INBTSerializable.java
@@ -6,17 +6,15 @@
 package net.neoforged.neoforge.common.util;
 
 import net.minecraft.nbt.Tag;
+import org.jetbrains.annotations.UnknownNullability;
 
 /**
  * An interface designed to unify various things in the Minecraft
  * code base that can be serialized to and from a NBT tag.
  */
 public interface INBTSerializable<T extends Tag> {
+    @UnknownNullability
     T serializeNBT();
 
     void deserializeNBT(T nbt);
-
-    default boolean canSerialize() {
-        return true;
-    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
@@ -57,11 +57,12 @@ public final class LevelChunkAuxiliaryLightManager implements AuxiliaryLightMana
     }
 
     @Override
-    public ListTag serializeNBT() {
-        if (lights.isEmpty()) {
-            return null;
-        }
+    public boolean canSerialize() {
+        return !lights.isEmpty();
+    }
 
+    @Override
+    public ListTag serializeNBT() {
         ListTag list = new ListTag();
         lights.forEach((pos, light) -> {
             CompoundTag tag = new CompoundTag();

--- a/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/LevelChunkAuxiliaryLightManager.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.lighting.LightEngine;
 import net.neoforged.neoforge.common.util.INBTSerializable;
 import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class LevelChunkAuxiliaryLightManager implements AuxiliaryLightManager, INBTSerializable<ListTag> {
@@ -56,13 +57,13 @@ public final class LevelChunkAuxiliaryLightManager implements AuxiliaryLightMana
         return lights.getOrDefault(pos, (byte) 0);
     }
 
-    @Override
-    public boolean canSerialize() {
-        return !lights.isEmpty();
-    }
-
+    @Nullable
     @Override
     public ListTag serializeNBT() {
+        if (lights.isEmpty()) {
+            return null;
+        }
+
         ListTag list = new ListTag();
         lights.forEach((pos, light) -> {
             CompoundTag tag = new CompoundTag();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -264,4 +264,59 @@ public class AttachmentTests {
             helper.succeed();
         });
     }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Ensures that attachments can opt-out of serializing default values")
+    static void itemAttachmentSkipSerialization(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).skipDefaultSerialization().build());
+
+        test.onGameTest(helper -> {
+            ItemStack stack = Items.APPLE.getDefaultInstance();
+            stack.setData(attachmentType, 1);
+            helper.assertTrue(stack.serializeAttachments() != null, "Stack should have serialized attachments");
+            stack.setData(attachmentType, 0);
+            helper.assertTrue(stack.serializeAttachments() == null, "None of the stack's attachments should be serialized");
+            helper.assertTrue(stack.hasData(attachmentType), "Stack should have attached data");
+
+            helper.succeed();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Ensures that removing attachments works")
+    static void itemAttachmentRemoval(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).build());
+
+        test.onGameTest(helper -> {
+            ItemStack stack = Items.APPLE.getDefaultInstance();
+            stack.setData(attachmentType, 1);
+            helper.assertTrue(stack.hasData(attachmentType), "Stack should have attached data");
+            stack.removeData(attachmentType);
+            helper.assertFalse(stack.hasData(attachmentType), "Stack should not have attached data");
+
+            helper.succeed();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Ensures that the presence of non-serializable attachments can be checked")
+    static void itemAttachmentPresence(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+              .register("test_int", () -> AttachmentType.builder(() -> 0).build());
+
+        test.onGameTest(helper -> {
+            ItemStack stack = Items.APPLE.getDefaultInstance();
+            stack.setData(attachmentType, 1);
+            helper.assertTrue(stack.hasData(attachmentType), "Stack should have attached data");
+            //Also check we can detect the presence if we don't know what types are attached
+            helper.assertTrue(stack.hasData(), "Stack should have attached data");
+
+            helper.succeed();
+        });
+    }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -270,7 +270,7 @@ public class AttachmentTests {
     @TestHolder(description = "Ensures that attachments can opt-out of serializing default values")
     static void itemAttachmentSkipSerialization(final DynamicTest test, final RegistrationHelper reg) {
         var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
-                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).skipSerialization(i -> i == 0).build());
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT, i -> i != 0).build());
 
         test.onGameTest(helper -> {
             ItemStack stack = Items.APPLE.getDefaultInstance();
@@ -314,7 +314,7 @@ public class AttachmentTests {
             stack.setData(attachmentType, 1);
             helper.assertTrue(stack.hasData(attachmentType), "Stack should have attached data");
             //Also check we can detect the presence if we don't know what types are attached
-            helper.assertTrue(stack.hasData(), "Stack should have attached data");
+            helper.assertTrue(stack.hasAttachments(), "Stack should have attached data");
 
             helper.succeed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -307,7 +307,7 @@ public class AttachmentTests {
     @TestHolder(description = "Ensures that the presence of non-serializable attachments can be checked")
     static void itemAttachmentPresence(final DynamicTest test, final RegistrationHelper reg) {
         var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
-              .register("test_int", () -> AttachmentType.builder(() -> 0).build());
+                .register("test_int", () -> AttachmentType.builder(() -> 0).build());
 
         test.onGameTest(helper -> {
             ItemStack stack = Items.APPLE.getDefaultInstance();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -270,7 +270,7 @@ public class AttachmentTests {
     @TestHolder(description = "Ensures that attachments can opt-out of serializing default values")
     static void itemAttachmentSkipSerialization(final DynamicTest test, final RegistrationHelper reg) {
         var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
-                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).skipDefaultSerialization().build());
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).skipSerialization(i -> i == 0).build());
 
         test.onGameTest(helper -> {
             ItemStack stack = Items.APPLE.getDefaultInstance();


### PR DESCRIPTION
- Allows checking if an `AttachmentHolder` has any attachments without having to serialize all the attachments just to check (might return slightly different results than comparing against serialization if it has attachments that are not serializable or should skip serialization)
- Allows removing attachments from `AttachmentHolder`s
- Makes `IAttachmentSerializer#write` Nullable to allow skipping serialization of specific attachment implementations

~~An alternative implementation I was considering for this was to either store a `@Nullable Tag` on the `AttachmentType` that we compare to for if the serialization should be skipped or either store a `Predicate<Tag>` or add to `IAttachmentSerializer` a `boolean shouldSerialize(T attachment)` method. If either of these are preferable let me know and I can switch the implementation.~~ Alternative implementation implemented as requested by @embeddedt to make profiling more clear

~~One other consideration that I am unsure how we want to handle is: with the current implementation of this PR it means that attachments that are marked to skip serialization lose their attachments (as intended) when the world is shut and opened, but when the attachments are copied (say when a stack gets copied) the attachments get copied over rather than dropped. I think this is a reasonable state for it to be in but I wanted to mention it in case this is a case we should handle.~~ After implementing the method that tech proposed they get dropped in both cases.