### PR TITLE
Add support for custom entity predicates and make some advancements support modded types

### DIFF
--- a/patches/net/minecraft/advancements/critereon/EntityPredicate.java.patch
+++ b/patches/net/minecraft/advancements/critereon/EntityPredicate.java.patch
@@ -1,0 +1,52 @@
+--- a/net/minecraft/advancements/critereon/EntityPredicate.java
++++ b/net/minecraft/advancements/critereon/EntityPredicate.java
+@@ -36,9 +_,10 @@
+     Optional<EntityPredicate> vehicle,
+     Optional<EntityPredicate> passenger,
+     Optional<EntityPredicate> targetedEntity,
+-    Optional<String> team
++    Optional<String> team,
++    Optional<net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate> customLogic
+ ) {
+-    public static final Codec<EntityPredicate> CODEC = ExtraCodecs.recursive(
++    public static final Codec<EntityPredicate> VANILLA_CODEC = ExtraCodecs.recursive(
+         "EntityPredicate",
+         p_297888_ -> RecordCodecBuilder.create(
+                 p_297890_ -> p_297890_.group(
+@@ -59,8 +_,26 @@
+                         .apply(p_297890_, EntityPredicate::new)
+             )
+     );
++    public static Codec<EntityPredicate> CODEC = ExtraCodecs.<net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate, EntityPredicate>either(
++            net.neoforged.neoforge.registries.NeoForgeRegistries.ENTITY_PREDICATE_SERIALIZERS.byNameCodec()
++                    .dispatch(
++                            net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate::codec,
++                            java.util.function.Function.identity()),
++            VANILLA_CODEC
++        ).xmap(either -> either.map(EntityPredicate::new, p -> p),
++          // Serialize using dispatch codec if custom logic is present, otherwise use vanilla codec
++          predicate -> predicate.customLogic.<com.mojang.datafixers.util.Either<net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate, EntityPredicate>>map(
++                com.mojang.datafixers.util.Either::left).orElseGet(() -> com.mojang.datafixers.util.Either.right(predicate)));
+     public static final Codec<ContextAwarePredicate> ADVANCEMENT_CODEC = ExtraCodecs.withAlternative(ContextAwarePredicate.CODEC, CODEC, EntityPredicate::wrap);
+ 
++    public EntityPredicate(Optional<EntityTypePredicate> entityType, Optional<DistancePredicate> distanceToPlayer, Optional<LocationPredicate> location, Optional<LocationPredicate> steppingOnLocation, Optional<MobEffectsPredicate> effects, Optional<NbtPredicate> nbt, Optional<EntityFlagsPredicate> flags, Optional<EntityEquipmentPredicate> equipment, Optional<EntitySubPredicate> subPredicate, Optional<net.minecraft.advancements.critereon.EntityPredicate> vehicle, Optional<net.minecraft.advancements.critereon.EntityPredicate> passenger, Optional<net.minecraft.advancements.critereon.EntityPredicate> targetedEntity, Optional<String> team) {
++        this(entityType, distanceToPlayer, location, steppingOnLocation, effects, nbt, flags, equipment, subPredicate, vehicle, passenger, targetedEntity, team, Optional.empty());
++    }
++
++    public EntityPredicate(net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate customLogic) {
++        this(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(customLogic));
++    }
++
+     public static ContextAwarePredicate wrap(EntityPredicate.Builder p_298222_) {
+         return wrap(p_298222_.build());
+     }
+@@ -83,6 +_,9 @@
+     }
+ 
+     public boolean matches(ServerLevel p_36608_, @Nullable Vec3 p_36609_, @Nullable Entity p_36610_) {
++        if (p_36610_ != null && this.customLogic.isPresent()) {
++            return this.customLogic.get().test(p_36608_, p_36609_, p_36610_);
++        }
+         if (p_36610_ == null) {
+             return false;
+         } else if (this.entityType.isPresent() && !this.entityType.get().matches(p_36610_.getType())) {

--- a/patches/net/minecraft/advancements/critereon/EntityPredicate.java.patch
+++ b/patches/net/minecraft/advancements/critereon/EntityPredicate.java.patch
@@ -17,7 +17,7 @@
                          .apply(p_297890_, EntityPredicate::new)
              )
      );
-+    public static Codec<EntityPredicate> CODEC = ExtraCodecs.<net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate, EntityPredicate>either(
++    public static final Codec<EntityPredicate> CODEC = ExtraCodecs.<net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate, EntityPredicate>either(
 +            net.neoforged.neoforge.registries.NeoForgeRegistries.ENTITY_PREDICATE_SERIALIZERS.byNameCodec()
 +                    .dispatch(
 +                            net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate::codec,

--- a/patches/net/minecraft/advancements/critereon/ItemPredicate.java.patch
+++ b/patches/net/minecraft/advancements/critereon/ItemPredicate.java.patch
@@ -17,10 +17,11 @@
          p_297904_ -> p_297904_.group(
                      ExtraCodecs.strictOptionalField(TagKey.codec(Registries.ITEM), "tag").forGetter(ItemPredicate::tag),
                      ExtraCodecs.strictOptionalField(ITEMS_CODEC, "items").forGetter(ItemPredicate::items),
-@@ -51,8 +_,33 @@
+@@ -51,8 +_,34 @@
                  )
                  .apply(p_297904_, ItemPredicate::new)
      );
++    //TODO - 1.20.5: Make this final
 +    public static Codec<ItemPredicate> CODEC = ExtraCodecs.<net.neoforged.neoforge.common.advancements.critereon.ICustomItemPredicate, ItemPredicate>either(
 +            net.neoforged.neoforge.registries.NeoForgeRegistries.ITEM_PREDICATE_SERIALIZERS.byNameCodec()
 +                    .dispatch(

--- a/src/generated/resources/data/minecraft/advancements/husbandry/wax_off.json
+++ b/src/generated/resources/data/minecraft/advancements/husbandry/wax_off.json
@@ -1,0 +1,82 @@
+{
+  "parent": "minecraft:husbandry/wax_on",
+  "criteria": {
+    "wax_off": {
+      "conditions": {
+        "location": [
+          {
+            "condition": "minecraft:location_check",
+            "predicate": {
+              "block": {
+                "blocks": [
+                  "minecraft:waxed_copper_block",
+                  "minecraft:waxed_exposed_copper",
+                  "minecraft:waxed_weathered_copper",
+                  "minecraft:waxed_oxidized_copper",
+                  "minecraft:waxed_cut_copper",
+                  "minecraft:waxed_exposed_cut_copper",
+                  "minecraft:waxed_weathered_cut_copper",
+                  "minecraft:waxed_oxidized_cut_copper",
+                  "minecraft:waxed_cut_copper_slab",
+                  "minecraft:waxed_exposed_cut_copper_slab",
+                  "minecraft:waxed_weathered_cut_copper_slab",
+                  "minecraft:waxed_oxidized_cut_copper_slab",
+                  "minecraft:waxed_cut_copper_stairs",
+                  "minecraft:waxed_exposed_cut_copper_stairs",
+                  "minecraft:waxed_weathered_cut_copper_stairs",
+                  "minecraft:waxed_oxidized_cut_copper_stairs",
+                  "minecraft:waxed_chiseled_copper",
+                  "minecraft:waxed_exposed_chiseled_copper",
+                  "minecraft:waxed_weathered_chiseled_copper",
+                  "minecraft:waxed_oxidized_chiseled_copper",
+                  "minecraft:waxed_copper_door",
+                  "minecraft:waxed_exposed_copper_door",
+                  "minecraft:waxed_weathered_copper_door",
+                  "minecraft:waxed_oxidized_copper_door",
+                  "minecraft:waxed_copper_trapdoor",
+                  "minecraft:waxed_exposed_copper_trapdoor",
+                  "minecraft:waxed_weathered_copper_trapdoor",
+                  "minecraft:waxed_oxidized_copper_trapdoor",
+                  "minecraft:waxed_copper_grate",
+                  "minecraft:waxed_exposed_copper_grate",
+                  "minecraft:waxed_weathered_copper_grate",
+                  "minecraft:waxed_oxidized_copper_grate",
+                  "minecraft:waxed_copper_bulb",
+                  "minecraft:waxed_exposed_copper_bulb",
+                  "minecraft:waxed_weathered_copper_bulb",
+                  "minecraft:waxed_oxidized_copper_bulb"
+                ]
+              }
+            }
+          },
+          {
+            "condition": "minecraft:match_tool",
+            "predicate": {
+              "type": "neoforge:tool_action",
+              "value": "axe_wax_off"
+            }
+          }
+        ]
+      },
+      "trigger": "minecraft:item_used_on_block"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "advancements.husbandry.wax_off.description"
+    },
+    "icon": {
+      "item": "minecraft:stone_axe",
+      "nbt": "{Damage:0}"
+    },
+    "title": {
+      "translate": "advancements.husbandry.wax_off.title"
+    }
+  },
+  "requirements": [
+    [
+      "wax_off"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/src/generated/resources/data/minecraft/advancements/nether/distract_piglin.json
+++ b/src/generated/resources/data/minecraft/advancements/nether/distract_piglin.json
@@ -1,0 +1,87 @@
+{
+  "parent": "minecraft:nether/root",
+  "criteria": {
+    "distract_piglin": {
+      "conditions": {
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:piglin",
+              "flags": {
+                "is_baby": false
+              }
+            }
+          }
+        ],
+        "item": {
+          "tag": "minecraft:piglin_loved"
+        },
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type": "neoforge:piglin_neutral_armor"
+              }
+            }
+          }
+        ]
+      },
+      "trigger": "minecraft:thrown_item_picked_up_by_entity"
+    },
+    "distract_piglin_directly": {
+      "conditions": {
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:piglin",
+              "flags": {
+                "is_baby": false
+              }
+            }
+          }
+        ],
+        "item": {
+          "type": "neoforge:piglin_currency"
+        },
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "type": "neoforge:piglin_neutral_armor"
+              }
+            }
+          }
+        ]
+      },
+      "trigger": "minecraft:player_interacted_with_entity"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "advancements.nether.distract_piglin.description"
+    },
+    "icon": {
+      "item": "minecraft:gold_ingot"
+    },
+    "title": {
+      "translate": "advancements.nether.distract_piglin.title"
+    }
+  },
+  "requirements": [
+    [
+      "distract_piglin",
+      "distract_piglin_directly"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/src/generated/resources/reports/registry_order.json
+++ b/src/generated/resources/reports/registry_order.json
@@ -75,6 +75,7 @@
     "neoforge:condition_codecs",
     "neoforge:display_contexts",
     "neoforge:entity_data_serializers",
+    "neoforge:entity_predicates",
     "neoforge:fluid_type",
     "neoforge:global_loot_modifier_serializers",
     "neoforge:holder_set_type",

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -95,6 +95,11 @@ import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
 import net.neoforged.neoforge.client.ClientCommandHandler;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.ICustomItemPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEntityPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.ToolActionItemPredicate;
 import net.neoforged.neoforge.common.conditions.AndCondition;
 import net.neoforged.neoforge.common.conditions.FalseCondition;
 import net.neoforged.neoforge.common.conditions.ICondition;
@@ -111,6 +116,7 @@ import net.neoforged.neoforge.common.crafting.IntersectionIngredient;
 import net.neoforged.neoforge.common.crafting.NBTIngredient;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.common.data.NeoForgeDamageTypeTagsProvider;
+import net.neoforged.neoforge.common.data.internal.NeoForgeAdvancementProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeBiomeTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeBlockTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeDataMapsProvider;
@@ -388,6 +394,13 @@ public class NeoForgeMod {
 
     public static final DeferredHolder<IngredientType<?>, IngredientType<Ingredient>> VANILLA_INGREDIENT_TYPE = VANILLA_INGREDIENT_TYPES.register("item", () -> new IngredientType<>(Ingredient.VANILLA_CODEC, Ingredient.VANILLA_CODEC_NONEMPTY));
 
+    private static final DeferredRegister<Codec<? extends ICustomEntityPredicate>> ENTITY_PREDICATE_CODECS = DeferredRegister.create(NeoForgeRegistries.Keys.ENTITY_PREDICATE_SERIALIZERS, NeoForgeVersion.MOD_ID);
+    public static final DeferredHolder<Codec<? extends ICustomEntityPredicate>, Codec<PiglinNeutralArmorEntityPredicate>> PIGLIN_NEUTRAL_ARMOR_PREDICATE = ENTITY_PREDICATE_CODECS.register("piglin_neutral_armor", () -> PiglinNeutralArmorEntityPredicate.CODEC);
+
+    private static final DeferredRegister<Codec<? extends ICustomItemPredicate>> ITEM_PREDICATE_CODECS = DeferredRegister.create(NeoForgeRegistries.Keys.ITEM_PREDICATE_SERIALIZERS, NeoForgeVersion.MOD_ID);
+    public static final DeferredHolder<Codec<? extends ICustomItemPredicate>, Codec<ToolActionItemPredicate>> TOOL_ACTION_PREDICATE = ITEM_PREDICATE_CODECS.register("tool_action", () -> ToolActionItemPredicate.CODEC);
+    public static final DeferredHolder<Codec<? extends ICustomItemPredicate>, Codec<PiglinCurrencyItemPredicate>> PIGLIN_CURRENCY_PREDICATE = ITEM_PREDICATE_CODECS.register("piglin_currency", () -> PiglinCurrencyItemPredicate.CODEC);
+
     private static final DeferredRegister<FluidType> VANILLA_FLUID_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.FLUID_TYPES, "minecraft");
 
     public static final Holder<FluidType> EMPTY_TYPE = VANILLA_FLUID_TYPES.register("empty", () -> new FluidType(FluidType.Properties.create()
@@ -579,6 +592,8 @@ public class NeoForgeMod {
         HOLDER_SET_TYPES.register(modEventBus);
         VANILLA_FLUID_TYPES.register(modEventBus);
         VANILLA_INGREDIENT_TYPES.register(modEventBus);
+        ENTITY_PREDICATE_CODECS.register(modEventBus);
+        ITEM_PREDICATE_CODECS.register(modEventBus);
         INGREDIENT_TYPES.register(modEventBus);
         CONDITION_CODECS.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
@@ -638,6 +653,7 @@ public class NeoForgeMod {
                         Component.translatable("pack.neoforge.description"),
                         DetectedVersion.BUILT_IN.getPackVersion(PackType.SERVER_DATA),
                         Optional.of(new InclusiveRange<>(0, Integer.MAX_VALUE)))));
+        gen.addProvider(event.includeServer(), new NeoForgeAdvancementProvider(packOutput, lookupProvider, existingFileHelper));
         NeoForgeBlockTagsProvider blockTags = new NeoForgeBlockTagsProvider(packOutput, lookupProvider, existingFileHelper);
         gen.addProvider(event.includeServer(), blockTags);
         gen.addProvider(event.includeServer(), new NeoForgeItemTagsProvider(packOutput, lookupProvider, blockTags.contentsGetter(), existingFileHelper));

--- a/src/main/java/net/neoforged/neoforge/common/advancements/critereon/ICustomEntityPredicate.java
+++ b/src/main/java/net/neoforged/neoforge/common/advancements/critereon/ICustomEntityPredicate.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.advancements.critereon;
+
+import com.mojang.serialization.Codec;
+import javax.annotation.Nullable;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+/**
+ * Interface that mods can use to define {@link EntityPredicate}s with custom matching logic.
+ */
+public interface ICustomEntityPredicate {
+    /**
+     * {@return the codec for this predicate}
+     * <p>
+     * The codec must be registered to {@link NeoForgeRegistries#ENTITY_PREDICATE_SERIALIZERS}.
+     */
+    Codec<? extends ICustomEntityPredicate> codec();
+
+    /**
+     * Convert to a vanilla {@link EntityPredicate}.
+     */
+    default EntityPredicate toVanilla() {
+        return new EntityPredicate(this);
+    }
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param level    Level the predicate is being tested in.
+     * @param position Position in the level the test is being run from.
+     * @param entity   Entity to test.
+     *
+     * @return {@code true} if the input arguments matches the predicate, otherwise {@code false}
+     */
+    boolean test(ServerLevel level, @Nullable Vec3 position, Entity entity);
+}

--- a/src/main/java/net/neoforged/neoforge/common/advancements/critereon/PiglinCurrencyItemPredicate.java
+++ b/src/main/java/net/neoforged/neoforge/common/advancements/critereon/PiglinCurrencyItemPredicate.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.advancements.critereon;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.world.item.ItemStack;
+
+public class PiglinCurrencyItemPredicate implements ICustomItemPredicate {
+    public static final PiglinCurrencyItemPredicate INSTANCE = new PiglinCurrencyItemPredicate();
+    public static final Codec<PiglinCurrencyItemPredicate> CODEC = Codec.unit(INSTANCE);
+
+    private PiglinCurrencyItemPredicate() {}
+
+    @Override
+    public Codec<PiglinCurrencyItemPredicate> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public boolean test(ItemStack stack) {
+        return stack.isPiglinCurrency();
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/advancements/critereon/PiglinNeutralArmorEntityPredicate.java
+++ b/src/main/java/net/neoforged/neoforge/common/advancements/critereon/PiglinNeutralArmorEntityPredicate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.advancements.critereon;
+
+import com.mojang.serialization.Codec;
+import javax.annotation.Nullable;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
+
+public class PiglinNeutralArmorEntityPredicate implements ICustomEntityPredicate {
+    public static final PiglinNeutralArmorEntityPredicate INSTANCE = new PiglinNeutralArmorEntityPredicate();
+    public static final Codec<PiglinNeutralArmorEntityPredicate> CODEC = Codec.unit(INSTANCE);
+
+    private PiglinNeutralArmorEntityPredicate() {}
+
+    @Override
+    public Codec<PiglinNeutralArmorEntityPredicate> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public boolean test(ServerLevel level, @Nullable Vec3 position, Entity entity) {
+        if (entity instanceof LivingEntity living) {
+            for (ItemStack armor : entity.getArmorSlots()) {
+                if (!armor.isEmpty() && armor.makesPiglinsNeutral(living)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/advancements/critereon/ToolActionItemPredicate.java
+++ b/src/main/java/net/neoforged/neoforge/common/advancements/critereon/ToolActionItemPredicate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.advancements.critereon;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.common.ToolAction;
+
+public record ToolActionItemPredicate(ToolAction action) implements ICustomItemPredicate {
+    public static final Codec<ToolActionItemPredicate> CODEC = ToolAction.CODEC.xmap(ToolActionItemPredicate::new, ToolActionItemPredicate::action);
+
+    @Override
+    public Codec<ToolActionItemPredicate> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public boolean test(ItemStack stack) {
+        return stack.canPerformAction(action);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeAdvancementProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeAdvancementProvider.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.data.internal;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import net.minecraft.Util;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.critereon.ContextAwarePredicate;
+import net.minecraft.advancements.critereon.EntityEquipmentPredicate;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.ItemPredicate;
+import net.minecraft.advancements.critereon.ItemUsedOnLocationTrigger;
+import net.minecraft.advancements.critereon.PlayerInteractTrigger;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
+import net.minecraft.data.PackOutput;
+import net.minecraft.data.advancements.AdvancementSubProvider;
+import net.minecraft.data.advancements.packs.VanillaAdvancementProvider;
+import net.minecraft.data.advancements.packs.VanillaHusbandryAdvancements;
+import net.minecraft.world.entity.monster.piglin.PiglinAi;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.storage.loot.predicates.InvertedLootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemEntityPropertyCondition;
+import net.minecraft.world.level.storage.loot.predicates.MatchTool;
+import net.neoforged.fml.util.ObfuscationReflectionHelper;
+import net.neoforged.neoforge.common.ToolAction;
+import net.neoforged.neoforge.common.ToolActions;
+import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEntityPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.ToolActionItemPredicate;
+import net.neoforged.neoforge.common.data.AdvancementProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.Nullable;
+
+public class NeoForgeAdvancementProvider extends AdvancementProvider {
+    public NeoForgeAdvancementProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, ExistingFileHelper existingFileHelper) {
+        super(output, registries, existingFileHelper, getVanillaAdvancementProviders(output, registries));
+    }
+
+    private static List<AdvancementGenerator> getVanillaAdvancementProviders(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        List<UnaryOperator<Criterion<?>>> criteriaReplacers = new ArrayList<>();
+        criteriaReplacers.add(replaceMatchToolCriteria(ToolActions.AXE_WAX_OFF, getPrivateValue(VanillaHusbandryAdvancements.class, null, "WAX_SCRAPING_TOOLS")));
+        criteriaReplacers.add(replaceInteractCriteria(PiglinCurrencyItemPredicate.INSTANCE.toVanilla(), PiglinAi.BARTERING_ITEM));
+        criteriaReplacers.add(replaceWearingPredicate(PiglinNeutralArmorEntityPredicate.INSTANCE.toVanilla(), predicate -> {
+            if (predicate.head().filter(item -> predicateMatches(item, Items.GOLDEN_HELMET)).isPresent()) {
+                return true;
+            } else if (predicate.chest().filter(item -> predicateMatches(item, Items.GOLDEN_CHESTPLATE)).isPresent()) {
+                return true;
+            } else if (predicate.legs().filter(item -> predicateMatches(item, Items.GOLDEN_LEGGINGS)).isPresent()) {
+                return true;
+            }
+            return predicate.feet().filter(item -> predicateMatches(item, Items.GOLDEN_BOOTS)).isPresent();
+        }));
+
+        List<AdvancementSubProvider> subProviders = getPrivateValue(net.minecraft.data.advancements.AdvancementProvider.class, VanillaAdvancementProvider.create(output, registries), "subProviders");
+        return subProviders.stream()
+                .<AdvancementGenerator>map(vanillaProvider -> new NeoForgeAdvancementGenerator(vanillaProvider, criteriaReplacers))
+                .toList();
+    }
+
+    private static UnaryOperator<Criterion<?>> replaceMatchToolCriteria(ToolAction toolAction, ItemLike... targetItem) {
+        UnaryOperator<LootItemCondition> replacer = condition -> {
+            if (condition instanceof MatchTool toolMatch && toolMatch.predicate().filter(predicate -> predicateMatches(predicate, targetItem)).isPresent()) {
+                return new MatchTool(Optional.of(new ToolActionItemPredicate(toolAction).toVanilla()));
+            }
+            return null;
+        };
+        return criterion -> {
+            if (criterion.trigger() instanceof ItemUsedOnLocationTrigger trigger && criterion.triggerInstance() instanceof ItemUsedOnLocationTrigger.TriggerInstance instance) {
+                ContextAwarePredicate newLocation = replaceConditions(instance.location().orElse(null), replacer, condition -> false);
+                if (newLocation != null) {
+                    return new Criterion<>(trigger, new ItemUsedOnLocationTrigger.TriggerInstance(instance.player(), Optional.of(newLocation)));
+                }
+            }
+            return null;
+        };
+    }
+
+    private static UnaryOperator<Criterion<?>> replaceInteractCriteria(ItemPredicate replacement, ItemLike... targetItem) {
+        return criterion -> {
+            if (criterion.trigger() instanceof PlayerInteractTrigger trigger && criterion.triggerInstance() instanceof PlayerInteractTrigger.TriggerInstance instance) {
+                if (instance.item().filter(predicate -> predicateMatches(predicate, targetItem)).isPresent()) {
+                    return new Criterion<>(trigger, new PlayerInteractTrigger.TriggerInstance(instance.player(), Optional.of(replacement), instance.entity()));
+                }
+            }
+            return null;
+        };
+    }
+
+    private static boolean predicateMatches(ItemPredicate predicate, ItemLike... targets) {
+        Optional<HolderSet<Item>> items = predicate.items();
+        if (items.isEmpty()) {
+            return false;
+        }
+        HolderSet<Item> holders = items.get();
+        for (ItemLike target : targets) {
+            if (!holders.contains(target.asItem().builtInRegistryHolder())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static UnaryOperator<Criterion<?>> replaceWearingPredicate(EntityPredicate replacement, Predicate<EntityEquipmentPredicate> shouldReplace) {
+        return replacePlayerPredicate(condition -> {
+            if (condition instanceof InvertedLootItemCondition inverted) {
+                if (inverted.term() instanceof LootItemEntityPropertyCondition entityPropertyCondition) {
+                    Optional<EntityPredicate> predicate = entityPropertyCondition.predicate();
+                    if (predicate.isPresent()) {
+                        EntityPredicate entityPredicate = predicate.get();
+                        if (entityPredicate.equipment().filter(shouldReplace).isPresent()) {
+                            //Note: We as currently there are no issues, we just skip any cases where other fields in the entity predicate are present
+                            return LootItemEntityPropertyCondition.hasProperties(entityPropertyCondition.entityTarget(), replacement).invert().build();
+                        }
+                    }
+                }
+            }
+            return null;
+        }, condition -> true);//Skip any additional replacements as we know they would be duplicates
+    }
+
+    private static UnaryOperator<Criterion<?>> replacePlayerPredicate(UnaryOperator<LootItemCondition> replacer, Predicate<LootItemCondition> shouldSkipReplacement) {
+        return criterion -> {
+            if (criterion.triggerInstance() instanceof SimpleCriterionTrigger.SimpleInstance simpleInstance) {
+                ContextAwarePredicate newPlayer = replaceConditions(simpleInstance.player().orElse(null), replacer, shouldSkipReplacement);
+                if (newPlayer != null) {
+                    return replacePlayerPredicate((Criterion) criterion, newPlayer);
+                }
+            }
+            return null;
+        };
+    }
+
+    private static <T extends SimpleCriterionTrigger.SimpleInstance> Criterion<T> replacePlayerPredicate(Criterion<T> old, ContextAwarePredicate newPlayer) {
+        Codec<T> codec = old.trigger().codec();
+        return Util.getOrThrow(codec.encodeStart(JsonOps.INSTANCE, old.triggerInstance())
+                .flatMap(element -> {
+                    if (element instanceof JsonObject object && object.has("player")) {
+                        object.add("player", Util.getOrThrow(ContextAwarePredicate.CODEC.encodeStart(JsonOps.INSTANCE, newPlayer), error -> new IllegalStateException("Unable to serialize new player predicate")));
+                        return codec.parse(JsonOps.INSTANCE, object);
+                    }
+                    return DataResult.error(() -> "Serialized instance does not contain a 'player' element");
+                })
+                .map(old.trigger()::createCriterion),
+                error -> new IllegalStateException("Unable to convert criterion serialization and replacement"));
+    }
+
+    @Nullable
+    private static ContextAwarePredicate replaceConditions(@Nullable ContextAwarePredicate basePredicate, UnaryOperator<LootItemCondition> replacer, Predicate<LootItemCondition> shouldSkipReplacement) {
+        if (basePredicate == null) {
+            return null;
+        }
+        List<LootItemCondition> conditions = getPrivateValue(ContextAwarePredicate.class, basePredicate, "conditions");
+        if (!conditions.isEmpty()) {
+            boolean shouldReplace = false;
+            List<LootItemCondition> clonedConditions = new ArrayList<>(conditions.size());
+            for (LootItemCondition condition : conditions) {
+                LootItemCondition replacement = replacer.apply(condition);
+                if (replacement != null) {
+                    if (shouldReplace && shouldSkipReplacement.test(replacement)) {
+                        continue;
+                    }
+                    shouldReplace = true;
+                    condition = replacement;
+                }
+                clonedConditions.add(condition);
+            }
+            if (shouldReplace) {
+                return ContextAwarePredicate.create(clonedConditions.toArray(LootItemCondition[]::new));
+            }
+        }
+        return null;
+    }
+
+    private static <T, C> T getPrivateValue(Class<C> clazz, @Nullable C inst, String name) {
+        T value = ObfuscationReflectionHelper.getPrivateValue(clazz, inst, name);
+        if (value == null) {
+            throw new IllegalStateException(clazz.getName() + " is missing field " + name);
+        }
+        return value;
+    }
+
+    private record NeoForgeAdvancementGenerator(AdvancementSubProvider vanillaProvider, List<UnaryOperator<Criterion<?>>> criteriaReplacers) implements AdvancementGenerator {
+        @Override
+        public void generate(HolderLookup.Provider registries, Consumer<AdvancementHolder> saver, ExistingFileHelper existingFileHelper) {
+            vanillaProvider.generate(registries, advancementHolder -> {
+                Advancement.Builder newBuilder = findAndReplaceInHolder(advancementHolder);
+                if (newBuilder != null) {
+                    newBuilder.save(saver, advancementHolder.id(), existingFileHelper);
+                }
+            });
+        }
+
+        @Nullable
+        private Advancement.Builder findAndReplaceInHolder(AdvancementHolder advancementHolder) {
+            Advancement advancement = advancementHolder.value();
+            Advancement.Builder builder = Advancement.Builder.advancement();
+            boolean hasReplaced = false;
+            for (var entry : advancement.criteria().entrySet()) {
+                Criterion<?> criterion = entry.getValue();
+                for (var criteriaReplacer : criteriaReplacers) {
+                    Criterion<?> replacedCriterion = criteriaReplacer.apply(criterion);
+                    if (replacedCriterion != null) {
+                        hasReplaced = true;
+                        criterion = replacedCriterion;
+                        //Don't break out, but instead continue going allowing applying replacers to our already replaced criteria
+                        //This allows for different replacers to replace different parts of the criteria
+                    }
+                }
+                builder.addCriterion(entry.getKey(), criterion);
+            }
+            if (!hasReplaced) {
+                return null;
+            }
+            advancement.parent().ifPresent(builder::parent);
+            advancement.display().ifPresent(builder::display);
+            builder.rewards(advancement.rewards());
+            builder.requirements(advancement.requirements());
+            if (advancement.sendsTelemetryEvent()) {
+                builder.sendsTelemetryEvent();
+            }
+            return builder;
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
@@ -14,6 +14,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.common.advancements.critereon.ICustomEntityPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.ICustomItemPredicate;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.crafting.IngredientType;
@@ -45,6 +46,7 @@ public class NeoForgeRegistries {
             .create();
     public static final Registry<IngredientType<?>> INGREDIENT_TYPES = new RegistryBuilder<>(Keys.INGREDIENT_TYPES).create();
     public static final Registry<Codec<? extends ICondition>> CONDITION_SERIALIZERS = new RegistryBuilder<>(Keys.CONDITION_CODECS).create();
+    public static final Registry<Codec<? extends ICustomEntityPredicate>> ENTITY_PREDICATE_SERIALIZERS = new RegistryBuilder<>(Keys.ENTITY_PREDICATE_SERIALIZERS).create();
     public static final Registry<Codec<? extends ICustomItemPredicate>> ITEM_PREDICATE_SERIALIZERS = new RegistryBuilder<>(Keys.ITEM_PREDICATE_SERIALIZERS).create();
     public static final Registry<AttachmentType<?>> ATTACHMENT_TYPES = new RegistryBuilder<>(Keys.ATTACHMENT_TYPES).create();
 
@@ -61,6 +63,7 @@ public class NeoForgeRegistries {
         public static final ResourceKey<Registry<ItemDisplayContext>> DISPLAY_CONTEXTS = key("display_contexts");
         public static final ResourceKey<Registry<IngredientType<?>>> INGREDIENT_TYPES = key("ingredient_serializer");
         public static final ResourceKey<Registry<Codec<? extends ICondition>>> CONDITION_CODECS = key("condition_codecs");
+        public static final ResourceKey<Registry<Codec<? extends ICustomEntityPredicate>>> ENTITY_PREDICATE_SERIALIZERS = key("entity_predicates");
         public static final ResourceKey<Registry<Codec<? extends ICustomItemPredicate>>> ITEM_PREDICATE_SERIALIZERS = key("item_predicates");
         public static final ResourceKey<Registry<AttachmentType<?>>> ATTACHMENT_TYPES = key("attachment_types");
 

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -58,6 +58,7 @@ public class NeoForgeRegistriesSetup {
         event.register(NeoForgeRegistries.DISPLAY_CONTEXTS);
         event.register(NeoForgeRegistries.INGREDIENT_TYPES);
         event.register(NeoForgeRegistries.CONDITION_SERIALIZERS);
+        event.register(NeoForgeRegistries.ENTITY_PREDICATE_SERIALIZERS);
         event.register(NeoForgeRegistries.ITEM_PREDICATE_SERIALIZERS);
         event.register(NeoForgeRegistries.ATTACHMENT_TYPES);
     }


### PR DESCRIPTION
The goal of this PR was initially just to fix https://github.com/mekanism/Mekanism/issues/7954 by replacing the advancement with one that supported a tool action, but I also noticed two other cases (related to distracting piglins) that I thought it made sense to replace the advancements for to reference some extension methods we provide in `IItemExtension`. To accomplish this I also had to add support for custom EntityPredicates.