### PR TITLE
Optimize ModelData when used with very few properties

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -75,7 +75,7 @@ public final class ModelData {
          * Hash maps are slower than array maps for *extremely* small maps (empty maps or singletons are the most
          * extreme examples). Many block entities/models only use a single model data property, which means the
          * overhead of hashing is quite wasteful. However, we do want to support any number of properties with
-         * reasonable performance. Therefore, we use an array map until the number of properties exceeds this
+         * reasonable performance. Therefore, we use an array map until the number of properties reaches this
          * threshold, at which point we convert it to a hash map.
          */
         private static final int HASH_THRESHOLD = 4;

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -6,8 +6,9 @@
 package net.neoforged.neoforge.client.model.data;
 
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceArrayMap;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 import net.minecraft.client.renderer.RenderType;
@@ -37,12 +38,19 @@ public final class ModelData {
 
     private final Map<ModelProperty<?>, Object> properties;
 
+    @Nullable
+    private Set<ModelProperty<?>> propertySetView;
+
     private ModelData(Map<ModelProperty<?>, Object> properties) {
         this.properties = properties;
     }
 
     public Set<ModelProperty<?>> getProperties() {
-        return properties.keySet();
+        var view = propertySetView;
+        if (view == null) {
+            propertySetView = view = Collections.unmodifiableSet(properties.keySet());
+        }
+        return view;
     }
 
     public boolean has(ModelProperty<?> property) {
@@ -63,11 +71,23 @@ public final class ModelData {
     }
 
     public static final class Builder {
-        private final Map<ModelProperty<?>, Object> properties = new IdentityHashMap<>();
+        /**
+         * Hash maps are slower than array maps for *extremely* small maps (empty maps or singletons are the most
+         * extreme examples). Many block entities/models only use a single model data property, which means the
+         * overhead of hashing is quite wasteful. However, we do want to support any number of properties with
+         * reasonable performance. Therefore, we use an array map until the number of properties exceeds this
+         * threshold, at which point we convert it to a hash map.
+         */
+        private static final int HASH_THRESHOLD = 4;
+
+        private Map<ModelProperty<?>, Object> properties;
 
         private Builder(@Nullable ModelData parent) {
             if (parent != null) {
-                properties.putAll(parent.properties);
+                // When cloning the map, use the expected type based on size
+                properties = parent.properties.size() >= HASH_THRESHOLD ? new Reference2ReferenceOpenHashMap<>(parent.properties) : new Reference2ReferenceArrayMap<>(parent.properties);
+            } else {
+                properties = new Reference2ReferenceArrayMap<>();
             }
         }
 
@@ -75,13 +95,16 @@ public final class ModelData {
         public <T> Builder with(ModelProperty<T> property, T value) {
             Preconditions.checkState(property.test(value), "The provided value is invalid for this property.");
             properties.put(property, value);
+            // Convert to a hash map if needed
+            if (properties.size() >= HASH_THRESHOLD && properties instanceof Reference2ReferenceArrayMap<ModelProperty<?>, Object>) {
+                properties = new Reference2ReferenceOpenHashMap<>(properties);
+            }
             return this;
         }
 
         @Contract("-> new")
         public ModelData build() {
-            // IdentityHashMap is slow when calling get() on an empty instance, so use a singleton empty map if possible
-            return new ModelData(properties.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(properties));
+            return new ModelData(properties);
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -87,7 +87,10 @@ public final class ModelData {
                 // When cloning the map, use the expected type based on size
                 properties = parent.properties.size() >= HASH_THRESHOLD ? new Reference2ReferenceOpenHashMap<>(parent.properties) : new Reference2ReferenceArrayMap<>(parent.properties);
             } else {
-                properties = new Reference2ReferenceArrayMap<>();
+                // Allocate the maximum number of entries we'd ever put into the map.
+                // We convert to a hash map *after* insertion of the HASH_THRESHOLD
+                // entry, so we need at least that many spots.
+                properties = new Reference2ReferenceArrayMap<>(HASH_THRESHOLD);
             }
         }
 

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -96,7 +96,7 @@ public final class ModelData {
             Preconditions.checkState(property.test(value), "The provided value is invalid for this property.");
             properties.put(property, value);
             // Convert to a hash map if needed
-            if (properties.size() >= HASH_THRESHOLD && properties instanceof Reference2ReferenceArrayMap<ModelProperty<?>, Object>) {
+            if (properties.size() == HASH_THRESHOLD && properties instanceof Reference2ReferenceArrayMap<ModelProperty<?>, Object>) {
                 properties = new Reference2ReferenceOpenHashMap<>(properties);
             }
             return this;


### PR DESCRIPTION
While testing a refactor to FramedBlocks, I noticed that getting values out of `ModelData` is quite inefficient for cases where the model data only uses a single property (which seems likely to be the case, and CTM/FramedBlocks are good examples of this).

We can make `ModelData` very fast for this use case by using an array map for extremely small instances and only switching to the hash map once the number of properties is large enough to justify the cost savings. In a [synthetic benchmark](https://gist.github.com/embeddedt/6a82283e88375610ecbc11bb3995956a) I wrote, I saw ~50% improvement in `ModelData.get()` execution time. Profiling FramedBlocks also showed similar gains, as `ModelData.get()` was no longer a bottleneck.

A second optimization/cleanup is to remove the `unmodifiableMap` wrapper from the map given to the `ModelData` constructor . Since the map is not accessible to user code by most APIs, this does nothing but add an extra layer of indirection to the already hot `get()` method. The one exception is `getProperties`, which we fix by caching an unmodifiable set wrapper. (This will not regress memory usage, since `unmodifiableMap` does the same thing internally.)

I also tested with my original benchmark for https://github.com/neoforged/NeoForge/pull/653 (a chunk section full of vanilla oak fences), and confirmed there is no performance regression caused by using an empty array map in place of `Collections.emptyMap()`. We can't use `Collections.emptyMap()` anymore, because doing so would cause there to be three concrete `Map` implementations in use, instead of two, which prevents the JIT from doing as much optimization on the call sites.