### PR TITLE
Minimize allocations and avoid rebuilding weighted list when retrieving potential spawns

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -850,10 +850,14 @@ public class EventHooks {
         NeoForge.EVENT_BUS.post(new TickEvent.ServerTickEvent(TickEvent.Phase.END, haveTime, server));
     }
 
+    private static final WeightedRandomList<MobSpawnSettings.SpawnerData> NO_SPAWNS = WeightedRandomList.create();
+
     public static WeightedRandomList<MobSpawnSettings.SpawnerData> getPotentialSpawns(LevelAccessor level, MobCategory category, BlockPos pos, WeightedRandomList<MobSpawnSettings.SpawnerData> oldList) {
         LevelEvent.PotentialSpawns event = new LevelEvent.PotentialSpawns(level, category, pos, oldList);
         if (NeoForge.EVENT_BUS.post(event).isCanceled())
-            return WeightedRandomList.create();
+            return NO_SPAWNS;
+        else if (event.getSpawnerDataList() == oldList.unwrap())
+            return oldList;
         return WeightedRandomList.create(event.getSpawnerDataList());
     }
 


### PR DESCRIPTION
The current implementation of `EventHooks.getPotentialSpawns` is rather inefficient - it fires the event, then constructs an entirely new weighted random list from the event's results, even if no mods changed the potential spawns. This is not very efficient and leads to a lot of allocation overhead beyond the vanilla code, as shown here:

![potentialspawns](https://github.com/neoforged/NeoForge/assets/42941056/c3c6d136-dacf-4fa8-9556-6fa872d9069c)

This PR solves the issue by making a few changes:

* `LevelEvent.PotentialSpawns` now allocates its backing list lazily, rather than in the constructor.
* `EventHooks` now takes advantage of that change to reuse the existing weighted list from vanilla if no mods modify potential spawns.

With these changes, the only allocation overhead left is that of allocating the `LevelEvent.PotentialSpawns` object itself. Unfortunately, that still shows up in the allocation profiler, but solving it is not really possible unless we move to pooling hot events like this.
