### PR TITLE
Add `TestHolderGenerator` annotation

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/annotation/TestHolderGenerator.java
+++ b/testframework/src/main/java/net/neoforged/testframework/annotation/TestHolderGenerator.java
@@ -1,16 +1,14 @@
 package net.neoforged.testframework.annotation;
 
-import net.neoforged.testframework.Test;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import net.neoforged.testframework.Test;
 
 /**
  * Annotation used to generate {@link Test}. Annotated methods must be static, take no parameters, and return an {@link Iterable} of {@link Test}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })
-public @interface TestHolderGenerator {
-}
+public @interface TestHolderGenerator {}

--- a/testframework/src/main/java/net/neoforged/testframework/annotation/TestHolderGenerator.java
+++ b/testframework/src/main/java/net/neoforged/testframework/annotation/TestHolderGenerator.java
@@ -1,0 +1,16 @@
+package net.neoforged.testframework.annotation;
+
+import net.neoforged.testframework.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to generate {@link Test}. Annotated methods must be static, take no parameters, and return an {@link Iterable} of {@link Test}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface TestHolderGenerator {
+}

--- a/testframework/src/main/java/net/neoforged/testframework/annotation/TestHolderGenerator.java
+++ b/testframework/src/main/java/net/neoforged/testframework/annotation/TestHolderGenerator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.testframework.annotation;
 
 import java.lang.annotation.ElementType;

--- a/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
@@ -69,7 +69,6 @@ import org.jetbrains.annotations.UnknownNullability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 @ApiStatus.Internal
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault

--- a/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
@@ -51,6 +51,7 @@ import net.neoforged.testframework.Test;
 import net.neoforged.testframework.TestListener;
 import net.neoforged.testframework.annotation.OnInit;
 import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.annotation.TestHolderGenerator;
 import net.neoforged.testframework.conf.Feature;
 import net.neoforged.testframework.conf.FrameworkConfiguration;
 import net.neoforged.testframework.gametest.DynamicStructureTemplates;
@@ -67,6 +68,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 @ApiStatus.Internal
 @ParametersAreNonnullByDefault
@@ -262,6 +264,7 @@ public class TestFrameworkImpl implements MutableTestFramework {
         tests.addAll(FrameworkCollectors.Tests.forMethodsWithAnnotation(container, TestHolder.class));
         tests.addAll(FrameworkCollectors.Tests.forGameTestMethodsWithAnnotation(container, TestHolder.class));
         tests.addAll(FrameworkCollectors.Tests.forClassesWithAnnotation(container, TestHolder.class));
+        tests.addAll(FrameworkCollectors.Tests.forGeneratorMethodsWithAnnotation(container, TestHolderGenerator.class));
         return tests;
     }
 

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/SimpleGameTestTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/SimpleGameTestTest.java
@@ -1,18 +1,21 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.testframework.impl.test;
 
 import java.util.function.Consumer;
-import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.chat.Component;
 import net.neoforged.testframework.TestFramework;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.gametest.GameTestData;
 
-public class SimpleGameTestTest<T extends GameTestHelper> extends AbstractTest.Dynamic {
-    private final Class<T> helperType;
-    private final Consumer<T> function;
+public class SimpleGameTestTest extends AbstractTest.Dynamic {
+    private final Consumer<ExtendedGameTestHelper> function;
 
-    public SimpleGameTestTest(GameTestData data, Class<T> helperType, Consumer<T> function) {
+    public SimpleGameTestTest(GameTestData data, Consumer<ExtendedGameTestHelper> function) {
         this.gameTestData = data;
-        this.helperType = helperType;
         this.function = function;
 
         this.visuals.description().add(Component.literal("GameTest-only"));
@@ -21,7 +24,7 @@ public class SimpleGameTestTest<T extends GameTestHelper> extends AbstractTest.D
     @Override
     public void init(TestFramework framework) {
         super.init(framework);
-        onGameTest(helperType, helper -> {
+        onGameTest(helper -> {
             try {
                 function.accept(helper);
             } catch (Throwable e) {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/SimpleGameTestTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/SimpleGameTestTest.java
@@ -1,16 +1,12 @@
 package net.neoforged.testframework.impl.test;
 
+import java.util.function.Consumer;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.chat.Component;
 import net.neoforged.testframework.TestFramework;
-import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.gametest.GameTestData;
-import net.neoforged.testframework.gametest.GameTestHelperFactory;
-
-import java.util.function.Consumer;
 
 public class SimpleGameTestTest<T extends GameTestHelper> extends AbstractTest.Dynamic {
-
     private final Class<T> helperType;
     private final Consumer<T> function;
 

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/SimpleGameTestTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/SimpleGameTestTest.java
@@ -1,0 +1,36 @@
+package net.neoforged.testframework.impl.test;
+
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.chat.Component;
+import net.neoforged.testframework.TestFramework;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
+import net.neoforged.testframework.gametest.GameTestData;
+import net.neoforged.testframework.gametest.GameTestHelperFactory;
+
+import java.util.function.Consumer;
+
+public class SimpleGameTestTest<T extends GameTestHelper> extends AbstractTest.Dynamic {
+
+    private final Class<T> helperType;
+    private final Consumer<T> function;
+
+    public SimpleGameTestTest(GameTestData data, Class<T> helperType, Consumer<T> function) {
+        this.gameTestData = data;
+        this.helperType = helperType;
+        this.function = function;
+
+        this.visuals.description().add(Component.literal("GameTest-only"));
+    }
+
+    @Override
+    public void init(TestFramework framework) {
+        super.init(framework);
+        onGameTest(helperType, helper -> {
+            try {
+                function.accept(helper);
+            } catch (Throwable e) {
+                throw new RuntimeException("Encountered exception running method-based test", e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR add the `TestHolderGenerator` to the testframework. It's the contrepart  of the `GameTestGenerator` annotation.
ex:

```java
@TestHolderGenerator
public static List<Test> generateTests() {
    return List.of(
        ...
    );
}
```