### PR TITLE
Create `AddSectionGeometryEvent`

### DIFF
--- a/patches/net/minecraft/client/renderer/chunk/RenderRegionCache.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/RenderRegionCache.java.patch
@@ -1,5 +1,26 @@
 --- a/net/minecraft/client/renderer/chunk/RenderRegionCache.java
 +++ b/net/minecraft/client/renderer/chunk/RenderRegionCache.java
+@@ -17,6 +_,11 @@
+ 
+     @Nullable
+     public RenderChunkRegion createRegion(Level p_200466_, BlockPos p_200467_, BlockPos p_200468_, int p_200469_) {
++        return createRegion(p_200466_, p_200467_, p_200468_, p_200469_, true);
++    }
++
++    @Nullable
++    public RenderChunkRegion createRegion(Level p_200466_, BlockPos p_200467_, BlockPos p_200468_, int p_200469_, boolean nullForEmpty) {
+         int i = SectionPos.blockToSectionCoord(p_200467_.getX() - p_200469_);
+         int j = SectionPos.blockToSectionCoord(p_200467_.getZ() - p_200469_);
+         int k = SectionPos.blockToSectionCoord(p_200468_.getX() + p_200469_);
+@@ -33,7 +_,7 @@
+             }
+         }
+ 
+-        if (isAllEmpty(p_200467_, p_200468_, i, j, arenderregioncache$chunkinfo)) {
++        if (nullForEmpty && isAllEmpty(p_200467_, p_200468_, i, j, arenderregioncache$chunkinfo)) {
+             return null;
+         } else {
+             RenderChunk[][] arenderchunk = new RenderChunk[k - i + 1][l - j + 1];
 @@ -44,7 +_,10 @@
                  }
              }

--- a/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
@@ -1,16 +1,32 @@
 --- a/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java
 +++ b/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java
-@@ -502,10 +_,13 @@
+@@ -440,7 +_,7 @@
+             }
+ 
+             this.lastRebuildTask = new SectionRenderDispatcher.RenderSection.RebuildTask(
+-                this.getDistToPlayerSqr(), renderchunkregion, !flag1 || this.initialCompilationCancelCount.get() > 2
++                this.getDistToPlayerSqr(), renderchunkregion, !flag1 || this.initialCompilationCancelCount.get() > 2, net.neoforged.neoforge.client.ClientHooks.gatherAdditionalRenderers(blockpos, SectionRenderDispatcher.this.level)
+             );
+             return this.lastRebuildTask;
+         }
+@@ -502,10 +_,20 @@
          class RebuildTask extends SectionRenderDispatcher.RenderSection.CompileTask {
              @Nullable
              protected RenderChunkRegion region;
 +            private final net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot modelData;
++            private final List<net.neoforged.neoforge.client.event.AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers;
  
++            @Deprecated
              public RebuildTask(double p_294400_, @Nullable RenderChunkRegion p_294382_, boolean p_295207_) {
++                this(p_294400_, p_294382_, p_295207_, List.of());
++            }
++
++            public RebuildTask(double p_294400_, @Nullable RenderChunkRegion p_294382_, boolean p_295207_, List<net.neoforged.neoforge.client.event.AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers) {
                  super(p_294400_, p_295207_);
                  this.region = p_294382_;
 +                var manager = p_294382_ != null ? p_294382_.getModelDataManager() : null;
 +                this.modelData = manager != null ? manager : net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot.EMPTY;
++                this.additionalRenderers = additionalRenderers;
              }
  
              @Override
@@ -27,7 +43,7 @@
                              BufferBuilder bufferbuilder2 = p_294319_.builder(rendertype2);
                              if (set.add(rendertype2)) {
                                  RenderSection.this.beginLayer(bufferbuilder2);
-@@ -617,8 +_,9 @@
+@@ -617,10 +_,14 @@
  
                              posestack.pushPose();
                              posestack.translate((float)(blockpos2.getX() & 15), (float)(blockpos2.getY() & 15), (float)(blockpos2.getZ() & 15));
@@ -37,7 +53,12 @@
 +                            }
                          }
                      }
++                    net.neoforged.neoforge.client.ClientHooks.addAdditionalGeometry(
++                        additionalRenderers, set, p_294319_, renderchunkregion, posestack
++                    );
  
+                     if (set.contains(RenderType.translucent())) {
+                         BufferBuilder bufferbuilder1 = p_294319_.builder(RenderType.translucent());
 @@ -651,9 +_,10 @@
              private <E extends BlockEntity> void handleBlockEntity(SectionRenderDispatcher.RenderSection.RebuildTask.CompileResults p_294198_, E p_296214_) {
                  BlockEntityRenderer<E> blockentityrenderer = Minecraft.getInstance().getBlockEntityRenderDispatcher().getRenderer(p_296214_);

--- a/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
@@ -1,11 +1,22 @@
 --- a/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java
 +++ b/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java
+@@ -431,8 +_,9 @@
+             boolean flag = this.cancelTasks();
+             BlockPos blockpos = this.origin.immutable();
+             int i = 1;
++            var additionalRenderers = net.neoforged.neoforge.client.ClientHooks.gatherAdditionalRenderers(blockpos, SectionRenderDispatcher.this.level);
+             RenderChunkRegion renderchunkregion = p_295324_.createRegion(
+-                SectionRenderDispatcher.this.level, blockpos.offset(-1, -1, -1), blockpos.offset(16, 16, 16), 1
++                SectionRenderDispatcher.this.level, blockpos.offset(-1, -1, -1), blockpos.offset(16, 16, 16), 1, additionalRenderers.isEmpty()
+             );
+             boolean flag1 = this.compiled.get() == SectionRenderDispatcher.CompiledSection.UNCOMPILED;
+             if (flag1 && flag) {
 @@ -440,7 +_,7 @@
              }
  
              this.lastRebuildTask = new SectionRenderDispatcher.RenderSection.RebuildTask(
 -                this.getDistToPlayerSqr(), renderchunkregion, !flag1 || this.initialCompilationCancelCount.get() > 2
-+                this.getDistToPlayerSqr(), renderchunkregion, !flag1 || this.initialCompilationCancelCount.get() > 2, net.neoforged.neoforge.client.ClientHooks.gatherAdditionalRenderers(blockpos, SectionRenderDispatcher.this.level)
++                this.getDistToPlayerSqr(), renderchunkregion, !flag1 || this.initialCompilationCancelCount.get() > 2, additionalRenderers
              );
              return this.lastRebuildTask;
          }
@@ -43,7 +54,7 @@
                              BufferBuilder bufferbuilder2 = p_294319_.builder(rendertype2);
                              if (set.add(rendertype2)) {
                                  RenderSection.this.beginLayer(bufferbuilder2);
-@@ -617,10 +_,14 @@
+@@ -617,10 +_,20 @@
  
                              posestack.pushPose();
                              posestack.translate((float)(blockpos2.getX() & 15), (float)(blockpos2.getY() & 15), (float)(blockpos2.getZ() & 15));
@@ -54,7 +65,13 @@
                          }
                      }
 +                    net.neoforged.neoforge.client.ClientHooks.addAdditionalGeometry(
-+                        additionalRenderers, set, p_294319_, renderchunkregion, posestack
++                        additionalRenderers, type -> {
++                            BufferBuilder builder = p_294319_.builder(type);
++                            if (set.add(type)) {
++                                RenderSection.this.beginLayer(builder);
++                            }
++                            return builder;
++                        }, renderchunkregion, posestack
 +                    );
  
                      if (set.contains(RenderType.translucent())) {

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -68,12 +68,14 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.SectionBufferBuilderPack;
 import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockElement;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.chunk.RenderChunkRegion;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -129,6 +131,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.event.AddSectionGeometryEvent;
 import net.neoforged.neoforge.client.event.CalculatePlayerTurnEvent;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.ClientChatReceivedEvent;
@@ -971,6 +974,30 @@ public class ClientHooks {
             }
         }
         return elements;
+    }
+
+    public static List<AddSectionGeometryEvent.AdditionalSectionRenderer> gatherAdditionalRenderers(
+        BlockPos sectionOrigin, Level level
+    ) {
+        final var event = new AddSectionGeometryEvent(sectionOrigin, level);
+        NeoForge.EVENT_BUS.post(event);
+        return event.getAdditionalRenderers();
+    }
+
+    public static void addAdditionalGeometry(
+        List<AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers,
+        Set<RenderType> layers,
+        SectionBufferBuilderPack buffers,
+        RenderChunkRegion region,
+        PoseStack transformation
+    ) {
+        if (additionalRenderers.isEmpty()) {
+            return;
+        }
+        final var context = new AddSectionGeometryEvent.SectionRenderingContext(layers, buffers, region, transformation);
+        for (final var renderer : additionalRenderers) {
+            renderer.render(context);
+        }
     }
 
     // Make sure the below method is only ever called once (by forge).

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -68,7 +68,6 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.SectionBufferBuilderPack;
 import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.block.model.BakedQuad;

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -977,20 +977,18 @@ public class ClientHooks {
     }
 
     public static List<AddSectionGeometryEvent.AdditionalSectionRenderer> gatherAdditionalRenderers(
-        BlockPos sectionOrigin, Level level
-    ) {
+            BlockPos sectionOrigin, Level level) {
         final var event = new AddSectionGeometryEvent(sectionOrigin, level);
         NeoForge.EVENT_BUS.post(event);
         return event.getAdditionalRenderers();
     }
 
     public static void addAdditionalGeometry(
-        List<AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers,
-        Set<RenderType> layers,
-        SectionBufferBuilderPack buffers,
-        RenderChunkRegion region,
-        PoseStack transformation
-    ) {
+            List<AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers,
+            Set<RenderType> layers,
+            SectionBufferBuilderPack buffers,
+            RenderChunkRegion region,
+            PoseStack transformation) {
         if (additionalRenderers.isEmpty()) {
             return;
         }

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -985,14 +985,13 @@ public class ClientHooks {
 
     public static void addAdditionalGeometry(
             List<AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers,
-            Set<RenderType> layers,
-            SectionBufferBuilderPack buffers,
+            Function<RenderType, VertexConsumer> getOrCreateBuilder,
             RenderChunkRegion region,
             PoseStack transformation) {
         if (additionalRenderers.isEmpty()) {
             return;
         }
-        final var context = new AddSectionGeometryEvent.SectionRenderingContext(layers, buffers, region, transformation);
+        final var context = new AddSectionGeometryEvent.SectionRenderingContext(getOrCreateBuilder, region, transformation);
         for (final var renderer : additionalRenderers) {
             renderer.render(context);
         }

--- a/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.neoforged.neoforge.client.event;
+
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.SectionBufferBuilderPack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.client.model.lighting.LightPipelineAwareModelBlockRenderer;
+import net.neoforged.neoforge.client.model.lighting.QuadLighter;
+import net.neoforged.neoforge.common.NeoForge;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This event can be used to add static geometry to chunk sections. The event is fired on the main client thread
+ * whenever a section is queued for (re)building. A rebuild can be triggered manually using e.g.
+ * {@link net.minecraft.client.renderer.LevelRenderer#setSectionDirty(int, int, int)}.<br>
+ *
+ * While the event itself is fired on the main client thread, the renderers registered using
+ * {@link net.neoforged.neoforge.client.event.AddSectionGeometryEvent#addRenderer(net.neoforged.neoforge.client.event.AddSectionGeometryEvent.AdditionalSectionRenderer)}
+ * while be executed on the thread performing the rebuild, which will typically <b>not</b> be the main thread.
+ * Therefore, any data from non-thread-safe data structures need to be retrieved during the event handler itself rather
+ * than the renderer. A typical usage would look like
+ * <pre>
+ * {@code
+ * @SubscribeEvent
+ * public static void addChunkGeometry(AddSectionGeometryEvent ev) {
+ *     if (shouldAddGeometryTo(ev.getLevel(), ev.getSectionOrigin())) {
+ *         final var renderingData = getDataOnMainThread(ev.getLevel(), ev.getSectionOrigin());
+ *         ev.addRenderer(context -> renderThreadsafe(renderingData, context));
+ *     }
+ * }
+ * }
+ * </pre>
+ * Note that the renderer is only added if something will actually be rendered in this example. This structure should be
+ * replicated whenever the event is used, to allow for optimizations related to entirely empty sections.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
+ *
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}, only on the
+ * {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class AddSectionGeometryEvent extends Event {
+    private final List<AdditionalSectionRenderer> additionalRenderers = new ArrayList<>();
+    private final BlockPos sectionOrigin;
+    private final Level level;
+
+    public AddSectionGeometryEvent(BlockPos sectionOrigin, Level level) {
+        this.sectionOrigin = sectionOrigin;
+        this.level = level;
+    }
+
+    /**
+     * Adds a renderer which will add geometry to the chunk section.
+     * @param renderer the renderer to add
+     */
+    public void addRenderer(AdditionalSectionRenderer renderer) {
+        additionalRenderers.add(renderer);
+    }
+
+    /**
+     * @return the list of all added renderers. Do not modify the result.
+     */
+    public List<AdditionalSectionRenderer> getAdditionalRenderers() {
+        return additionalRenderers;
+    }
+
+    /**
+     * @return the origin of the section to add renderers to, i.e. the block with the smallest coordinates contained in
+     * the section.
+     */
+    public BlockPos getSectionOrigin() {
+        return sectionOrigin;
+    }
+
+    /**
+     * @return the level to render in. This can differ from the current client level in case of e.g. guidebooks.
+     */
+    public Level getLevel() {
+        return level;
+    }
+
+    /**
+     * A rendering callback that will be invoked during chunk meshing.
+     */
+    @FunctionalInterface
+    public interface AdditionalSectionRenderer {
+        void render(SectionRenderingContext context);
+    }
+
+    public static final class SectionRenderingContext {
+        private final Set<RenderType> layers;
+        private final SectionBufferBuilderPack buffers;
+        private final BlockAndTintGetter region;
+        private final PoseStack poseStack;
+
+        /**
+         * @param layers the set of currently present render types in this chunk. This will be modified whenever new
+         *                     types are added!
+         * @param buffers the collection of buffers rendering to the current section
+         * @param region a view of the section and some surrounding blocks
+         * @param poseStack the transformations to use, currently set to the chunk origin at unit scaling and no
+         *                        rotation.
+         */
+        public SectionRenderingContext(
+            Set<RenderType> layers, SectionBufferBuilderPack buffers, BlockAndTintGetter region, PoseStack poseStack
+        ) {
+            this.layers = layers;
+            this.buffers = buffers;
+            this.region = region;
+            this.poseStack = poseStack;
+        }
+
+        /**
+         * Returns the builder for the given render type/layer in the chunk section. If the render type is not already
+         * present in the section, marks the type as present in the section.
+         * @param type the render type to retrieve a builder for
+         * @return a vertex consumer adding geometry of the specified layer
+         */
+        public VertexConsumer getOrCreateBuffer(RenderType type) {
+            BufferBuilder builder = buffers.builder(type);
+            if(layers.add(type))
+                builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
+            return builder;
+        }
+
+        /**
+         * @param smooth whether a lighter for "smooth"/"ambient occlusion" lighting should be returned rather than a
+         *                     "flat" one
+         * @return a quad lighter usable on the current thread
+         */
+        public QuadLighter getQuadLighter(boolean smooth) {
+            final var renderer = (LightPipelineAwareModelBlockRenderer) Minecraft.getInstance().getBlockRenderer().getModelRenderer();
+            return renderer.getQuadLighter(smooth);
+        }
+
+        public PoseStack getPoseStack() {
+            return poseStack;
+        }
+
+        /**
+         * @return the "view" on the client world used in the current chunk meshing thread. This will generally only
+         * contain blocks in a small radius around the section being rendered.
+         */
+        public BlockAndTintGetter getRegion() { return region; }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -2,6 +2,7 @@
  * Copyright (c) NeoForged and contributors
  * SPDX-License-Identifier: LGPL-2.1-only
  */
+
 package net.neoforged.neoforge.client.event;
 
 import com.google.common.base.Preconditions;
@@ -10,6 +11,9 @@ import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.SectionBufferBuilderPack;
@@ -23,10 +27,6 @@ import net.neoforged.neoforge.client.model.lighting.LightPipelineAwareModelBlock
 import net.neoforged.neoforge.client.model.lighting.QuadLighter;
 import net.neoforged.neoforge.common.NeoForge;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 /**
  * This event can be used to add static geometry to chunk sections. The event is fired on the main client thread
  * whenever a section is queued for (re)building. A rebuild can be triggered manually using e.g.
@@ -37,6 +37,7 @@ import java.util.Set;
  * while be executed on the thread performing the rebuild, which will typically <b>not</b> be the main thread.
  * Therefore, any data from non-thread-safe data structures need to be retrieved during the event handler itself rather
  * than the renderer. A typical usage would look like
+ * 
  * <pre>
  * {@code
  * @SubscribeEvent
@@ -48,6 +49,7 @@ import java.util.Set;
  * }
  * }
  * </pre>
+ * 
  * Note that the renderer is only added if something will actually be rendered in this example. This structure should be
  * replicated whenever the event is used, to allow for optimizations related to entirely empty sections.
  *
@@ -68,6 +70,7 @@ public class AddSectionGeometryEvent extends Event {
 
     /**
      * Adds a renderer which will add geometry to the chunk section.
+     * 
      * @param renderer the renderer to add
      */
     public void addRenderer(AdditionalSectionRenderer renderer) {
@@ -83,7 +86,7 @@ public class AddSectionGeometryEvent extends Event {
 
     /**
      * @return the origin of the section to add renderers to, i.e. the block with the smallest coordinates contained in
-     * the section.
+     *         the section.
      */
     public BlockPos getSectionOrigin() {
         return sectionOrigin;
@@ -112,16 +115,15 @@ public class AddSectionGeometryEvent extends Event {
         private final PoseStack poseStack;
 
         /**
-         * @param layers the set of currently present render types in this chunk. This will be modified whenever new
-         *                     types are added!
-         * @param buffers the collection of buffers rendering to the current section
-         * @param region a view of the section and some surrounding blocks
+         * @param layers    the set of currently present render types in this chunk. This will be modified whenever new
+         *                  types are added!
+         * @param buffers   the collection of buffers rendering to the current section
+         * @param region    a view of the section and some surrounding blocks
          * @param poseStack the transformations to use, currently set to the chunk origin at unit scaling and no
-         *                        rotation.
+         *                  rotation.
          */
         public SectionRenderingContext(
-            Set<RenderType> layers, SectionBufferBuilderPack buffers, BlockAndTintGetter region, PoseStack poseStack
-        ) {
+                Set<RenderType> layers, SectionBufferBuilderPack buffers, BlockAndTintGetter region, PoseStack poseStack) {
             this.layers = layers;
             this.buffers = buffers;
             this.region = region;
@@ -131,23 +133,24 @@ public class AddSectionGeometryEvent extends Event {
         /**
          * Returns the builder for the given render type/layer in the chunk section. If the render type is not already
          * present in the section, marks the type as present in the section.
+         * 
          * @param type the render type to retrieve a builder for. This has to be one of the render types listed in
-         * {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
+         *             {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
          * @return a vertex consumer adding geometry of the specified layer
          * @throws IllegalArgumentException if the passed render type is not in
-         * {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
+         *                                  {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
          */
         public VertexConsumer getOrCreateChunkBuffer(RenderType type) {
             Preconditions.checkArgument(RenderType.chunkBufferLayers().contains(type));
             BufferBuilder builder = buffers.builder(type);
-            if(layers.add(type))
+            if (layers.add(type))
                 builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
             return builder;
         }
 
         /**
          * @param smooth whether a lighter for "smooth"/"ambient occlusion" lighting should be returned rather than a
-         *                     "flat" one
+         *               "flat" one
          * @return a quad lighter usable on the current thread
          */
         public QuadLighter getQuadLighter(boolean smooth) {
@@ -161,8 +164,10 @@ public class AddSectionGeometryEvent extends Event {
 
         /**
          * @return the "view" on the client world used in the current chunk meshing thread. This will generally only
-         * contain blocks in a small radius around the section being rendered.
+         *         contain blocks in a small radius around the section being rendered.
          */
-        public BlockAndTintGetter getRegion() { return region; }
+        public BlockAndTintGetter getRegion() {
+            return region;
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -134,7 +134,9 @@ public class AddSectionGeometryEvent extends Event {
          *                                  {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
          */
         public VertexConsumer getOrCreateChunkBuffer(RenderType type) {
-            Preconditions.checkArgument(RenderType.chunkBufferLayers().contains(type));
+            Preconditions.checkArgument(
+                    type.getChunkLayerId() != -1,
+                    "Cannot create a chunk render buffer for a non-chunk render type");
             return getOrCreateLayer.apply(type);
         }
 

--- a/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -6,19 +6,13 @@
 package net.neoforged.neoforge.client.event;
 
 import com.google.common.base.Preconditions;
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import com.mojang.blaze3d.vertex.VertexFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.SectionBufferBuilderPack;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.Level;
@@ -117,14 +111,14 @@ public class AddSectionGeometryEvent extends Event {
 
         /**
          * @param getOrCreateLayer a function that, given a "chunk render type", returns the corresponding buffer and
-		 *                         adds it to the section if it is not already present.
+         *                         adds it to the section if it is not already present.
          * @param region           a view of the section and some surrounding blocks
          * @param poseStack        the transformations to use, currently set to the chunk origin at unit scaling and no
          *                         rotation.
          */
         public SectionRenderingContext(
-				Function<RenderType, VertexConsumer> getOrCreateLayer, BlockAndTintGetter region, PoseStack poseStack) {
-			this.getOrCreateLayer = getOrCreateLayer;
+                Function<RenderType, VertexConsumer> getOrCreateLayer, BlockAndTintGetter region, PoseStack poseStack) {
+            this.getOrCreateLayer = getOrCreateLayer;
             this.region = region;
             this.poseStack = poseStack;
         }

--- a/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -4,6 +4,7 @@
  */
 package net.neoforged.neoforge.client.event;
 
+import com.google.common.base.Preconditions;
 import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -92,6 +93,7 @@ public class AddSectionGeometryEvent extends Event {
      * @return the level to render in. This can differ from the current client level in case of e.g. guidebooks.
      */
     public Level getLevel() {
+        Preconditions.checkState(Minecraft.getInstance().isSameThread());
         return level;
     }
 
@@ -129,10 +131,14 @@ public class AddSectionGeometryEvent extends Event {
         /**
          * Returns the builder for the given render type/layer in the chunk section. If the render type is not already
          * present in the section, marks the type as present in the section.
-         * @param type the render type to retrieve a builder for
+         * @param type the render type to retrieve a builder for. This has to be one of the render types listed in
+         * {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
          * @return a vertex consumer adding geometry of the specified layer
+         * @throws IllegalArgumentException if the passed render type is not in
+         * {@link net.minecraft.client.renderer.RenderType#chunkBufferLayers}.
          */
-        public VertexConsumer getOrCreateBuffer(RenderType type) {
+        public VertexConsumer getOrCreateChunkBuffer(RenderType type) {
+            Preconditions.checkArgument(RenderType.chunkBufferLayers().contains(type));
             BufferBuilder builder = buffers.builder(type);
             if(layers.add(type))
                 builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);

--- a/src/main/java/net/neoforged/neoforge/client/model/lighting/LightPipelineAwareModelBlockRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/lighting/LightPipelineAwareModelBlockRenderer.java
@@ -111,4 +111,8 @@ public class LightPipelineAwareModelBlockRenderer extends ModelBlockRenderer {
             flatLighter.reset();
         return !empty;
     }
+
+    public QuadLighter getQuadLighter(boolean smooth) {
+        return (smooth ? smoothLighter : flatLighter).get();
+    }
 }


### PR DESCRIPTION
This event can be used to implement features that add static geometry to the world based on things other than blocks. See [here](https://github.com/malte0811/ImmersiveEngineering/commit/8d5749d861f22973b3e74defc39d2a86e3a71915) for an example usage for Immersive Engineering wires (which is my usecase for this event).

The performance impact is one event fired on the main thread for each chunk section for which a rebuild task is started, which should be acceptable, plus whatever overhead mods add in their event handlers and custom renderers.

Some points brought up by @Technici4n in an earlier discussion:
- Collection of data on the main thread for thread-safety
  - The event is fired on the main thread and the actual renderer is then added as a callback to be invoked on the meshing thread. Typical usage would be to collect the data in the event handler and then capture it in the lambda.
- How will the AO work for the extra quads?
  - `SectionRenderingContext::getQuadLighter` can be used to obtain both AO and non-AO lighters as required
- The system should ideally be usable for other rendering systems (e.g. guidebook previews) without too much effort
  - The main obstacle for guidebook usage is the fact that a full `Level` is required. I think this is reasonable since  
    a) it is possible with reasonable effort to create a fake `Level` instance and  
   b) most usecases will need access to data beyond what the "easier" interfaces of `Level` can provide (e.g. data attachments).

CC @embeddedt, since we had some discussions about implementing this in Embeddium: I know you do not have all the objects needed to construct a `SectionRenderingContext` directly. However I did not want to use a `Function` here when there is no direct motivation for doing so in vanilla/NeoForge. My suggestion would be a Mixin that adds whatever fields you need to the context (set to `null` in the constructor), and chooses between a custom implementation of `getOrCreateBuffer` and the default one based on which fields are set.
