### PR TITLE
[1.20.4] Restrict network error logging to config and play phase

### DIFF
--- a/patches/net/minecraft/network/Connection.java.patch
+++ b/patches/net/minecraft/network/Connection.java.patch
@@ -16,11 +16,15 @@
      }
  
      @Override
-@@ -135,6 +_,7 @@
+@@ -135,6 +_,11 @@
                      this.disconnect(Component.translatable("disconnect.timeout"));
                  } else {
                      Component component = Component.translatable("disconnect.genericReason", "Internal Exception: " + p_129534_);
-+                    LOGGER.error("Exception caught in connection", p_129534_); // Neo: Always log critical network exceptions
++                    ConnectionProtocol protocol = this.channel.attr(getProtocolKey(this.getSending())).get().protocol();
++                    if (protocol == ConnectionProtocol.CONFIGURATION || protocol == ConnectionProtocol.PLAY) {
++                        // Neo: Always log critical network exceptions for config and play packets
++                        LOGGER.error("Exception caught in connection", p_129534_);
++                    }
                      if (flag) {
                          LOGGER.debug("Failed to sent packet", p_129534_);
                          if (this.getSending() == PacketFlow.CLIENTBOUND) {

--- a/patches/net/minecraft/network/Connection.java.patch
+++ b/patches/net/minecraft/network/Connection.java.patch
@@ -16,14 +16,17 @@
      }
  
      @Override
-@@ -135,6 +_,11 @@
+@@ -135,6 +_,14 @@
                      this.disconnect(Component.translatable("disconnect.timeout"));
                  } else {
                      Component component = Component.translatable("disconnect.genericReason", "Internal Exception: " + p_129534_);
-+                    ConnectionProtocol protocol = this.channel.attr(getProtocolKey(this.getSending())).get().protocol();
-+                    if (protocol == ConnectionProtocol.CONFIGURATION || protocol == ConnectionProtocol.PLAY) {
-+                        // Neo: Always log critical network exceptions for config and play packets
-+                        LOGGER.error("Exception caught in connection", p_129534_);
++                    PacketListener listener = this.packetListener;
++                    if (listener != null) {
++                        ConnectionProtocol protocol = listener.protocol();
++                        if (protocol == ConnectionProtocol.CONFIGURATION || protocol == ConnectionProtocol.PLAY) {
++                            // Neo: Always log critical network exceptions for config and play packets
++                            LOGGER.error("Exception caught in connection", p_129534_);
++                        }
 +                    }
                      if (flag) {
                          LOGGER.debug("Failed to sent packet", p_129534_);


### PR DESCRIPTION
This PR restricts the increased logging of networking errors added by NeoForge to the configuration and play phases. Logging networking errors in the other four phases is rarely useful and can also cause undesired logging under certain circumstances.