### PR TITLE
Proto Chunk Attachments

### DIFF
--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/chunk/ChunkAccess.java
 +++ b/net/minecraft/world/level/chunk/ChunkAccess.java
+@@ -54,7 +_,7 @@
+ import net.minecraft.world.ticks.TickContainerAccess;
+ import org.slf4j.Logger;
+ 
+-public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiomeSource, LightChunk, StructureAccess {
++public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiomeSource, LightChunk, StructureAccess, net.neoforged.neoforge.attachment.IAttachmentHolder {
+     public static final int NO_FILLED_SECTION = -1;
+     private static final Logger LOGGER = LogUtils.getLogger();
+     private static final LongSet EMPTY_REFERENCE_SET = new LongOpenHashSet();
 @@ -308,23 +_,28 @@
  
      @Override
@@ -33,11 +42,69 @@
                              }
                          }
                      }
-@@ -469,4 +_,7 @@
+@@ -469,4 +_,65 @@
  
      public static record TicksToSave(SerializableTickContainer<Block> blocks, SerializableTickContainer<Fluid> fluids) {
      }
 +
++    // FORGE START
++    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
++
++    @Override
++    public boolean hasAttachments() {
++        return getAttachmentHolder().hasAttachments();
++    }
++
++    @Override
++    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
++        return getAttachmentHolder().hasData(type);
++    }
++
++    @Override
++    public <T> T getData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        return getAttachmentHolder().getData(type);
++    }
++
++    @Override
++    @Nullable
++    public <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
++        setUnsaved(true);
++        return getAttachmentHolder().setData(type, data);
++    }
++
++    @Override
++    @Nullable
++    public <T> T removeData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        setUnsaved(true);
++        return getAttachmentHolder().removeData(type);
++    }
++
++    /**
++     * <strong>FOR INTERNAL USE ONLY</strong>
++     * <p>
++     * Only public for use in {@link net.minecraft.world.level.chunk.storage.ChunkSerializer}.
++     */
++    @org.jetbrains.annotations.ApiStatus.Internal
++    @Nullable
++    public final CompoundTag writeAttachmentsToNBT() {
++        return getAttachmentHolder().serializeAttachments();
++    }
++
++    /**
++     * <strong>FOR INTERNAL USE ONLY</strong>
++     * <p>
++     * Only public for use in {@link net.minecraft.world.level.chunk.storage.ChunkSerializer}.
++     *
++     */
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public final void readAttachmentsFromNBT(CompoundTag tag) {
++        getAttachmentHolder().deserializeInternal(tag);
++    }
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    protected net.neoforged.neoforge.attachment.AttachmentHolder.AsField getAttachmentHolder() {
++        return attachmentHolder;
++    }
 +    @Nullable
 +    public net.minecraft.world.level.LevelAccessor getWorldForge() { return null; }
  }

--- a/patches/net/minecraft/world/level/chunk/ImposterProtoChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ImposterProtoChunk.java.patch
@@ -11,3 +11,14 @@
      public TickContainerAccess<Block> getBlockTicks() {
          return this.allowWrites ? this.wrapped.getBlockTicks() : BlackholeTickAccess.emptyContainer();
      }
+@@ -289,5 +_,10 @@
+     @Override
+     public ChunkSkyLightSources getSkyLightSources() {
+         return this.wrapped.getSkyLightSources();
++    }
++
++    @Override
++    public net.neoforged.neoforge.attachment.AttachmentHolder.AsField getAttachmentHolder() {
++        return wrapped.getAttachmentHolder();
+     }
+ }

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -9,6 +9,14 @@
      static final Logger LOGGER = LogUtils.getLogger();
      private static final TickingBlockEntity NULL_TICKER = new TickingBlockEntity() {
          @Override
+@@ -137,6 +_,7 @@
+         this.setAllStarts(p_196851_.getAllStarts());
+         this.setAllReferences(p_196851_.getAllReferences());
+ 
++        net.neoforged.neoforge.attachment.AttachmentInternals.copyAttachments(p_196851_.getAttachmentHolder(), this.getAttachmentHolder(), type -> true);
+         for(Entry<Heightmap.Types, Heightmap> entry : p_196851_.getHeightmaps()) {
+             if (ChunkStatus.FULL.heightmapsAfter().contains(entry.getKey())) {
+                 this.setHeightmap(entry.getKey(), entry.getValue().getRawData());
 @@ -270,14 +_,14 @@
                  boolean flag2 = blockstate.hasBlockEntity();
                  if (!this.level.isClientSide) {
@@ -111,42 +119,12 @@
          this.blockEntities.values().forEach(p_187988_ -> {
              Level level = this.level;
              if (level instanceof ServerLevel serverlevel) {
-@@ -646,6 +_,45 @@
+@@ -646,6 +_,15 @@
          return new LevelChunk.BoundTickingBlockEntity<>(p_156376_, p_156377_);
      }
  
 +    // FORGE START
-+    private final net.neoforged.neoforge.attachment.AttachmentHolder.AsField attachmentHolder = new net.neoforged.neoforge.attachment.AttachmentHolder.AsField(this);
 +    private final net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager auxLightManager = new net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager(this);
-+
-+    @Override
-+    public boolean hasAttachments() {
-+        return attachmentHolder.hasAttachments();
-+    }
-+
-+    @Override
-+    public boolean hasData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
-+        return attachmentHolder.hasData(type);
-+    }
-+
-+    @Override
-+    public <T> T getData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
-+        return attachmentHolder.getData(type);
-+    }
-+
-+    @Override
-+    @Nullable
-+    public <T> T setData(net.neoforged.neoforge.attachment.AttachmentType<T> type, T data) {
-+        setUnsaved(true);
-+        return attachmentHolder.setData(type, data);
-+    }
-+
-+    @Override
-+    @Nullable
-+    public <T> T removeData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
-+        setUnsaved(true);
-+        return attachmentHolder.removeData(type);
-+    }
 +
 +    @Override
 +    public net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager getAuxLightManager(ChunkPos pos) {
@@ -178,33 +156,10 @@
                          throw new ReportedException(crashreport);
                      }
                  }
-@@ -715,6 +_,34 @@
+@@ -715,6 +_,11 @@
          IMMEDIATE,
          QUEUED,
          CHECK;
-+    }
-+
-+
-+    /**
-+     * <strong>FOR INTERNAL USE ONLY</strong>
-+     * <p>
-+     * Only public for use in {@link net.minecraft.world.level.chunk.storage.ChunkSerializer}.
-+     */
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    @Nullable
-+    public final CompoundTag writeAttachmentsToNBT() {
-+        return attachmentHolder.serializeAttachments();
-+    }
-+
-+    /**
-+     * <strong>FOR INTERNAL USE ONLY</strong>
-+     * <p>
-+     * Only public for use in {@link net.minecraft.world.level.chunk.storage.ChunkSerializer}.
-+     *
-+     */
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    public final void readAttachmentsFromNBT(CompoundTag tag) {
-+        attachmentHolder.deserializeInternal(tag);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -13,7 +13,7 @@
          this.setAllStarts(p_196851_.getAllStarts());
          this.setAllReferences(p_196851_.getAllReferences());
  
-+        net.neoforged.neoforge.attachment.AttachmentInternals.copyAttachments(p_196851_.getAttachmentHolder(), this.getAttachmentHolder(), type -> true);
++        net.neoforged.neoforge.attachment.AttachmentInternals.copyChunkAttachmentsOnPromotion(p_196851_.getAttachmentHolder(), this.getAttachmentHolder());
          for(Entry<Heightmap.Types, Heightmap> entry : p_196851_.getHeightmaps()) {
              if (ChunkStatus.FULL.heightmapsAfter().contains(entry.getKey())) {
                  this.setHeightmap(entry.getKey(), entry.getValue().getRawData());

--- a/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/ChunkSerializer.java.patch
@@ -1,16 +1,23 @@
 --- a/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-@@ -180,6 +_,10 @@
+@@ -180,6 +_,8 @@
                  postLoadChunk(p_188231_, p_188234_),
                  blendingdata
              );
-+            if (p_188234_.contains(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND))
-+                ((LevelChunk)chunkaccess).readAttachmentsFromNBT(p_188234_.getCompound(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY));
 +            if (p_188234_.contains(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_LIST))
 +                Objects.requireNonNull(((LevelChunk)chunkaccess).getAuxLightManager(p_188233_)).deserializeNBT(p_188234_.getList(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND));
          } else {
              ProtoChunkTicks<Block> protochunkticks = ProtoChunkTicks.load(
                  p_188234_.getList("block_ticks", 10), p_258992_ -> BuiltInRegistries.BLOCK.getOptional(ResourceLocation.tryParse(p_258992_)), p_188233_
+@@ -206,6 +_,8 @@
+             }
+         }
+ 
++        if (p_188234_.contains(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, net.minecraft.nbt.Tag.TAG_COMPOUND))
++            chunkaccess.readAttachmentsFromNBT(p_188234_.getCompound(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY));
+         chunkaccess.setLightCorrect(flag);
+         CompoundTag compoundtag2 = p_188234_.getCompound("Heightmaps");
+         EnumSet<Heightmap.Types> enumset = EnumSet.noneOf(Heightmap.Types.class);
 @@ -238,6 +_,7 @@
          }
  
@@ -27,21 +34,28 @@
              return protochunk1;
          }
      }
-@@ -372,6 +_,17 @@
-             }
+@@ -373,6 +_,11 @@
  
              compoundtag.put("CarvingMasks", compoundtag4);
-+        }
+         }
 +        else if (p_63456_ instanceof LevelChunk levelChunk){
-+             try {
-+                  final CompoundTag capTag = levelChunk.writeAttachmentsToNBT();
-+                  if (capTag != null) compoundtag.put(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, capTag);
-+             } catch (Exception exception) {
-+                  LOGGER.error("Failed to write chunk attachments. An attachment has likely thrown an exception trying to write state. It will not persist. Report this to the mod author", exception);
-+             }
 +
 +             Tag lightTag = levelChunk.getAuxLightManager(chunkpos).serializeNBT();
 +             if (lightTag != null) compoundtag.put(net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager.LIGHT_NBT_KEY, lightTag);
-         }
++        }
  
          saveTicks(p_63455_, compoundtag, p_63456_.getTicksForSerialization());
+         compoundtag.put("PostProcessing", packOffsets(p_63456_.getPostProcessing()));
+@@ -384,6 +_,12 @@
+             }
+         }
+ 
++        try {
++            final CompoundTag capTag = p_63456_.writeAttachmentsToNBT();
++            if (capTag != null) compoundtag.put(net.neoforged.neoforge.attachment.AttachmentHolder.ATTACHMENTS_NBT_KEY, capTag);
++        } catch (Exception exception) {
++            LOGGER.error("Failed to write chunk attachments. An attachment has likely thrown an exception trying to write state. It will not persist. Report this to the mod author", exception);
++        }
+         compoundtag.put("Heightmaps", compoundtag2);
+         compoundtag.put(
+             "structures",

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
@@ -78,7 +78,7 @@ public final class AttachmentInternals {
     /**
      * Copy some attachments to another holder.
      */
-    private static <H extends AttachmentHolder> void copyAttachments(H from, H to, Predicate<AttachmentType<?>> filter) {
+    public static <H extends AttachmentHolder> void copyAttachments(H from, H to, Predicate<AttachmentType<?>> filter) {
         if (from.attachments == null) {
             return;
         }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentInternals.java
@@ -78,7 +78,7 @@ public final class AttachmentInternals {
     /**
      * Copy some attachments to another holder.
      */
-    public static <H extends AttachmentHolder> void copyAttachments(H from, H to, Predicate<AttachmentType<?>> filter) {
+    private static <H extends AttachmentHolder> void copyAttachments(H from, H to, Predicate<AttachmentType<?>> filter) {
         if (from.attachments == null) {
             return;
         }
@@ -96,6 +96,10 @@ public final class AttachmentInternals {
     }
 
     public static void copyStackAttachments(ItemStack from, ItemStack to) {
+        copyAttachments(from, to, type -> true);
+    }
+
+    public static void copyChunkAttachmentsOnPromotion(AttachmentHolder.AsField from, AttachmentHolder.AsField to) {
         copyAttachments(from, to, type -> true);
     }
 

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -17,7 +17,9 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.ProtoChunk;
 import net.neoforged.neoforge.common.util.INBTSerializable;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import org.jetbrains.annotations.Nullable;
@@ -46,9 +48,10 @@ import org.jetbrains.annotations.Nullable;
  * <ul>
  * <li>(nothing)</li>
  * </ul>
- * <h3>{@link LevelChunk}-exclusive behavior:</h3>
+ * <h3>{@link ChunkAccess}-exclusive behavior:</h3>
  * <ul>
- * <li>Modifications to attachments should be followed by a call to {@link LevelChunk#setUnsaved(boolean)}.</li>
+ * <li>Modifications to attachments should be followed by a call to {@link ChunkAccess#setUnsaved(boolean)}.</li>
+ * <li>Serializable attachments are copied from a {@link ProtoChunk} to a {@link LevelChunk} on promotion.</li>
  * </ul>
  */
 // TODO Future work: maybe add copy handlers for stacks and entities, to customize copying behavior (instead of serializing, copying the NBT, deserializing).


### PR DESCRIPTION
Adds the ability to attach data to ProtoChunks and copies them on promotion to a LevelChunk