### PR TITLE
Refactor localized mod info support

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -87,8 +87,8 @@ public class ModListScreen extends Screen {
 
         @Override
         public int compare(IModInfo o1, IModInfo o2) {
-            String name1 = StringUtils.toLowerCase(stripControlCodes(I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + o1.getModId(), o1::getDisplayName)));
-            String name2 = StringUtils.toLowerCase(stripControlCodes(I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + o2.getModId(), o2::getDisplayName)));
+            String name1 = StringUtils.toLowerCase(stripControlCodes(I18nExtension.getDisplayName(o1)));
+            String name2 = StringUtils.toLowerCase(stripControlCodes(I18nExtension.getDisplayName(o2)));
             return compare(name1, name2);
         }
 
@@ -247,7 +247,7 @@ public class ModListScreen extends Screen {
     @Override
     public void init() {
         for (IModInfo mod : mods) {
-            listWidth = Math.max(listWidth, getFontRenderer().width(I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + mod.getModId(), mod::getDisplayName)) + 10);
+            listWidth = Math.max(listWidth, getFontRenderer().width(I18nExtension.getDisplayName(mod)) + 10);
             listWidth = Math.max(listWidth, getFontRenderer().width(MavenVersionStringHelper.artifactVersionToString(mod.getVersion())) + 5);
         }
         listWidth = Math.max(Math.min(listWidth, width / 3), 100);
@@ -326,10 +326,7 @@ public class ModListScreen extends Screen {
     }
 
     private void reloadMods() {
-        this.mods = this.unsortedMods.stream().filter(mi -> {
-            String name = I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + mi.getModId(), mi::getDisplayName);
-            return StringUtils.toLowerCase(stripControlCodes(name)).contains(StringUtils.toLowerCase(search.getValue()));
-        }).collect(Collectors.toList());
+        this.mods = this.unsortedMods.stream().filter(mi -> StringUtils.toLowerCase(stripControlCodes(I18nExtension.getDisplayName(mi))).contains(StringUtils.toLowerCase(search.getValue()))).collect(Collectors.toList());
         lastFilterText = search.getValue();
     }
 
@@ -406,7 +403,7 @@ public class ModListScreen extends Screen {
             return Pair.<ResourceLocation, Size2i>of(null, new Size2i(0, 0));
         }).orElse(Pair.of(null, new Size2i(0, 0)));
 
-        lines.add(I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + selectedMod.getModId(), selectedMod::getDisplayName));
+        lines.add(I18nExtension.getDisplayName(selectedMod));
         lines.add(I18nExtension.parseMessage("fml.menu.mods.info.version", MavenVersionStringHelper.artifactVersionToString(selectedMod.getVersion())));
         lines.add(I18nExtension.parseMessage("fml.menu.mods.info.idstate", selectedMod.getModId(), ModList.get().getModContainerById(selectedMod.getModId()).map(ModContainer::getCurrentState).map(Object::toString).orElse("NONE")));
 
@@ -416,13 +413,13 @@ public class ModListScreen extends Screen {
         if (selectedMod.getOwningFile() == null || selectedMod.getOwningFile().getMods().size() == 1)
             lines.add(I18nExtension.parseMessage("fml.menu.mods.info.nochildmods"));
         else
-            lines.add(I18nExtension.parseMessage("fml.menu.mods.info.childmods", selectedMod.getOwningFile().getMods().stream().map(mi -> I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + mi.getModId(), mi::getDisplayName)).collect(Collectors.joining(","))));
+            lines.add(I18nExtension.parseMessage("fml.menu.mods.info.childmods", selectedMod.getOwningFile().getMods().stream().map(I18nExtension::getDisplayName).collect(Collectors.joining(","))));
 
         if (vercheck.status() == VersionChecker.Status.OUTDATED || vercheck.status() == VersionChecker.Status.BETA_OUTDATED)
             lines.add(I18nExtension.parseMessage("fml.menu.mods.info.updateavailable", vercheck.url() == null ? "" : vercheck.url()));
         lines.add(I18nExtension.parseMessage("fml.menu.mods.info.license", ((ModFileInfo) selectedMod.getOwningFile()).getLicense()));
         lines.add(null);
-        lines.add(I18nExtension.parseMessageWithFallback("fml.menu.mods.info.description." + selectedMod.getModId(), selectedMod::getDescription));
+        lines.add(I18nExtension.getDescription(selectedMod));
 
         /* Removed because people bitched that this information was misleading.
         lines.add(null);

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -70,12 +70,12 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
 
         @Override
         public Component getNarration() {
-            return Component.translatable("narrator.select", Component.translatableWithFallback("fml.menu.mods.info.displayname." + modInfo.getModId(), modInfo.getDisplayName()));
+            return Component.translatable("narrator.select", I18nExtension.getDisplayName(modInfo));
         }
 
         @Override
         public void render(GuiGraphics guiGraphics, int entryIdx, int top, int left, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isMouseOver, float partialTick) {
-            Component name = Component.literal(stripControlCodes(I18nExtension.parseMessageWithFallback("fml.menu.mods.info.displayname." + modInfo.getModId(), modInfo::getDisplayName)));
+            Component name = Component.literal(stripControlCodes(I18nExtension.getDisplayName(modInfo)));
             Component version = Component.literal(stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion())));
             VersionChecker.CheckResult vercheck = VersionChecker.getResult(modInfo);
             Font font = this.parent.getFontRenderer();

--- a/src/main/java/net/neoforged/neoforge/common/I18nExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/I18nExtension.java
@@ -74,7 +74,7 @@ public class I18nExtension {
         if (Objects.equals(formatString, "id")) {
             stringBuffer.append(info.getModId());
         } else if (Objects.equals(formatString, "name")) {
-            stringBuffer.append(info.getDisplayName());
+            stringBuffer.append(getDisplayName(info));
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/I18nExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/I18nExtension.java
@@ -110,6 +110,14 @@ public class I18nExtension {
         return extendedMessageFormat.format(args);
     }
 
+    public static String getDisplayName(final IModInfo modInfo) {
+        return parseMessageWithFallback("fml.menu.mods.info.displayname." + modInfo.getModId(), modInfo::getDisplayName);
+    }
+
+    public static String getDescription(final IModInfo modInfo) {
+        return parseMessageWithFallback("fml.menu.mods.info.description." + modInfo.getModId(), modInfo::getDescription);
+    }
+
     public static String stripSpecialChars(String message) {
         // We can't handle many unicode points in the splash renderer
         return DISALLOWED_CHAR_MATCHER.removeFrom(stripControlCodes(message));


### PR DESCRIPTION
Improving on #649, this PR _DRYs_ up my initial implementation, introducing `I18nExtension.getDisplayName(IModInfo)` & `I18nExtension.getDescription(IModInfo)`.

Localization support is also extended to the `{0,modinfo,name}` format string, so other translations referincing a mod's display name will use the localized variant too.