### PR TITLE
Do not fire UseItemOnBlockEvent for null players

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -96,19 +96,23 @@
      }
  
      public boolean is(HolderSet<Item> p_298683_) {
-@@ -262,6 +_,19 @@
+@@ -262,6 +_,23 @@
      }
  
      public InteractionResult useOn(UseOnContext p_41662_) {
-+        var e = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent(p_41662_, net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent.UsePhase.ITEM_AFTER_BLOCK));
-+        if (e.isCanceled()) return e.getCancellationResult();
++        if (p_41662_.getPlayer() != null) { // TODO 1.20.5: Make event accept nullable player, and remove this check.
++            var e = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent(p_41662_, net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent.UsePhase.ITEM_AFTER_BLOCK));
++            if (e.isCanceled()) return e.getCancellationResult();
++        }
 +        if (!p_41662_.getLevel().isClientSide) return net.neoforged.neoforge.common.CommonHooks.onPlaceItemIntoWorld(p_41662_);
 +        return onItemUse(p_41662_, (c) -> getItem().useOn(p_41662_));
 +    }
 +
 +    public InteractionResult onItemUseFirst(UseOnContext p_41662_) {
-+        var e = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent(p_41662_, net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent.UsePhase.ITEM_BEFORE_BLOCK));
-+        if (e.isCanceled()) return e.getCancellationResult();
++        if (p_41662_.getPlayer() != null) { // TODO 1.20.5: Make event accept nullable player, and remove this check.
++            var e = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent(p_41662_, net.neoforged.neoforge.event.entity.player.UseItemOnBlockEvent.UsePhase.ITEM_BEFORE_BLOCK));
++            if (e.isCanceled()) return e.getCancellationResult();
++        }
 +        return onItemUse(p_41662_, (c) -> getItem().onItemUseFirst(this, p_41662_));
 +    }
 +

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/BonemealEvent.java
@@ -22,6 +22,7 @@ import net.neoforged.bus.api.ICancellableEvent;
  *
  * setResult(ALLOW) is the same as the old setHandled()
  */
+// TODO 1.20.5: Make player nullable. Remove extends PlayerEvent and remove the dispenser fake player.
 @Event.HasResult
 public class BonemealEvent extends PlayerEvent implements ICancellableEvent {
     private final Level level;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/UseItemOnBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/UseItemOnBlockEvent.java
@@ -29,6 +29,7 @@ import net.neoforged.neoforge.common.extensions.IItemExtension;
  * then the normal interaction behavior for that phase will not run,
  * and the specified {@link InteractionResult} will be returned instead.</p>
  */
+// TODO 1.20.5: We want to support nullable player. Remove extends PlayerInteractEvent to support that.
 public class UseItemOnBlockEvent extends PlayerInteractEvent implements ICancellableEvent {
     private final UseOnContext context;
     private final UsePhase usePhase;


### PR DESCRIPTION
Fixes #661 by not firing the event. This is a stopgap solution to fix the issue without introducing a breaking change. A proper solution will be implemented in 1.20.5.