### PR TITLE
Address UseItemOnBlockEvent player nullability by fixing event inheritance

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/BonemealEvent.java
@@ -23,6 +23,7 @@ import net.neoforged.bus.api.ICancellableEvent;
  * setResult(ALLOW) is the same as the old setHandled()
  */
 @Event.HasResult
+// TODO 1.20.5: do not make this event extend PlayerEvent, make Player nullable instead of passing a FakePlayer for dispensers.
 public class BonemealEvent extends PlayerEvent implements ICancellableEvent {
     private final Level level;
     private final BlockPos pos;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/UseItemOnBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/UseItemOnBlockEvent.java
@@ -5,13 +5,21 @@
 
 package net.neoforged.neoforge.event.entity.player;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.extensions.IItemExtension;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * <p></p>Fires on both the client and server thread when a player interacts with a block.
@@ -29,12 +37,12 @@ import net.neoforged.neoforge.common.extensions.IItemExtension;
  * then the normal interaction behavior for that phase will not run,
  * and the specified {@link InteractionResult} will be returned instead.</p>
  */
-public class UseItemOnBlockEvent extends PlayerInteractEvent implements ICancellableEvent {
+public class UseItemOnBlockEvent extends Event implements ICancellableEvent {
     private final UseOnContext context;
     private final UsePhase usePhase;
+    private InteractionResult cancellationResult = InteractionResult.PASS;
 
     public UseItemOnBlockEvent(UseOnContext context, UsePhase usePhase) {
-        super(context.getPlayer(), context.getHand(), context.getClickedPos(), context.getClickedFace());
         this.context = context;
         this.usePhase = usePhase;
     }
@@ -74,6 +82,52 @@ public class UseItemOnBlockEvent extends PlayerInteractEvent implements ICancell
     public void cancelWithResult(InteractionResult result) {
         this.setCancellationResult(result);
         this.setCanceled(true);
+    }
+
+    /**
+     * @return The InteractionResult that will be returned to vanilla if the event is cancelled, instead of calling the relevant
+     *         method of the event. By default, this is {@link InteractionResult#PASS}, meaning cancelled events will cause
+     *         the client to keep trying more interactions until something works.
+     */
+    public InteractionResult getCancellationResult() {
+        return cancellationResult;
+    }
+
+    /**
+     * Set the InteractionResult that will be returned to vanilla if the event is cancelled, instead of calling the relevant
+     * method of the event.
+     */
+    public void setCancellationResult(InteractionResult result) {
+        this.cancellationResult = result;
+    }
+
+    public InteractionHand getHand() {
+        return context.getHand();
+    }
+
+    public ItemStack getItemStack() {
+        return context.getItemInHand();
+    }
+
+    public BlockPos getPos() {
+        return context.getClickedPos();
+    }
+
+    public Direction getFace() {
+        return context.getClickedFace();
+    }
+
+    public Level getLevel() {
+        return context.getLevel();
+    }
+
+    public LogicalSide getSide() {
+        return getLevel().isClientSide ? LogicalSide.CLIENT : LogicalSide.SERVER;
+    }
+
+    @Nullable
+    public Player getEntity() {
+        return context.getPlayer();
     }
 
     public static enum UsePhase {

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -66,8 +66,10 @@ public class ExtendedGameTestHelper extends GameTestHelper {
         return sq;
     }
 
-    public void useOn(BlockPos pos, ItemStack item, Player player, Direction direction) {
-        player.setItemInHand(InteractionHand.MAIN_HAND, item);
+    public void useOn(BlockPos pos, ItemStack item, @Nullable Player player, Direction direction) {
+        if (player != null) {
+            player.setItemInHand(InteractionHand.MAIN_HAND, item);
+        }
         pos = this.absolutePos(pos);
         item.useOn(new UseOnContext(
                 this.getLevel(), player, InteractionHand.MAIN_HAND, item, new BlockHitResult(

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.entity.player;
 
+import com.mojang.logging.LogUtils;
 import java.util.Objects;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
@@ -78,7 +79,12 @@ public class PlayerEventTests {
                     BlockPos placePos = context.getClickedPos().relative(context.getClickedFace());
                     if (level.getBlockState(placePos.below()).getBlock() == Blocks.DISPENSER) {
                         if (!level.isClientSide) {
-                            context.getPlayer().displayClientMessage(Component.literal("Can't place dirt on dispenser"), false);
+                            String text = "Can't place dirt on dispenser";
+                            if (context.getPlayer() != null) {
+                                context.getPlayer().displayClientMessage(Component.literal(text), false);
+                            } else {
+                                LogUtils.getLogger().info(text);
+                            }
                         }
                         test.pass();
                         event.cancelWithResult(InteractionResult.SUCCESS);
@@ -92,7 +98,7 @@ public class PlayerEventTests {
                 .thenExecute(() -> helper.useOn(
                         new BlockPos(1, 1, 1),
                         Items.DIRT.getDefaultInstance(),
-                        helper.makeMockPlayer(),
+                        null, // Test that null players are allowed too.
                         Direction.UP))
                 .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DIRT, 1, 2, 1))
                 .thenSucceed());


### PR DESCRIPTION
The breakage has been minimized by reimplementing every method from the previous parents. If mods were casting the event to one of its superclasses, then the breakage cannot be avoided.

Fixes #661.