### PR TITLE
Fix regressions in difference and intersection ingredients

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.crafting;
+
+import it.unimi.dsi.fastutil.ints.IntComparators;
+import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import org.jetbrains.annotations.Nullable;
+
+/** Intermediary class for easing handling of ingredients that make use of multiple children */
+public abstract class ChildBasedIngredient extends Ingredient {
+    protected final List<Ingredient> children;
+    private final boolean isSimple;
+    private final boolean synchronizeWithContents;
+
+    @Nullable
+    private ItemStack[] filteredMatchingStacks;
+    @Nullable
+    private IntList packedMatchingStacks;
+
+    protected ChildBasedIngredient(Stream<? extends Ingredient.Value> values, Supplier<? extends IngredientType<?>> type, List<Ingredient> children) {
+        super(values, type);
+        this.children = Collections.unmodifiableList(children);
+        this.isSimple = children.stream().allMatch(Ingredient::isSimple);
+        this.synchronizeWithContents = children.stream().anyMatch(Ingredient::synchronizeWithContents);
+    }
+
+    protected abstract Stream<ItemStack> generateMatchingStacks();
+
+    protected abstract boolean testNonSynchronized(@Nullable ItemStack stack);
+
+    protected abstract IntList generateStackingIds();
+
+    @Override
+    public final ItemStack[] getItems() {
+        if (synchronizeWithContents())
+            return super.getItems();
+
+        if (this.filteredMatchingStacks == null) {
+            this.filteredMatchingStacks = generateMatchingStacks()
+                    .distinct()//Mimic super that calls distinct on the stacks
+                    .toArray(ItemStack[]::new);
+        }
+        return this.filteredMatchingStacks;
+    }
+
+    @Override
+    public final boolean test(@Nullable ItemStack stack) {
+        return synchronizeWithContents() ? super.test(stack) : testNonSynchronized(stack);
+    }
+
+    @Override
+    public final IntList getStackingIds() {
+        if (synchronizeWithContents()) {
+            return super.getStackingIds();
+        }
+
+        if (this.packedMatchingStacks == null) {
+            this.packedMatchingStacks = generateStackingIds();
+            this.packedMatchingStacks.sort(IntComparators.NATURAL_COMPARATOR);
+        }
+        return this.packedMatchingStacks;
+    }
+
+    @Override
+    public final boolean isSimple() {
+        return isSimple;
+    }
+
+    @Override
+    public final boolean synchronizeWithContents() {
+        return synchronizeWithContents;
+    }
+
+    public final List<Ingredient> getChildren() {
+        return this.children;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
@@ -31,7 +31,7 @@ public abstract class ChildBasedIngredient extends Ingredient {
 
     protected abstract Stream<ItemStack> generateMatchingStacks();
 
-    protected abstract boolean testNonSynchronized(@Nullable ItemStack stack);
+    protected abstract boolean testComplex(@Nullable ItemStack stack);
 
     @Override
     public final ItemStack[] getItems() {
@@ -49,7 +49,7 @@ public abstract class ChildBasedIngredient extends Ingredient {
 
     @Override
     public final boolean test(@Nullable ItemStack stack) {
-        return synchronizeWithContents() && isSimple() ? super.test(stack) : testNonSynchronized(stack);
+        return synchronizeWithContents() && isSimple() ? super.test(stack) : testComplex(stack);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
@@ -5,8 +5,6 @@
 
 package net.neoforged.neoforge.common.crafting;
 
-import it.unimi.dsi.fastutil.ints.IntComparators;
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -23,8 +21,6 @@ public abstract class ChildBasedIngredient extends Ingredient {
 
     @Nullable
     private ItemStack[] filteredMatchingStacks;
-    @Nullable
-    private IntList packedMatchingStacks;
 
     protected ChildBasedIngredient(Stream<? extends Ingredient.Value> values, Supplier<? extends IngredientType<?>> type, List<Ingredient> children) {
         super(values, type);
@@ -36,8 +32,6 @@ public abstract class ChildBasedIngredient extends Ingredient {
     protected abstract Stream<ItemStack> generateMatchingStacks();
 
     protected abstract boolean testNonSynchronized(@Nullable ItemStack stack);
-
-    protected abstract IntList generateStackingIds();
 
     @Override
     public final ItemStack[] getItems() {
@@ -55,19 +49,6 @@ public abstract class ChildBasedIngredient extends Ingredient {
     @Override
     public final boolean test(@Nullable ItemStack stack) {
         return synchronizeWithContents() ? super.test(stack) : testNonSynchronized(stack);
-    }
-
-    @Override
-    public final IntList getStackingIds() {
-        if (synchronizeWithContents()) {
-            return super.getStackingIds();
-        }
-
-        if (this.packedMatchingStacks == null) {
-            this.packedMatchingStacks = generateStackingIds();
-            this.packedMatchingStacks.sort(IntComparators.NATURAL_COMPARATOR);
-        }
-        return this.packedMatchingStacks;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ChildBasedIngredient.java
@@ -35,8 +35,9 @@ public abstract class ChildBasedIngredient extends Ingredient {
 
     @Override
     public final ItemStack[] getItems() {
-        if (synchronizeWithContents())
+        if (synchronizeWithContents() && isSimple()) {
             return super.getItems();
+        }
 
         if (this.filteredMatchingStacks == null) {
             this.filteredMatchingStacks = generateMatchingStacks()
@@ -48,7 +49,7 @@ public abstract class ChildBasedIngredient extends Ingredient {
 
     @Override
     public final boolean test(@Nullable ItemStack stack) {
-        return synchronizeWithContents() ? super.test(stack) : testNonSynchronized(stack);
+        return synchronizeWithContents() && isSimple() ? super.test(stack) : testNonSynchronized(stack);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
@@ -43,7 +43,7 @@ public class CompoundIngredient extends ChildBasedIngredient {
     }
 
     @Override
-    protected boolean testNonSynchronized(@Nullable ItemStack stack) {
+    protected boolean testComplex(@Nullable ItemStack stack) {
         return children.stream().anyMatch(i -> i.test(stack));
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
@@ -6,8 +6,6 @@
 package net.neoforged.neoforge.common.crafting;
 
 import com.mojang.serialization.Codec;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -47,11 +45,6 @@ public class CompoundIngredient extends ChildBasedIngredient {
     @Override
     protected boolean testNonSynchronized(@Nullable ItemStack stack) {
         return children.stream().anyMatch(i -> i.test(stack));
-    }
-
-    @Override
-    protected IntList generateStackingIds() {
-        return IntArrayList.toList(children.stream().flatMapToInt(child -> child.getStackingIds().intStream()).distinct());
     }
 
     private record Value(Ingredient inner) implements Ingredient.Value {

--- a/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
@@ -7,8 +7,6 @@ package net.neoforged.neoforge.common.crafting;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -60,13 +58,6 @@ public class DifferenceIngredient extends ChildBasedIngredient {
     @Override
     protected boolean testNonSynchronized(@Nullable ItemStack stack) {
         return base.test(stack) && !subtracted.test(stack);
-    }
-
-    @Override
-    protected IntList generateStackingIds() {
-        final IntList stackingIds = new IntArrayList(base.getStackingIds());
-        stackingIds.removeAll(subtracted.getStackingIds());
-        return stackingIds;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
@@ -5,20 +5,21 @@
 
 package net.neoforged.neoforge.common.crafting;
 
-import com.google.common.collect.Lists;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import org.jetbrains.annotations.Nullable;
 
 /** Ingredient that matches everything from the first ingredient that is not included in the second ingredient */
-public class DifferenceIngredient extends Ingredient {
+public class DifferenceIngredient extends ChildBasedIngredient {
     public static final Codec<DifferenceIngredient> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(
@@ -37,7 +38,7 @@ public class DifferenceIngredient extends Ingredient {
     private final Ingredient subtracted;
 
     protected DifferenceIngredient(Ingredient base, Ingredient subtracted) {
-        super(Arrays.stream(base.getValues()).map(value -> new SubtractingValue(value, subtracted)), NeoForgeMod.DIFFERENCE_INGREDIENT_TYPE);
+        super(Arrays.stream(base.getValues()).map(value -> new SubtractingValue(value, subtracted)), NeoForgeMod.DIFFERENCE_INGREDIENT_TYPE, List.of(base, subtracted));
 
         this.base = base;
         this.subtracted = subtracted;
@@ -52,38 +53,20 @@ public class DifferenceIngredient extends Ingredient {
     }
 
     @Override
-    public boolean isSimple() {
-        return false;
+    protected Stream<ItemStack> generateMatchingStacks() {
+        return Arrays.stream(base.getItems()).filter(subtracted.negate());
     }
 
     @Override
-    public ItemStack[] getItems() {
-        if (synchronizeWithContents())
-            return super.getItems();
-
-        final var list = Lists.newArrayList(base.getItems());
-        for (ItemStack item : subtracted.getItems()) {
-            list.removeIf(i -> areStacksEqual(i, item));
-        }
-        return list.toArray(ItemStack[]::new);
+    protected boolean testNonSynchronized(@Nullable ItemStack stack) {
+        return base.test(stack) && !subtracted.test(stack);
     }
 
     @Override
-    public boolean test(@Nullable ItemStack p_43914_) {
-        if (synchronizeWithContents())
-            return super.test(p_43914_);
-
-        return base.test(p_43914_) && !subtracted.test(p_43914_);
-    }
-
-    @Override
-    public IntList getStackingIds() {
-        return super.getStackingIds();
-    }
-
-    @Override
-    public boolean synchronizeWithContents() {
-        return base.synchronizeWithContents() && subtracted.synchronizeWithContents();
+    protected IntList generateStackingIds() {
+        final IntList stackingIds = new IntArrayList(base.getStackingIds());
+        stackingIds.removeAll(subtracted.getStackingIds());
+        return stackingIds;
     }
 
     /**
@@ -100,9 +83,7 @@ public class DifferenceIngredient extends Ingredient {
     private record SubtractingValue(Value inner, Ingredient subtracted) implements Ingredient.Value {
         @Override
         public Collection<ItemStack> getItems() {
-            final Collection<ItemStack> innerItems = new ArrayList<>(inner().getItems());
-            innerItems.removeIf(subtracted);
-            return innerItems;
+            return inner().getItems().stream().filter(subtracted.negate()).toList();
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
@@ -56,7 +56,7 @@ public class DifferenceIngredient extends ChildBasedIngredient {
     }
 
     @Override
-    protected boolean testNonSynchronized(@Nullable ItemStack stack) {
+    protected boolean testComplex(@Nullable ItemStack stack) {
         return base.test(stack) && !subtracted.test(stack);
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
@@ -7,13 +7,10 @@ package net.neoforged.neoforge.common.crafting;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -68,18 +65,6 @@ public class IntersectionIngredient extends ChildBasedIngredient {
     @Override
     protected boolean testNonSynchronized(@Nullable ItemStack stack) {
         return children.stream().allMatch(c -> c.test(stack));
-    }
-
-    @Override
-    protected IntList generateStackingIds() {
-        if (children.isEmpty()) {
-            return new IntArrayList();
-        }
-        //Start with the stacking ids of the first listed child
-        final IntList stackingIds = new IntArrayList(children.get(0).getStackingIds());
-        //Remove any ids that aren't also in all the other children
-        stackingIds.removeIf(id -> IntStream.range(1, children.size()).anyMatch(child -> !children.get(child).getStackingIds().contains(id)));
-        return stackingIds;
     }
 
     public record IntersectionValue(Value inner, List<Ingredient> other) implements Ingredient.Value {

--- a/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
@@ -59,11 +59,11 @@ public class IntersectionIngredient extends ChildBasedIngredient {
     protected Stream<ItemStack> generateMatchingStacks() {
         return children.stream()
                 .flatMap(child -> Arrays.stream(child.getItems()))
-                .filter(this::testNonSynchronized);
+                .filter(this::testComplex);
     }
 
     @Override
-    protected boolean testNonSynchronized(@Nullable ItemStack stack) {
+    protected boolean testComplex(@Nullable ItemStack stack) {
         return children.stream().allMatch(c -> c.test(stack));
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
@@ -5,34 +5,34 @@
 
 package net.neoforged.neoforge.common.crafting;
 
-import com.google.common.collect.Lists;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import org.jetbrains.annotations.Nullable;
 
 /** Ingredient that matches if all child ingredients match */
-public class IntersectionIngredient extends Ingredient {
+public class IntersectionIngredient extends ChildBasedIngredient {
     public static final Codec<IntersectionIngredient> CODEC = RecordCodecBuilder.create(
             builder -> builder
                     .group(
-                            Ingredient.LIST_CODEC.fieldOf("children").forGetter(IntersectionIngredient::getChildren))
+                            Ingredient.LIST_CODEC.fieldOf("children").forGetter(ChildBasedIngredient::getChildren))
                     .apply(builder, IntersectionIngredient::new));
 
     public static final Codec<IntersectionIngredient> CODEC_NONEMPTY = RecordCodecBuilder.create(
             builder -> builder
                     .group(
-                            Ingredient.LIST_CODEC_NONEMPTY.fieldOf("children").forGetter(IntersectionIngredient::getChildren))
+                            Ingredient.LIST_CODEC_NONEMPTY.fieldOf("children").forGetter(ChildBasedIngredient::getChildren))
                     .apply(builder, IntersectionIngredient::new));
-
-    private final List<Ingredient> children;
 
     protected IntersectionIngredient(List<Ingredient> children) {
         super(children.stream().flatMap(ingredient -> Arrays.stream(ingredient.getValues()).map(value -> {
@@ -40,13 +40,7 @@ public class IntersectionIngredient extends Ingredient {
             matchers.remove(ingredient);
 
             return new IntersectionValue(value, matchers);
-        })), NeoForgeMod.INTERSECTION_INGREDIENT_TYPE);
-
-        this.children = Collections.unmodifiableList(children);
-    }
-
-    public List<Ingredient> getChildren() {
-        return children;
+        })), NeoForgeMod.INTERSECTION_INGREDIENT_TYPE, children);
     }
 
     /**
@@ -65,47 +59,35 @@ public class IntersectionIngredient extends Ingredient {
     }
 
     @Override
-    public ItemStack[] getItems() {
-        if (synchronizeWithContents())
-            return super.getItems();
+    protected Stream<ItemStack> generateMatchingStacks() {
+        return children.stream()
+                .flatMap(child -> Arrays.stream(child.getItems()))
+                .filter(this::testNonSynchronized);
+    }
 
-        final List<ItemStack> list = Lists.newArrayList();
-        for (Ingredient child : children) {
-            final var stacks = child.getItems();
-            Arrays.stream(stacks).filter(this).forEach(list::add);
+    @Override
+    protected boolean testNonSynchronized(@Nullable ItemStack stack) {
+        return children.stream().allMatch(c -> c.test(stack));
+    }
+
+    @Override
+    protected IntList generateStackingIds() {
+        if (children.isEmpty()) {
+            return new IntArrayList();
         }
-
-        return list.toArray(ItemStack[]::new);
-    }
-
-    @Override
-    public boolean test(@Nullable ItemStack p_43914_) {
-        if (synchronizeWithContents())
-            return super.test(p_43914_);
-
-        return children.stream().allMatch(c -> c.test(p_43914_));
-    }
-
-    @Override
-    public boolean synchronizeWithContents() {
-        return children.stream().allMatch(Ingredient::synchronizeWithContents);
-    }
-
-    @Override
-    public boolean isSimple() {
-        return false;
+        //Start with the stacking ids of the first listed child
+        final IntList stackingIds = new IntArrayList(children.get(0).getStackingIds());
+        //Remove any ids that aren't also in all the other children
+        stackingIds.removeIf(id -> IntStream.range(1, children.size()).anyMatch(child -> !children.get(child).getStackingIds().contains(id)));
+        return stackingIds;
     }
 
     public record IntersectionValue(Value inner, List<Ingredient> other) implements Ingredient.Value {
         @Override
         public Collection<ItemStack> getItems() {
-            final Collection<ItemStack> inner = new ArrayList<>(inner().getItems());
-
-            inner.removeIf(stack -> {
-                return !other().stream().allMatch(ingredient -> ingredient.test(stack));
-            });
-
-            return inner;
+            return inner().getItems().stream()
+                    .filter(stack -> other().stream().allMatch(ingredient -> ingredient.test(stack)))
+                    .toList();
         }
     }
 }


### PR DESCRIPTION
In the port to 1.20.2 there was a variety of regressions to some of our custom ingredient implementations.

`DifferenceIngredient` had a regression that caused the implementation of `getItems` to rely on the subtracted ingredient's `getItem` implementation rather than on `test` provided by the subtracted ingredient.

For both `DifferenceIngredient` and `IntersectionIngredient` had a few regressions:
- No longer overrode `isSimple` based on if their children were all simple
- No longer overrode `getStackingIds`, causing them to not properly generate the list of stacking ids for cases when a custom ingredient might provide a custom impl of `getStackingIds` but not be able to represent all items via `getItems`

Additionally for `CompoundIngredient`,  `DifferenceIngredient`, and `IntersectionIngredient`:
- No longer cached the result of items or stacking ids when the ingredient was not `synchronizeWithContents`

To fix some of these problems where our ingredients that rely on children for certain things I created an abstract class to help hold this data and ensure it is properly set, as well as perform any caching necessary.