### PR TITLE
Improve performance of entity fluid ticking

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -154,7 +154,7 @@
 -        double d0 = this.level().dimensionType().ultraWarm() ? 0.007 : 0.0023333333333333335;
 -        boolean flag = this.updateFluidHeightAndDoFluidPushing(FluidTags.LAVA, d0);
 -        return this.isInWater() || flag;
-+        if (!(this.getVehicle() instanceof Boat)) {
++        if (this.isInFluidType() && !(this.getVehicle() instanceof Boat)) {
 +            this.fallDistance *= this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().filter(e -> !e.getKey().isAir() && !e.getKey().isVanilla()).map(e -> this.getFluidFallDistanceModifier(e.getKey())).min(Float::compare).orElse(1F);
 +            if (this.isInFluidType((fluidType, height) -> !fluidType.isAir() && !fluidType.isVanilla() && this.canFluidExtinguish(fluidType))) this.clearFire();
 +        }
@@ -410,11 +410,11 @@
          } else {
              AABB aabb = this.getBoundingBox().deflate(0.001);
              int i = Mth.floor(aabb.minX);
-@@ -3093,25 +_,28 @@
+@@ -3093,25 +_,31 @@
              Vec3 vec3 = Vec3.ZERO;
              int k1 = 0;
              BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
-+            it.unimi.dsi.fastutil.objects.Object2ObjectMap<net.neoforged.neoforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>> interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>(net.neoforged.neoforge.fluids.FluidType.SIZE.get() - 1);
++            it.unimi.dsi.fastutil.objects.Object2ObjectMap<net.neoforged.neoforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>> interimCalcs = null;
  
              for(int l1 = i; l1 < j; ++l1) {
                  for(int i2 = k; i2 < l; ++i2) {
@@ -429,6 +429,9 @@
                                  flag1 = true;
 -                                d0 = Math.max(d1 - aabb.minY, d0);
 -                                if (flag) {
++                                if (interimCalcs == null) {
++                                    interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>(net.neoforged.neoforge.fluids.FluidType.SIZE.get() - 1);
++                                }
 +                                org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer> interim = interimCalcs.computeIfAbsent(fluidType, t -> org.apache.commons.lang3.tuple.MutableTriple.of(0.0D, Vec3.ZERO, 0));
 +                                interim.setLeft(Math.max(d1 - aabb.minY, interim.getLeft()));
 +                                if (this.isPushedByFluid(fluidType)) {
@@ -446,13 +449,14 @@
                                  }
                              }
                          }
-@@ -3119,27 +_,28 @@
+@@ -3119,27 +_,30 @@
                  }
              }
  
 -            if (vec3.length() > 0.0) {
 -                if (k1 > 0) {
 -                    vec3 = vec3.scale(1.0 / (double)k1);
++            if(interimCalcs != null) {
 +            interimCalcs.forEach((fluidType, interim) -> {
 +            if (interim.getMiddle().length() > 0.0D) {
 +                if (interim.getRight() > 0) {
@@ -482,6 +486,7 @@
 -            return flag1;
 +            this.setFluidTypeHeight(fluidType, interim.getLeft());
 +            });
++            }
          }
      }
  
@@ -532,7 +537,7 @@
      public void setMaxUpStep(float p_275672_) {
          this.maxUpStep = p_275672_;
      }
-@@ -3419,6 +_,120 @@
+@@ -3419,6 +_,123 @@
      public boolean mayInteract(Level p_146843_, BlockPos p_146844_) {
          return true;
      }
@@ -615,6 +620,9 @@
 +    }
 +    @Override
 +    public final boolean isInFluidType(java.util.function.BiPredicate<net.neoforged.neoforge.fluids.FluidType, Double> predicate, boolean forAllTypes) {
++        if (this.forgeFluidTypeHeight.isEmpty()) {
++            return false;
++        }
 +        return forAllTypes ? this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().allMatch(e -> predicate.test(e.getKey(), e.getDoubleValue()))
 +                  : this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().anyMatch(e -> predicate.test(e.getKey(), e.getDoubleValue()));
 +    }

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -435,7 +435,7 @@
 -                                d0 = Math.max(d1 - aabb.minY, d0);
 -                                if (flag) {
 +                                if (interimCalcs == null) {
-+                                    interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>(net.neoforged.neoforge.fluids.FluidType.SIZE.get() - 1);
++                                    interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>();
 +                                }
 +                                InterimCalculation interim = interimCalcs.computeIfAbsent(fluidType, t -> new InterimCalculation());
 +                                interim.fluidHeight = Math.max(d1 - aabb.minY, interim.fluidHeight);

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -537,7 +537,7 @@
      public void setMaxUpStep(float p_275672_) {
          this.maxUpStep = p_275672_;
      }
-@@ -3419,6 +_,123 @@
+@@ -3419,6 +_,126 @@
      public boolean mayInteract(Level p_146843_, BlockPos p_146844_) {
          return true;
      }
@@ -636,6 +636,9 @@
 +    }
 +    @Override
 +    public net.neoforged.neoforge.fluids.FluidType getMaxHeightFluidType() {
++        if (this.forgeFluidTypeHeight.isEmpty()) {
++            return net.neoforged.neoforge.common.NeoForgeMod.EMPTY_TYPE.value();
++        }
 +        return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.neoforged.neoforge.common.NeoForgeMod.EMPTY_TYPE::value);
 +    }
 +

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -410,11 +410,16 @@
          } else {
              AABB aabb = this.getBoundingBox().deflate(0.001);
              int i = Mth.floor(aabb.minX);
-@@ -3093,25 +_,31 @@
+@@ -3093,25 +_,36 @@
              Vec3 vec3 = Vec3.ZERO;
              int k1 = 0;
              BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
-+            it.unimi.dsi.fastutil.objects.Object2ObjectMap<net.neoforged.neoforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>> interimCalcs = null;
++            class InterimCalculation {
++                double fluidHeight = 0.0D;
++                Vec3 flowVector = Vec3.ZERO;
++                int blockCount = 0;
++            }
++            it.unimi.dsi.fastutil.objects.Object2ObjectMap<net.neoforged.neoforge.fluids.FluidType, InterimCalculation> interimCalcs = null;
  
              for(int l1 = i; l1 < j; ++l1) {
                  for(int i2 = k; i2 < l; ++i2) {
@@ -432,20 +437,20 @@
 +                                if (interimCalcs == null) {
 +                                    interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>(net.neoforged.neoforge.fluids.FluidType.SIZE.get() - 1);
 +                                }
-+                                org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer> interim = interimCalcs.computeIfAbsent(fluidType, t -> org.apache.commons.lang3.tuple.MutableTriple.of(0.0D, Vec3.ZERO, 0));
-+                                interim.setLeft(Math.max(d1 - aabb.minY, interim.getLeft()));
++                                InterimCalculation interim = interimCalcs.computeIfAbsent(fluidType, t -> new InterimCalculation());
++                                interim.fluidHeight = Math.max(d1 - aabb.minY, interim.fluidHeight);
 +                                if (this.isPushedByFluid(fluidType)) {
                                      Vec3 vec31 = fluidstate.getFlow(this.level(), blockpos$mutableblockpos);
 -                                    if (d0 < 0.4) {
 -                                        vec31 = vec31.scale(d0);
-+                                    if (interim.getLeft() < 0.4D) {
-+                                        vec31 = vec31.scale(interim.getLeft());
++                                    if (interim.fluidHeight < 0.4D) {
++                                        vec31 = vec31.scale(interim.fluidHeight);
                                      }
  
 -                                    vec3 = vec3.add(vec31);
 -                                    ++k1;
-+                                    interim.setMiddle(interim.getMiddle().add(vec31));
-+                                    interim.setRight(interim.getRight() + 1);
++                                    interim.flowVector = interim.flowVector.add(vec31);
++                                    interim.blockCount++;
                                  }
                              }
                          }
@@ -458,33 +463,33 @@
 -                    vec3 = vec3.scale(1.0 / (double)k1);
 +            if(interimCalcs != null) {
 +            interimCalcs.forEach((fluidType, interim) -> {
-+            if (interim.getMiddle().length() > 0.0D) {
-+                if (interim.getRight() > 0) {
-+                    interim.setMiddle(interim.getMiddle().scale(1.0D / (double)interim.getRight()));
++            if (interim.flowVector.length() > 0.0D) {
++                if (interim.blockCount > 0) {
++                    interim.flowVector = interim.flowVector.scale(1.0D / (double)interim.blockCount);
                  }
  
                  if (!(this instanceof Player)) {
 -                    vec3 = vec3.normalize();
-+                    interim.setMiddle(interim.getMiddle().normalize());
++                    interim.flowVector = interim.flowVector.normalize();
                  }
  
                  Vec3 vec32 = this.getDeltaMovement();
 -                vec3 = vec3.scale(p_204033_ * 1.0);
-+                interim.setMiddle(interim.getMiddle().scale(this.getFluidMotionScale(fluidType)));
++                interim.flowVector = interim.flowVector.scale(this.getFluidMotionScale(fluidType));
                  double d2 = 0.003;
 -                if (Math.abs(vec32.x) < 0.003 && Math.abs(vec32.z) < 0.003 && vec3.length() < 0.0045000000000000005) {
 -                    vec3 = vec3.normalize().scale(0.0045000000000000005);
-+                if (Math.abs(vec32.x) < 0.003D && Math.abs(vec32.z) < 0.003D && interim.getMiddle().length() < 0.0045000000000000005D) {
-+                    interim.setMiddle(interim.getMiddle().normalize().scale(0.0045000000000000005D));
++                if (Math.abs(vec32.x) < 0.003D && Math.abs(vec32.z) < 0.003D && interim.flowVector.length() < 0.0045000000000000005D) {
++                    interim.flowVector = interim.flowVector.normalize().scale(0.0045000000000000005D);
                  }
  
 -                this.setDeltaMovement(this.getDeltaMovement().add(vec3));
-+                this.setDeltaMovement(this.getDeltaMovement().add(interim.getMiddle()));
++                this.setDeltaMovement(this.getDeltaMovement().add(interim.flowVector));
              }
  
 -            this.fluidHeight.put(p_204032_, d0);
 -            return flag1;
-+            this.setFluidTypeHeight(fluidType, interim.getLeft());
++            this.setFluidTypeHeight(fluidType, interim.fluidHeight);
 +            });
 +            }
          }


### PR DESCRIPTION
This PR applies some trivial optimizations to NeoForge's logic for ticking entities within fluids that are fairly simple and should not break anything. Listed in order:

* The fall distance and extinguishment logic in `Entity#updateInWaterStateAndDoFluidPushing` is now skipped if the entity is outside a fluid. This should behave identically to the old code, because it would multiply the fall distance by 1 and the `isInFluidType` call would return `false` since the fluid height map is empty. This saves some CPU time and avoids allocation of the streams/optional/method handles inside that `if` block.
* The `interimCalcs` map in `Entity#updateFluidHeightAndDoFluidPushing` is now not allocated until the entity is found to be intersecting a fluid state. This is important because most entities are not in fluids on a given tick, so allocating the map ends up being pointless. 
* The `interimCalcs` map now stores a simple local class for the values instead of a `MutableTriple`, which avoids boxing.
* `Entity#getMaxHeightFluidType` and the predicate version of `Entity#isInFluidType` now check if the fluid height map is empty and early-exits. This allows the vast majority of calls to fail fast and avoid the overhead of setting up a stream and allocating a capturing lambda.

All of these changes were guided by profiling, but as an example, here's a profiler screenshot showing the heavy allocations in `updateInWaterStateAndDoFluidPushing` (it is hard to see without context, but this does end up being quite hot overall).

![allocation_hot](https://github.com/neoforged/NeoForge/assets/42941056/dd5a9f9b-529d-480c-bc8f-9052806c9885)

In general, more performance could probably be extracted by revamping this code to not use streams, but I've attempted to keep the changes minimal since I believe the fluid system is getting overhauled a second time anyway in the future. Future work should keep in mind that any code needs to be fast since it is going to run on every entity, every tick.