### PR TITLE
Add support to NBTIngredient for handling attachments

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
@@ -9,7 +9,6 @@ import com.google.common.base.Preconditions;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
@@ -98,16 +98,13 @@ public class NBTIngredient extends Ingredient {
      * Creates a new ingredient matching any item from the list, containing the given NBT
      */
     public static NBTIngredient of(boolean strict, CompoundTag nbt, ItemLike... items) {
-        Objects.requireNonNull(nbt, "NBT Ingredient requires NBT");
-        return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), nbt, null, strict);
+        return of(strict, nbt, null, items);
     }
 
     /**
      * Creates a new ingredient matching any item from the list, containing the given NBT
      */
-    public static NBTIngredient of(boolean strict, CompoundTag nbt, CompoundTag attachmentNbt, ItemLike... items) {
-        Objects.requireNonNull(nbt, "NBT Ingredient requires NBT");
-        Objects.requireNonNull(attachmentNbt, "NBT Ingredient requires attachment NBT");
+    public static NBTIngredient of(boolean strict, @Nullable CompoundTag nbt, @Nullable CompoundTag attachmentNbt, ItemLike... items) {
         return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), nbt, attachmentNbt, strict);
     }
 
@@ -115,8 +112,7 @@ public class NBTIngredient extends Ingredient {
      * Creates a new ingredient matching any item from the list, containing the given NBT
      */
     public static NBTIngredient ofAttachment(boolean strict, CompoundTag attachmentNbt, ItemLike... items) {
-        Objects.requireNonNull(attachmentNbt, "NBT Ingredient requires attachment NBT");
-        return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), null, attachmentNbt, strict);
+        return of(strict, null, attachmentNbt, items);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
@@ -118,6 +118,7 @@ public class NBTIngredient extends Ingredient {
      * Creates a new ingredient matching the given item, containing the given NBT
      */
     public static NBTIngredient of(boolean strict, ItemStack stack) {
+        //TODO - 1.20.5: return of(strict, stack.getTag(), stack.serializeAttachments(), stack.getItem());
         CompoundTag attachmentNbt = stack.serializeAttachments();
         //Only force create a tag if there is no serializable attachments
         CompoundTag nbt = attachmentNbt == null ? stack.getOrCreateTag() : stack.getTag();

--- a/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
@@ -74,7 +74,9 @@ public class NBTIngredient extends Ingredient {
             return new Ingredient.ItemValue(stack, strict ? ItemStack::matches : NBTIngredient::compareStacksWithNBT);
         }), NeoForgeMod.NBT_INGREDIENT_TYPE);
         Preconditions.checkArgument(!items.isEmpty(), "At least one item needs to be provided for a nbt matching ingredient");
-        Preconditions.checkArgument(tag != null || attachmentTag != null, "Either nbt or attachment nbt needs to be provided for a nbt matching ingredient");
+        if (!strict) {
+            Preconditions.checkArgument(tag != null || attachmentTag != null, "Either nbt or attachment nbt needs to be provided for a non-strict nbt matching ingredient");
+        }
         this.strict = strict;
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/NBTIngredient.java
@@ -9,17 +9,22 @@ import com.google.common.base.Preconditions;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
+import net.neoforged.neoforge.attachment.AttachmentHolder;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Ingredient that matches the given items, performing either a {@link NBTIngredient#isStrict() strict} or a partial NBT test.
@@ -32,7 +37,8 @@ public class NBTIngredient extends Ingredient {
             builder -> builder
                     .group(
                             NeoForgeExtraCodecs.singularOrPluralCodec(BuiltInRegistries.ITEM.byNameCodec(), "item").forGetter(NBTIngredient::getContainedItems),
-                            CraftingHelper.TAG_CODEC.fieldOf("tag").forGetter(NBTIngredient::getTag),
+                            ExtraCodecs.strictOptionalField(CraftingHelper.TAG_CODEC, "tag").forGetter(NBTIngredient::getOptionalTag),
+                            ExtraCodecs.strictOptionalField(CraftingHelper.TAG_CODEC, AttachmentHolder.ATTACHMENTS_NBT_KEY).forGetter(NBTIngredient::getAttachmentNbt),
                             Codec.BOOL.optionalFieldOf("strict", false).forGetter(NBTIngredient::isStrict))
                     .apply(builder, NBTIngredient::new));
 
@@ -40,20 +46,35 @@ public class NBTIngredient extends Ingredient {
             builder -> builder
                     .group(
                             NeoForgeExtraCodecs.singularOrPluralCodecNotEmpty(BuiltInRegistries.ITEM.byNameCodec(), "item").forGetter(NBTIngredient::getContainedItems),
-                            CraftingHelper.TAG_CODEC.fieldOf("tag").forGetter(NBTIngredient::getTag),
+                            ExtraCodecs.strictOptionalField(CraftingHelper.TAG_CODEC, "tag").forGetter(NBTIngredient::getOptionalTag),
+                            ExtraCodecs.strictOptionalField(CraftingHelper.TAG_CODEC, AttachmentHolder.ATTACHMENTS_NBT_KEY).forGetter(NBTIngredient::getAttachmentNbt),
                             Codec.BOOL.optionalFieldOf("strict", false).forGetter(NBTIngredient::isStrict))
                     .apply(builder, NBTIngredient::new));
 
     private final boolean strict;
 
+    @Deprecated(forRemoval = true, since = "1.20.4")
     protected NBTIngredient(Set<Item> items, CompoundTag tag, boolean strict) {
+        this(items, tag, null, strict);
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private NBTIngredient(Set<Item> items, Optional<CompoundTag> tag, Optional<CompoundTag> attachmentTag, boolean strict) {
+        this(items, tag.orElse(null), attachmentTag.orElse(null), strict);
+    }
+
+    protected NBTIngredient(Set<Item> items, @Nullable CompoundTag tag, @Nullable CompoundTag attachmentTag, boolean strict) {
         super(items.stream().map(item -> {
-            ItemStack stack = new ItemStack(item, 1);
+            //Copy the attachment tag in case a modder mutates the tag they get passed when deserializing an attachment
+            ItemStack stack = new ItemStack(item, 1, attachmentTag == null ? null : attachmentTag.copy());
             // copy NBT to prevent the stack from modifying the original, as attachments or vanilla item durability will modify the tag
-            stack.setTag(tag.copy());
+            if (tag != null) {
+                stack.setTag(tag.copy());
+            }
             return new Ingredient.ItemValue(stack, strict ? ItemStack::matches : NBTIngredient::compareStacksWithNBT);
         }), NeoForgeMod.NBT_INGREDIENT_TYPE);
         Preconditions.checkArgument(!items.isEmpty(), "At least one item needs to be provided for a nbt matching ingredient");
+        Preconditions.checkArgument(tag != null || attachmentTag != null, "Either nbt or attachment nbt needs to be provided for a nbt matching ingredient");
         this.strict = strict;
     }
 
@@ -68,21 +89,42 @@ public class NBTIngredient extends Ingredient {
     }
 
     private static boolean compareStacksWithNBT(ItemStack left, ItemStack right) {
-        return left.getItem() == right.getItem() && NbtUtils.compareNbt(left.getTag(), right.getTag(), true);
+        return left.is(right.getItem()) && NbtUtils.compareNbt(left.getTag(), right.getTag(), true) && NbtUtils.compareNbt(left.serializeAttachments(), right.serializeAttachments(), true);
     }
 
     /**
      * Creates a new ingredient matching any item from the list, containing the given NBT
      */
     public static NBTIngredient of(boolean strict, CompoundTag nbt, ItemLike... items) {
-        return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), nbt, strict);
+        Objects.requireNonNull(nbt, "NBT Ingredient requires NBT");
+        return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), nbt, null, strict);
+    }
+
+    /**
+     * Creates a new ingredient matching any item from the list, containing the given NBT
+     */
+    public static NBTIngredient of(boolean strict, CompoundTag nbt, CompoundTag attachmentNbt, ItemLike... items) {
+        Objects.requireNonNull(nbt, "NBT Ingredient requires NBT");
+        Objects.requireNonNull(attachmentNbt, "NBT Ingredient requires attachment NBT");
+        return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), nbt, attachmentNbt, strict);
+    }
+
+    /**
+     * Creates a new ingredient matching any item from the list, containing the given NBT
+     */
+    public static NBTIngredient ofAttachment(boolean strict, CompoundTag attachmentNbt, ItemLike... items) {
+        Objects.requireNonNull(attachmentNbt, "NBT Ingredient requires attachment NBT");
+        return new NBTIngredient(Arrays.stream(items).map(ItemLike::asItem).collect(Collectors.toSet()), null, attachmentNbt, strict);
     }
 
     /**
      * Creates a new ingredient matching the given item, containing the given NBT
      */
     public static NBTIngredient of(boolean strict, ItemStack stack) {
-        return new NBTIngredient(Set.of(stack.getItem()), stack.getOrCreateTag(), strict);
+        CompoundTag attachmentNbt = stack.serializeAttachments();
+        //Only force create a tag if there is no serializable attachments
+        CompoundTag nbt = attachmentNbt == null ? stack.getOrCreateTag() : stack.getTag();
+        return new NBTIngredient(Set.of(stack.getItem()), nbt, attachmentNbt, strict);
     }
 
     public Set<Item> getContainedItems() {
@@ -90,11 +132,21 @@ public class NBTIngredient extends Ingredient {
     }
 
     public CompoundTag getTag() {
-        final ItemStack[] items = getItems();
-        if (items.length == 0)
-            return new CompoundTag();
+        return getOptionalTag().orElseGet(CompoundTag::new);
+    }
 
-        return items[0].getOrCreateTag();
+    //TODO - 1.20.5: Replace getTag with this method and rename this to getTag
+    public Optional<CompoundTag> getOptionalTag() {
+        return getFirstItem().map(ItemStack::getTag);
+    }
+
+    public Optional<CompoundTag> getAttachmentNbt() {
+        return getFirstItem().map(AttachmentHolder::serializeAttachments);
+    }
+
+    private Optional<ItemStack> getFirstItem() {
+        final ItemStack[] items = getItems();
+        return items.length == 0 ? Optional.empty() : Optional.of(items[0]);
     }
 
     @Override

--- a/tests/src/generated/resources/data/neotests_partial_attachment_ingredient/advancements/recipes/misc/partial_attachments.json
+++ b/tests/src/generated/resources/data/neotests_partial_attachment_ingredient/advancements/recipes/misc/partial_attachments.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_pick": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_pickaxe"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_partial_attachment_ingredient:partial_attachments"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_pick"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_partial_attachment_ingredient:partial_attachments"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_partial_attachment_ingredient/recipes/partial_attachments.json
+++ b/tests/src/generated/resources/data/neotests_partial_attachment_ingredient/recipes/partial_attachments.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "minecraft:diamond"
+    },
+    "E": {
+      "item": "minecraft:emerald"
+    },
+    "I": {
+      "type": "testframework:test_enabled",
+      "base": {
+        "type": "neoforge:nbt",
+        "item": "minecraft:iron_pickaxe",
+        "neoforge:attachments": "{\"neotests_partial_attachment_ingredient:test_int\":1}",
+        "tag": "{Damage:0}"
+      },
+      "framework": "neotests:tests",
+      "testId": "partialAttachmentIngredient"
+    }
+  },
+  "pattern": [
+    "IDE"
+  ],
+  "result": {
+    "item": "minecraft:poppy"
+  }
+}

--- a/tests/src/generated/resources/data/neotests_partial_nbt_attachment_ingredient/advancements/recipes/misc/partial_nbt_and_attachments.json
+++ b/tests/src/generated/resources/data/neotests_partial_nbt_attachment_ingredient/advancements/recipes/misc/partial_nbt_and_attachments.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_pick": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_pickaxe"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_partial_nbt_attachment_ingredient:partial_nbt_and_attachments"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_pick"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_partial_nbt_attachment_ingredient:partial_nbt_and_attachments"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_partial_nbt_attachment_ingredient/recipes/partial_nbt_and_attachments.json
+++ b/tests/src/generated/resources/data/neotests_partial_nbt_attachment_ingredient/recipes/partial_nbt_and_attachments.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "minecraft:diamond"
+    },
+    "E": {
+      "item": "minecraft:emerald"
+    },
+    "I": {
+      "type": "testframework:test_enabled",
+      "base": {
+        "type": "neoforge:nbt",
+        "item": "minecraft:netherite_pickaxe",
+        "neoforge:attachments": "{\"neotests_partial_nbt_attachment_ingredient:test_int\":1}",
+        "tag": "{Damage:2}"
+      },
+      "framework": "neotests:tests",
+      "testId": "partialNbtAttachmentIngredient"
+    }
+  },
+  "pattern": [
+    "IDE"
+  ],
+  "result": {
+    "item": "minecraft:azalea"
+  }
+}

--- a/tests/src/generated/resources/data/neotests_strict_attachment_ingredient/advancements/recipes/misc/strict_attachments.json
+++ b/tests/src/generated/resources/data/neotests_strict_attachment_ingredient/advancements/recipes/misc/strict_attachments.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_apple": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:apple"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_strict_attachment_ingredient:strict_attachments"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_apple"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_strict_attachment_ingredient:strict_attachments"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_strict_attachment_ingredient/recipes/strict_attachments.json
+++ b/tests/src/generated/resources/data/neotests_strict_attachment_ingredient/recipes/strict_attachments.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "type": "testframework:test_enabled",
+      "base": {
+        "type": "neoforge:nbt",
+        "item": "minecraft:apple",
+        "neoforge:attachments": "{\"neotests_strict_attachment_ingredient:test_int\":4}",
+        "strict": true
+      },
+      "framework": "neotests:tests",
+      "testId": "strictAttachmentIngredient"
+    },
+    {
+      "item": "minecraft:acacia_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:acacia_chest_boat"
+  }
+}

--- a/tests/src/generated/resources/data/neotests_strict_nbt_attachment_ingredient/advancements/recipes/misc/strict_attachments.json
+++ b/tests/src/generated/resources/data/neotests_strict_nbt_attachment_ingredient/advancements/recipes/misc/strict_attachments.json
@@ -1,0 +1,34 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_axe": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:diamond_axe"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_strict_nbt_attachment_ingredient:strict_attachments"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_axe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_strict_nbt_attachment_ingredient:strict_attachments"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_strict_nbt_attachment_ingredient/recipes/strict_attachments.json
+++ b/tests/src/generated/resources/data/neotests_strict_nbt_attachment_ingredient/recipes/strict_attachments.json
@@ -1,0 +1,24 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "type": "testframework:test_enabled",
+      "base": {
+        "type": "neoforge:nbt",
+        "item": "minecraft:diamond_axe",
+        "neoforge:attachments": "{\"neotests_strict_nbt_attachment_ingredient:test_int\":4}",
+        "strict": true,
+        "tag": "{Damage:4}"
+      },
+      "framework": "neotests:tests",
+      "testId": "strictNbtAttachmentIngredient"
+    },
+    {
+      "item": "minecraft:acacia_planks"
+    }
+  ],
+  "result": {
+    "item": "minecraft:acacia_fence"
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.crafting;
 
+import com.mojang.serialization.Codec;
 import java.util.Optional;
 import net.minecraft.core.FrontAndTop;
 import net.minecraft.data.recipes.RecipeCategory;
@@ -21,7 +22,9 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CrafterBlock;
 import net.minecraft.world.level.block.entity.CrafterBlockEntity;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.common.crafting.NBTIngredient;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -120,9 +123,244 @@ public class IngredientTests {
                 .thenIdle(5) // Crafter cooldown
 
                 // The superfluous element is gone, so the recipe should now work
-                .thenExecute(crafter -> crafter.getItem(1).getOrCreateTag().remove("abcd"))
+                .thenExecute(crafter -> crafter.getItem(1).removeTagKey("abcd"))
                 .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
                 .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.ACACIA_BOAT))
+
+                .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if partial NBT ingredients match the correct stacks using partial attachments")
+    static void partialAttachmentIngredient(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).build());
+        var altAttachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_bool", () -> AttachmentType.builder(() -> false).serialize(Codec.BOOL).build());
+
+        reg.addProvider(event -> new RecipeProvider(event.getGenerator().getPackOutput()) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                ShapedRecipeBuilder.shaped(RecipeCategory.MISC, Items.POPPY)
+                        .pattern("IDE")
+                        .define('I', new TestEnabledIngredient(
+                                NBTIngredient.ofAttachment(false, putInt(new CompoundTag(), attachmentType.getId().toString(), 1), Items.IRON_PICKAXE),
+                                test.framework(), test.id()))
+                        .define('D', Items.DIAMOND)
+                        .define('E', Items.EMERALD)
+                        .unlockedBy("has_pick", has(Items.IRON_PICKAXE))
+                        .save(output, new ResourceLocation(reg.modId(), "partial_attachments"));
+            }
+        });
+
+        test.onGameTest(helper -> helper
+                .startSequence()
+                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.CRAFTER.defaultBlockState().setValue(BlockStateProperties.ORIENTATION, FrontAndTop.UP_NORTH).setValue(CrafterBlock.CRAFTING, true)))
+                .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.CHEST))
+
+                .thenMap(() -> helper.requireBlockEntity(1, 1, 1, CrafterBlockEntity.class))
+                .thenExecute(crafter -> crafter.setItem(0, Items.IRON_PICKAXE.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(1, Items.DIAMOND.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(2, Items.EMERALD.getDefaultInstance()))
+                .thenIdle(3)
+
+                // Pick has no attachments, the recipe shouldn't work
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Pick now has the attachment, we expect the recipe to work, even if we also add other random attachments and nbt
+                .thenExecute(crafter -> crafter.getItem(0).setData(attachmentType, 1))
+                .thenExecute(crafter -> crafter.getItem(0).setData(altAttachmentType, true))
+                .thenExecute(crafter -> crafter.getItem(0).getTag().putFloat("abcd", helper.getLevel().random.nextFloat()))
+
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.POPPY))
+
+                .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if strict NBT ingredients match the correct stacks using attachments")
+    static void strictAttachmentIngredient(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).build());
+        var altAttachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_bool", () -> AttachmentType.builder(() -> false).serialize(Codec.BOOL).build());
+
+        reg.addProvider(event -> new RecipeProvider(event.getGenerator().getPackOutput()) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, Items.ACACIA_CHEST_BOAT)
+                        .requires(new TestEnabledIngredient(
+                                NBTIngredient.ofAttachment(true, putInt(new CompoundTag(), attachmentType.getId().toString(), 4), Items.APPLE),
+                                test.framework(), test.id()))
+                        .requires(Items.ACACIA_PLANKS)
+                        .unlockedBy("has_apple", has(Items.APPLE))
+                        .save(output, new ResourceLocation(reg.modId(), "strict_attachments"));
+            }
+        });
+
+        test.onGameTest(helper -> helper
+                .startSequence()
+                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.CRAFTER.defaultBlockState().setValue(BlockStateProperties.ORIENTATION, FrontAndTop.UP_NORTH).setValue(CrafterBlock.CRAFTING, true)))
+                .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.CHEST))
+
+                .thenMap(() -> helper.requireBlockEntity(1, 1, 1, CrafterBlockEntity.class))
+                .thenExecute(crafter -> crafter.setItem(1, new ItemStack(Items.APPLE, 1, putInt(new CompoundTag(), attachmentType.getId().toString(), 3))))
+                .thenExecute(crafter -> crafter.setItem(0, Items.ACACIA_PLANKS.getDefaultInstance()))
+                .thenIdle(3)
+
+                // Axe has the attachment but at the wrong value, so, the recipe shouldn't work
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Axe now has the attachment at the correct value of 4, but has other superfluous attachments, so the recipe should still not work
+                .thenExecute(crafter -> crafter.getItem(1).setData(attachmentType, 4))
+                .thenExecute(crafter -> crafter.getItem(1).setData(altAttachmentType, true))
+
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Axe now has the attachment at the correct value of 4, without superfluous attachments, but has nbt, so the recipe should still not work
+                .thenExecute(crafter -> crafter.getItem(1).removeData(altAttachmentType))
+                .thenExecute(crafter -> crafter.getItem(1).getOrCreateTag().putFloat("abcd", 12f))
+
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // The superfluous element is gone, so the recipe should now work
+                .thenExecute(crafter -> crafter.getItem(1).removeTagKey("abcd"))
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.ACACIA_CHEST_BOAT))
+
+                .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if partial NBT ingredients match the correct stacks using partial attachments and nbt")
+    static void partialNbtAttachmentIngredient(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).build());
+        var altAttachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_bool", () -> AttachmentType.builder(() -> false).serialize(Codec.BOOL).build());
+
+        reg.addProvider(event -> new RecipeProvider(event.getGenerator().getPackOutput()) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                ShapedRecipeBuilder.shaped(RecipeCategory.MISC, Items.AZALEA)
+                        .pattern("IDE")
+                        .define('I', new TestEnabledIngredient(
+                                NBTIngredient.of(false, putInt(new CompoundTag(), ItemStack.TAG_DAMAGE, 2), putInt(new CompoundTag(), attachmentType.getId().toString(), 1), Items.NETHERITE_PICKAXE),
+                                test.framework(), test.id()))
+                        .define('D', Items.DIAMOND)
+                        .define('E', Items.EMERALD)
+                        .unlockedBy("has_pick", has(Items.NETHERITE_PICKAXE))
+                        .save(output, new ResourceLocation(reg.modId(), "partial_nbt_and_attachments"));
+            }
+        });
+
+        test.onGameTest(helper -> helper
+                .startSequence()
+                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.CRAFTER.defaultBlockState().setValue(BlockStateProperties.ORIENTATION, FrontAndTop.UP_NORTH).setValue(CrafterBlock.CRAFTING, true)))
+                .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.CHEST))
+
+                .thenMap(() -> helper.requireBlockEntity(1, 1, 1, CrafterBlockEntity.class))
+                .thenExecute(crafter -> crafter.setItem(0, Items.NETHERITE_PICKAXE.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(1, Items.DIAMOND.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(2, Items.EMERALD.getDefaultInstance()))
+                .thenIdle(3)
+
+                // Pick has no attachments, the recipe shouldn't work
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Pick now has the correct damage and attachment, we expect the recipe to work, even if we also add other random attachments and nbt
+                .thenExecute(crafter -> crafter.getItem(0).hurt(2, helper.getLevel().random, null))
+                .thenExecute(crafter -> crafter.getItem(0).setData(attachmentType, 1))
+                .thenExecute(crafter -> crafter.getItem(0).setData(altAttachmentType, true))
+                .thenExecute(crafter -> crafter.getItem(0).getTag().putFloat("abcd", helper.getLevel().random.nextFloat()))
+
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.AZALEA))
+
+                .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if strict NBT ingredients match the correct stacks using attachments and nbt")
+    static void strictNbtAttachmentIngredient(final DynamicTest test, final RegistrationHelper reg) {
+        var attachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_int", () -> AttachmentType.builder(() -> 0).serialize(Codec.INT).build());
+        var altAttachmentType = reg.registrar(NeoForgeRegistries.Keys.ATTACHMENT_TYPES)
+                .register("test_bool", () -> AttachmentType.builder(() -> false).serialize(Codec.BOOL).build());
+
+        reg.addProvider(event -> new RecipeProvider(event.getGenerator().getPackOutput()) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, Items.ACACIA_FENCE)
+                        .requires(new TestEnabledIngredient(
+                                NBTIngredient.of(true, putInt(new CompoundTag(), ItemStack.TAG_DAMAGE, 4), putInt(new CompoundTag(), attachmentType.getId().toString(), 4), Items.DIAMOND_AXE),
+                                test.framework(), test.id()))
+                        .requires(Items.ACACIA_PLANKS)
+                        .unlockedBy("has_axe", has(Items.DIAMOND_AXE))
+                        .save(output, new ResourceLocation(reg.modId(), "strict_attachments"));
+            }
+        });
+
+        test.onGameTest(helper -> helper
+                .startSequence()
+                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.CRAFTER.defaultBlockState().setValue(BlockStateProperties.ORIENTATION, FrontAndTop.UP_NORTH).setValue(CrafterBlock.CRAFTING, true)))
+                .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.CHEST))
+
+                .thenMap(() -> helper.requireBlockEntity(1, 1, 1, CrafterBlockEntity.class))
+                .thenExecute(crafter -> crafter.setItem(1, new ItemStack(Items.DIAMOND_AXE, 1, putInt(new CompoundTag(), attachmentType.getId().toString(), 3))))
+                .thenExecute(crafter -> crafter.getItem(1).setTag(putInt(new CompoundTag(), ItemStack.TAG_DAMAGE, 1)))
+                .thenExecute(crafter -> crafter.setItem(0, Items.ACACIA_PLANKS.getDefaultInstance()))
+                .thenIdle(3)
+
+                // Axe is damaged and has the attachment but at the wrong value, so, the recipe shouldn't work
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Axe now has the attachment and damage at the correct value of 4, but has other superfluous attachments, so the recipe should still not work
+                .thenExecute(crafter -> crafter.getItem(1).hurt(3, helper.getLevel().random, null))
+                .thenExecute(crafter -> crafter.getItem(1).setData(attachmentType, 4))
+                .thenExecute(crafter -> crafter.getItem(1).setData(altAttachmentType, true))
+
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Axe now has the attachment at the correct value of 4, without superfluous attachments, but has superfluous nbt, so the recipe should still not work
+                .thenExecute(crafter -> crafter.getItem(1).removeData(altAttachmentType))
+                .thenExecute(crafter -> crafter.getItem(1).getOrCreateTag().putFloat("abcd", 12f))
+
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerEmpty(1, 2, 1))
+
+                .thenIdle(5) // Crafter cooldown
+
+                // The superfluous element is gone, so the recipe should now work
+                .thenExecute(crafter -> crafter.getItem(1).removeTagKey("abcd"))
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.ACACIA_FENCE))
 
                 .thenSucceed());
     }


### PR DESCRIPTION
This adds support so NBT Ingredients will support the following cases (some they already supported):
- partial nbt
- partial attachment data
- partial nbt and partial attachment data
- strict nbt with no attachments present
- strict attachment matching with no nbt present
- strict attachment matching and strict nbt matching