### PR TITLE
Issue #733 Add getRelevantPlayers method to OnDatapackSyncEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -109,12 +109,11 @@ public class NeoForgeEventHandler {
 
     @SubscribeEvent
     public void onDpSync(final OnDatapackSyncEvent event) {
-        final List<ServerPlayer> players = event.getPlayer() == null ? event.getPlayerList().getPlayers() : List.of(event.getPlayer());
         RegistryManager.getDataMaps().forEach((registry, values) -> {
             final var regOpt = event.getPlayerList().getServer().overworld().registryAccess()
                     .registry(registry);
             if (regOpt.isEmpty()) return;
-            players.forEach(player -> {
+            event.getRelevantPlayers().forEach(player -> {
                 if (!player.connection.isConnected(RegistryDataMapSyncPayload.ID)) {
                     return;
                 }

--- a/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
@@ -27,23 +27,27 @@ public class OnDatapackSyncEvent extends Event {
     }
 
     /**
-     * @return The server's player list to get a view of all players.
+     * Gets the server's player list, containing all players, when the event fires.
+     *
+     * @return The server's player list.
      */
     public PlayerList getPlayerList() {
         return this.playerList;
     }
 
     /**
-     * @return A stream of players to sync datapacks to. If a player is specified,
-     *         the stream will only contain that player.
+     * Creates a stream of players that need to receive data during this event, which is the specified player (if present) or all players.
+     *
+     * @return A stream of players to sync data to.
      */
     public Stream<ServerPlayer> getRelevantPlayers() {
         return this.player == null ? this.playerList.getPlayers().stream() : Stream.of(this.player);
     }
 
     /**
-     * @return The player to sync datapacks to. Null when syncing for all players,
-     *         such as when the reload command runs.
+     * Gets the player that is joining the server, or null when syncing for all players, such as when the reload command runs.
+     *
+     * @return The player to sync datapacks to. Null when syncing for all players.
      */
     @Nullable
     public ServerPlayer getPlayer() {

--- a/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.event;
 
+import java.util.stream.Stream;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
 import net.neoforged.bus.api.Event;
@@ -30,6 +31,14 @@ public class OnDatapackSyncEvent extends Event {
      */
     public PlayerList getPlayerList() {
         return this.playerList;
+    }
+
+    /**
+     * @return A stream of players to sync datapacks to. If a player is specified,
+     *         the stream will only contain that player.
+     */
+    public Stream<ServerPlayer> getRelevantPlayers() {
+        return this.player == null ? this.playerList.getPlayers().stream() : Stream.of(this.player);
     }
 
     /**


### PR DESCRIPTION
Adds the util method requested under issue #733. Simply checks if it is one player or many and adds it to a stream. It also includes migrating the NeoForgeEventHandler class to using the util method. 