### PR TITLE
Avoid unnecessarily converting render types to strings

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ChunkRenderTypeSet.java
+++ b/src/main/java/net/neoforged/neoforge/client/ChunkRenderTypeSet.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.client;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -51,7 +50,9 @@ public sealed class ChunkRenderTypeSet implements Iterable<RenderType> {
         var bits = new BitSet();
         for (RenderType renderType : renderTypes) {
             int index = renderType.getChunkLayerId();
-            Preconditions.checkArgument(index >= 0, "Attempted to create chunk render type set with a non-chunk render type: " + renderType);
+            if (index < 0) {
+                throw new IllegalArgumentException("Attempted to create chunk render type set with a non-chunk render type: " + renderType);
+            }
             bits.set(index);
         }
         return new ChunkRenderTypeSet(bits);


### PR DESCRIPTION
The use of `Preconditions` here required evaluating the string concatenation early, even if the index was actually valid. `RenderType#toString` is relatively complex, so it should not be called unnecessarily. The explicit `if`/`throw` pattern avoids this problem, and isn't really that much worse to read.

![chunkrendertypeset](https://github.com/neoforged/NeoForge/assets/42941056/b3db8843-0d3b-4a91-b24e-966362b74922)
