### PR TITLE
Optional data attachment method

### DIFF
--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -66,8 +66,8 @@
 +    }
 +
 +    @Override
-+    public <T> java.util.Optional<T> getOptionalData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
-+        return getAttachmentHolder().getOptionalData(type);
++    public <T> java.util.Optional<T> getExistingData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        return getAttachmentHolder().getExistingData(type);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -42,7 +42,7 @@
                              }
                          }
                      }
-@@ -469,4 +_,65 @@
+@@ -469,4 +_,70 @@
  
      public static record TicksToSave(SerializableTickContainer<Block> blocks, SerializableTickContainer<Fluid> fluids) {
      }
@@ -63,6 +63,11 @@
 +    @Override
 +    public <T> T getData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
 +        return getAttachmentHolder().getData(type);
++    }
++
++    @Override
++    public <T> java.util.Optional<T> getOptionalData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        return getAttachmentHolder().getOptionalData(type);
 +    }
 +
 +    @Override

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -9,6 +9,8 @@ import com.mojang.logging.LogUtils;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
@@ -78,6 +80,15 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
             attachments.put(type, ret);
         }
         return ret;
+    }
+
+    @Override
+    public <T> Optional<T> getOptionalData(AttachmentType<T> type) {
+        validateAttachmentType(type);
+        if (attachments == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable((T) this.attachments.get(type));
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -82,7 +82,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
     }
 
     @Override
-    public <T> Optional<T> getOptionalData(AttachmentType<T> type) {
+    public <T> Optional<T> getExistingData(AttachmentType<T> type) {
         validateAttachmentType(type);
         if (attachments == null) {
             return Optional.empty();

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -10,7 +10,6 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -52,15 +52,15 @@ public interface IAttachmentHolder {
      *
      * <p>If there is no data attachment of the given type, an empty optional is returned.
      */
-    <T> Optional<T> getOptionalData(AttachmentType<T> type);
+    <T> Optional<T> getExistingData(AttachmentType<T> type);
 
     /**
      * {@return an optional possibly containing a data attachment value of the given type}
      *
      * <p>If there is no data attachment of the given type, an empty optional is returned.
      */
-    default <T> Optional<T> getOptionalData(Supplier<AttachmentType<T>> type) {
-        return getOptionalData(type.get());
+    default <T> Optional<T> getExistingData(Supplier<AttachmentType<T>> type) {
+        return getExistingData(type.get());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.attachment;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,6 +45,22 @@ public interface IAttachmentHolder {
      */
     default <T> T getData(Supplier<AttachmentType<T>> type) {
         return getData(type.get());
+    }
+
+    /**
+     * {@return an optional possibly containing a data attachment value of the given type}
+     *
+     * <p>If there is no data attachment of the given type, an empty optional is returned.
+     */
+    <T> Optional<T> getOptionalData(AttachmentType<T> type);
+
+    /**
+     * {@return an optional possibly containing a data attachment value of the given type}
+     *
+     * <p>If there is no data attachment of the given type, an empty optional is returned.
+     */
+    default <T> Optional<T> getOptionalData(Supplier<AttachmentType<T>> type) {
+        return getOptionalData(type.get());
     }
 
     /**

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -435,10 +435,10 @@ public class AttachmentTests {
 
         test.onGameTest(helper -> {
             ItemStack stack = Items.APPLE.getDefaultInstance();
-            Optional<Integer> optional = stack.getOptionalData(attachmentType);
+            Optional<Integer> optional = stack.getExistingData(attachmentType);
             helper.assertTrue(optional.isEmpty(), "Optional should be empty");
             stack.setData(attachmentType, 1);
-            optional = stack.getOptionalData(attachmentType);
+            optional = stack.getExistingData(attachmentType);
             helper.assertTrue(optional.isPresent(), "Optional should have attached data");
             helper.succeed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -13,7 +13,6 @@ import com.mojang.serialization.Codec;
 import io.netty.buffer.Unpooled;
 import java.util.List;
 import java.util.Optional;
-
 import net.minecraft.Util;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -12,6 +12,8 @@ import com.mojang.brigadier.Command;
 import com.mojang.serialization.Codec;
 import io.netty.buffer.Unpooled;
 import java.util.List;
+import java.util.Optional;
+
 import net.minecraft.Util;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
@@ -421,6 +423,24 @@ public class AttachmentTests {
             helper.assertTrue(stack.getData(attachmentType) == 1, "Stack should have attached data");
             stack = stack.copy();
             helper.assertTrue(stack.getData(attachmentType) == 2, "Stack cloner should have cloned and modified the data");
+            helper.succeed();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Ensures that optional data can be queried")
+    static void itemAttachmentOptional(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).build());
+
+        test.onGameTest(helper -> {
+            ItemStack stack = Items.APPLE.getDefaultInstance();
+            Optional<Integer> optional = stack.getOptionalData(attachmentType);
+            helper.assertTrue(optional.isEmpty(), "Optional should be empty");
+            stack.setData(attachmentType, 1);
+            optional = stack.getOptionalData(attachmentType);
+            helper.assertTrue(optional.isPresent(), "Optional should have attached data");
             helper.succeed();
         });
     }


### PR DESCRIPTION
Allows for retrieval of an optional data attachment. This allows users to avoid verbose `if (has) doSomething() else doSomethingElse()` and avoids creating and adding the default value. Returning an optional also provides multiple functional methods for the handling of data.