### PR TITLE
Add sprite getter to FluidSpriteCache

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
@@ -43,7 +43,7 @@ public final class FluidSpriteCache {
     }
 
     /**
-     * {@return a specified sprite or a missing sprite texture if sprite is not found.
+     * {@return a specified sprite or a missing sprite texture if sprite is not found}
      */
     public static TextureAtlasSprite getSprite(ResourceLocation texture) {
         return textureLookup.getOrDefault(texture, missingSprite);

--- a/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
@@ -42,6 +42,13 @@ public final class FluidSpriteCache {
         };
     }
 
+    /**
+     * {@return a specified sprite or a missing sprite texture if sprite is not found.
+     */
+    public static TextureAtlasSprite getSprites(ResourceLocation texture) {
+        return textureLookup.getOrDefault(texture, missingSprite);
+    }
+
     @ApiStatus.Internal
     @SuppressWarnings("deprecation")
     public static void reload() {

--- a/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/FluidSpriteCache.java
@@ -45,7 +45,7 @@ public final class FluidSpriteCache {
     /**
      * {@return a specified sprite or a missing sprite texture if sprite is not found.
      */
-    public static TextureAtlasSprite getSprites(ResourceLocation texture) {
+    public static TextureAtlasSprite getSprite(ResourceLocation texture) {
         return textureLookup.getOrDefault(texture, missingSprite);
     }
 


### PR DESCRIPTION
Allows modders to use the sprite cache in their renderFluid method within IClientFluidTypeExtensions. Allows modders to not need to maintain their own texture cache and a resourcelistener to bust that cache. Instead, allow Neoforge to handle all that for them.