### PR TITLE
Allow retrieving all registered `ColorResolver`s

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ColorResolverManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/ColorResolverManager.java
@@ -28,6 +28,16 @@ public final class ColorResolverManager {
     }
 
     /**
+     * Get all registered custom {@link ColorResolver}s. The returned list does not include vanilla resolvers,
+     * since they are not explicitly registered.
+     *
+     * @return a list of all registered color resolvers, not including vanilla color resolvers
+     */
+    public static ImmutableList<ColorResolver> getRegisteredResolvers() {
+        return colorResolvers;
+    }
+
+    /**
      * Register a {@link BlockTintCache} for every registered {@link ColorResolver} into the given target map.
      *
      * @param level  the level to use


### PR DESCRIPTION
This PR adds the static method `ColorResolverManager#getRegisteredResolvers()`, which returns an `ImmutableList<ColorResolver>` containing every registered resolver. Currently, doing this cleanly is not possible.