### PR TITLE
Include modid in "failedtoloadmodclass" error

### DIFF
--- a/src/main/resources/assets/neoforge/lang/da_dk.json
+++ b/src/main/resources/assets/neoforge/lang/da_dk.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n§7We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/de_de.json
+++ b/src/main/resources/assets/neoforge/lang/de_de.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod-Datei {5} benötigt Sprachanbieter {3}:{4,vr} zum Laden\n§7Wir haben {6,i18n,fml.messages.artifactversion} gefunden",
   "fml.modloading.missingclasses": "Die Mod-Datei {3} hat Mods, die nicht gefunden wurden",
   "fml.modloading.missingmetadata": "mods.toml fehlen Metadaten für modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} hat Fehler beim Laden der Klasse\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) hat Fehler beim Laden der Klasse\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) konnte nicht korrekt geladen werden\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name}({0,modinfo,id}) fehlt ein Feature das es zum Funktionieren benötigt \n§7Es benötigt {3,featurebound} aber {4} ist verfügbar",
   "fml.modloading.uncaughterror": "Ein nicht abgefangener paralleler Verarbeitungsfehler ist aufgetreten.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/en_gb.json
+++ b/src/main/resources/assets/neoforge/lang/en_gb.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n§7We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n\u00a77We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass":"{0,modinfo,name} has class loading errors\n\u00a77{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass":"{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n\u00a77{2,exc,msg}",
   "fml.modloading.failedtoloadmod":"{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n\u00a77{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror":"An uncaught parallel processing error has occurred.\n\u00a77{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/es_es.json
+++ b/src/main/resources/assets/neoforge/lang/es_es.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "El archivo del mod {5} necesita un proveedor de idioma {3}:{4,vr} para cargar\n§7Hemos encontrado {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "El archivo del mod {3} tiene mods que no se encontraron",
   "fml.modloading.missingmetadata": "mods.toml falta metadata para modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} tiene errores de carga de clase\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) tiene errores de carga de clase\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) no se ha cargado correctamente\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) falta una característica que necesita ejecutarse\n§7Requiere {3,featurebound} pero {4} está disponible",
   "fml.modloading.uncaughterror": "Se ha producido un error no detectado en el procesamiento paralelo.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/et_ee.json
+++ b/src/main/resources/assets/neoforge/lang/et_ee.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Modifail {5} vajab laadimiseks keelepakkujat {3}:{4,vr}\n§7Me leidsime {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "Modifailil {3} on mode, mida ei leitud",
   "fml.modloading.missingmetadata": "Failis mods.toml puuduvad metaandmed modi IDle {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} on klassilaadimise vead\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) on klassilaadimise vead\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) korrektne laadimine ebaõnnestus\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) puudub käitamiseks vajalik funktsioon\n§7See nõuab {3,featurebound} kuid saadaval on hoopis {4}",
   "fml.modloading.uncaughterror": "Esines püüdmata paralleeltöötluse viga.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/fr_fr.json
+++ b/src/main/resources/assets/neoforge/lang/fr_fr.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Le fichier mod {5} a besoin du fournisseur de langage {3}:{4,vr} pour charger\n§7Nous avons trouvé {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "Le fichier de mod {3} a des mods qui n'ont pas été trouvés",
   "fml.modloading.missingmetadata": "le fichier mods.toml pour le modid {3} ne possède pas certaines métadonnées",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} a des erreurs de chargement de classes\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) a des erreurs de chargement de classes\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) n'a pas réussi à se charger correctement\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) a besoin d'une fonctionnalité manquante nécessaire pour s'exécuter\n§7Il nécessite {3,featurebound} mais {4} est disponible",
   "fml.modloading.uncaughterror": "Une erreur de traitement parallèle non capturée est survenue.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/hu_hu.json
+++ b/src/main/resources/assets/neoforge/lang/hu_hu.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n§7We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/it_it.json
+++ b/src/main/resources/assets/neoforge/lang/it_it.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Il file della mod {5} richiede il provider di lingua {3}:{4,vr} per essere caricata\n§7Abbiamo trovato {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "Il File della Mod {3} ha delle mod che non sono state trovate",
   "fml.modloading.missingmetadata": "mods.toml ha metadati mancanti per il modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ha errori di caricamento classe\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) ha errori di caricamento classe\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) non è riuscito a caricarsi correttamente\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) manca una funzione che richiede di eseguire\n§7Richiede {3,featurebound} ma {4} è disponibile",
   "fml.modloading.uncaughterror": "Si è verificato un errore di elaborazione parallela.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/ko_kr.json
+++ b/src/main/resources/assets/neoforge/lang/ko_kr.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "모드 파일 {5}은(는) 언어 제공자 {3}:{4,vr}이(가) 필요합니다\n§7{6,i18n,fml.messages.artifactversion}을(를) 발견했습니다",
   "fml.modloading.missingclasses": "모드 파일 {3}의 모드를 찾을 수 없습니다",
   "fml.modloading.missingmetadata": "mods.toml 이 모드 아이디 {3} 의 메타데이터를 포함하고 있지 않습니다.",
-  "fml.modloading.failedtoloadmodclass": "모드 {0,modinfo,name} 에서 오류가 발생했습니다!\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "모드 {0,modinfo,name} ({0,modinfo,id}) 에서 오류가 발생했습니다!\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "모드 {0,modinfo,name} ({0,modinfo,id}) 를 불러오는데 실패했습니다.\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) 를 불러오기 위한 기능을 찾을 수 없습니다\n§7{3}=>{4} 가 충족되어야 하나, 사용 가능한 버전은 {5} 입니다",
   "fml.modloading.uncaughterror": "처리되지 않은 모드 병렬 호출 문제가 발생하였습니다: §7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/nl_nl.json
+++ b/src/main/resources/assets/neoforge/lang/nl_nl.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Modbestand {5} heeft de taalaanbieder {3}:{4,vr} nodig om te kunnen laden\n§7We hebben {6,i18n,fml.messages.artifactversion} gevonden",
   "fml.modloading.missingclasses": "Het Modbestand {3} heeft mods die niet gevonden zijn",
   "fml.modloading.missingmetadata": "mods.toml mist metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} heeft class laadfouten\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) heeft class laadfouten\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name}({0,modinfo,id}) is niet correct geladen\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) mist een functie die nodig is om het te runnen.\n§7Het heeft {3,featurebound} nodig, maar {4} is beschikbaar",
   "fml.modloading.uncaughterror": "Er is een onbetrapte, parallelle verwerkingsfout opgetreden.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/pl_pl.json
+++ b/src/main/resources/assets/neoforge/lang/pl_pl.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Plik modyfikacji {5} potrzebuje przekazanego języka {3}: {4, vr} do załadowania\n§7Znaleźliśmy {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "Mod {3} posiada zależności do innych modów, których nie możemy znaleźć",
   "fml.modloading.missingmetadata": "mods.toml brakuje metadata dla modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/ro_ro.json
+++ b/src/main/resources/assets/neoforge/lang/ro_ro.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n§7We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/ru_ru.json
+++ b/src/main/resources/assets/neoforge/lang/ru_ru.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Файл мода {5} требует языковой провайдер {3}:{4,vr}, чтобы загрузиться\n§7Мы обнаружили {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "Файл мода {3} содержит моды, которые не были найдены",
   "fml.modloading.missingmetadata": "В mods.toml отсутствуют метаданные для modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} содержит ошибки при загрузке классов\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) содержит ошибки при загрузке классов\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) не удалось правильно загрузить\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "В {0,modinfo,name} ({0,modinfo,id}) отсутствует функция, необходимая для запуска\n§7Для запуска требуется {3,featurebound}, а {4} доступен",
   "fml.modloading.uncaughterror": "Произошла неперехваченная ошибка параллельной обработки.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/sk_sk.json
+++ b/src/main/resources/assets/neoforge/lang/sk_sk.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Súbor módu {5} potrebuje poskytovateľa jazyku {3}:{4,vr} pre načítanie §7 Našli sme {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "Súbor módu {3} obsahuje módy, ktoré neboli nájdené",
   "fml.modloading.missingmetadata": "v mods.toml chýbajú metadata pre modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} má chyby načítavania triedy §7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) má chyby načítavania triedy §7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name}({0,modinfo,id}) sa nenačítal správne\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) neobsahuje funkciu ktorú potrebuje pre spustenie\n§7Vyžaduje {3,featurebound} ale {4} je k dispozícii",
   "fml.modloading.uncaughterror": "Vyskytla sa nezachytená chyba paralelného spracovania.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/tr_tr.json
+++ b/src/main/resources/assets/neoforge/lang/tr_tr.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n§7We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/tt_ru.json
+++ b/src/main/resources/assets/neoforge/lang/tt_ru.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "Mod File {5} needs language provider {3}:{4,vr} to load\n§7We have found {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "The Mod File {3} has mods that were not found",
   "fml.modloading.missingmetadata": "mods.toml missing metadata for modid {3}",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} has class loading errors\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) has class loading errors\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name} ({0,modinfo,id}) has failed to load correctly\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name} ({0,modinfo,id}) is missing a feature it requires to run\n§7It requires {3,featurebound} but {4} is available",
   "fml.modloading.uncaughterror": "An uncaught parallel processing error has occurred.\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/zh_cn.json
+++ b/src/main/resources/assets/neoforge/lang/zh_cn.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "模组文件 {5} 需要语言提供模组 {3}:{4,vr} 才能加载\n§7我们找到 {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "模组文件 {3} 有已声明但未找到的模组",
   "fml.modloading.missingmetadata": "mods.toml 缺少模组 id {3} 的元数据",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} 有类加载错误\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) 有类加载错误\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name}（{0,modinfo,id}）未能正确加载\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name}（{0,modinfo,id}）缺少运行所需的一个功能\n§7需要 {3,featurebound} 但 {4} 可用",
   "fml.modloading.uncaughterror": "发生了一个未捕获的并行处理错误。\n§7{2,exc,msg}",

--- a/src/main/resources/assets/neoforge/lang/zh_hk.json
+++ b/src/main/resources/assets/neoforge/lang/zh_hk.json
@@ -61,7 +61,7 @@
   "fml.language.missingversion": "模組檔案 {5} 需要語言提供模組 {3}:{4,vr} 才能載入\n§7我們找到 {6,i18n,fml.messages.artifactversion}",
   "fml.modloading.missingclasses": "模組檔案 {3} 有要求的但找不到的模組",
   "fml.modloading.missingmetadata": "mods.toml 缺少模組 id {3} 的後設資料",
-  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} 有類別載入錯誤\n§7{2,exc,msg}",
+  "fml.modloading.failedtoloadmodclass": "{0,modinfo,name} ({0,modinfo,id}) 有類別載入錯誤\n§7{2,exc,msg}",
   "fml.modloading.failedtoloadmod": "{0,modinfo,name}（{0,modinfo,id}）無法正確載入\n§7{2,exc,msg}",
   "fml.modloading.feature.missing": "{0,modinfo,name}（{0,modinfo,id}）缺少執行所需的功能\n§7它需要 {3,featurebound}，但 {4} 可用",
   "fml.modloading.uncaughterror": "發生未捕獲的平行處理錯誤。\n§7{2,exc,msg}",


### PR DESCRIPTION
For consistency with other error messages, include both mod name & id.