### PR TITLE
Show modid and raw display name in mod list entries

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.client.gui.widget;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.ObjectSelectionList;
@@ -75,12 +76,14 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
 
         @Override
         public void render(GuiGraphics guiGraphics, int entryIdx, int top, int left, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isMouseOver, float partialTick) {
-            Component name = Component.literal(stripControlCodes(I18nExtension.getDisplayName(modInfo)));
-            Component version = Component.literal(stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion())));
+            String name = stripControlCodes(I18nExtension.getDisplayName(modInfo));
+            String version = stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion()));
+            Component heading = Component.literal(name).withStyle(ChatFormatting.WHITE);
+            Component subheading = Component.literal(version).withStyle(ChatFormatting.GRAY);
             VersionChecker.CheckResult vercheck = VersionChecker.getResult(modInfo);
             Font font = this.parent.getFontRenderer();
-            guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(name, listWidth))), left + 3, top + 2, 0xFFFFFF, false);
-            guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(version, listWidth))), left + 3, top + 2 + font.lineHeight, 0xCCCCCC, false);
+            guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(heading, listWidth))), left + 3, top + 2, 0xFFFFFF, false);
+            guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(subheading, listWidth))), left + 3, top + 2 + font.lineHeight, 0xCCCCCC, false);
             if (vercheck.status().shouldDraw()) {
                 //TODO: Consider adding more icons for visualization
                 RenderSystem.setShaderColor(1, 1, 1, 1);

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -76,10 +76,11 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
 
         @Override
         public void render(GuiGraphics guiGraphics, int entryIdx, int top, int left, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isMouseOver, float partialTick) {
+            String modid = stripControlCodes(modInfo.getModId());
             String name = stripControlCodes(I18nExtension.getDisplayName(modInfo));
             String version = stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion()));
             Component heading = Component.literal(name).withStyle(ChatFormatting.WHITE);
-            Component subheading = Component.literal(version).withStyle(ChatFormatting.GRAY);
+            Component subheading = Component.literal(modid + " " + version).withStyle(ChatFormatting.GRAY);
             VersionChecker.CheckResult vercheck = VersionChecker.getResult(modInfo);
             Font font = this.parent.getFontRenderer();
             guiGraphics.drawString(font, Language.getInstance().getVisualOrder(FormattedText.composite(font.substrByWidth(heading, listWidth))), left + 3, top + 2, 0xFFFFFF, false);

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -13,6 +13,7 @@ import net.minecraft.client.gui.components.ObjectSelectionList;
 import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.VersionChecker;
 import net.neoforged.neoforge.client.gui.ModListScreen;
@@ -77,9 +78,13 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
         @Override
         public void render(GuiGraphics guiGraphics, int entryIdx, int top, int left, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isMouseOver, float partialTick) {
             String modid = stripControlCodes(modInfo.getModId());
-            String name = stripControlCodes(I18nExtension.getDisplayName(modInfo));
+            String i18nName = stripControlCodes(I18nExtension.getDisplayName(modInfo));
+            String rawName = stripControlCodes(modInfo.getDisplayName());
             String version = stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion()));
-            Component heading = Component.literal(name).withStyle(ChatFormatting.WHITE);
+            MutableComponent heading = Component.literal(i18nName).withStyle(ChatFormatting.WHITE);
+            if (!rawName.equals(i18nName)) {
+                heading.append(Component.literal(" (" + rawName + ")").withStyle(ChatFormatting.GRAY).withStyle(ChatFormatting.ITALIC));
+            }
             Component subheading = Component.literal(modid + " " + version).withStyle(ChatFormatting.GRAY);
             VersionChecker.CheckResult vercheck = VersionChecker.getResult(modInfo);
             Font font = this.parent.getFontRenderer();


### PR DESCRIPTION
## Motivation

This PR was inspired by feedback that localised display names can make it hard to identify compatibility issues at a glance from mod-list screenshots.

While that's technically a more fundamental issue with display names, because they can be ambiguous or foreign anyway, translation support certainly has the potential to exacerbate this.

## Summary

- Mod IDs are now displayed alongside version info in the entry's subheading.
- "Raw" display names (from `mods.toml`) are shown alongside the localized version **if different**
- Formatting is tweaked to (hopefully) make the additional information easy to read at a glance.

## Example

Using these test translations while running `:tests:runClient` renders like this:

<details><summary>Translations</summary>
<p>

```json
{
  "fml.menu.mods.info.displayname.testframework": "test framework",
  "fml.menu.mods.info.displayname.neotests": "Translation!"
}
```

</p>
</details> 

![image](https://github.com/neoforged/NeoForge/assets/5046562/2f27f631-1188-49ca-8805-2388c7c64fe3)

## Further consideration

- Should the modid still be shown when it is similar to the displayname?
  - "Minecraft" & `minecraft`
  - "Test Framework" & `testframework`
  - "Foo Bar" & `foo_bar`
- How different should translated display names be to display the raw name?
  - Currently any difference is enough
  - Should we be case insensitive?
  - What about formatting differences?
- Is modid and version readable enough when **on one line**?
- Should we consider making the entry bigger?
  - It's pretty likely that entry lines will get truncated atm...
- Should we consider rendering the mod's **icon** in the entry?
  - This could further help to distinguish similarly named mods.

I've tried to keep the changes here minimal. Hopefully they can act as a starting point, so the above considerations and any feedback can be iterated on; either in this PR or in future work.