### PR TITLE
Update BoatDispenseItemBehavior.java.patch

### DIFF
--- a/patches/net/minecraft/core/dispenser/BoatDispenseItemBehavior.java.patch
+++ b/patches/net/minecraft/core/dispenser/BoatDispenseItemBehavior.java.patch
@@ -4,7 +4,7 @@
          double d2 = vec3.y() + (double)((float)direction.getStepY() * 1.125F);
          double d3 = vec3.z() + (double)direction.getStepZ() * d0;
          BlockPos blockpos = p_302460_.pos().relative(direction);
-+        Boat boat = (Boat)(this.isChestBoat ? new ChestBoat(serverlevel, d0, d1, d2) : new Boat(serverlevel, d0, d1, d2));
++        Boat boat = (Boat)(this.isChestBoat ? new ChestBoat(serverlevel, d1, d2, d3) : new Boat(serverlevel, d1, d2, d3));
 +        EntityType.<Boat>createDefaultStackConfig(serverlevel, p_123376_, null).accept(boat);
 +        boat.setVariant(this.type);
 +        boat.setYRot(direction.toYRot());


### PR DESCRIPTION
Parameters are not matching x, y, z. This might cause by some unconscious edit.

Although there's nothing wrong because of the following `boat.setPos(d1, d2 + d4, d3)`. If other mods use mixin between this line and the `setPos` line, problems may happen unexpectedly.