### PR TITLE
Add the custom payload id to exceptions thrown by custom payload serializers/deserializers

### DIFF
--- a/patches/net/minecraft/network/protocol/common/ClientboundCustomPayloadPacket.java.patch
+++ b/patches/net/minecraft/network/protocol/common/ClientboundCustomPayloadPacket.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/network/protocol/common/ClientboundCustomPayloadPacket.java
 +++ b/net/minecraft/network/protocol/common/ClientboundCustomPayloadPacket.java
-@@ -53,10 +_,43 @@
+@@ -53,10 +_,47 @@
          .put(WorldGenAttemptDebugPayload.ID, WorldGenAttemptDebugPayload::new)
          .build();
  
@@ -33,8 +33,12 @@
 +     * @return The payload
 +     */
 +    private static CustomPacketPayload readPayload(ResourceLocation p_294367_, FriendlyByteBuf p_294321_, io.netty.channel.ChannelHandlerContext context, net.minecraft.network.ConnectionProtocol protocol) {
++        try {
 +        FriendlyByteBuf.Reader<? extends CustomPacketPayload> reader = net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().getReader(p_294367_, context, protocol, KNOWN_TYPES);
-+        return (CustomPacketPayload)(reader != null ? reader.apply(p_294321_) : readUnknownPayload(p_294367_, p_294321_));
++        return (CustomPacketPayload) (reader != null ? reader.apply(p_294321_) : readUnknownPayload(p_294367_, p_294321_));
++        } catch (RuntimeException e) {
++            throw new RuntimeException("Failed reading custom payload " + p_294367_ + ": " + e, e); // Make it easier to debug which mod payload failed to be decoded
++        }
 +    }
 +
 +    /**
@@ -44,3 +48,15 @@
      private static CustomPacketPayload readPayload(ResourceLocation p_294802_, FriendlyByteBuf p_294886_) {
          FriendlyByteBuf.Reader<? extends CustomPacketPayload> reader = KNOWN_TYPES.get(p_294802_);
          return (CustomPacketPayload)(reader != null ? reader.apply(p_294886_) : readUnknownPayload(p_294802_, p_294886_));
+@@ -75,7 +_,11 @@
+     @Override
+     public void write(FriendlyByteBuf p_295630_) {
+         p_295630_.writeResourceLocation(this.payload.id());
++        try {
+         this.payload.write(p_295630_);
++        } catch (RuntimeException e) {
++            throw new RuntimeException("Failed writing custom payload " + this.payload.id() + ": " + e, e); // Make it easier to debug which mod payload failed to be encoded
++        }
+     }
+ 
+     public void handle(ClientCommonPacketListener p_295761_) {

--- a/patches/net/minecraft/network/protocol/common/ServerboundCustomPayloadPacket.java.patch
+++ b/patches/net/minecraft/network/protocol/common/ServerboundCustomPayloadPacket.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/network/protocol/common/ServerboundCustomPayloadPacket.java
 +++ b/net/minecraft/network/protocol/common/ServerboundCustomPayloadPacket.java
-@@ -17,10 +_,49 @@
+@@ -17,10 +_,53 @@
          .put(BrandPayload.ID, BrandPayload::new)
          .build();
  
@@ -36,7 +36,11 @@
 +     */
 +    private static CustomPacketPayload readPayload(ResourceLocation p_294367_, FriendlyByteBuf p_294321_, io.netty.channel.ChannelHandlerContext context, net.minecraft.network.ConnectionProtocol protocol) {
 +        FriendlyByteBuf.Reader<? extends CustomPacketPayload> reader = net.neoforged.neoforge.network.registration.NetworkRegistry.getInstance().getReader(p_294367_, context, protocol, KNOWN_TYPES);
-+        return (CustomPacketPayload)(reader != null ? reader.apply(p_294321_) : readUnknownPayload(p_294367_, p_294321_));
++        try {
++        return (CustomPacketPayload) (reader != null ? reader.apply(p_294321_) : readUnknownPayload(p_294367_, p_294321_));
++        } catch (RuntimeException e) {
++            throw new RuntimeException("Failed reading custom payload " + p_294367_ + ": " + e, e); // Make it easier to debug which mod payload failed to be decoded
++        }
 +    }
 +
 +    /**
@@ -50,3 +54,15 @@
      private static CustomPacketPayload readPayload(ResourceLocation p_294367_, FriendlyByteBuf p_294321_) {
          FriendlyByteBuf.Reader<? extends CustomPacketPayload> reader = KNOWN_TYPES.get(p_294367_);
          return (CustomPacketPayload)(reader != null ? reader.apply(p_294321_) : readUnknownPayload(p_294367_, p_294321_));
+@@ -39,7 +_,11 @@
+     @Override
+     public void write(FriendlyByteBuf p_295621_) {
+         p_295621_.writeResourceLocation(this.payload.id());
++        try {
+         this.payload.write(p_295621_);
++        } catch (RuntimeException e) {
++            throw new RuntimeException("Failed writing custom payload " + this.payload.id() + ": " + e, e); // Make it easier to debug which mod payload failed to be encoded
++        }
+     }
+ 
+     public void handle(ServerCommonPacketListener p_295862_) {


### PR DESCRIPTION
Currently the message sent to clients when a packet encode/decode fails does not include the payload id, making it difficult to debug.

I couldn't find a built-in modded serverbound packet to test this with, but I inserted a `NullPointerException` into both read/write of `MinecraftRegisterPayload` to see what it does.

Clientbound, Exception occurs when writing the packet on the server-side:
![image](https://github.com/neoforged/NeoForge/assets/1261399/99a72ec2-56b8-4afa-87db-0d91d862485b)

Clientbound, Exception occurs when reading the packet on the client-side:
![image](https://github.com/neoforged/NeoForge/assets/1261399/e6866ac3-6ca9-484e-af3d-01be3fdf46d9)
