### PR TITLE
[24w12a] Fix registry order for data components

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -119,6 +119,7 @@ public class GameData {
     public static Set<ResourceLocation> getRegistrationOrder() {
         Set<ResourceLocation> ordered = new LinkedHashSet<>();
         ordered.add(Registries.ATTRIBUTE.location()); // Vanilla order is incorrect, both Item and MobEffect depend on Attribute at construction time.
+        ordered.add(Registries.DATA_COMPONENT_TYPE.location()); // Vanilla order is incorrect, Item depends on data components at construction time.
         ordered.addAll(BuiltInRegistries.getVanillaRegistrationOrder());
         ordered.addAll(BuiltInRegistries.REGISTRY.keySet().stream().sorted(ResourceLocation::compareNamespaced).toList());
         return ordered;


### PR DESCRIPTION
Data components are required for `Item` construction, but vanilla's order bootstraps it toward the end of the operation. This works for vanilla due to classloading and static init, though for mod added data components it does not. For mods which wish to use other registry objects within a data component, all data components should internally use `Holder<RegistryDataType>` or suppliers, rather than the `RegistryDataType` directly, and thus this position in the bootstrap order is adequate.

Example:
```java
Holder<DataComponentType<Integer>> MY_INT_COMPONENT = register("my_int", 
builder -> builder.persistent(Codec.INT).networkSynchronized(ByteBufCodecs.VAR_INT));

Holder<Item> MY_ITEM = registerItem("my_item", new Item.Properties().component(MY_INT_COMPONENT.value(), 3));
```

<details>
<summary>New registry order:</summary>

```
 1. "minecraft:attribute"
 2. "minecraft:data_component_type"
 3. "minecraft:game_event"
 4. "minecraft:sound_event"
 5. "minecraft:fluid"
 6. "minecraft:mob_effect"
 7. "minecraft:block"
 8. "minecraft:enchantment"
 9. "minecraft:entity_type"
10. "minecraft:item"
11. "minecraft:potion"
12. "minecraft:particle_type"
13. "minecraft:block_entity_type"
14. "minecraft:painting_variant"
15. "minecraft:custom_stat"
16. "minecraft:chunk_status"
17. "minecraft:rule_test"
18. "minecraft:rule_block_entity_modifier"
19. "minecraft:pos_rule_test"
20. "minecraft:menu"
21. "minecraft:recipe_type"
22. "minecraft:recipe_serializer"
23. "minecraft:position_source_type"
24. "minecraft:command_argument_type"
25. "minecraft:stat_type"
26. "minecraft:villager_type"
27. "minecraft:villager_profession"
28. "minecraft:point_of_interest_type"
29. "minecraft:memory_module_type"
30. "minecraft:sensor_type"
31. "minecraft:schedule"
32. "minecraft:activity"
33. "minecraft:loot_pool_entry_type"
34. "minecraft:loot_function_type"
35. "minecraft:loot_condition_type"
36. "minecraft:loot_number_provider_type"
37. "minecraft:loot_nbt_provider_type"
38. "minecraft:loot_score_provider_type"
39. "minecraft:float_provider_type"
40. "minecraft:int_provider_type"
41. "minecraft:height_provider_type"
42. "minecraft:block_predicate_type"
43. "minecraft:worldgen/carver"
44. "minecraft:worldgen/feature"
45. "minecraft:worldgen/structure_placement"
46. "minecraft:worldgen/structure_piece"
47. "minecraft:worldgen/structure_type"
48. "minecraft:worldgen/placement_modifier_type"
49. "minecraft:worldgen/block_state_provider_type"
50. "minecraft:worldgen/foliage_placer_type"
51. "minecraft:worldgen/trunk_placer_type"
52. "minecraft:worldgen/root_placer_type"
53. "minecraft:worldgen/tree_decorator_type"
54. "minecraft:worldgen/feature_size_type"
55. "minecraft:worldgen/biome_source"
56. "minecraft:worldgen/chunk_generator"
57. "minecraft:worldgen/material_condition"
58. "minecraft:worldgen/material_rule"
59. "minecraft:worldgen/density_function_type"
60. "minecraft:block_type"
61. "minecraft:worldgen/structure_processor"
62. "minecraft:worldgen/structure_pool_element"
63. "minecraft:worldgen/pool_alias_binding"
64. "minecraft:cat_variant"
65. "minecraft:frog_variant"
66. "minecraft:instrument"
67. "minecraft:decorated_pot_patterns"
68. "minecraft:creative_mode_tab"
69. "minecraft:trigger_type"
70. "minecraft:number_format_type"
71. "minecraft:armor_material"
72. "minecraft:entity_sub_predicate_type"
73. "minecraft:item_sub_predicate_type"
74. "minecraft:map_decoration_type"
75. "neoforge:attachment_types"
76. "neoforge:biome_modifier_serializers"
77. "neoforge:condition_codecs"
78. "neoforge:display_contexts"
79. "neoforge:entity_data_serializers"
80. "neoforge:fluid_type"
81. "neoforge:global_loot_modifier_serializers"
82. "neoforge:holder_set_type"
83. "neoforge:ingredient_serializer"
84. "neoforge:structure_modifier_serializers"
```
</details>
