### PR TITLE
[1.20.1] Use LegacyInstaller v3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
     SECUREJARHANDLER_VERSION = '2.1.10'
     BOOTSTRAPLAUNCHER_VERSION = '1.1.2'
     ASM_VERSION = '9.5'
-    INSTALLER_VERSION = '2.1.+'
+    INSTALLER_VERSION = '3.+'
     MIXIN_VERSION = '0.8.5'
     TERMINALCONSOLEAPPENDER_VERSION = '1.2.0'
     JLINE_VERSION = '3.12.+'
@@ -626,7 +626,7 @@ project(':forge') {
     }
 
     task([type: DownloadMavenArtifact], 'downloadInstaller') {
-        artifact = "net.minecraftforge:installer:${INSTALLER_VERSION}:shrunk"
+        artifact = "net.neoforged:legacyinstaller:${INSTALLER_VERSION}:shrunk"
         changing = true
     }
 


### PR DESCRIPTION
This includes the patch for https://github.com/neoforged/NeoForge/issues/671, and matches the retroactive patch done to the earlier installers.