### PR TITLE
[1.20.1] Avoid lambda use in `RegistryObject#get`

### DIFF
--- a/src/main/java/net/minecraftforge/registries/RegistryObject.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryObject.java
@@ -201,7 +201,7 @@ public final class RegistryObject<T> implements Supplier<T>
     public T get()
     {
         T ret = this.value;
-        Objects.requireNonNull(ret, () -> "Registry Object not present: " + this.name);
+        if (ret == null) throw new NullPointerException("Registry Object not present: " + this.name);
         return ret;
     }
 


### PR DESCRIPTION
Very simple change, it should be impossible for this to break anything. The JVM unfortunately does not reliably skip allocating the lambda when `ret != null` (see the following profiler results, for example). This isn't an issue in newer versions because `RegistryObject` no longer exists.

![registryobj](https://github.com/neoforged/NeoForge/assets/42941056/8390a02e-c440-4fb6-89a4-7c1fac4841d5)
![registryobj2](https://github.com/neoforged/NeoForge/assets/42941056/17178b72-954c-47ed-858f-b19daed1c747)
