### PR TITLE
Add java toolchain block to testframework subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ allprojects {
     }
 }
 
+subprojects {
+    apply plugin: 'java'
+
+    java.toolchain.languageVersion.set(JavaLanguageVersion.of(project.java_version))
+}
+
 apply plugin: 'com.diffplug.spotless'
 apply plugin: 'net.neoforged.licenser'
 

--- a/projects/base/build.gradle
+++ b/projects/base/build.gradle
@@ -1,9 +1,3 @@
 dynamicProject {
     neoform("${project.minecraft_version}-${project.neoform_version}")
 }
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(project.java_version))
-    }
-}

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -15,12 +15,6 @@ installerProfile {
     profile = 'NeoForge'
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(project.java_version))
-    }
-}
-
 minecraft {
     accessTransformers {
         file rootProject.file('src/main/resources/META-INF/accesstransformer.cfg')

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'net.neoforged.licenser'
 def neoforgeProject = project(':neoforge')
 def testframeworkProject = project(':testframework')
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(project.java_version))
-
 repositories {
     mavenLocal()
     maven {


### PR DESCRIPTION
Currently, if your system java is anything besides java 17, the `gradlew runClient` task will fail in neodev due to the testframework subproject not specifying a java version:

```
> ./gradlew runClient

> Configure project :
NeoForge version 20.4.198
Path for java installation '/usr/lib/jvm/openjdk-17' (Common Linux Locations) does not contain a java executable
Path for java installation '/usr/lib/jvm/openjdk-21' (Common Linux Locations) does not contain a java executable

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':tests:compileJava'.
> Could not resolve all task dependencies for configuration ':tests:compileClasspath'.
   > Could not resolve project :testframework.
     Required by:
         project :tests
      > No matching variant of project :testframework was found. The consumer was configured to find a library for use during compile-time, compatible with Java 17, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally but:
          - Variant 'apiElements' capability net.neoforged:testframework:20.4.198 declares a library for use during compile-time, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 19 and the consumer needed a component, compatible with Java 17
              - Other compatible attribute:
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
          - Variant 'mainSourceElements' capability net.neoforged:testframework:20.4.198 declares a component, and its dependencies declared externally:
              - Incompatible because this component declares a component of category 'verification' and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 17)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
                  - Doesn't say anything about its usage (required compile-time)
          - Variant 'runtimeElements' capability net.neoforged:testframework:20.4.198 declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component, compatible with Java 19 and the consumer needed a component, compatible with Java 17
              - Other compatible attribute:
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
          - Variant 'testResultsElementsForTest' capability net.neoforged:testframework:20.4.198:
              - Incompatible because this component declares a component of category 'verification' and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 17)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
                  - Doesn't say anything about its usage (required compile-time)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```

This PR fixes this by specifying a toolchain version in the subproject, just like the other subprojects currently do.