### PR TITLE
Creative flight attribute

### DIFF
--- a/patches/net/minecraft/client/player/LocalPlayer.java.patch
+++ b/patches/net/minecraft/client/player/LocalPlayer.java.patch
@@ -68,6 +68,15 @@
                      this.setSprinting(false);
                  }
              } else if (flag8) {
+@@ -736,7 +_,7 @@
+         }
+ 
+         boolean flag9 = false;
+-        if (this.getAbilities().mayfly) {
++        if (this.mayFly()) {
+             if (this.minecraft.gameMode.isAlwaysFlying()) {
+                 if (!this.getAbilities().flying) {
+                     this.getAbilities().flying = true;
 @@ -757,14 +_,15 @@
  
          if (this.input.jumping && !flag9 && !flag && !this.getAbilities().flying && !this.isPassenger() && !this.onClimbable()) {
@@ -95,3 +104,12 @@
          this.handsBusy = false;
          Entity entity = this.getControlledVehicle();
          if (entity instanceof Boat boat) {
+@@ -1053,7 +_,7 @@
+     }
+ 
+     private boolean hasEnoughFoodToStartSprinting() {
+-        return this.isPassenger() || (float)this.getFoodData().getFoodLevel() > 6.0F || this.getAbilities().mayfly;
++        return this.isPassenger() || (float)this.getFoodData().getFoodLevel() > 6.0F || this.mayFly();
+     }
+ 
+     public float getWaterVision() {

--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -11,6 +11,18 @@
              ServerPlayer.this.connection.send(new ClientboundContainerSetDataPacket(p_143455_.containerId, p_143456_, p_143457_));
          }
      };
+@@ -546,6 +_,11 @@
+                 this.connection.send(new ClientboundSetExperiencePacket(this.experienceProgress, this.totalExperience, this.experienceLevel));
+             }
+ 
++            if (this.getAbilities().flying && !this.mayFly()) {
++                this.getAbilities().flying = false;
++                this.onUpdateAbilities();
++            }
++
+             if (this.tickCount % 20 == 0) {
+                 CriteriaTriggers.LOCATION.trigger(this);
+             }
 @@ -594,6 +_,7 @@
      @Override
      public void die(DamageSource p_9035_) {

--- a/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -4,7 +4,7 @@
      protected void setGameModeForPlayer(GameType p_9274_, @Nullable GameType p_9275_) {
          this.previousGameModeForPlayer = p_9275_;
          this.gameModeForPlayer = p_9274_;
-+        // Neoforge: preserve flying state, removed on tick if Attribute or ability no longer applies
++        // Neo: preserve flying state, removed on tick if Attribute or ability no longer applies
 +        boolean wasFlying = this.player.getAbilities().flying;
          p_9274_.updatePlayerAbilities(this.player.getAbilities());
 +        this.player.getAbilities().flying = wasFlying || this.player.getAbilities().flying;

--- a/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/net/minecraft/server/level/ServerPlayerGameMode.java
+@@ -65,7 +_,10 @@
+     protected void setGameModeForPlayer(GameType p_9274_, @Nullable GameType p_9275_) {
+         this.previousGameModeForPlayer = p_9275_;
+         this.gameModeForPlayer = p_9274_;
++        // Neoforge: preserve flying state, removed on tick if Attribute or ability no longer applies
++        boolean wasFlying = this.player.getAbilities().flying;
+         p_9274_.updatePlayerAbilities(this.player.getAbilities());
++        this.player.getAbilities().flying = wasFlying || this.player.getAbilities().flying;
+     }
+ 
+     public GameType getGameModeForPlayer() {
 @@ -126,7 +_,11 @@
      }
  

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -73,6 +73,15 @@
  
              itemstack1.addTagElement("author", StringTag.valueOf(this.player.getName().getString()));
              if (this.player.isTextFilteringEnabled()) {
+@@ -952,7 +_,7 @@
+                                     && !flag
+                                     && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR
+                                     && !this.server.isFlightAllowed()
+-                                    && !this.player.getAbilities().mayfly
++                                    && !this.player.mayFly()
+                                     && !this.player.hasEffect(MobEffects.LEVITATION)
+                                     && !this.player.isFallFlying()
+                                     && !this.player.isAutoSpinAttack()
 @@ -1028,8 +_,10 @@
              case SWAP_ITEM_WITH_OFFHAND:
                  if (!this.player.isSpectator()) {
@@ -146,6 +155,15 @@
                          }
      
                          @Override
+@@ -1688,7 +_,7 @@
+     @Override
+     public void handlePlayerAbilities(ServerboundPlayerAbilitiesPacket p_9887_) {
+         PacketUtils.ensureRunningOnSameThread(p_9887_, this, this.player.serverLevel());
+-        this.player.getAbilities().flying = p_9887_.isFlying() && this.player.getAbilities().mayfly;
++        this.player.getAbilities().flying = p_9887_.isFlying() && this.player.mayFly();
+     }
+ 
+     @Override
 @@ -1745,7 +_,7 @@
              throw new IllegalStateException("Client acknowledged config, but none was requested");
          } else {

--- a/patches/net/minecraft/world/entity/player/Abilities.java.patch
+++ b/patches/net/minecraft/world/entity/player/Abilities.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/entity/player/Abilities.java
++++ b/net/minecraft/world/entity/player/Abilities.java
+@@ -5,6 +_,10 @@
+ public class Abilities {
+     public boolean invulnerable;
+     public boolean flying;
++    /**
++     * @deprecated Neoforge: use {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly} to read and {@link net.neoforged.neoforge.common.NeoForgeMod#CREATIVE_FLIGHT} Attribute to modify
++     */
++    @Deprecated
+     public boolean mayfly;
+     public boolean instabuild;
+     public boolean mayBuild = true;

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -20,7 +20,7 @@
  
      public Player(Level p_250508_, BlockPos p_250289_, float p_251702_, GameProfile p_252153_) {
          super(EntityType.PLAYER, p_250508_);
-@@ -206,7 +_,10 @@
+@@ -206,7 +_,11 @@
              .add(Attributes.ATTACK_DAMAGE, 1.0)
              .add(Attributes.MOVEMENT_SPEED, 0.1F)
              .add(Attributes.ATTACK_SPEED)
@@ -28,7 +28,8 @@
 +            .add(Attributes.LUCK)
 +            .add(net.neoforged.neoforge.common.NeoForgeMod.BLOCK_REACH.value())
 +            .add(Attributes.ATTACK_KNOCKBACK)
-+            .add(net.neoforged.neoforge.common.NeoForgeMod.ENTITY_REACH.value());
++            .add(net.neoforged.neoforge.common.NeoForgeMod.ENTITY_REACH.value())
++            .add(net.neoforged.neoforge.common.NeoForgeMod.CREATIVE_FLIGHT.value());
      }
  
      @Override
@@ -320,10 +321,12 @@
          } else {
              boolean flag = block.isPossibleToRespawnInThis(blockstate);
              BlockState blockstate1 = p_36131_.getBlockState(p_36132_.above());
-@@ -1501,6 +_,7 @@
+@@ -1500,7 +_,8 @@
+ 
      @Override
      public boolean causeFallDamage(float p_150093_, float p_150094_, DamageSource p_150095_) {
-         if (this.abilities.mayfly) {
+-        if (this.abilities.mayfly) {
++        if (this.mayFly()) {
 +            net.neoforged.neoforge.event.EventHooks.onPlayerFall(this, p_150093_, p_150093_);
              return false;
          } else {

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -200,6 +200,7 @@ public class NeoForgeMod {
     public static final Holder<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("neoforge.swim_speed", 1.0D, 0.0D, 1024.0D).setSyncable(true));
     public static final Holder<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("neoforge.name_tag_distance", 64.0D, 0.0D, 64.0).setSyncable(true));
     public static final Holder<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("neoforge.entity_gravity", 0.08D, -8.0D, 8.0D).setSyncable(true));
+    public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new RangedAttribute("neoforge.creative_flight", 0D, 0D, Double.MAX_VALUE).setSyncable(true));
 
     /**
      * Reach Distance represents the distance at which a player may interact with the world. The default is 4.5 blocks. Players in creative mode have an additional 0.5 blocks of block reach.

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -212,8 +212,17 @@ public class NeoForgeMod {
     /**
      * Grants the player the ability to use creative flight when not in creative mode.
      * Anything above zero allows flight.
-     *
-     * @see net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly
+     * <p></p>
+     * For this attribute, you should only use the following modifier values:
+     * <ul>
+     * <li>A value of 1 with {@link net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation#ADDITION} to enable the effect.</li>
+     * <li>A value of -1 with {@link net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation#MULTIPLY_TOTAL} to forcibly disable the effect.</li>
+     * </ul>
+     * This behavior allows for multiple enables to coexist, not removing the effect unless all enabling modifiers are removed.<br>
+     * Additionally, it permits forcibly disabling the attribute through multiply total.
+     * <p></p>
+     * To determine if a player has flight access via game mode or attribute, use {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly}<br>
+     * Game mode flight cannot be disabled via this attribute.
      */
     public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new RangedAttribute("neoforge.creative_flight", 0D, 0D, Double.MAX_VALUE).setSyncable(true));
 

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -212,16 +212,18 @@ public class NeoForgeMod {
     /**
      * Grants the player the ability to use creative flight when not in creative mode.
      * Anything above zero allows flight.
-     * <p></p>
+     * <p>
      * For this attribute, you should only use the following modifier values:
      * <ul>
      * <li>A value of 1 with {@link net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation#ADDITION} to enable the effect.</li>
      * <li>A value of -1 with {@link net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation#MULTIPLY_TOTAL} to forcibly disable the effect.</li>
      * </ul>
-     * This behavior allows for multiple enables to coexist, not removing the effect unless all enabling modifiers are removed.<br>
+     * This behavior allows for multiple enables to coexist, not removing the effect unless all enabling modifiers are removed.
+     * <p>
      * Additionally, it permits forcibly disabling the attribute through multiply total.
-     * <p></p>
-     * To determine if a player has flight access via game mode or attribute, use {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly}<br>
+     * <p>
+     * To determine if a player has flight access via game mode or attribute, use {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly}
+     * <p>
      * Game mode flight cannot be disabled via this attribute.
      */
     public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new RangedAttribute("neoforge.creative_flight", 0D, 0D, Double.MAX_VALUE).setSyncable(true));

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -200,7 +200,6 @@ public class NeoForgeMod {
     public static final Holder<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new RangedAttribute("neoforge.swim_speed", 1.0D, 0.0D, 1024.0D).setSyncable(true));
     public static final Holder<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("neoforge.name_tag_distance", 64.0D, 0.0D, 64.0).setSyncable(true));
     public static final Holder<Attribute> ENTITY_GRAVITY = ATTRIBUTES.register("entity_gravity", () -> new RangedAttribute("neoforge.entity_gravity", 0.08D, -8.0D, 8.0D).setSyncable(true));
-    public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new RangedAttribute("neoforge.creative_flight", 0D, 0D, Double.MAX_VALUE).setSyncable(true));
 
     /**
      * Reach Distance represents the distance at which a player may interact with the world. The default is 4.5 blocks. Players in creative mode have an additional 0.5 blocks of block reach.
@@ -209,6 +208,14 @@ public class NeoForgeMod {
      * @see IPlayerExtension#canReach(BlockPos, double)
      */
     public static final Holder<Attribute> BLOCK_REACH = ATTRIBUTES.register("block_reach", () -> new RangedAttribute("neoforge.block_reach", 4.5D, 0.0D, 1024.0D).setSyncable(true));
+
+    /**
+     * Grants the player the ability to use creative flight when not in creative mode.
+     * Anything above zero allows flight.
+     *
+     * @see net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly
+     */
+    public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new RangedAttribute("neoforge.creative_flight", 0D, 0D, Double.MAX_VALUE).setSyncable(true));
 
     /**
      * Attack Range represents the distance at which a player may attack an entity. The default is 3 blocks. Players in creative mode have an additional 2 blocks of entity reach.

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.phys.AABB;
@@ -127,8 +128,16 @@ public interface IPlayerExtension {
         return OptionalInt.empty();
     }
 
+    /**
+     * Determine whether a player is allowed creative flight via game mode or attribute.<br>
+     * Modders are discouraged from setting {@link Abilities#mayfly} directly.
+     *
+     * @return true when creative flight is available
+     * @see NeoForgeMod#CREATIVE_FLIGHT
+     */
     @SuppressWarnings("deprecation")
     default boolean mayFly() {
+        // TODO 1.20.5: consider forcing mods to use the attribute
         return self().getAbilities().mayfly || self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -127,6 +127,7 @@ public interface IPlayerExtension {
         return OptionalInt.empty();
     }
 
+    @SuppressWarnings("deprecation")
     default boolean mayFly() {
         return self().getAbilities().mayfly || self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -129,7 +129,8 @@ public interface IPlayerExtension {
     }
 
     /**
-     * Determine whether a player is allowed creative flight via game mode or attribute.<br>
+     * Determine whether a player is allowed creative flight via game mode or attribute.
+     * <p>
      * Modders are discouraged from setting {@link Abilities#mayfly} directly.
      *
      * @return true when creative flight is available

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -126,4 +126,8 @@ public interface IPlayerExtension {
     default OptionalInt openMenu(MenuProvider menuProvider, Consumer<FriendlyByteBuf> extraDataWriter) {
         return OptionalInt.empty();
     }
+
+    default boolean mayFly() {
+        return self().getAbilities().mayfly || self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
+    }
 }

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -223,6 +223,7 @@
   "neoforge.block_reach": "Block Reach",
   "neoforge.entity_reach": "Entity Reach",
   "neoforge.step_height": "Step Height",
+  "neoforge.creative_flight": "Creative Flight",
 
   "fluid_type.minecraft.milk": "Milk",
   "fluid_type.minecraft.flowing_milk": "Milk",

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/MayFlyAttributeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/MayFlyAttributeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.oldtest.item;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
+import net.neoforged.neoforge.registries.DeferredItem;
+import net.neoforged.neoforge.registries.DeferredRegister;
+
+/**
+ * This test mod provides two items for testing the Forge onStopUsing hook. Both items attempt to create an item that increases FOV and allows creative flight when used
+ * <ul>
+ * <li>{@code stop_using_item:bad_scope}: Implements the item without the onStopUsing to demonstrate the problem.
+ * Should see that when selecting another hotbar slot or dropping the item, the FOV is not properly reverted and you remain flying.
+ * </li>
+ * <li>{@code stop_using_item:good_scope}: Implements the item with onStopUsing to test that the hook hook works.
+ * Should see that when selecting another hotbar slot or dropping the item, the FOV is properly reverted and you stop flying.
+ * </li>
+ * </ul>
+ */
+@Mod(MayFlyAttributeTest.MODID)
+public class MayFlyAttributeTest {
+    protected static final String MODID = "may_fly_attribute_item";
+    private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
+
+    private static final AttributeModifier MODIFIER = new AttributeModifier(MODID, 1D, AttributeModifier.Operation.ADDITION);
+
+    public MayFlyAttributeTest(IEventBus modEventBus) {
+        ITEMS.register(modEventBus);
+        modEventBus.addListener(this::addCreative);
+    }
+
+    /** Successful "scope item" using the Forge method, all cases of stopping using the item will remove the flight ability */
+    public static DeferredItem<Item> GOOD = ITEMS.register("good_scope", () -> new InvertedTelescope(new Item.Properties()));
+
+    private void addCreative(BuildCreativeModeTabContentsEvent event) {
+        if (event.getTabKey() == CreativeModeTabs.COMBAT) {
+            event.accept(GOOD);
+        }
+    }
+
+    private static class InvertedTelescope extends Item {
+        public InvertedTelescope(Properties props) {
+            super(props);
+        }
+
+        @Override
+        public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot slot, ItemStack stack) {
+            return ImmutableMultimap.<Attribute, AttributeModifier>builder()
+                    .put(NeoForgeMod.CREATIVE_FLIGHT.value(), MODIFIER)
+                    .build();
+        }
+    }
+}

--- a/tests/src/main/resources/META-INF/mods.toml
+++ b/tests/src/main/resources/META-INF/mods.toml
@@ -217,5 +217,7 @@ modId="custom_fluid_container_test"
 modId="player_spawn_phantoms_event_test"
 [[mods]]
 modId="conditional_codec_test"
+[[mods]]
+modId="may_fly_attribute_item"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
Adds a creative flight ability so we can all stop trampling over each other's usage of `Abilities.mayfly`

Should be non breaking, but perhaps at next breakage window we can force modders to use the attribute.