### PR TITLE
Fix MenuType patch for RegistryFriendlyByteBuf

### DIFF
--- a/patches/net/minecraft/world/food/FoodProperties.java.patch
+++ b/patches/net/minecraft/world/food/FoodProperties.java.patch
@@ -26,15 +26,14 @@
          public static final Codec<FoodProperties.PossibleEffect> CODEC = RecordCodecBuilder.create(
              p_336029_ -> p_336029_.group(
                          MobEffectInstance.CODEC.fieldOf("effect").forGetter(FoodProperties.PossibleEffect::effect),
-@@ -94,9 +_,13 @@
-             FoodProperties.PossibleEffect::probability,
+@@ -95,8 +_,12 @@
              FoodProperties.PossibleEffect::new
          );
-+
+ 
 +        private PossibleEffect(MobEffectInstance effect, float probability) {
 +            this(() -> effect, probability);
 +        }
- 
++
          public MobEffectInstance effect() {
 -            return new MobEffectInstance(this.effect);
 +            return new MobEffectInstance(this.effectSupplier.get());

--- a/patches/net/minecraft/world/inventory/MenuType.java.patch
+++ b/patches/net/minecraft/world/inventory/MenuType.java.patch
@@ -16,7 +16,7 @@
 +    }
 +
 +    @Override
-+    public T create(int windowId, Inventory playerInv, net.minecraft.network.FriendlyByteBuf extraData) {
++    public T create(int windowId, Inventory playerInv, net.minecraft.network.RegistryFriendlyByteBuf extraData) {
 +        if (this.constructor instanceof net.neoforged.neoforge.network.IContainerFactory) {
 +            return ((net.neoforged.neoforge.network.IContainerFactory<T>) this.constructor).create(windowId, playerInv, extraData);
 +        }


### PR DESCRIPTION
In the last PR, this patch apparently was missing (my fault) and it got lost in the unrelated spotless errors.

Regenerating patches also realigned FoodProperties.java.patch for some reason 🤔 