### PR TITLE
Pass RegistryFriendlyByteBuf to additional data writers for menus/entities

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -106,11 +106,11 @@
  
      @Override
      public OptionalInt openMenu(@Nullable MenuProvider p_9033_) {
-+        return openMenu(p_9033_, (java.util.function.Consumer<net.minecraft.network.FriendlyByteBuf>) null);
++        return openMenu(p_9033_, (java.util.function.Consumer<net.minecraft.network.RegistryFriendlyByteBuf>) null);
 +    }
 +
 +    @Override
-+    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable java.util.function.Consumer<net.minecraft.network.FriendlyByteBuf> extraDataWriter) {
++    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable java.util.function.Consumer<net.minecraft.network.RegistryFriendlyByteBuf> extraDataWriter) {
          if (p_9033_ == null) {
              return OptionalInt.empty();
          } else {
@@ -131,7 +131,7 @@
                      .send(new ClientboundOpenScreenPacket(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName()));
 +                } else {
 +                    this.connection
-+                        .send(new net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName(), extraDataWriter));
++                        .send(new net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName(), net.neoforged.neoforge.common.util.FriendlyByteBufUtil.writeCustomData(extraDataWriter, registryAccess())));
 +                }
                  this.initMenu(abstractcontainermenu);
                  this.containerMenu = abstractcontainermenu;

--- a/patches/net/minecraft/world/food/FoodProperties.java.patch
+++ b/patches/net/minecraft/world/food/FoodProperties.java.patch
@@ -30,7 +30,7 @@
              FoodProperties.PossibleEffect::probability,
              FoodProperties.PossibleEffect::new
          );
-+        
++
 +        private PossibleEffect(MobEffectInstance effect, float probability) {
 +            this(() -> effect, probability);
 +        }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IMenuTypeExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IMenuTypeExtension.java
@@ -5,7 +5,7 @@
 
 package net.neoforged.neoforge.common.extensions;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -17,5 +17,5 @@ public interface IMenuTypeExtension<T> {
         return new MenuType<>(factory, FeatureFlags.DEFAULT_FLAGS);
     }
 
-    T create(int windowId, Inventory playerInv, FriendlyByteBuf extraData);
+    T create(int windowId, Inventory playerInv, RegistryFriendlyByteBuf extraData);
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -8,7 +8,7 @@ package net.neoforged.neoforge.common.extensions;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -62,7 +62,7 @@ public interface IPlayerExtension {
      * @param extraDataWriter Consumer to write any additional data the GUI needs
      * @return The window ID of the opened GUI, or empty if the GUI could not be opened
      */
-    default OptionalInt openMenu(MenuProvider menuProvider, Consumer<FriendlyByteBuf> extraDataWriter) {
+    default OptionalInt openMenu(MenuProvider menuProvider, Consumer<RegistryFriendlyByteBuf> extraDataWriter) {
         return OptionalInt.empty();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/FriendlyByteBufUtil.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FriendlyByteBufUtil.java
@@ -7,7 +7,9 @@ package net.neoforged.neoforge.common.util;
 
 import io.netty.buffer.Unpooled;
 import java.util.function.Consumer;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 
 /**
  * Utility class for working with {@link FriendlyByteBuf}s.
@@ -18,13 +20,14 @@ public class FriendlyByteBufUtil {
     }
 
     /**
-     * Writes custom data to a {@link FriendlyByteBuf}, then returns the written data as a byte array.
+     * Writes custom data to a {@link RegistryFriendlyByteBuf}, then returns the written data as a byte array.
      *
-     * @param dataWriter The data writer.
+     * @param dataWriter     The data writer.
+     * @param registryAccess The registry access used by registry dependent writers on the buffer
      * @return The written data.
      */
-    public static byte[] writeCustomData(Consumer<FriendlyByteBuf> dataWriter) {
-        final FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
+    public static byte[] writeCustomData(Consumer<RegistryFriendlyByteBuf> dataWriter, RegistryAccess registryAccess) {
+        final RegistryFriendlyByteBuf buf = new RegistryFriendlyByteBuf(Unpooled.buffer(), registryAccess);
         try {
             dataWriter.accept(buf);
             return buf.array();

--- a/src/main/java/net/neoforged/neoforge/entity/IEntityWithComplexSpawn.java
+++ b/src/main/java/net/neoforged/neoforge/entity/IEntityWithComplexSpawn.java
@@ -5,7 +5,7 @@
 
 package net.neoforged.neoforge.entity;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 
 /**
  * An interface for Entities that need extra information to be communicated
@@ -18,7 +18,7 @@ public interface IEntityWithComplexSpawn {
      *
      * @param buffer The packet data stream
      */
-    void writeSpawnData(FriendlyByteBuf buffer);
+    void writeSpawnData(RegistryFriendlyByteBuf buffer);
 
     /**
      * Called by the client when it receives a Entity spawn packet.
@@ -26,5 +26,5 @@ public interface IEntityWithComplexSpawn {
      *
      * @param additionalData The packet data stream
      */
-    void readSpawnData(FriendlyByteBuf additionalData);
+    void readSpawnData(RegistryFriendlyByteBuf additionalData);
 }

--- a/src/main/java/net/neoforged/neoforge/network/IContainerFactory.java
+++ b/src/main/java/net/neoforged/neoforge/network/IContainerFactory.java
@@ -5,13 +5,13 @@
 
 package net.neoforged.neoforge.network;
 
-import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 
 public interface IContainerFactory<T extends AbstractContainerMenu> extends MenuType.MenuSupplier<T> {
-    T create(int windowId, Inventory inv, FriendlyByteBuf data);
+    T create(int windowId, Inventory inv, RegistryFriendlyByteBuf data);
 
     @Override
     default T create(int p_create_1_, Inventory p_create_2_) {

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedAddEntityPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedAddEntityPayload.java
@@ -42,7 +42,7 @@ public record AdvancedAddEntityPayload(int entityId, byte[] customPayload) imple
             return new byte[0];
         }
 
-        return FriendlyByteBufUtil.writeCustomData(additionalSpawnData::writeSpawnData);
+        return FriendlyByteBufUtil.writeCustomData(additionalSpawnData::writeSpawnData, entity.registryAccess());
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
@@ -5,9 +5,7 @@
 
 package net.neoforged.neoforge.network.payload;
 
-import java.util.function.Consumer;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentSerialization;
@@ -16,7 +14,6 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.MenuType;
-import net.neoforged.neoforge.common.util.FriendlyByteBufUtil;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.network.codec.NeoForgeStreamCodecs;
 import org.jetbrains.annotations.ApiStatus;
@@ -43,10 +40,6 @@ public record AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Comp
             NeoForgeStreamCodecs.UNBOUNDED_BYTE_ARRAY,
             AdvancedOpenScreenPayload::additionalData,
             AdvancedOpenScreenPayload::new);
-    public AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Component name, Consumer<FriendlyByteBuf> dataWriter) {
-        this(windowId, menuType, name, FriendlyByteBufUtil.writeCustomData(dataWriter));
-    }
-
     @Override
     public Type<AdvancedOpenScreenPayload> type() {
         return TYPE;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.syncher.SynchedEntityData;
@@ -98,10 +99,10 @@ public class EntityTests {
         protected void addAdditionalSaveData(CompoundTag tag) {}
 
         @Override
-        public void writeSpawnData(FriendlyByteBuf buffer) {}
+        public void writeSpawnData(RegistryFriendlyByteBuf buffer) {}
 
         @Override
-        public void readSpawnData(FriendlyByteBuf additionalData) {}
+        public void readSpawnData(RegistryFriendlyByteBuf additionalData) {}
     }
 
     public static final class AdaptedSpawnEntity extends Entity {


### PR DESCRIPTION
Many StreamCodecs require a `RegistryFriendlyByteBuf` rather than `FriendlyByteBuf` to work. 
To support this, we need to pass `RegistryFriendlyByteBuf` to the custom data writers for entity spawn and open menu packets.