### PR TITLE
FluidResource and ItemResource proof of concept

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -9,6 +9,17 @@
      private static final Codec<Holder<Item>> ITEM_NON_AIR_CODEC = ExtraCodecs.validate(
          BuiltInRegistries.ITEM.holderByNameCodec(),
          p_330100_ -> p_330100_.is(Items.AIR.builtInRegistryHolder()) ? DataResult.error(() -> "Item must not be minecraft:air") : DataResult.success(p_330100_)
+@@ -204,6 +_,10 @@
+         return !this.isEmpty() ? this.components.asPatch() : DataComponentPatch.EMPTY;
+     }
+ 
++    public static ItemStack of(net.neoforged.neoforge.transfer.ResourceAmount<net.neoforged.neoforge.items.ItemResource> resourceAmount) {
++        return resourceAmount.resource().toStack(resourceAmount.amount());
++    }
++
+     public ItemStack(ItemLike p_41599_) {
+         this(p_41599_, 1);
+     }
 @@ -291,7 +_,7 @@
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -150,7 +150,6 @@ import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.fluids.BaseFlowingFluid;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.fluids.FluidResource;
-import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.forge.snapshots.ForgeSnapshotsMod;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
@@ -213,9 +212,8 @@ public class NeoForgeMod {
      * Inter-mod fluid container interactions should happen using {@link Capabilities.FluidHandler#ITEM}.</b>
      */
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<ResourceAmount<FluidResource>>> FLUID_STACK_COMPONENT = DATA_COMPONENTS.register("fluid_stack", () -> DataComponentType.<ResourceAmount<FluidResource>>builder()
-            // TODO: we need proper codec support somewhere
-            .persistent(FluidStack.CODEC.xmap(fs -> new ResourceAmount<>(FluidResource.of(fs), fs.getAmount()), ra -> ra.resource().toStack(ra.amount())))
-            // TODO restore .networkSynchronized(FluidStack.STREAM_CODEC)
+            .persistent(FluidResource.OPTIONAL_WITH_AMOUNT_CODEC)
+            .networkSynchronized(ResourceAmount.streamCodec(FluidResource.OPTIONAL_STREAM_CODEC))
             .build());
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -149,6 +149,7 @@ import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.fluids.BaseFlowingFluid;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
+import net.neoforged.neoforge.fluids.FluidResource;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.forge.snapshots.ForgeSnapshotsMod;
@@ -172,6 +173,7 @@ import net.neoforged.neoforge.server.command.ModIdArgument;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
 import net.neoforged.neoforge.server.permission.nodes.PermissionNode;
 import net.neoforged.neoforge.server.permission.nodes.PermissionTypes;
+import net.neoforged.neoforge.transfer.ResourceAmount;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
@@ -209,12 +211,12 @@ public class NeoForgeMod {
      * <p><b>This component should only be used on item stacks from your mod.
      * Otherwise, do not query it or assume it exists.
      * Inter-mod fluid container interactions should happen using {@link Capabilities.FluidHandler#ITEM}.</b>
-     *
-     * <p><b>Do not mutate the returned fluid stack.</b>
-     *
-     * TODO 1.20.5: replace by immutable FluidStack version/wrapper.
      */
-    public static final DeferredHolder<DataComponentType<?>, DataComponentType<FluidStack>> FLUID_STACK_COMPONENT = DATA_COMPONENTS.register("fluid_stack", () -> DataComponentType.<FluidStack>builder().persistent(FluidStack.CODEC).networkSynchronized(FluidStack.STREAM_CODEC).build());
+    public static final DeferredHolder<DataComponentType<?>, DataComponentType<ResourceAmount<FluidResource>>> FLUID_STACK_COMPONENT = DATA_COMPONENTS.register("fluid_stack", () -> DataComponentType.<ResourceAmount<FluidResource>>builder()
+            // TODO: we need proper codec support somewhere
+            .persistent(FluidStack.CODEC.xmap(fs -> new ResourceAmount<>(FluidResource.of(fs), fs.getAmount()), ra -> ra.resource().toStack(ra.amount())))
+            // TODO restore .networkSynchronized(FluidStack.STREAM_CODEC)
+            .build());
 
     /**
      * Stock loot modifier type that adds loot from a subtable to the final loot.

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -38,6 +38,8 @@ import net.neoforged.neoforge.capabilities.ItemCapability;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
 import net.neoforged.neoforge.event.EventHooks;
+import net.neoforged.neoforge.items.ItemResource;
+import net.neoforged.neoforge.transfer.ResourceAmount;
 import org.jetbrains.annotations.Nullable;
 
 /*
@@ -491,5 +493,12 @@ public interface IItemStackExtension {
     @Nullable
     default <T> T getCapability(ItemCapability<T, Void> capability) {
         return capability.getCapability(self(), null);
+    }
+
+    /**
+     * Creates a new {@link ResourceAmount} that represents this item stack.
+     */
+    default ResourceAmount<ItemResource> immutable() {
+        return new ResourceAmount<>(ItemResource.of(self()), self().getCount());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidResource.java
@@ -1,0 +1,61 @@
+package net.neoforged.neoforge.fluids;
+
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.transfer.IResource;
+
+/**
+ * Immutable combination of a {@link Fluid} and data components.
+ * Similar to a {@link FluidStack}, but immutable and without amount information.
+ */
+public final class FluidResource implements IResource, DataComponentHolder {
+    // TODO: we need codecs and stream codecs...
+    public static final FluidResource EMPTY = new FluidResource(FluidStack.EMPTY);
+
+    public static FluidResource of(FluidStack fluidStack) {
+        return fluidStack.isEmpty() ? EMPTY : new FluidResource(fluidStack.copyWithAmount(1));
+    }
+
+    /**
+     * We wrap a fluid stack which must never be exposed and/or modified.
+     */
+    private final FluidStack innerStack;
+
+    private FluidResource(FluidStack innerStack) {
+        this.innerStack = innerStack;
+    }
+
+    @Override
+    public boolean isBlank() {
+        return innerStack.isEmpty();
+    }
+
+    public Fluid getFluid() {
+        return innerStack.getFluid();
+    }
+
+    @Override
+    public DataComponentMap getComponents() {
+        return innerStack.getComponents();
+    }
+
+    public boolean matches(FluidStack stack) {
+        return FluidStack.isSameFluidSameComponents(stack, innerStack);
+    }
+
+    public FluidStack toStack(int amount) {
+        return this.innerStack.copyWithAmount(amount);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        return obj instanceof FluidResource v && FluidStack.isSameFluidSameComponents(v.innerStack, innerStack);
+    }
+
+    @Override
+    public int hashCode() {
+        return FluidStack.hashFluidAndComponents(innerStack);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidResource.java
@@ -1,20 +1,70 @@
 package net.neoforged.neoforge.fluids;
 
+import com.mojang.serialization.Codec;
+import java.util.Optional;
+import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentHolder;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.transfer.IResource;
+import net.neoforged.neoforge.transfer.ResourceAmount;
 
 /**
  * Immutable combination of a {@link Fluid} and data components.
  * Similar to a {@link FluidStack}, but immutable and without amount information.
  */
 public final class FluidResource implements IResource, DataComponentHolder {
-    // TODO: we need codecs and stream codecs...
+    /**
+     * Codec for a fluid resource.
+     * Same format as {@link FluidStack#fixedAmountCodec}.
+     * Does <b>not</b> accept blank resources.
+     */
+    public static final Codec<FluidResource> CODEC = FluidStack.fixedAmountCodec(1)
+            .xmap(FluidResource::of, r -> r.toStack(1));
+    /**
+     * Codec for a fluid resource. Same format as {@link #CODEC}, and also accepts blank resources.
+     */
+    public static final Codec<FluidResource> OPTIONAL_CODEC = ExtraCodecs.optionalEmptyMap(CODEC)
+            .xmap(o -> o.orElse(FluidResource.EMPTY), r -> r.isBlank() ? Optional.of(FluidResource.EMPTY) : Optional.of(r));
+    /**
+     * Codec for a fluid resource and an amount. Does <b>not</b> accept empty stacks.
+     */
+    public static final Codec<ResourceAmount<FluidResource>> WITH_AMOUNT_CODEC = FluidStack.CODEC
+            .xmap(FluidStack::immutable, FluidStack::of);
+    /**
+     * Codec for a fluid resource and an amount. Accepts empty stacks.
+     */
+    public static final Codec<ResourceAmount<FluidResource>> OPTIONAL_WITH_AMOUNT_CODEC = FluidStack.OPTIONAL_CODEC
+            .xmap(FluidStack::immutable, FluidStack::of);
+    /**
+     * Stream codec for a fluid resource. Accepts blank resources.
+     */
+    public static final StreamCodec<RegistryFriendlyByteBuf, FluidResource> OPTIONAL_STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.holderRegistry(Registries.FLUID),
+            FluidResource::getFluidHolder,
+            DataComponentPatch.STREAM_CODEC,
+            FluidResource::getComponentsPatch,
+            FluidResource::of);
+
     public static final FluidResource EMPTY = new FluidResource(FluidStack.EMPTY);
 
     public static FluidResource of(FluidStack fluidStack) {
         return fluidStack.isEmpty() ? EMPTY : new FluidResource(fluidStack.copyWithAmount(1));
+    }
+
+    public static FluidResource of(Fluid fluid) {
+        return fluid == Fluids.EMPTY ? EMPTY : new FluidResource(new FluidStack(fluid, 1));
+    }
+
+    public static FluidResource of(Holder<Fluid> fluid, DataComponentPatch patch) {
+        return fluid.value() == Fluids.EMPTY ? EMPTY : new FluidResource(new FluidStack(fluid, 1, patch));
     }
 
     /**
@@ -35,9 +85,17 @@ public final class FluidResource implements IResource, DataComponentHolder {
         return innerStack.getFluid();
     }
 
+    public Holder<Fluid> getFluidHolder() {
+        return innerStack.getFluidHolder();
+    }
+
     @Override
     public DataComponentMap getComponents() {
         return innerStack.getComponents();
+    }
+
+    public DataComponentPatch getComponentsPatch() {
+        return innerStack.getComponentsPatch();
     }
 
     public boolean matches(FluidStack stack) {

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidResource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.fluids;
 
 import com.mojang.serialization.Codec;

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -7,8 +7,10 @@ package net.neoforged.neoforge.fluids.capability.templates;
 
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.fluids.FluidResource;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
+import net.neoforged.neoforge.transfer.ResourceAmount;
 
 /**
  * FluidHandlerItemStack is a template capability provider for ItemStacks.
@@ -38,12 +40,12 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
     }
 
     public FluidStack getFluid() {
-        // TODO 1.20.5: should not need a copy if it's immutable.
-        return container.getOrDefault(NeoForgeMod.FLUID_STACK_COMPONENT.get(), FluidStack.EMPTY).copy();
+        var component = container.get(NeoForgeMod.FLUID_STACK_COMPONENT.get());
+        return component == null ? FluidStack.EMPTY : component.resource().toStack(component.amount());
     }
 
     protected void setFluid(FluidStack fluid) {
-        container.set(NeoForgeMod.FLUID_STACK_COMPONENT.get(), fluid);
+        container.set(NeoForgeMod.FLUID_STACK_COMPONENT.get(), new ResourceAmount<>(FluidResource.of(fluid), fluid.getAmount()));
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -7,8 +7,10 @@ package net.neoforged.neoforge.fluids.capability.templates;
 
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.fluids.FluidResource;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
+import net.neoforged.neoforge.transfer.ResourceAmount;
 
 /**
  * FluidHandlerItemStackSimple is a template capability provider for ItemStacks.
@@ -35,12 +37,12 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
     }
 
     public FluidStack getFluid() {
-        // TODO 1.20.5: should not need a copy if it's immutable.
-        return container.getOrDefault(NeoForgeMod.FLUID_STACK_COMPONENT.get(), FluidStack.EMPTY).copy();
+        var component = container.get(NeoForgeMod.FLUID_STACK_COMPONENT.get());
+        return component == null ? FluidStack.EMPTY : component.resource().toStack(component.amount());
     }
 
     protected void setFluid(FluidStack fluid) {
-        container.set(NeoForgeMod.FLUID_STACK_COMPONENT.get(), fluid);
+        container.set(NeoForgeMod.FLUID_STACK_COMPONENT.get(), new ResourceAmount<>(FluidResource.of(fluid), fluid.getAmount()));
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/items/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemResource.java
@@ -1,0 +1,62 @@
+package net.neoforged.neoforge.items;
+
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.transfer.IResource;
+
+/**
+ * Immutable combination of an {@link Item} and data components.
+ * Similar to an {@link ItemStack}, but immutable and without amount information.
+ */
+public final class ItemResource implements IResource, DataComponentHolder {
+    // TODO: we need codecs and stream codecs...
+    public static final ItemResource EMPTY = new ItemResource(ItemStack.EMPTY);
+
+    public static ItemResource of(ItemStack itemStack) {
+        return itemStack.isEmpty() ? EMPTY : new ItemResource(itemStack.copyWithCount(1));
+    }
+
+    /**
+     * We wrap an item stack which must never be exposed and/or modified.
+     */
+    private final ItemStack innerStack;
+
+    private ItemResource(ItemStack innerStack) {
+        this.innerStack = innerStack;
+    }
+
+    @Override
+    public boolean isBlank() {
+        return innerStack.isEmpty();
+    }
+
+    public Item getItem() {
+        return innerStack.getItem();
+    }
+
+    @Override
+    public DataComponentMap getComponents() {
+        return innerStack.getComponents();
+    }
+
+    public boolean matches(ItemStack stack) {
+        return ItemStack.isSameItemSameComponents(stack, innerStack);
+    }
+
+    public ItemStack toStack(int count) {
+        return this.innerStack.copyWithCount(count);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        return obj instanceof ItemResource v && ItemStack.isSameItemSameComponents(v.innerStack, innerStack);
+    }
+
+    @Override
+    public int hashCode() {
+        return ItemStack.hashItemAndComponents(innerStack);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/items/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemResource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.items;
 
 import com.mojang.serialization.Codec;

--- a/src/main/java/net/neoforged/neoforge/transfer/IResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/IResource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.transfer;
 
 /**

--- a/src/main/java/net/neoforged/neoforge/transfer/IResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/IResource.java
@@ -1,0 +1,16 @@
+package net.neoforged.neoforge.transfer;
+
+/**
+ * Most general form of a resource that can be quantified and moved around.
+ *
+ * <p>Instances must all be immutable, comparable with {@link Object#equals(Object)}
+ * and they must implement a suitable {@link Object#hashCode()}.
+ */
+public interface IResource {
+    /**
+     * Returns {@code true} if this represents the absence of a resource.
+     *
+     * <p>Examples include item resource with air as an item.
+     */
+    boolean isBlank(); // TODO: potentially use a different name
+}

--- a/src/main/java/net/neoforged/neoforge/transfer/ResourceAmount.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ResourceAmount.java
@@ -1,0 +1,29 @@
+package net.neoforged.neoforge.transfer;
+
+import java.util.Objects;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.fluids.FluidStack;
+
+/**
+ * Represents an immutable resource and an amount.
+ * Can be seen as an immutable version of {@link ItemStack} or {@link FluidStack}.
+ *
+ * @param <T> the held resource type
+ */
+public record ResourceAmount<T extends IResource>(T resource, int amount) {
+    // TODO: currently very awkward to use without codecs and stream codecs
+    // TODO: also very painful to convert to/from ItemStack/FluidStack
+    public ResourceAmount {
+        Objects.requireNonNull(resource, "resource");
+    }
+
+    /**
+     * Checks if this is empty, meaning that the amount is not positive
+     * or that the resource is {@link IResource#isBlank() blank}.
+     *
+     * @return {@code true} if empty
+     */
+    public boolean isEmpty() {
+        return amount <= 0 || resource.isBlank();
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/transfer/ResourceAmount.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ResourceAmount.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.transfer;
 
 import java.util.Objects;


### PR DESCRIPTION
Currently throwing ideas around...

`FluidStack` and `ItemStack` are very convenient, but they are also mutable. There are cases where we want to prevent mutation of fluid and item stacks. There are also many use cases where we would really like an immutable and **count-less** stack, for example for filtering, recipe ingredients, or other logic that should not depend on the count/amount.

This proof of concept is motivated by the move of `ItemStack` (and `FluidStack`) from NBT to data components. **Data components are immutable.** This makes exposing an immutable abstraction of a stack very practical, as we just need to expose 1) the item or fluid, 2) the count or amount and 3) an immutable data component map.

**The goal is to provide the necessary abstractions in this PR for modder that want to move to immutable stack handling.**

Right now this PR adds:
- `FluidResource`: immutable fluid and component map. Can be seen as a countless immutable `FluidStack`.
- `ItemResource`: immutable item and component map. Can be seen as a countless immutable `ItemStack`.
- `IResource` is a supertype of these two, in preparation for more generic handling of resources.
- `ResourceAmount` is a simple record of a resource and an amount. This can be used as an immutable stack.

Note that thanks to stacks being shallow-copied, **stack copies have become cheap**. Calling `stack.copy()` will allocate exactly two objects regardless of the stored components. The backing component map is only copied lazily if one of the stacks is mutated.

Conversions:
- From stack to resource: `FluidResource.of(fluidStack)`.
- From resource + amount to stack: `fluidResource.toStack(amount)`.
- From `ResourceAmount` to resource: `resourceAmount.resource()`.
- From resource + amount to `ResourceAmount`: `new ResourceAmount<>(resource, amount)`.
- From stack to `ResourceAmount`: `stack.immutable()`.
- From `ResourceAmount` to stack: `FluidStack.of(resourceAmount)`.