### PR TITLE
[24w11a] Expose PoseStack in RenderLevelStageEvent and RenderHighlightEvent again

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -75,7 +75,7 @@
              .prepareCullFrustum(camera.getPosition(), matrix4f1, this.getProjectionMatrix(Math.max(d0, (double)this.minecraft.options.fov().get().intValue())));
          this.minecraft.levelRenderer.renderLevel(p_109090_, p_109091_, flag, camera, this, this.lightTexture, matrix4f1, matrix4f);
 +        this.minecraft.getProfiler().popPush("neoforge_render_last");
-+        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_LEVEL, this.minecraft.levelRenderer, matrix4f1, matrix4f, this.minecraft.levelRenderer.getTicks(), camera, this.minecraft.levelRenderer.getFrustum());
++        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_LEVEL, this.minecraft.levelRenderer, null, matrix4f1, matrix4f, this.minecraft.levelRenderer.getTicks(), camera, this.minecraft.levelRenderer.getFrustum());
          this.minecraft.getProfiler().popPush("hand");
          if (this.renderHand) {
              RenderSystem.clear(256, Minecraft.ON_OSX);

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -26,7 +26,7 @@
          profilerfiller.popPush("sky");
          RenderSystem.setShader(GameRenderer::getPositionShader);
          this.renderSky(p_254120_, p_323920_, f, p_109604_, flag1, () -> FogRenderer.setupFog(p_109604_, FogRenderer.FogMode.FOG_SKY, f1, flag1, f));
-+        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_SKY, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_SKY, this, null, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
          profilerfiller.popPush("fog");
          FogRenderer.setupFog(p_109604_, FogRenderer.FogMode.FOG_TERRAIN, Math.max(f1, 32.0F), flag1, f);
          profilerfiller.popPush("terrain_setup");
@@ -54,7 +54,7 @@
          multibuffersource$buffersource.endBatch(RenderType.entityCutout(TextureAtlas.LOCATION_BLOCKS));
          multibuffersource$buffersource.endBatch(RenderType.entityCutoutNoCull(TextureAtlas.LOCATION_BLOCKS));
          multibuffersource$buffersource.endBatch(RenderType.entitySmoothCutout(TextureAtlas.LOCATION_BLOCKS));
-+        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_ENTITIES, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_ENTITIES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
          profilerfiller.popPush("blockentities");
  
          for(SectionRenderDispatcher.RenderSection sectionrenderdispatcher$rendersection : this.visibleSections) {
@@ -93,7 +93,7 @@
              this.minecraft.getMainRenderTarget().bindWrite(false);
          }
  
-+        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_BLOCK_ENTITIES, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_BLOCK_ENTITIES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
          profilerfiller.popPush("destroyProgress");
  
          for(Entry<SortedSet<BlockDestructionProgress>> entry : this.destructionProgress.long2ObjectEntrySet()) {
@@ -113,13 +113,13 @@
              profilerfiller.popPush("outline");
              BlockPos blockpos1 = ((BlockHitResult)hitresult).getBlockPos();
              BlockState blockstate = this.level.getBlockState(blockpos1);
-+            if (!net.neoforged.neoforge.client.ClientHooks.onDrawHighlight(this, p_109604_, hitresult, p_109601_, p_254120_, multibuffersource$buffersource))
++            if (!net.neoforged.neoforge.client.ClientHooks.onDrawHighlight(this, p_109604_, hitresult, p_109601_, posestack, multibuffersource$buffersource))
              if (!blockstate.isAir() && this.level.getWorldBorder().isWithinBounds(blockpos1)) {
                  VertexConsumer vertexconsumer2 = multibuffersource$buffersource.getBuffer(RenderType.lines());
                  this.renderHitOutline(posestack, vertexconsumer2, p_109604_.getEntity(), d0, d1, d2, blockpos1, blockstate);
              }
 +        } else if (hitresult != null && hitresult.getType() == HitResult.Type.ENTITY) {
-+            net.neoforged.neoforge.client.ClientHooks.onDrawHighlight(this, p_109604_, hitresult, p_109601_, p_254120_, multibuffersource$buffersource);
++            net.neoforged.neoforge.client.ClientHooks.onDrawHighlight(this, p_109604_, hitresult, p_109601_, posestack, multibuffersource$buffersource);
          }
  
          this.minecraft.debugRenderer.render(posestack, multibuffersource$buffersource, d0, d1, d2);
@@ -129,7 +129,7 @@
              profilerfiller.popPush("particles");
 -            this.minecraft.particleEngine.render(p_109606_, p_109604_, f);
 +            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum);
-+            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
              RenderStateShard.PARTICLES_TARGET.clearRenderState();
          } else {
              profilerfiller.popPush("translucent");
@@ -139,7 +139,7 @@
              profilerfiller.popPush("particles");
 -            this.minecraft.particleEngine.render(p_109606_, p_109604_, f);
 +            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum);
-+            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
          }
  
          if (this.minecraft.options.getCloudsType() != CloudStatus.OFF) {
@@ -147,7 +147,7 @@
              RenderStateShard.WEATHER_TARGET.setupRenderState();
              profilerfiller.popPush("weather");
              this.renderSnowAndRain(p_109606_, f, d0, d1, d2);
-+            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_WEATHER, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_WEATHER, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
              this.renderWorldBorder(p_109604_);
              RenderStateShard.WEATHER_TARGET.clearRenderState();
              this.transparencyChain.process(f);
@@ -155,7 +155,7 @@
              RenderSystem.depthMask(false);
              profilerfiller.popPush("weather");
              this.renderSnowAndRain(p_109606_, f, d0, d1, d2);
-+            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_WEATHER, this, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_WEATHER, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
              this.renderWorldBorder(p_109604_);
              RenderSystem.depthMask(true);
          }

--- a/src/main/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
@@ -36,8 +36,7 @@ public final class BlockEntityRenderBoundsDebugRenderer {
         }
 
         LevelRenderer levelRenderer = Minecraft.getInstance().levelRenderer;
-        PoseStack poseStack = new PoseStack();
-        poseStack.mulPose(event.getModelViewMatrix());
+        PoseStack poseStack = event.getPoseStack();
         Vec3 camera = event.getCamera().getPosition();
         VertexConsumer consumer = Minecraft.getInstance().renderBuffers().bufferSource().getBuffer(RenderType.lines());
 

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -244,32 +244,32 @@ public class ClientHooks {
         NeoForge.EVENT_BUS.post(new ClientPauseUpdatedEvent(paused));
     }
 
-    public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, Matrix4f modelViewMatrix, MultiBufferSource bufferSource) {
+    public static boolean onDrawHighlight(LevelRenderer context, Camera camera, HitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource) {
         switch (target.getType()) {
             case BLOCK:
                 if (!(target instanceof BlockHitResult blockTarget)) return false;
-                return NeoForge.EVENT_BUS.post(new RenderHighlightEvent.Block(context, camera, blockTarget, partialTick, modelViewMatrix, bufferSource)).isCanceled();
+                return NeoForge.EVENT_BUS.post(new RenderHighlightEvent.Block(context, camera, blockTarget, partialTick, poseStack, bufferSource)).isCanceled();
             case ENTITY:
                 if (!(target instanceof EntityHitResult entityTarget)) return false;
-                NeoForge.EVENT_BUS.post(new RenderHighlightEvent.Entity(context, camera, entityTarget, partialTick, modelViewMatrix, bufferSource));
+                NeoForge.EVENT_BUS.post(new RenderHighlightEvent.Entity(context, camera, entityTarget, partialTick, poseStack, bufferSource));
                 return false;
             default:
                 return false; // NO-OP - This doesn't even get called for anything other than blocks and entities
         }
     }
 
-    public static void dispatchRenderStage(RenderLevelStageEvent.Stage stage, LevelRenderer levelRenderer, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, Camera camera, Frustum frustum) {
+    public static void dispatchRenderStage(RenderLevelStageEvent.Stage stage, LevelRenderer levelRenderer, @Nullable PoseStack poseStack, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, Camera camera, Frustum frustum) {
         var mc = Minecraft.getInstance();
         var profiler = mc.getProfiler();
         profiler.push(stage.toString());
-        NeoForge.EVENT_BUS.post(new RenderLevelStageEvent(stage, levelRenderer, modelViewMatrix, projectionMatrix, renderTick, mc.getPartialTick(), camera, frustum));
+        NeoForge.EVENT_BUS.post(new RenderLevelStageEvent(stage, levelRenderer, poseStack, modelViewMatrix, projectionMatrix, renderTick, mc.getPartialTick(), camera, frustum));
         profiler.pop();
     }
 
     public static void dispatchRenderStage(RenderType renderType, LevelRenderer levelRenderer, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, Camera camera, Frustum frustum) {
         RenderLevelStageEvent.Stage stage = RenderLevelStageEvent.Stage.fromRenderType(renderType);
         if (stage != null)
-            dispatchRenderStage(stage, levelRenderer, modelViewMatrix, projectionMatrix, renderTick, camera, frustum);
+            dispatchRenderStage(stage, levelRenderer, null, modelViewMatrix, projectionMatrix, renderTick, camera, frustum);
     }
 
     public static boolean renderSpecificFirstPersonHand(InteractionHand hand, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, float partialTick, float interpPitch, float swingProgress, float equipProgress, ItemStack stack) {

--- a/src/main/java/net/neoforged/neoforge/client/event/RenderHighlightEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RenderHighlightEvent.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.client.event;
 
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -16,7 +17,6 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
-import org.joml.Matrix4f;
 
 /**
  * Fired before a selection highlight is rendered.
@@ -30,16 +30,16 @@ public abstract class RenderHighlightEvent extends Event {
     private final Camera camera;
     private final HitResult target;
     private final float partialTick;
-    private final Matrix4f modelViewMatrix;
+    private final PoseStack poseStack;
     private final MultiBufferSource multiBufferSource;
 
     @ApiStatus.Internal
-    protected RenderHighlightEvent(LevelRenderer levelRenderer, Camera camera, HitResult target, float partialTick, Matrix4f modelViewMatrix, MultiBufferSource multiBufferSource) {
+    protected RenderHighlightEvent(LevelRenderer levelRenderer, Camera camera, HitResult target, float partialTick, PoseStack poseStack, MultiBufferSource multiBufferSource) {
         this.levelRenderer = levelRenderer;
         this.camera = camera;
         this.target = target;
         this.partialTick = partialTick;
-        this.modelViewMatrix = modelViewMatrix;
+        this.poseStack = poseStack;
         this.multiBufferSource = multiBufferSource;
     }
 
@@ -72,10 +72,10 @@ public abstract class RenderHighlightEvent extends Event {
     }
 
     /**
-     * {@return the model view matrix used for rendering}
+     * {@return the pose stack used for rendering}
      */
-    public Matrix4f getModelViewMatrix() {
-        return modelViewMatrix;
+    public PoseStack getPoseStack() {
+        return poseStack;
     }
 
     /**
@@ -96,8 +96,8 @@ public abstract class RenderHighlightEvent extends Event {
      */
     public static class Block extends RenderHighlightEvent implements ICancellableEvent {
         @ApiStatus.Internal
-        public Block(LevelRenderer levelRenderer, Camera camera, BlockHitResult target, float partialTick, Matrix4f modelViewMatrix, MultiBufferSource bufferSource) {
-            super(levelRenderer, camera, target, partialTick, modelViewMatrix, bufferSource);
+        public Block(LevelRenderer levelRenderer, Camera camera, BlockHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource) {
+            super(levelRenderer, camera, target, partialTick, poseStack, bufferSource);
         }
 
         /**
@@ -119,8 +119,8 @@ public abstract class RenderHighlightEvent extends Event {
      */
     public static class Entity extends RenderHighlightEvent {
         @ApiStatus.Internal
-        public Entity(LevelRenderer levelRenderer, Camera camera, EntityHitResult target, float partialTick, Matrix4f modelViewMatrix, MultiBufferSource bufferSource) {
-            super(levelRenderer, camera, target, partialTick, modelViewMatrix, bufferSource);
+        public Entity(LevelRenderer levelRenderer, Camera camera, EntityHitResult target, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource) {
+            super(levelRenderer, camera, target, partialTick, poseStack, bufferSource);
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
@@ -5,9 +5,9 @@
 
 package net.neoforged.neoforge.client.event;
 
+import com.mojang.blaze3d.vertex.PoseStack;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
 import net.minecraft.client.Camera;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
@@ -21,6 +21,7 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.neoforge.client.NeoForgeRenderTypes;
 import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 
 /**
@@ -35,6 +36,7 @@ import org.joml.Matrix4f;
 public class RenderLevelStageEvent extends Event {
     private final Stage stage;
     private final LevelRenderer levelRenderer;
+    private final PoseStack poseStack;
     private final Matrix4f modelViewMatrix;
     private final Matrix4f projectionMatrix;
     private final int renderTick;
@@ -42,9 +44,10 @@ public class RenderLevelStageEvent extends Event {
     private final Camera camera;
     private final Frustum frustum;
 
-    public RenderLevelStageEvent(Stage stage, LevelRenderer levelRenderer, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, float partialTick, Camera camera, Frustum frustum) {
+    public RenderLevelStageEvent(Stage stage, LevelRenderer levelRenderer, @Nullable PoseStack poseStack, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, float partialTick, Camera camera, Frustum frustum) {
         this.stage = stage;
         this.levelRenderer = levelRenderer;
+        this.poseStack = poseStack != null ? poseStack : new PoseStack();
         this.modelViewMatrix = modelViewMatrix;
         this.projectionMatrix = projectionMatrix;
         this.renderTick = renderTick;
@@ -66,6 +69,13 @@ public class RenderLevelStageEvent extends Event {
      */
     public LevelRenderer getLevelRenderer() {
         return levelRenderer;
+    }
+
+    /**
+     * {@return the pose stack used for rendering}
+     */
+    public PoseStack getPoseStack() {
+        return poseStack;
     }
 
     /**

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
@@ -128,8 +128,7 @@ public class RenderableTest {
 
             Vec3 cam = event.getCamera().getPosition();
             if (xOffset > -1) {
-                PoseStack poseStack = new PoseStack();
-                poseStack.mulPose(event.getModelViewMatrix());
+                PoseStack poseStack = event.getPoseStack();
                 render(stage, poseStack, event.getRenderTick(), event.getPartialTick(), cam.x, cam.y, cam.z, xOffset);
             }
         }


### PR DESCRIPTION
This PR exposes the `PoseStack` again in `RenderLevelStageEvent` and `RenderHighlightEvent`. I initially misinterpreted the relation between the model view matrix and the pose stack when handling this in the 24w07a port. However, due to the pose stack not being available anymore in some contexts (`AFTER_SKY` stage, `AFTER_LEVEL` stage and all chunk layer stages), the pose stack now has to be constructed by the event in these cases instead of using one provided by the level renderer. I have opted to immediately make one if the given one is null, though I would like to discuss whether making one on demand would be better considering most of the affected render stages are rarely used.