### PR TITLE
Add a spotless task to prevent the removal of interfaces from MC classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ spotless {
             def interfaceChanges = fileContents.findAll(interfaceChange)
             if (interfaceChanges.isEmpty()) return fileContents
             String removalChange = ""
-            interfaceChanges.eachWithIndex{ String change, int index ->
+            interfaceChanges.each { String change ->
                 if (change.startsWith('-')) {
                     //Skip the - and the ending brace
                     int implementsIndex = change.indexOf("implements")

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ spotless {
                 }
             }
             if (!removalChange.isEmpty()) {
-                throw new GradleException("Interfaces cannot be removed in patches!")
+                throw new GradleException("Removal of interfaces via patches is not allowed!")
             }
             return fileContents
         }

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,31 @@ spotless {
             return fileContents
         }
 
+        def interfaceChange = Pattern.compile('^[-+].*(implements|(interface.*extends)).*\$', Pattern.UNIX_LINES | Pattern.MULTILINE)
+        custom 'noInterfaceRemoval', { String fileContents ->
+            def interfaceChanges = fileContents.findAll(interfaceChange)
+            if (interfaceChanges.isEmpty()) return fileContents
+            String removalChange = ""
+            interfaceChanges.eachWithIndex{ String change, int index ->
+                if (change.startsWith('-')) {
+                    //Skip the - and the ending brace
+                    int implementsIndex = change.indexOf("implements")
+                    if (implementsIndex == -1) implementsIndex = change.indexOf("extends")
+                    //It should never still be -1 based on our initial matching regex, but if it does fail so we can figure out why
+                    if (implementsIndex == -1) implementsIndex = 1
+                    removalChange = change.substring(implementsIndex, change.length() - 1).trim()
+                } else if (!removalChange.isEmpty() && !change.contains(removalChange)) {
+                    throw new GradleException("Removal of interfaces via patches is not allowed!")
+                } else {
+                    removalChange = ""
+                }
+            }
+            if (!removalChange.isEmpty()) {
+                throw new GradleException("Interfaces cannot be removed in patches!")
+            }
+            return fileContents
+        }
+
         //Trim any trailing whitespace from patch additions
         def trailingWhitespace = Pattern.compile('^\\+.*[ \t]+\$', Pattern.UNIX_LINES | Pattern.MULTILINE)
         custom 'trimTrailingWhitespacePatches', { String fileContents ->
@@ -87,7 +112,7 @@ spotless {
             return sb.toString()
         }
 
-        bumpThisNumberIfACustomStepChanges(2)
+        bumpThisNumberIfACustomStepChanges(3)
     }
 }
 

--- a/patches/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
@@ -5,7 +5,7 @@
  
  @OnlyIn(Dist.CLIENT)
 -public class MultiPartBakedModel implements BakedModel {
-+public class MultiPartBakedModel implements net.neoforged.neoforge.client.model.IDynamicBakedModel {
++public class MultiPartBakedModel implements BakedModel, net.neoforged.neoforge.client.model.IDynamicBakedModel {
      private final List<Pair<Predicate<BlockState>, BakedModel>> selectors;
      protected final boolean hasAmbientOcclusion;
      protected final boolean isGui3d;

--- a/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
@@ -5,7 +5,7 @@
  
  @OnlyIn(Dist.CLIENT)
 -public class WeightedBakedModel implements BakedModel {
-+public class WeightedBakedModel implements net.neoforged.neoforge.client.model.IDynamicBakedModel {
++public class WeightedBakedModel implements BakedModel, net.neoforged.neoforge.client.model.IDynamicBakedModel {
      private final int totalWeight;
      private final List<WeightedEntry.Wrapper<BakedModel>> list;
      private final BakedModel wrapped;


### PR DESCRIPTION
In order to prevent cases like #650

This PR also adds back the interfaces in two other classes that got removed. They are duplicated by the neo one that is extending the interface, but it is a better policy to just have the duplicate declaration rather than not be able to detect when we are removing an interface