### PR TITLE
[1.20.1] Bump FML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
     SLF4J_API_VERSION = '1.8.0-beta4'
     APACHE_MAVEN_ARTIFACT_VERSION = '3.8.5'
     JARJAR_VERSION = '0.3.19'
-    FANCY_MOD_LOADER_VERSION = '47.1.47'
+    FANCY_MOD_LOADER_VERSION = '47.2.2'
 
     // These versions should be kept in sync with the version manifest JSON
     // To use a version newer than the version manifest JSON, the dependency must be added to the installer configuration


### PR DESCRIPTION
To enable https://github.com/neoforged/FancyModLoader/pull/86 and https://github.com/neoforged/FancyModLoader/pull/85 to be used in production.