### PR TITLE
Synchronize the Fluid Registry with clients

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -36,6 +36,7 @@ public class NeoForgeRegistriesSetup {
             BuiltInRegistries.ENCHANTMENT, // Required for EnchantmentMenu syncing
             BuiltInRegistries.ENTITY_TYPE, // Required for Entity spawn packets
             BuiltInRegistries.ITEM, // Required for Item/ItemStack packets
+            BuiltInRegistries.FLUID, // Required for Fluid/FluidStack packets
             BuiltInRegistries.PARTICLE_TYPE, // Required for ParticleType packets
             BuiltInRegistries.BLOCK_ENTITY_TYPE, // Required for BlockEntity packets
             BuiltInRegistries.PAINTING_VARIANT, // Required for EntityDataSerializers


### PR DESCRIPTION
Fixes server/client fluid mismatches due to network serialization of fluids as part of recipe serializers or FluidStack.

As observed on ForgeCraft, mods use numeric ids for serializing Fluids between server/client, since this worked before the rework.

This also affects Neoforge itself since FluidStack relies on numeric ids to serialize the Fluid: 
https://github.com/neoforged/NeoForge/blob/1.20.x/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java#L129

