### PR TITLE
add `CalculateDetachedCameraDistanceEvent`

### DIFF
--- a/patches/net/minecraft/client/Camera.java.patch
+++ b/patches/net/minecraft/client/Camera.java.patch
@@ -5,7 +5,7 @@
              }
  
 -            this.move(-this.getMaxZoom(4.0), 0.0, 0.0);
-+            this.move(-this.getMaxZoom(net.neoforged.neoforge.client.ClientHooks.getDetachedCameraDistance(this, p_90579_)), 0.0, 0.0);
++            this.move(-this.getMaxZoom(net.neoforged.neoforge.client.ClientHooks.getDetachedCameraDistance(this, p_90579_, 4.0)), 0.0, 0.0);
          } else if (p_90577_ instanceof LivingEntity && ((LivingEntity)p_90577_).isSleeping()) {
              Direction direction = ((LivingEntity)p_90577_).getBedOrientation();
              this.setRotation(direction != null ? direction.toYRot() - 180.0F : 0.0F, 0.0F);

--- a/patches/net/minecraft/client/Camera.java.patch
+++ b/patches/net/minecraft/client/Camera.java.patch
@@ -1,9 +1,20 @@
 --- a/net/minecraft/client/Camera.java
 +++ b/net/minecraft/client/Camera.java
-@@ -225,6 +_,18 @@
-         return this.partialTickTime;
-     }
+@@ -56,7 +_,7 @@
+                 this.setRotation(this.yRot + 180.0F, -this.xRot);
+             }
  
+-            this.move(-this.getMaxZoom(4.0), 0.0, 0.0);
++            this.move(-this.getMaxZoom(net.neoforged.neoforge.client.ClientHooks.getDetachedCameraDistance(this, p_90579_)), 0.0, 0.0);
+         } else if (p_90577_ instanceof LivingEntity && ((LivingEntity)p_90577_).isSleeping()) {
+             Direction direction = ((LivingEntity)p_90577_).getBedOrientation();
+             this.setRotation(direction != null ? direction.toYRot() - 180.0F : 0.0F, 0.0F);
+@@ -223,6 +_,18 @@
+ 
+     public float getPartialTickTime() {
+         return this.partialTickTime;
++    }
++
 +    public void setAnglesInternal(float yaw, float pitch) {
 +        this.yRot = yaw;
 +        this.xRot = pitch;
@@ -14,8 +25,6 @@
 +            return net.minecraft.world.level.block.Blocks.AIR.defaultBlockState();
 +        else
 +            return this.level.getBlockState(this.blockPosition).getStateAtViewpoint(this.level, this.blockPosition, this.position);
-+    }
-+
+     }
+ 
      @OnlyIn(Dist.CLIENT)
-     public static class NearPlane {
-         final Vec3 forward;

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -131,6 +131,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.AddSectionGeometryEvent;
+import net.neoforged.neoforge.client.event.CalculateDetachedCameraDistanceEvent;
 import net.neoforged.neoforge.client.event.CalculatePlayerTurnEvent;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.ClientChatReceivedEvent;
@@ -345,6 +346,12 @@ public class ClientHooks {
         var event = new CalculatePlayerTurnEvent(mouseSensitivity, cinematicCameraEnabled);
         NeoForge.EVENT_BUS.post(event);
         return event;
+    }
+    
+    public static double getDetachedCameraDistance(Camera camera, boolean flipped) {
+        var event = new CalculateDetachedCameraDistanceEvent(camera, flipped);
+        NeoForge.EVENT_BUS.post(event);
+        return event.getDistance();
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -348,8 +348,8 @@ public class ClientHooks {
         return event;
     }
     
-    public static double getDetachedCameraDistance(Camera camera, boolean flipped) {
-        var event = new CalculateDetachedCameraDistanceEvent(camera, flipped);
+    public static double getDetachedCameraDistance(Camera camera, boolean flipped, double distance) {
+        var event = new CalculateDetachedCameraDistanceEvent(camera, flipped, distance);
         NeoForge.EVENT_BUS.post(event);
         return event.getDistance();
     }

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -347,7 +347,7 @@ public class ClientHooks {
         NeoForge.EVENT_BUS.post(event);
         return event;
     }
-    
+
     public static double getDetachedCameraDistance(Camera camera, boolean flipped, double distance) {
         var event = new CalculateDetachedCameraDistanceEvent(camera, flipped, distance);
         NeoForge.EVENT_BUS.post(event);

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import net.minecraft.client.Camera;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.BlockGetter;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Fired in {@linkplain Camera#setup(BlockGetter, Entity, boolean, boolean, float) Camera#setup(BlockGetter, Entity, boolean, boolean, float)} when camera is detached before calculating the distance of the camera from the {@linkplain Camera#getEntity() camera entity} based on a hard-coded maximum and a raycast.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
+ *
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class CalculateDetachedCameraDistanceEvent extends Event {
+    
+    private final Camera camera;
+    private final boolean cameraFlipped;
+    
+    private double distance = 4D; // might need to be set in constructor if vanilla ever makes this dynamic
+    
+    @ApiStatus.Internal
+    public CalculateDetachedCameraDistanceEvent(Camera camera, boolean cameraFlipped) {
+        this.camera = camera;
+        this.cameraFlipped = cameraFlipped;
+    }
+    
+    /**
+     * Returns the {@linkplain Camera camera} instance.
+     */
+    public Camera getCamera() {
+        return camera;
+    }
+    
+    /**
+     * Returns `true` if the camera is flipped (ie facing backward instead of forward).
+     */
+    public boolean isCameraFlipped() {
+        return cameraFlipped;
+    }
+    
+    /**
+     * Returns the distance from the camera to the {@linkplain Camera#getEntity() camera entity}.
+     */
+    public double getDistance() {
+        return distance;
+    }
+    
+    /**
+     * Sets the distance from the camera to the {@linkplain Camera#getEntity() camera entity}.
+     * 
+     * @param distance The new distance from the camera to the {@linkplain Camera#getEntity() camera entity}
+     */
+    public void setDistance(double distance) {
+        this.distance = distance;
+    }
+    
+}

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
@@ -27,12 +27,13 @@ public class CalculateDetachedCameraDistanceEvent extends Event {
     private final Camera camera;
     private final boolean cameraFlipped;
     
-    private double distance = 4D; // might need to be set in constructor if vanilla ever makes this dynamic
+    private double distance;
     
     @ApiStatus.Internal
-    public CalculateDetachedCameraDistanceEvent(Camera camera, boolean cameraFlipped) {
+    public CalculateDetachedCameraDistanceEvent(Camera camera, boolean cameraFlipped, double distance) {
         this.camera = camera;
         this.cameraFlipped = cameraFlipped;
+        this.distance = distance;
     }
     
     /**

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
@@ -6,8 +6,6 @@
 package net.neoforged.neoforge.client.event;
 
 import net.minecraft.client.Camera;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.BlockGetter;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
@@ -15,7 +13,8 @@ import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * Fired in {@linkplain Camera#setup(BlockGetter, Entity, boolean, boolean, float) Camera#setup(BlockGetter, Entity, boolean, boolean, float)} when camera is detached before calculating the distance of the camera from the {@linkplain Camera#getEntity() camera entity} based on a hard-coded maximum and a raycast.
+ * Fired for hooking the maximum distance from the player to the camera in third-person view.
+ * The ray-cast that reduces this distance based on the blocks around the player is invoked after this event is fired.
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *

--- a/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
@@ -23,40 +23,39 @@ import org.jetbrains.annotations.ApiStatus;
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class CalculateDetachedCameraDistanceEvent extends Event {
-    
     private final Camera camera;
     private final boolean cameraFlipped;
-    
+
     private double distance;
-    
+
     @ApiStatus.Internal
     public CalculateDetachedCameraDistanceEvent(Camera camera, boolean cameraFlipped, double distance) {
         this.camera = camera;
         this.cameraFlipped = cameraFlipped;
         this.distance = distance;
     }
-    
+
     /**
      * Returns the {@linkplain Camera camera} instance.
      */
     public Camera getCamera() {
         return camera;
     }
-    
+
     /**
      * Returns `true` if the camera is flipped (ie facing backward instead of forward).
      */
     public boolean isCameraFlipped() {
         return cameraFlipped;
     }
-    
+
     /**
      * Returns the distance from the camera to the {@linkplain Camera#getEntity() camera entity}.
      */
     public double getDistance() {
         return distance;
     }
-    
+
     /**
      * Sets the distance from the camera to the {@linkplain Camera#getEntity() camera entity}.
      * 
@@ -65,5 +64,4 @@ public class CalculateDetachedCameraDistanceEvent extends Event {
     public void setDistance(double distance) {
         this.distance = distance;
     }
-    
 }


### PR DESCRIPTION
This PR adds an event which allows hooking the distance of the third-person camera from the camera entity.

I intend to use it in my mod, [Zume](https://github.com/Nolij/Zume), and it can also be used in other existing mods to replace less cross-compatible mixins, such as [this one](https://github.com/terrarium-earth/Ad-Astra/blob/1.20.x/common/src/main/java/earth/terrarium/adastra/mixins/client/CameraMixin.java) in Ad Astra.