### PR TITLE
[1.20.4] Improve detection of dynamic block light sources during light updates in chunk generation and loading

### DIFF
--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -37,7 +37,7 @@
 -                            if (p_285343_.test(blockstate)) {
 -                                p_285030_.accept(blockpos$mutableblockpos.setWithOffset(blockpos, l, j, k), blockstate);
 +                            blockpos$mutableblockpos.setWithOffset(blockpos, l, j, k);
-+                            if (fineFilter.test(blockstate, blockpos$mutableblockpos.immutable())) {
++                            if (fineFilter.test(blockstate, blockpos$mutableblockpos)) {
 +                                p_285030_.accept(blockpos$mutableblockpos, blockstate);
                              }
                          }

--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -9,35 +9,35 @@
      public static final int NO_FILLED_SECTION = -1;
      private static final Logger LOGGER = LogUtils.getLogger();
      private static final LongSet EMPTY_REFERENCE_SET = new LongOpenHashSet();
-@@ -308,23 +_,28 @@
+@@ -308,10 +_,19 @@
  
      @Override
      public final void findBlockLightSources(BiConsumer<BlockPos, BlockState> p_285269_) {
 -        this.findBlocks(p_284897_ -> p_284897_.getLightEmission() != 0, p_285269_);
-+        this.findBlocks((p_284897_, pos) -> p_284897_.getLightEmission(this, pos) != 0, p_285269_);
++        this.findBlocks(p_284897_ -> p_284897_.hasDynamicLightEmission() || p_284897_.getLightEmission(net.minecraft.world.level.EmptyBlockGetter.INSTANCE, BlockPos.ZERO) != 0, (p_284897_, pos) -> p_284897_.getLightEmission(this, pos) != 0, p_285269_);
      }
  
      public void findBlocks(Predicate<BlockState> p_285343_, BiConsumer<BlockPos, BlockState> p_285030_) {
-+        findBlocks((state, pos) -> p_285343_.test(state), p_285030_);
++        findBlocks(p_285343_, (state, pos) -> p_285343_.test(state), p_285030_);
 +    }
 +
++    @Deprecated(forRemoval = true)
 +    public void findBlocks(java.util.function.BiPredicate<BlockState, BlockPos> p_285343_, BiConsumer<BlockPos, BlockState> p_285030_) {
++        findBlocks(state -> p_285343_.test(state, BlockPos.ZERO), p_285343_, p_285030_);
++    }
++
++    public void findBlocks(Predicate<BlockState> p_285343_, java.util.function.BiPredicate<BlockState, BlockPos> fineFilter, BiConsumer<BlockPos, BlockState> p_285030_) {
          BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
  
          for(int i = this.getMinSection(); i < this.getMaxSection(); ++i) {
-             LevelChunkSection levelchunksection = this.getSection(this.getSectionIndexFromSectionY(i));
--            if (levelchunksection.maybeHas(p_285343_)) {
-+            if (levelchunksection.maybeHas((state) -> p_285343_.test(state, BlockPos.ZERO))) {
-                 BlockPos blockpos = SectionPos.of(this.chunkPos, i).origin();
- 
-                 for(int j = 0; j < 16; ++j) {
+@@ -323,8 +_,9 @@
                      for(int k = 0; k < 16; ++k) {
                          for(int l = 0; l < 16; ++l) {
                              BlockState blockstate = levelchunksection.getBlockState(l, j, k);
 -                            if (p_285343_.test(blockstate)) {
 -                                p_285030_.accept(blockpos$mutableblockpos.setWithOffset(blockpos, l, j, k), blockstate);
 +                            blockpos$mutableblockpos.setWithOffset(blockpos, l, j, k);
-+                            if (p_285343_.test(blockstate, blockpos$mutableblockpos.immutable())) {
++                            if (fineFilter.test(blockstate, blockpos$mutableblockpos.immutable())) {
 +                                p_285030_.accept(blockpos$mutableblockpos, blockstate);
                              }
                          }

--- a/patches/net/minecraft/world/level/chunk/ImposterProtoChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ImposterProtoChunk.java.patch
@@ -1,11 +1,16 @@
 --- a/net/minecraft/world/level/chunk/ImposterProtoChunk.java
 +++ b/net/minecraft/world/level/chunk/ImposterProtoChunk.java
-@@ -217,6 +_,10 @@
+@@ -217,6 +_,15 @@
      }
  
      @Override
-+    public void findBlocks(java.util.function.BiPredicate<BlockState, BlockPos> p_285343_, BiConsumer<BlockPos, BlockState> p_285030_) {
-+        this.wrapped.findBlocks(p_285343_, p_285030_);
++    public void findBlocks(java.util.function.BiPredicate<BlockState, BlockPos> p_285465_, BiConsumer<BlockPos, BlockState> p_285030_) {
++        this.wrapped.findBlocks(p_285465_, p_285030_);
++    }
++
++    @Override
++    public void findBlocks(Predicate<BlockState> p_285465_, java.util.function.BiPredicate<BlockState, BlockPos> fineFilter, BiConsumer<BlockPos, BlockState> p_285030_) {
++        this.wrapped.findBlocks(p_285465_, fineFilter, p_285030_);
 +    }
 +
      public TickContainerAccess<Block> getBlockTicks() {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -42,6 +42,7 @@ import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.common.IPlantable;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
+import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.EventHooks;
 import org.jetbrains.annotations.Nullable;
 
@@ -66,6 +67,17 @@ public interface IBlockStateExtension {
      */
     default float getFriction(LevelReader level, BlockPos pos, @Nullable Entity entity) {
         return self().getBlock().getFriction(self(), level, pos, entity);
+    }
+
+    /**
+     * Whether this block state has dynamic light emission which is not solely based on its underlying block or its
+     * state properties and instead uses the {@link BlockPos}, the {@link AuxiliaryLightManager} or another external
+     * data source to determine its light value in {@link #getLightEmission(BlockGetter, BlockPos)}
+     *
+     * @return true if this block state cannot determine its light emission solely based on its properties, false otherwise
+     */
+    default boolean hasDynamicLightEmission() {
+        return self().getBlock().hasDynamicLightEmission(self());
     }
 
     /**

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
@@ -120,6 +120,11 @@ public class BlockPropertyTests {
         }
 
         @Override
+        public boolean hasDynamicLightEmission(BlockState state) {
+            return true;
+        }
+
+        @Override
         public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
             AuxiliaryLightManager lightManager = level.getAuxLightManager(pos);
             if (lightManager != null) {


### PR DESCRIPTION
This PR improves the way dynamic block light sources are handled when a chunk determines whether it contains any potentially light-emitting blocks during chunk generation or loading. This removes the hack of having to check the position for reference equality with `BlockPos.ZERO` (which not even the test mod was doing correctly).