### PR TITLE
[1.20.1] Move firing of BuildCreativeModeTabContentsEvent to ForgeHooks

### DIFF
--- a/patches/minecraft/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/minecraft/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -60,7 +60,7 @@
           return new IllegalStateException("Unregistered creative tab: " + this);
        });
 -      this.f_256824_.m_257865_(p_270156_, creativemodetab$itemdisplaybuilder);
-+      net.minecraftforge.client.ForgeHooksClient.onCreativeModeTabBuildContents(this, resourcekey, this.f_256824_, p_270156_, creativemodetab$itemdisplaybuilder);
++      net.minecraftforge.common.ForgeHooks.onCreativeModeTabBuildContents(this, resourcekey, this.f_256824_, p_270156_, creativemodetab$itemdisplaybuilder);
        this.f_243839_ = creativemodetab$itemdisplaybuilder.f_244363_;
        this.f_243841_ = creativemodetab$itemdisplaybuilder.f_244585_;
        this.m_257466_();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -146,6 +146,7 @@ import net.minecraftforge.client.gui.overlay.GuiOverlayManager;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.textures.ForgeTextureMetadata;
 import net.minecraftforge.client.textures.TextureAtlasSpriteLoaderManager;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ForgeI18n;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
@@ -1192,27 +1193,10 @@ public class ForgeHooksClient
         return new ResourceLocation(loc.getNamespace(), normalised);
     }
 
+    @Deprecated
     public static void onCreativeModeTabBuildContents(CreativeModeTab tab, ResourceKey<CreativeModeTab> tabKey, CreativeModeTab.DisplayItemsGenerator originalGenerator, CreativeModeTab.ItemDisplayParameters params, CreativeModeTab.Output output)
     {
-        final var entries = new MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility>(ItemStackLinkedSet.TYPE_AND_TAG,
-            (key, left, right) -> {
-                //throw new IllegalStateException("Accidentally adding the same item stack twice " + key.getDisplayName().getString() + " to a Creative Mode Tab: " + tab.getDisplayName().getString());
-                // Vanilla adds enchanting books twice in both visibilities.
-                // This is just code cleanliness for them. For us lets just increase the visibility and merge the entries.
-                return CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS;
-            }
-        );
-
-        originalGenerator.accept(params, (stack, vis) -> {
-            if (stack.getCount() != 1)
-                throw new IllegalArgumentException("The stack count must be 1");
-            entries.put(stack, vis);
-        });
-
-        ModLoader.get().postEvent(new BuildCreativeModeTabContentsEvent(tab, tabKey, params, entries));
-
-        for (var entry : entries)
-            output.accept(entry.getKey(), entry.getValue());
+        ForgeHooks.onCreativeModeTabBuildContents(tab, tabKey, originalGenerator, params, output);
     }
 
     // Make sure the below method is only ever called once (by forge).

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -133,6 +133,7 @@ import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.common.util.MavenVersionStringHelper;
 import net.minecraftforge.common.util.MutableHashedLinkedMap;
 import net.minecraftforge.event.AnvilUpdateEvent;
+import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.GrindstoneEvent;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -131,6 +131,7 @@ import net.minecraftforge.common.loot.LootTableIdCondition;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.common.util.MavenVersionStringHelper;
+import net.minecraftforge.common.util.MutableHashedLinkedMap;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -1624,5 +1625,28 @@ public class ForgeHooks
         {
             entity.stopRiding();
         }
+    }
+
+    public static void onCreativeModeTabBuildContents(CreativeModeTab tab, ResourceKey<CreativeModeTab> tabKey, CreativeModeTab.DisplayItemsGenerator originalGenerator, CreativeModeTab.ItemDisplayParameters params, CreativeModeTab.Output output)
+    {
+        final var entries = new MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility>(ItemStackLinkedSet.TYPE_AND_TAG,
+                (key, left, right) -> {
+                    //throw new IllegalStateException("Accidentally adding the same item stack twice " + key.getDisplayName().getString() + " to a Creative Mode Tab: " + tab.getDisplayName().getString());
+                    // Vanilla adds enchanting books twice in both visibilities.
+                    // This is just code cleanliness for them. For us lets just increase the visibility and merge the entries.
+                    return CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS;
+                }
+        );
+
+        originalGenerator.accept(params, (stack, vis) -> {
+            if (stack.getCount() != 1)
+                throw new IllegalArgumentException("The stack count must be 1");
+            entries.put(stack, vis);
+        });
+
+        ModLoader.get().postEvent(new BuildCreativeModeTabContentsEvent(tab, tabKey, params, entries));
+
+        for (var entry : entries)
+            output.accept(entry.getKey(), entry.getValue());
     }
 }

--- a/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
+++ b/src/main/java/net/minecraftforge/event/BuildCreativeModeTabContentsEvent.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
  * This event is not {@linkplain Cancelable cancellable}, and does not {@linkplain HasResult have a result}.
  * <p>
  * This event is fired on the {@linkplain FMLJavaModLoadingContext#getModEventBus() mod-specific event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.
+ * on both clients and servers.
  */
 public final class BuildCreativeModeTabContentsEvent extends Event implements IModBusEvent, CreativeModeTab.Output {
     private final CreativeModeTab tab;


### PR DESCRIPTION
This PR fixes `CreativeModeTab#buildContents` crashing on dedicated servers by moving the firing of the event to `ForgeHooks`. The method in `ForgeHooksClient` is kept as a wrapper to preserve binary compatibility. Additionally, the javadoc of `BuildCreativeModeTabContentsEvent` was updated to reflect the actual behavior in the original implementation.