### PR TITLE
Register ItemHandler capability for the crafter

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
@@ -95,7 +95,8 @@ public class CapabilityHooks {
                 BlockEntityType.CHISELED_BOOKSHELF,
                 BlockEntityType.DISPENSER,
                 BlockEntityType.DROPPER,
-                BlockEntityType.JUKEBOX);
+                BlockEntityType.JUKEBOX,
+                BlockEntityType.CRAFTER);
         for (var type : nonSidedVanillaContainers) {
             event.registerBlockEntity(Capabilities.ItemHandler.BLOCK, type, (container, side) -> new InvWrapper(container));
         }


### PR DESCRIPTION
This allows mods to interact with it properly, like for other vanilla blocks such as droppers. Tested with Modern Dynamics. Also verified that this doesn't break loading worlds without the feature flag.