### PR TITLE
Add Test Framework Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,8 +47,15 @@ Please ensure you have a valid email address associated with your GitHub account
 
 [CLA]: https://cla-assistant.io/neoforged/NeoForge
 [Crowdin]: https://crowdin.neoforged.net/neoforge
+
 [Contributing]: ../docs/CONTRIBUTING.md
 [Discord]: https://discord.neoforged.net/
 [Documentation]: https://docs.neoforged.net/
 [Download]: https://neoforged.net/
 [Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
+
+## Test Framework
+Recently, NeoForge has recently created its own test framework, and we figured out modders might find it useful to test their own mods. To use the framework, simply add this line to your `dependencies` block:
+```gradle
+testCompileOnly "net.neoforged:testframework:${neo_version}"
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,6 @@ Please ensure you have a valid email address associated with your GitHub account
 
 [CLA]: https://cla-assistant.io/neoforged/NeoForge
 [Crowdin]: https://crowdin.neoforged.net/neoforge
-
 [Contributing]: ../docs/CONTRIBUTING.md
 [Discord]: https://discord.neoforged.net/
 [Documentation]: https://docs.neoforged.net/


### PR DESCRIPTION
With the `testframework` now being available to be utilised in mods now, I personally think this little section in the `README.md` helps modders further