### PR TITLE
Move contents of `ItemHandlerHelper.canItemStacksStack` to `IItemStackExtension.stacksWith`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -70,6 +70,16 @@ public interface IItemStackExtension {
     }
 
     /**
+     * {@return true if this item stack stacks with the provided one}
+     */
+    default boolean stacksWith(ItemStack otherStack) {
+        if (self().isEmpty() || !ItemStack.isSameItem(self(), otherStack) || self().hasTag() != otherStack.hasTag())
+            return false;
+
+        return (!self().hasTag() || self().getTag().equals(otherStack.getTag())) && self().areAttachmentsCompatible(otherStack);
+    }
+
+    /**
      * @return the fuel burn time for this itemStack in a furnace. Return 0 to make
      *         it not act as a fuel. Return -1 to let the default vanilla logic
      *         decide.

--- a/src/main/java/net/neoforged/neoforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemHandlerHelper.java
@@ -30,13 +30,6 @@ public class ItemHandlerHelper {
         return stack;
     }
 
-    public static boolean canItemStacksStack(ItemStack a, ItemStack b) {
-        if (a.isEmpty() || !ItemStack.isSameItem(a, b) || a.hasTag() != b.hasTag())
-            return false;
-
-        return (!a.hasTag() || a.getTag().equals(b.getTag())) && a.areAttachmentsCompatible(b);
-    }
-
     /**
      * A relaxed version of canItemStacksStack that stacks itemstacks with different metadata if they don't have subtypes.
      * This usually only applies when players pick up items.

--- a/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
@@ -64,7 +64,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
         int limit = getStackLimit(slot, stack);
 
         if (!existing.isEmpty()) {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
+            if (!stack.stacksWith(existing))
                 return stack;
 
             limit -= existing.getCount();

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -43,7 +43,7 @@ public class VanillaInventoryCodeHooks {
                         if (!extractItem.isEmpty()) {
                             for (int j = 0; j < dest.getContainerSize(); j++) {
                                 ItemStack destStack = dest.getItem(j);
-                                if (dest.canPlaceItem(j, extractItem) && (destStack.isEmpty() || destStack.getCount() < destStack.getMaxStackSize() && destStack.getCount() < dest.getMaxStackSize() && ItemHandlerHelper.canItemStacksStack(extractItem, destStack))) {
+                                if (dest.canPlaceItem(j, extractItem) && (destStack.isEmpty() || destStack.getCount() < destStack.getMaxStackSize() && destStack.getCount() < dest.getMaxStackSize() && extractItem.stacksWith(destStack))) {
                                     extractItem = handler.extractItem(i, 1, false);
                                     if (destStack.isEmpty())
                                         dest.setItem(j, extractItem);
@@ -141,7 +141,7 @@ public class VanillaInventoryCodeHooks {
                 destInventory.insertItem(slot, stack, false);
                 stack = ItemStack.EMPTY;
                 insertedItem = true;
-            } else if (ItemHandlerHelper.canItemStacksStack(itemstack, stack)) {
+            } else if (itemstack.stacksWith(stack)) {
                 int originalSize = stack.getCount();
                 stack = destInventory.insertItem(slot, stack, false);
                 insertedItem = originalSize < stack.getCount();

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -70,7 +70,7 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
         int limit = getStackLimit(slot, stack);
 
         if (!existing.isEmpty()) {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
+            if (!stack.stacksWith(existing))
                 return stack;
 
             limit -= existing.getCount();

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/InvWrapper.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.items.wrapper;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
-import net.neoforged.neoforge.items.ItemHandlerHelper;
 
 public class InvWrapper implements IItemHandlerModifiable {
     private final Container inv;
@@ -56,7 +55,7 @@ public class InvWrapper implements IItemHandlerModifiable {
             if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
                 return stack;
 
-            if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
+            if (!stack.stacksWith(stackInSlot))
                 return stack;
 
             if (!getInv().canPlaceItem(slot, stack))

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/ShulkerItemStackInvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/ShulkerItemStackInvWrapper.java
@@ -54,7 +54,7 @@ public class ShulkerItemStackInvWrapper implements IItemHandlerModifiable {
         int limit = Math.min(getSlotLimit(slot), stack.getMaxStackSize());
 
         if (!existing.isEmpty()) {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
+            if (!stack.stacksWith(existing))
                 return stack;
 
             limit -= existing.getCount();

--- a/src/main/java/net/neoforged/neoforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/items/wrapper/SidedInvWrapper.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.world.level.block.entity.BrewingStandBlockEntity;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
-import net.neoforged.neoforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Nullable;
 
 public class SidedInvWrapper implements IItemHandlerModifiable {
@@ -101,7 +100,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable {
             if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
                 return stack;
 
-            if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
+            if (!stack.stacksWith(stackInSlot))
                 return stack;
 
             if (!inv.canPlaceItemThroughFace(slot1, stack, side) || !inv.canPlaceItem(slot1, stack))


### PR DESCRIPTION
In my opinion, calling it statically just doesn't make sense and adding it via `IItemStackExtension` is more ergonomic