### PR TITLE
Fix bug with non Player Camera Entities causing crashes introduced by #627

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/ExtendedGui.java
@@ -119,6 +119,10 @@ public class ExtendedGui extends Gui {
         return minecraft.gameMode.canHurtPlayer() && minecraft.getCameraEntity() instanceof Player;
     }
 
+    public boolean shouldDrawPlayerElements() {
+        return minecraft.getCameraEntity() instanceof Player;
+    }
+
     protected void renderSubtitles(GuiGraphics guiGraphics) {
         this.subtitleOverlay.render(guiGraphics);
     }

--- a/src/main/java/net/neoforged/neoforge/client/gui/overlay/VanillaGuiOverlay.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/overlay/VanillaGuiOverlay.java
@@ -105,7 +105,7 @@ public enum VanillaGuiOverlay {
         }
     }),
     MOUNT_HEALTH("mount_health", (gui, guiGraphics, partialTick, screenWidth, screenHeight) -> {
-        if (!gui.getMinecraft().options.hideGui) {
+        if (!gui.getMinecraft().options.hideGui && gui.shouldDrawPlayerElements()) {
             gui.setupOverlayRenderState(true, false);
             gui.renderHealthMount(screenWidth, screenHeight, guiGraphics);
         }


### PR DESCRIPTION
[Discord Discussion](https://discord.com/channels/313125603924639766/852298000042164244/1214514795232108594)

#627 removed an intergral check for whether the current camera entity is an instance of a Player causing [crashes](https://pastebin.com/Biz9NETF) when a non Player Camera Entity is used, this reintroduces that check.