### PR TITLE
Fix ItemStack#is(Holder) for custom holders such as DeferredHolders

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -92,7 +92,7 @@
  
      public boolean is(Holder<Item> p_220166_) {
 -        return this.getItem().builtInRegistryHolder() == p_220166_;
-+        return is(p_220166_.value());//Neo: Fix comparing for custom holders such as DeferredHolders
++        return is(p_220166_.value()); // Neo: Fix comparing for custom holders such as DeferredHolders
      }
  
      public boolean is(HolderSet<Item> p_298683_) {

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -87,6 +87,15 @@
              this.setDamageValue(this.getDamageValue());
          }
      }
+@@ -250,7 +_,7 @@
+     }
+ 
+     public boolean is(Holder<Item> p_220166_) {
+-        return this.getItem().builtInRegistryHolder() == p_220166_;
++        return is(p_220166_.value());//Neo: Fix comparing for custom holders such as DeferredHolders
+     }
+ 
+     public boolean is(HolderSet<Item> p_298683_) {
 @@ -262,6 +_,19 @@
      }
  


### PR DESCRIPTION
Fixes it in the same way we do the check for `FluidStack#is(Holder)` and that mojang does the check for `BlockState#is(Holder)` so that if a modder passes a registry object (deferred holder) to it then it can evaluate as true instead of always evaluating as false.