### PR TITLE
Fix writing fluid stack to nbt not copying the stack's nbt and instead passing a direct reference

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -120,7 +120,7 @@ public class FluidStack {
         nbt.putInt("Amount", amount);
 
         if (tag != null) {
-            nbt.put("Tag", tag);
+            nbt.put("Tag", tag.copy());
         }
         return nbt;
     }


### PR DESCRIPTION
While going through my own code to validate that all the cases I read/write from nbt doesn't potentially leak references when sent via payload from server to client in single player, I noticed that FluidStack's don't copy their nbt's object when writing to a CompoundTag. ItemStack's do, so I just went ahead and mirrored that behavior for FluidStacks.