### PR TITLE
[1.20.4] Expand model-level AO hook to allow force-enabling AO irrespective of a block's light emission

### DIFF
--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -8,7 +8,7 @@
      public void tesselateBlock(
          BlockAndTintGetter p_234380_,
          BakedModel p_234381_,
-@@ -52,15 +_,31 @@
+@@ -52,15 +_,35 @@
          long p_234388_,
          int p_234389_
      ) {
@@ -29,7 +29,11 @@
 +        net.neoforged.neoforge.client.model.data.ModelData modelData,
 +        net.minecraft.client.renderer.RenderType renderType
 +    ) {
-+        boolean flag = Minecraft.useAmbientOcclusion() && p_234382_.getLightEmission(p_234380_, p_234383_) == 0 && p_234381_.useAmbientOcclusion(p_234382_, renderType);
++        boolean flag = Minecraft.useAmbientOcclusion() && switch(p_234381_.useAmbientOcclusion(p_234382_, modelData, renderType)) {
++            case TRUE -> true;
++            case DEFAULT -> p_234382_.getLightEmission(p_234380_, p_234383_) == 0;
++            case FALSE -> false;
++        };
          Vec3 vec3 = p_234382_.getOffset(p_234380_, p_234383_);
          p_234384_.translate(vec3.x, vec3.y, vec3.z);
  

--- a/patches/net/minecraft/client/renderer/block/model/BakedQuad.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/BakedQuad.java.patch
@@ -20,12 +20,16 @@
      }
  
      public TextureAtlasSprite getSprite() {
-@@ -43,5 +_,9 @@
+@@ -43,5 +_,13 @@
  
      public boolean isShade() {
          return this.shade;
 +    }
 +
++    /**
++     * {@return false to force-disable AO for this quad or true to use the behavior dictated by
++     * {@link net.neoforged.neoforge.client.extensions.IBakedModelExtension#useAmbientOcclusion(net.minecraft.world.level.block.state.BlockState, net.neoforged.neoforge.client.model.data.ModelData, net.minecraft.client.renderer.RenderType)}}
++     */
 +    public boolean hasAmbientOcclusion() {
 +        return this.hasAmbientOcclusion;
      }

--- a/patches/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
@@ -67,7 +67,7 @@
          }
      }
  
-@@ -79,6 +_,21 @@
+@@ -79,6 +_,26 @@
      }
  
      @Override
@@ -78,6 +78,11 @@
 +    @Override
 +    public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
 +        return this.defaultModel.useAmbientOcclusion(state, renderType);
++    }
++
++    @Override
++    public net.neoforged.neoforge.common.util.TriState useAmbientOcclusion(BlockState state, net.neoforged.neoforge.client.model.data.ModelData modelData, net.minecraft.client.renderer.RenderType renderType) {
++        return this.defaultModel.useAmbientOcclusion(state, modelData, renderType);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
@@ -22,7 +22,7 @@
              .orElse(Collections.emptyList());
      }
  
-@@ -41,6 +_,16 @@
+@@ -41,6 +_,21 @@
      }
  
      @Override
@@ -33,6 +33,11 @@
 +    @Override
 +    public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
 +        return this.wrapped.useAmbientOcclusion(state, renderType);
++    }
++
++    @Override
++    public net.neoforged.neoforge.common.util.TriState useAmbientOcclusion(BlockState state, net.neoforged.neoforge.client.model.data.ModelData modelData, net.minecraft.client.renderer.RenderType renderType) {
++        return this.wrapped.useAmbientOcclusion(state, modelData, renderType);
 +    }
 +
 +    @Override

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
@@ -23,6 +23,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.ChunkRenderTypeSet;
 import net.neoforged.neoforge.client.RenderTypeHelper;
 import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.common.util.TriState;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -40,12 +41,37 @@ public interface IBakedModelExtension {
         return self().getQuads(state, side, rand);
     }
 
+    /**
+     * @deprecated Use {@link #useAmbientOcclusion(BlockState, ModelData, RenderType)} instead
+     */
+    @Deprecated(forRemoval = true)
     default boolean useAmbientOcclusion(BlockState state) {
         return self().useAmbientOcclusion();
     }
 
+    /**
+     * @deprecated Use {@link #useAmbientOcclusion(BlockState, ModelData, RenderType)} instead
+     */
+    @Deprecated(forRemoval = true)
     default boolean useAmbientOcclusion(BlockState state, RenderType renderType) {
         return self().useAmbientOcclusion(state);
+    }
+
+    /**
+     * Controls the AO behavior for all quads of this model. The default behavior is to use AO unless the block emits light,
+     * {@link TriState#TRUE} and {@link TriState#FALSE} force AO to be enabled and disabled respectively, regardless of
+     * the block emitting light or not. {@link BakedQuad#hasAmbientOcclusion()} can be used to disable AO for a specific
+     * quad even if this method says otherwise.
+     * <p>
+     * This method cannot force AO if the global smooth lighting video setting is disabled.
+     *
+     * @param state      the block state this model is being rendered for
+     * @param data       the model data used to render this model
+     * @param renderType the render type the model is being rendered with
+     * @return {@link TriState#TRUE} to force-enable AO, {@link TriState#FALSE} to force-disable AO or {@link TriState#DEFAULT} to use vanilla AO behavior
+     */
+    default TriState useAmbientOcclusion(BlockState state, ModelData data, RenderType renderType) {
+        return useAmbientOcclusion(state, renderType) ? TriState.DEFAULT : TriState.FALSE;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
@@ -44,7 +44,7 @@ public interface IBakedModelExtension {
     /**
      * @deprecated Use {@link #useAmbientOcclusion(BlockState, ModelData, RenderType)} instead
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "1.20.4")
     default boolean useAmbientOcclusion(BlockState state) {
         return self().useAmbientOcclusion();
     }
@@ -52,7 +52,7 @@ public interface IBakedModelExtension {
     /**
      * @deprecated Use {@link #useAmbientOcclusion(BlockState, ModelData, RenderType)} instead
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "1.20.4")
     default boolean useAmbientOcclusion(BlockState state, RenderType renderType) {
         return self().useAmbientOcclusion(state);
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/BakedModelWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/BakedModelWrapper.java
@@ -22,6 +22,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.ChunkRenderTypeSet;
 import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.common.util.TriState;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -54,6 +55,11 @@ public abstract class BakedModelWrapper<T extends BakedModel> implements BakedMo
     @Override
     public boolean useAmbientOcclusion(BlockState state, RenderType renderType) {
         return originalModel.useAmbientOcclusion(state, renderType);
+    }
+
+    @Override
+    public TriState useAmbientOcclusion(BlockState state, ModelData data, RenderType renderType) {
+        return originalModel.useAmbientOcclusion(state, data, renderType);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/util/TriState.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/TriState.java
@@ -6,19 +6,19 @@
 package net.neoforged.neoforge.common.util;
 
 /**
- * Represents a boolean value that can be {@code true}, {@code false} or refer to a default value
+ * Represents a boolean value that can be {@code true}, {@code false} or refer to a default value.
  */
 public enum TriState {
     /**
-     * Represents the boolean value {@code true}
+     * Represents the boolean value {@code true}.
      */
     TRUE,
     /**
-     * Represents a "default" value, often used as a fallback
+     * Represents a "default" value, often used as a fallback.
      */
     DEFAULT,
     /**
-     * Represents the boolean value {@code false}
+     * Represents the boolean value {@code false}.
      */
     FALSE
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/TriState.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/TriState.java
@@ -5,8 +5,20 @@
 
 package net.neoforged.neoforge.common.util;
 
+/**
+ * Represents a boolean value that can be {@code true}, {@code false} or refer to a default value
+ */
 public enum TriState {
+    /**
+     * Represents the boolean value {@code true}
+     */
     TRUE,
+    /**
+     * Represents a "default" value, often used as a fallback
+     */
     DEFAULT,
+    /**
+     * Represents the boolean value {@code false}
+     */
     FALSE
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/TriState.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/TriState.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.util;
+
+public enum TriState {
+    TRUE,
+    DEFAULT,
+    FALSE
+}


### PR DESCRIPTION
This PR expands the `BakedModel` AO hook to allow custom models to override the AO behavior in both directions instead of only being able to force-disable AO. If smooth lighting is enabled in the video settings, then the default vanilla behavior is to render a model with AO unless the model opts out or the block emits any light. This behavior may in certain cases not be desired though and the expanded hook allows overriding it in those cases.
The global smooth lighting video setting cannot be overruled by this hook, it has final say whether AO is available or not.

Replicating this enhanced AO control on the per-quad AO hook would be desirable as well, but would require significantly more extensive changes and is therefore better left to a separate PR, if not even part of a more thorough rework of the model hooks.

My use case is to force-enable AO on light-emitting fake blocks to prevent the light emission breaking the illusion of the fake block. The screenshots below show the difference between the status-quo and force-enabling AO on light-emitting blocks:
<img src="https://github.com/neoforged/NeoForge/assets/11262040/cf89245f-fc81-421a-beff-908ddf783f68" width="50%"><img src="https://github.com/neoforged/NeoForge/assets/11262040/925313f4-4625-4880-a472-75db3934efee" width="50%">
The effect becomes significantly more obvious when shaders are in play as well (screenshots made in 1.20.1):
<img src="https://github.com/neoforged/NeoForge/assets/11262040/41277aae-1412-4fd1-8170-8b154378cbba" width="50%"><img src="https://github.com/neoforged/NeoForge/assets/11262040/ff8373ea-b159-4d01-862b-eceb84c90e9b" width="50%">
