### PR TITLE
[24w13a] Fix FluidTank not serializing fluids correctly 

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidTank.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.fluids.capability.templates;
 import java.util.function.Predicate;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.IFluidTank;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
@@ -61,10 +60,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
     }
 
     public FluidTank readFromNBT(HolderLookup.Provider lookupProvider, CompoundTag nbt) {
-        if (nbt.contains("Fluid", Tag.TAG_COMPOUND)) {
-            fluid = FluidStack.parseOptional(lookupProvider, nbt.getCompound("Fluid"));
-        }
-
+        fluid = FluidStack.parseOptional(lookupProvider, nbt.getCompound("Fluid"));
         return this;
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidTank.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.fluids.capability.templates;
 import java.util.function.Predicate;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.IFluidTank;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
@@ -60,14 +61,16 @@ public class FluidTank implements IFluidHandler, IFluidTank {
     }
 
     public FluidTank readFromNBT(HolderLookup.Provider lookupProvider, CompoundTag nbt) {
-        FluidStack fluid = FluidStack.parseOptional(lookupProvider, nbt);
-        setFluid(fluid);
+        if (nbt.contains("Fluid", Tag.TAG_COMPOUND)) {
+            fluid = FluidStack.parseOptional(lookupProvider, nbt.getCompound("Fluid"));
+        }
+
         return this;
     }
 
     public CompoundTag writeToNBT(HolderLookup.Provider lookupProvider, CompoundTag nbt) {
         if (!fluid.isEmpty()) {
-            fluid.save(lookupProvider, nbt);
+            nbt.put("Fluid", fluid.save(lookupProvider));
         }
 
         return nbt;


### PR DESCRIPTION
Variant of https://github.com/neoforged/NeoForge/pull/763 but for `FluidTank`.

`FluidTank` currently does not save the serialized `FluidStack` tag to disk, due to ignoring the return of `FluidStack#save`

This is fixed by writing the fluid to a `Fluid` sub tag in the provided `CompoundTag`, before the data was written directly to the `CompoundTag` but with how `FluidStack#save` works (by directly invoking the codec and writing its own tag) this is not possible any more.

Perhaps `FluidTank` should implement `INBTSerializable<CompoundTag>` now and serialize in a similar fashion of `ItemStackHandler`? where `serializeNBT` / `deserializeNBT` affect the tag directly and its left up to the caller as to where the tag is saved to/loaded from.

This would go against how `readFromNBT` and `writeToNBT` currently work though, where the caller passes their root tag and the tank itself handles saving into/loading from the root nbt tag.