### PR TITLE
Use object-form NBT when serializing

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CraftingHelper.java
@@ -22,7 +22,13 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 public class CraftingHelper {
-    public static final Codec<CompoundTag> TAG_CODEC = ExtraCodecs.withAlternative(TagParser.AS_CODEC, net.minecraft.nbt.CompoundTag.CODEC);
+
+    /**
+     * Codec that accepts either object-form NBT via {@link CompoundTag#CODEC} or stringified NBT via {@link TagParser#AS_CODEC}.
+     * <p>
+     * Always outputs object-form NBT.
+     */
+    public static final Codec<CompoundTag> TAG_CODEC = ExtraCodecs.withAlternative(CompoundTag.CODEC, TagParser.AS_CODEC);
 
     @ApiStatus.Internal
     public static Codec<ItemStack> smeltingResultCodec() {

--- a/src/main/java/net/neoforged/neoforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CraftingHelper.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 public class CraftingHelper {
-
     /**
      * Codec that accepts either object-form NBT via {@link CompoundTag#CODEC} or stringified NBT via {@link TagParser#AS_CODEC}.
      * <p>


### PR DESCRIPTION
Currently `CraftingHelper` specifies the `TAG_CODEC` as an alternative between `TagParser.AS_CODEC` and `CompoundTag.CODEC`.  The order of the parameters controls the serialized form that the codec emits, meaning this codec always emits stringified-nbt.

This PR changes the behavior to emit object NBT, which should always be preferred over stringified NBT due to ease of use and readability.