### PR TITLE
[1.20.1] Minor optimizations to entity ticking

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/Entity.java.patch
@@ -167,7 +167,7 @@
 -      double d0 = this.m_9236_().m_6042_().f_63857_() ? 0.007D : 0.0023333333333333335D;
 -      boolean flag = this.m_204031_(FluidTags.f_13132_, d0);
 -      return this.m_20069_() || flag;
-+      if (!(this.m_20202_() instanceof Boat)) {
++      if (this.isInFluidType() && !(this.m_20202_() instanceof Boat)) {
 +         this.f_19789_ *= this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().filter(e -> !e.getKey().isAir() && !e.getKey().isVanilla()).map(e -> this.getFluidFallDistanceModifier(e.getKey())).min(Float::compare).orElse(1F);
 +         if (this.isInFluidType((fluidType, height) -> !fluidType.isAir() && !fluidType.isVanilla() && this.canFluidExtinguish(fluidType))) this.m_20095_();
 +      }
@@ -423,11 +423,11 @@
        } else {
           AABB aabb = this.m_20191_().m_82406_(0.001D);
           int i = Mth.m_14107_(aabb.f_82288_);
-@@ -2997,25 +_,28 @@
+@@ -2997,25 +_,31 @@
           Vec3 vec3 = Vec3.f_82478_;
           int k1 = 0;
           BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
-+         it.unimi.dsi.fastutil.objects.Object2ObjectMap<net.minecraftforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>> interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>(net.minecraftforge.fluids.FluidType.SIZE.get() - 1);
++         it.unimi.dsi.fastutil.objects.Object2ObjectMap<net.minecraftforge.fluids.FluidType, org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer>> interimCalcs = null;
  
           for(int l1 = i; l1 < j; ++l1) {
              for(int i2 = k; i2 < l; ++i2) {
@@ -442,6 +442,9 @@
                          flag1 = true;
 -                        d0 = Math.max(d1 - aabb.f_82289_, d0);
 -                        if (flag) {
++                        if (interimCalcs == null) {
++                           interimCalcs = new it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap<>();
++                        }
 +                        org.apache.commons.lang3.tuple.MutableTriple<Double, Vec3, Integer> interim = interimCalcs.computeIfAbsent(fluidType, t -> org.apache.commons.lang3.tuple.MutableTriple.of(0.0D, Vec3.f_82478_, 0));
 +                        interim.setLeft(Math.max(d1 - aabb.f_82289_, interim.getLeft()));
 +                        if (this.isPushedByFluid(fluidType)) {
@@ -459,13 +462,14 @@
                          }
                       }
                    }
-@@ -3023,27 +_,28 @@
+@@ -3023,27 +_,30 @@
              }
           }
  
 -         if (vec3.m_82553_() > 0.0D) {
 -            if (k1 > 0) {
 -               vec3 = vec3.m_82490_(1.0D / (double)k1);
++         if(interimCalcs != null) {
 +         interimCalcs.forEach((fluidType, interim) -> {
 +         if (interim.getMiddle().m_82553_() > 0.0D) {
 +            if (interim.getRight() > 0) {
@@ -495,6 +499,7 @@
 -         return flag1;
 +         this.setFluidTypeHeight(fluidType, interim.getLeft());
 +         });
++         }
        }
     }
  
@@ -545,7 +550,7 @@
     public void m_274367_(float p_275672_) {
        this.f_19793_ = p_275672_;
     }
-@@ -3319,6 +_,103 @@
+@@ -3319,6 +_,109 @@
     public boolean m_142265_(Level p_146843_, BlockPos p_146844_) {
        return true;
     }
@@ -628,6 +633,9 @@
 +   }
 +   @Override
 +   public final boolean isInFluidType(java.util.function.BiPredicate<net.minecraftforge.fluids.FluidType, Double> predicate, boolean forAllTypes) {
++      if (this.forgeFluidTypeHeight.isEmpty()) {
++         return false;
++      }
 +      return forAllTypes ? this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().allMatch(e -> predicate.test(e.getKey(), e.getDoubleValue()))
 +              : this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().anyMatch(e -> predicate.test(e.getKey(), e.getDoubleValue()));
 +   }
@@ -641,6 +649,9 @@
 +   }
 +   @Override
 +   public net.minecraftforge.fluids.FluidType getMaxHeightFluidType() {
++      if (this.forgeFluidTypeHeight.isEmpty()) {
++         return net.minecraftforge.common.ForgeMod.EMPTY_TYPE.get();
++      }
 +      return this.forgeFluidTypeHeight.object2DoubleEntrySet().stream().max(java.util.Comparator.comparingDouble(Object2DoubleMap.Entry::getDoubleValue)).map(Object2DoubleMap.Entry::getKey).orElseGet(net.minecraftforge.common.ForgeMod.EMPTY_TYPE);
 +   }
 +

--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -716,7 +716,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.m_6084_()) {
 +         if (facing == null) return handlers[2].cast();
 +         else if (facing.m_122434_().m_122478_()) return handlers[0].cast();
 +         else if (facing.m_122434_().m_122479_()) return handlers[1].cast();

--- a/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -38,7 +38,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && itemHandler != null)
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.m_6084_() && itemHandler != null)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/player/Player.java.patch
@@ -462,7 +462,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.m_6084_()) {
 +         if (facing == null) return playerJoinedHandler.cast();
 +         else if (facing.m_122434_().m_122478_()) return playerMainHandler.cast();
 +         else if (facing.m_122434_().m_122479_()) return playerEquipmentHandler.cast();

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/AbstractMinecartContainer.java.patch
@@ -19,7 +19,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.m_6084_())
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
@@ -9,7 +9,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.core.Direction facing) {
-+      if (this.m_6084_() && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && this.m_6084_())
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -164,7 +164,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (!this.f_58859_ && facing != null && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.f_58859_ && facing != null) {
 +         if (facing == Direction.UP)
 +            return handlers[0].cast();
 +         else if (facing == Direction.DOWN)

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BaseContainerBlockEntity.java.patch
@@ -11,7 +11,7 @@
 +   }
 +
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @org.jetbrains.annotations.Nullable net.minecraft.core.Direction side) {
-+      if (!this.f_58859_ && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.f_58859_)
 +         return itemHandler.cast();
 +      return super.getCapability(cap, side);
 +   }

--- a/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -62,7 +62,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Direction facing) {
-+      if (!this.f_58859_ && facing != null && capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++      if (capability == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.f_58859_ && facing != null) {
 +         if (facing == Direction.UP)
 +            return handlers[0].cast();
 +         else if (facing == Direction.DOWN)

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ChestBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ChestBlockEntity.java.patch
@@ -17,7 +17,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, Direction side) {
-+       if (!this.f_58859_ && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER) {
++       if (cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.f_58859_) {
 +          if (this.chestHandler == null)
 +             this.chestHandler = net.minecraftforge.common.util.LazyOptional.of(this::createHandler);
 +          return this.chestHandler.cast();

--- a/patches/minecraft/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/level/block/entity/ChiseledBookShelfBlockEntity.java.patch
@@ -12,7 +12,7 @@
 +
 +   @Override
 +   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @org.jetbrains.annotations.Nullable net.minecraft.core.Direction side) {
-+      if (!this.f_58859_ && cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER)
++      if (cap == net.minecraftforge.common.capabilities.ForgeCapabilities.ITEM_HANDLER && !this.f_58859_)
 +         return itemHandler.cast();
 +      return super.getCapability(cap, side);
 +   }


### PR DESCRIPTION
This PR includes two changes:

* A backport of https://github.com/neoforged/NeoForge/pull/694 to 1.20.1. Note that I opted to keep using the `MutableTriple` rather than an inner class, as I'm unsure how the latter interacts with reobfuscation.
* Minor optimization to our patched-in `getCapability` implementations to check whether the requested capability is the item handler before calling `isAlive` or reading a field. This is because `isAlive` requires going through synced entity data and acquiring a lock, which is much more expensive than the equality comparison.