### PR TITLE
Allow control over the rendering of slot highlights

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -32,7 +32,7 @@
          ItemStack itemstack = this.draggingItem.isEmpty() ? this.menu.getCarried() : this.draggingItem;
          if (!itemstack.isEmpty()) {
              int l1 = 8;
-@@ -156,13 +_,21 @@
+@@ -156,13 +_,25 @@
      }
  
      public static void renderSlotHighlight(GuiGraphics p_283692_, int p_281453_, int p_281915_, int p_283504_) {
@@ -42,6 +42,10 @@
 +    public static void renderSlotHighlight(GuiGraphics p_283692_, int p_281453_, int p_281915_, int p_283504_, int color) {
 +        p_283692_.fillGradient(RenderType.guiOverlay(), p_281453_, p_281915_, p_281453_ + 16, p_281915_ + 16, color, color, p_283504_);
 +    }
++
++    /**
++     * Renders a highlight for the given slot to indicate the mouse is currently hovering over it.
++     */
 +    protected void renderSlotHighlight(GuiGraphics guiGraphics, Slot slot, int mouseX, int mouseY, float partialTick) {
 +        if (slot.isHighlightable()) {
 +            renderSlotHighlight(guiGraphics, slot.x, slot.y, 0, getSlotColor(slot.index));

--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -14,13 +14,16 @@
          RenderSystem.disableDepthTest();
          p_283479_.pose().pushPose();
          p_283479_.pose().translate((float)i, (float)j, 0.0F);
-@@ -108,12 +_,13 @@
-                 int l = slot.x;
-                 int i1 = slot.y;
-                 if (this.hoveredSlot.isHighlightable()) {
+@@ -105,15 +_,12 @@
+ 
+             if (this.isHovering(slot, (double)p_283661_, (double)p_281248_) && slot.isActive()) {
+                 this.hoveredSlot = slot;
+-                int l = slot.x;
+-                int i1 = slot.y;
+-                if (this.hoveredSlot.isHighlightable()) {
 -                    renderSlotHighlight(p_283479_, l, i1, 0);
-+                    renderSlotHighlight(p_283479_, l, i1, 0, getSlotColor(k));
-                 }
+-                }
++                this.renderSlotHighlight(p_283479_, slot, p_283661_, p_281248_, p_281886_);
              }
          }
  
@@ -29,7 +32,7 @@
          ItemStack itemstack = this.draggingItem.isEmpty() ? this.menu.getCarried() : this.draggingItem;
          if (!itemstack.isEmpty()) {
              int l1 = 8;
-@@ -156,13 +_,16 @@
+@@ -156,13 +_,21 @@
      }
  
      public static void renderSlotHighlight(GuiGraphics p_283692_, int p_281453_, int p_281915_, int p_283504_) {
@@ -38,6 +41,11 @@
 +    }
 +    public static void renderSlotHighlight(GuiGraphics p_283692_, int p_281453_, int p_281915_, int p_283504_, int color) {
 +        p_283692_.fillGradient(RenderType.guiOverlay(), p_281453_, p_281915_, p_281453_ + 16, p_281915_ + 16, color, color, p_283504_);
++    }
++    protected void renderSlotHighlight(GuiGraphics guiGraphics, Slot slot, int mouseX, int mouseY, float partialTick) {
++        if (slot.isHighlightable()) {
++            renderSlotHighlight(guiGraphics, slot.x, slot.y, 0, getSlotColor(slot.index));
++        }
      }
  
      protected void renderTooltip(GuiGraphics p_283594_, int p_282171_, int p_281909_) {


### PR DESCRIPTION
I would like the ability to override how the highlight of slots is rendered.

It is currently possible to (somewhat awkwardly) override the color of this highlight in `getSlotColor` (Potentially we should rename this to `getSlotHighlightColor` or drop it entirely in favor of this patch).

What is not possible, is actually changing the highlight itself.

Some examples:
- Making it bigger (I have larger than 16x16 slots)
- Changing its visuals beyond changing the color
- Rendering an outline around the slot instead of a highlight background, etc. etc. etc.