### PR TITLE
[24w13a] Fix ItemStackHandler not serializing items correctly

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
@@ -141,8 +141,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
             if (!stacks.get(i).isEmpty()) {
                 CompoundTag itemTag = new CompoundTag();
                 itemTag.putInt("Slot", i);
-                stacks.get(i).save(provider, itemTag);
-                nbtTagList.add(itemTag);
+                nbtTagList.add(stacks.get(i).save(provider, itemTag));
             }
         }
         CompoundTag nbt = new CompoundTag();


### PR DESCRIPTION
Basic PR to fix ItemStackHandlers not serializing items correctly.
They are calling the correct `ItemStack.save` method but are completly ignoring the result of the save, meaning only slot information is saved to disk, no item specific data.