### PR TITLE
Fix non-synced data maps being nuked in singeplayer

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -118,6 +118,10 @@ public class NeoForgeEventHandler {
                 if (!player.connection.isConnected(RegistryDataMapSyncPayload.ID)) {
                     return;
                 }
+                if (player.connection.getConnection().isMemoryConnection()) {
+                    // Note: don't send data maps over in-memory connections, else the client-side handling will wipe non-synced data maps.
+                    return;
+                }
                 final var playerMaps = player.connection.connection.channel().attr(RegistryManager.ATTRIBUTE_KNOWN_DATA_MAPS).get();
                 if (playerMaps == null) return; // Skip gametest players for instance
                 handleSync(player, regOpt.get(), playerMaps.getOrDefault(registry, List.of()));
@@ -133,8 +137,7 @@ public class NeoForgeEventHandler {
             if (attach == null || attach.networkCodec() == null) return;
             att.put(key, registry.getDataMap(attach));
         });
-        // Note: don't send data maps over in-memory connections, else the client-side handling will wipe non-synced data maps.
-        if (!att.isEmpty() && !player.connection.getConnection().isMemoryConnection()) {
+        if (!att.isEmpty()) {
             PacketDistributor.PLAYER.with(player).send(new RegistryDataMapSyncPayload<>(registry.key(), att));
         }
     }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -133,7 +133,8 @@ public class NeoForgeEventHandler {
             if (attach == null || attach.networkCodec() == null) return;
             att.put(key, registry.getDataMap(attach));
         });
-        if (!att.isEmpty()) {
+        // Note: don't send data maps over in-memory connections, else the client-side handling will wipe non-synced data maps.
+        if (!att.isEmpty() && !player.connection.getConnection().isMemoryConnection()) {
             PacketDistributor.PLAYER.with(player).send(new RegistryDataMapSyncPayload<>(registry.key(), att));
         }
     }


### PR DESCRIPTION
`ClientRegistryManager.handleDataMapSync` will nuke data maps and then re-populate them from the received packet. This is problematic over memory connections where this will also nuke non-synced data maps. The fix is to just not send the packet over in-memory connections.

Combined with #717, this fixes running our gametests in singleplayer.