### PR TITLE
Attempt implementing better safe component type detection

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -44,6 +44,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -1316,11 +1317,9 @@ public class CommonHooks {
 
     static {
         // Mark common singletons as valid
-        markComponentClassAsValid(Block.class);
         markComponentClassAsValid(BlockState.class);
-        markComponentClassAsValid(Fluid.class);
         markComponentClassAsValid(FluidState.class);
-        markComponentClassAsValid(Item.class);
+        // Block, Fluid, Item, etc. are handled via the registry check further down
     }
 
     /**
@@ -1341,10 +1340,30 @@ public class CommonHooks {
 
             if (overridesEqualsAndHashCode(clazz)) {
                 checkedComponentClasses.add(clazz);
-            } else {
-                throw new IllegalArgumentException("Data components must implement equals and hashCode. Keep in mind they must also be immutable. Problematic class: " + clazz);
+                return;
+            }
+
+            // By far the slowest check: Is this a registry object?
+            // If it is, we assume it must be usable as a singleton...
+            if (isPotentialRegistryObject(dataComponent)) {
+                checkedComponentClasses.add(clazz);
+                return;
+            }
+
+            throw new IllegalArgumentException("Data components must implement equals and hashCode. Keep in mind they must also be immutable. Problematic class: " + clazz);
+        }
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static boolean isPotentialRegistryObject(Object value) {
+        for (Registry registry : BuiltInRegistries.REGISTRY) {
+            if (registry.containsValue(value)) {
+                LOGGER.info("Whitelisting {} as component type, since {} is contained in registry {}",
+                        value.getClass(), value, registry.key().location());
+                return true;
             }
         }
+        return false;
     }
 
     private static boolean overridesEqualsAndHashCode(Class<?> clazz) {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1358,8 +1358,6 @@ public class CommonHooks {
     private static boolean isPotentialRegistryObject(Object value) {
         for (Registry registry : BuiltInRegistries.REGISTRY) {
             if (registry.containsValue(value)) {
-                LOGGER.info("Whitelisting {} as component type, since {} is contained in registry {}",
-                        value.getClass(), value, registry.key().location());
                 return true;
             }
         }


### PR DESCRIPTION
Fixes the following issue and introduces an annotation to whitelist modder classes.

```
Caused by: java.lang.IllegalArgumentException: Data components must implement equals and hashCode. Keep in mind they must also be immutable. Problematic class: class net.minecraft.world.item.BlockItem
```
