### PR TITLE
Use Collections.emptyMap() for empty ModelData instances

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -80,7 +80,7 @@ public final class ModelData {
 
         @Contract("-> new")
         public ModelData build() {
-            return new ModelData(Collections.unmodifiableMap(properties));
+            return new ModelData(properties.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(properties));
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -80,6 +80,7 @@ public final class ModelData {
 
         @Contract("-> new")
         public ModelData build() {
+            // IdentityHashMap is slow when calling get() on an empty instance, so use a singleton empty map if possible
             return new ModelData(properties.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(properties));
         }
     }


### PR DESCRIPTION
This provides a nontrivial speedup for anything that interacts with empty model data objects (e.g. `MultipartModelData` on vanilla multipart models) as there is no longer time wasted hashing the given key.

Before (refer to the fourth line):

![image](https://github.com/neoforged/NeoForge/assets/42941056/9c18f243-6b83-4745-9f22-5decd2777a15)

After (refer to the first line):

![image](https://github.com/neoforged/NeoForge/assets/42941056/4a0991a3-7658-48c5-9cd9-9d078a755638)
