### PR TITLE
Fix inaccessible constructor in `AddTableLootModifier`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/loot/AddTableLootModifier.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/AddTableLootModifier.java
@@ -44,7 +44,7 @@ public class AddTableLootModifier extends LootModifier {
 
     private final ResourceLocation table;
 
-    protected AddTableLootModifier(LootItemCondition[] conditionsIn, ResourceLocation table) {
+    public AddTableLootModifier(LootItemCondition[] conditionsIn, ResourceLocation table) {
         super(conditionsIn);
         this.table = table;
     }


### PR DESCRIPTION
A few weeks ago, I stumbled upon this discord message: https://discord.com/channels/313125603924639766/1116211620415283201/1211359886081007626

Where a modder was struggling with accessing an instance of the loot modifier for data generation. This PR aims to fix that, making the constructor public to let modders access the instance of `AddTableLootModifier`.