### PR TITLE
[1.20.4/5] Create BonusLootDropsEvent

### DIFF
--- a/patches/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java
++++ b/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java
+@@ -78,7 +_,8 @@
+         if (itemstack != null) {
+             int i = EnchantmentHelper.getItemEnchantmentLevel(this.enchantment.value(), itemstack);
+             int j = this.formula.calculateNewCount(p_79914_.getRandom(), p_79913_.getCount(), i);
+-            p_79913_.setCount(j);
++            int getBonusDropsCount = net.neoforged.neoforge.common.CommonHooks.getBonusLootDropsCount(p_79913_, p_79914_, this.enchantment.value(), this.formula, i, j);
++            p_79913_.setCount(getBonusDropsCount);
+         }
+ 
+         return p_79913_;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -105,6 +105,7 @@ import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.GameType;
@@ -125,6 +126,7 @@ import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.WorldData;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootPool;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -140,6 +142,7 @@ import net.neoforged.neoforge.common.util.BlockSnapshot;
 import net.neoforged.neoforge.common.util.Lazy;
 import net.neoforged.neoforge.common.util.MavenVersionStringHelper;
 import net.neoforged.neoforge.event.AnvilUpdateEvent;
+import net.neoforged.neoforge.event.BonusLootDropsEvent;
 import net.neoforged.neoforge.event.DifficultyChangeEvent;
 import net.neoforged.neoforge.event.EventHooks;
 import net.neoforged.neoforge.event.GrindstoneEvent;
@@ -293,6 +296,12 @@ public class CommonHooks {
         LivingEvent.LivingVisibilityEvent event = new LivingEvent.LivingVisibilityEvent(entity, lookingEntity, originalMultiplier);
         NeoForge.EVENT_BUS.post(event);
         return Math.max(0, event.getVisibilityModifier());
+    }
+
+    public static int getBonusLootDropsCount(ItemStack itemStack, LootContext context, Enchantment enchantment, ApplyBonusCount.Formula formula, int enchantmentLevel, int originalDropCount) {
+        BonusLootDropsEvent event = new BonusLootDropsEvent(itemStack, context, enchantment, formula, enchantmentLevel, originalDropCount);
+        NeoForge.EVENT_BUS.post(event);
+        return event.getDropCount();
     }
 
     public static Optional<BlockPos> isLivingOnLadder(BlockState state, Level level, BlockPos pos, LivingEntity entity) {

--- a/src/main/java/net/neoforged/neoforge/event/BonusLootDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/BonusLootDropsEvent.java
@@ -13,12 +13,16 @@ import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount.Formula;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.neoforged.bus.api.Event;
+import net.neoforged.neoforge.event.enchanting.GetEnchantmentLevelEvent;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Fired before setting the drop count of an {@link ItemStack} from the {@link ApplyBonusCount} loot function.
+ * Fired before setting the drop count of an {@link ItemStack} from the {@link ApplyBonusCount} loot function
+ * (for example, Fortune-like enchantments). It allows enchantment levels to be modified, or the drop count to
+ * be set to a specific value. It will run before Global Loot Modifiers are applied.
  * <p>
- * It allows enchantment levels to be modified, or the drop count to be set to a specific value.
+ * When possible, consider using the {@link GetEnchantmentLevelEvent} as it allows non-loot table contexts to
+ * properly query the enchantment.
  */
 public class BonusLootDropsEvent extends Event {
     private final ItemStack itemStack;

--- a/src/main/java/net/neoforged/neoforge/event/BonusLootDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/BonusLootDropsEvent.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount.Formula;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Fired before setting the drop count of an {@link ItemStack} from the {@link ApplyBonusCount} loot function.
+ * <p>
+ * It allows enchantment levels to be modified, or the drop count to be set to a specific value.
+ */
+public class BonusLootDropsEvent extends Event {
+    private final ItemStack itemStack;
+    private final LootContext context;
+    private final Enchantment enchantment;
+    private final Formula formula;
+    private int enchantmentLevel;
+    private final int originalDropCount;
+    private int newDropCount = -1;
+
+    public BonusLootDropsEvent(ItemStack itemStack, LootContext context, Enchantment enchantment, Formula formula, int enchantmentLevel, int originalDropCount) {
+        this.itemStack = itemStack;
+        this.context = context;
+        this.enchantment = enchantment;
+        this.formula = formula;
+        this.enchantmentLevel = enchantmentLevel;
+        this.originalDropCount = originalDropCount;
+    }
+
+    /**
+     * Get the {@link ItemStack} for this event.
+     *
+     * @return the item stack
+     */
+    public ItemStack getItemStack() {
+        return itemStack;
+    }
+
+    /**
+     * Get the {@link LootContext} for this event.
+     *
+     * @return the loot context
+     */
+    public LootContext getContext() {
+        return context;
+    }
+
+    /**
+     * Get the {@link Enchantment} which caused the loot function to apply.
+     *
+     * @return the enchantment
+     */
+    public Enchantment getEnchantment() {
+        return enchantment;
+    }
+
+    /**
+     * Get the {@link Formula} used to calculate the new drop count.
+     *
+     * @return the formula
+     */
+    public Formula getFormula() {
+        return formula;
+    }
+
+    /**
+     * Get the current enchantment level for this event.
+     *
+     * @return the current enchantment level
+     */
+    public int getEnchantmentLevel() {
+        return enchantmentLevel;
+    }
+
+    /**
+     * Set the new enchantment level for this event.
+     *
+     * @param newEnchantmentLevel the new enchantment level
+     */
+    public void setEnchantmentLevel(int newEnchantmentLevel) {
+        this.enchantmentLevel = newEnchantmentLevel;
+    }
+
+    /**
+     * Get the original drop count as initially calculated by the loot function.
+     *
+     * @return the original drop count
+     */
+    public int getOriginalDropCount() {
+        return originalDropCount;
+    }
+
+    /**
+     * Set the new drop count for this event. It will be used as the final drop count.
+     *
+     * @param newDropCount the new drop count
+     */
+    public void setDropCount(int newDropCount) {
+        this.newDropCount = newDropCount;
+    }
+
+    /**
+     * Calculate the final drop count for this event. If {@link #newDropCount} has been set, no randomness will be applied using the formula.
+     *
+     * @return the final drop count
+     */
+    public int getDropCount() {
+        if (newDropCount > -1) {
+            return newDropCount;
+        } else {
+            return formula.calculateNewCount(context.getRandom(), itemStack.getCount(), enchantmentLevel);
+        }
+    }
+
+    /**
+     * Get the entity that caused the loot function to apply, if any.
+     *
+     * @return the entity, or null if not applicable
+     */
+    @Nullable
+    public Entity getEntity() {
+        return context.getParamOrNull(LootContextParams.THIS_ENTITY);
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -542,3 +542,5 @@ public net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket KNOW
 public net.minecraft.server.network.ServerConfigurationPacketListenerImpl finishCurrentTask(Lnet/minecraft/server/network/ConfigurationTask$Type;)V
 public com.mojang.blaze3d.vertex.VertexFormatElement$Usage$SetupState
 public com.mojang.blaze3d.vertex.VertexFormatElement$Usage$ClearState
+public net.minecraft.world.level.storage.loot.functions.ApplyBonusCount$Formula
+public net.minecraft.world.level.storage.loot.functions.ApplyBonusCount$FormulaType


### PR DESCRIPTION
Create a `BonusLootDropsEvent` which is fired before dropping items via the `ApplyBonusCount` loot function (for example, blocks with Fortune modifiers). It allows enchantment levels to be modified or a specific drop count to be set.

All of the variables/parameters available in `ApplyBonusCount.run()` are exposed through the event.

Example Usages:
```java
@SubscribeEvent
public static void bonusLootDropsEvent(BonusLootDropsEvent event) {
	// Add two extra enchantment levels when specific conditions are met
	if (event.getEntity() instanceof Player player) {
		if (playerMeetsSpecificConditions()) {
			event.setEnchantmentLevel(event.getEnchantmentLevel() + 2);
		}
	}
}
```
```java
@SubscribeEvent
public static void bonusLootDropsEvent(BonusLootDropsEvent event) {
	// Always set the drops to three when specific conditions are met
	if (event.getEntity() instanceof Player player) {
		if (playerMeetsSpecificConditions()) {
			event.setDropCount(3);
		}
	}
}
```