### PR TITLE
Prevent registering synced data maps for non-synced datapack registries

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -136,7 +136,9 @@ public class NeoForgeEventHandler {
             if (attach == null || attach.networkCodec() == null) return;
             att.put(key, registry.getDataMap(attach));
         });
-        PacketDistributor.PLAYER.with(player).send(new RegistryDataMapSyncPayload<>(registry.key(), att));
+        if (!att.isEmpty()) {
+            PacketDistributor.PLAYER.with(player).send(new RegistryDataMapSyncPayload<>(registry.key(), att));
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/net/neoforged/neoforge/registries/DataPackRegistriesHooks.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataPackRegistriesHooks.java
@@ -19,6 +19,7 @@ import net.minecraft.core.RegistrySynchronization;
 import net.minecraft.resources.RegistryDataLoader;
 import net.minecraft.resources.ResourceKey;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class DataPackRegistriesHooks {
@@ -69,5 +70,12 @@ public final class DataPackRegistriesHooks {
      */
     public static Set<ResourceKey<? extends Registry<?>>> getSyncedCustomRegistries() {
         return SYNCED_CUSTOM_REGISTRIES_VIEW;
+    }
+
+    @Nullable
+    @ApiStatus.Internal
+    @SuppressWarnings("unchecked")
+    public static <T> RegistrySynchronization.NetworkedRegistryData<T> getSyncedRegistry(final ResourceKey<? extends Registry<T>> registry) {
+        return (RegistrySynchronization.NetworkedRegistryData<T>) NETWORKABLE_REGISTRIES.get(registry);
     }
 }


### PR DESCRIPTION
The sync will never work and will only lead to errors since the registry won't exist on the client.