### PR TITLE
Revert "Remove `CommonHooks#getBurnTime` and move contents to `ItemStack#getBurnTime`"

### DIFF
--- a/patches/net/minecraft/world/inventory/AbstractFurnaceMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AbstractFurnaceMenu.java.patch
@@ -5,7 +5,7 @@
  
      protected boolean isFuel(ItemStack p_38989_) {
 -        return AbstractFurnaceBlockEntity.isFuel(p_38989_);
-+        return p_38989_.getBurnTime(this.recipeType) > 0;
++        return net.neoforged.neoforge.common.CommonHooks.getBurnTime(p_38989_, this.recipeType) > 0;
      }
  
      public float getBurnProgress() {

--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -24,17 +24,14 @@
                  case 2:
                      return AbstractFurnaceBlockEntity.this.cookingProgress;
                  case 3:
-@@ -111,10 +_,29 @@
+@@ -111,10 +_,26 @@
      ) {
          super(p_154991_, p_154992_, p_154993_);
          this.quickCheck = RecipeManager.createCheck((RecipeType<AbstractCookingRecipe>)p_154994_);
 +        this.recipeType = p_154994_;
      }
  
-+    /**
-+     * @deprecated Neo: get burn times by calling {@link net.neoforged.neoforge.common.extensions.IItemStackExtension#getBurnTime(RecipeType)}
-+     */
-+    @Deprecated
++    /**@deprecated Forge: get burn times by calling CommonHooks#getBurnTime(ItemStack)*/ @Deprecated
      public static Map<Item, Integer> getFuel() {
          Map<Item, Integer> map = Maps.newLinkedHashMap();
 +        buildFuels((e, time) -> e.ifRight(tag -> add(map, tag, time)).ifLeft(item -> add(map, item, time)));
@@ -174,7 +171,7 @@
          } else {
              Item item = p_58343_.getItem();
 -            return getFuel().getOrDefault(item, 0);
-+            return p_58343_.getBurnTime(this.recipeType);
++            return net.neoforged.neoforge.common.CommonHooks.getBurnTime(p_58343_, this.recipeType);
          }
      }
  
@@ -183,7 +180,7 @@
  
      public static boolean isFuel(ItemStack p_58400_) {
 -        return getFuel().containsKey(p_58400_.getItem());
-+        return p_58400_.getBurnTime(null) > 0;
++        return net.neoforged.neoforge.common.CommonHooks.getBurnTime(p_58400_, null) > 0;
      }
  
      @Override
@@ -192,7 +189,7 @@
          } else {
              ItemStack itemstack = this.items.get(1);
 -            return isFuel(p_58390_) || p_58390_.is(Items.BUCKET) && !itemstack.is(Items.BUCKET);
-+            return p_58390_.getBurnTime(this.recipeType) > 0 || p_58390_.is(Items.BUCKET) && !itemstack.is(Items.BUCKET);
++            return net.neoforged.neoforge.common.CommonHooks.getBurnTime(p_58390_, this.recipeType) > 0 || p_58390_.is(Items.BUCKET) && !itemstack.is(Items.BUCKET);
          }
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -133,7 +133,6 @@ import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.extensions.IEntityExtension;
-import net.neoforged.neoforge.common.extensions.IItemStackExtension;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
 import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.common.loot.LootTableIdCondition;
@@ -181,6 +180,7 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.NoteBlockEvent;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
 import net.neoforged.neoforge.resource.ResourcePackLoader;
 import net.neoforged.neoforge.server.permission.PermissionAPI;
 import org.apache.logging.log4j.LogManager;
@@ -923,13 +923,18 @@ public class CommonHooks {
 
     /**
      * Gets the burn time of this itemstack.
-     * 
-     * @deprecated Use {@link IItemStackExtension#getBurnTime(RecipeType)} instead.
      */
-    @Deprecated(forRemoval = true, since = "1.20.4")
-    @ApiStatus.ScheduledForRemoval(inVersion = "1.20.5 or 1.21")
     public static int getBurnTime(ItemStack stack, @Nullable RecipeType<?> recipeType) {
-        return stack.getBurnTime(recipeType);
+        if (stack.isEmpty()) {
+            return 0;
+        } else {
+            int ret = stack.getBurnTime(recipeType);
+            if (ret == -1) {
+                var fuel = stack.getItemHolder().getData(NeoForgeDataMaps.FURNACE_FUELS);
+                ret = fuel == null ? 0 : fuel.burnTime();
+            }
+            return EventHooks.getItemBurnTime(stack, ret, recipeType);
+        }
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -48,8 +48,6 @@ import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
-import net.neoforged.neoforge.registries.datamaps.builtin.FurnaceFuel;
-import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -593,16 +591,15 @@ public interface IItemExtension {
     }
 
     /**
-     * @return the fuel burn time for this item stack in a furnace. Return 0 to make
+     * @return the fuel burn time for this itemStack in a furnace. Return 0 to make
      *         it not act as a fuel. Return -1 to let the default vanilla logic
      *         decide.
      * @apiNote This method takes precedence over the {@link net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps#FURNACE_FUELS data map}.
-     *          However, you should use the data map unless necessary (i.e. NBT-based burn times) so that users can configure burn times.
+     *          However, you should use the datamap unless necessary (i.e. NBT-based burn times) so that users can configure burn times.
      */
     @ApiStatus.OverrideOnly
     default int getBurnTime(ItemStack itemStack, @Nullable RecipeType<?> recipeType) {
-        FurnaceFuel fuel = self().builtInRegistryHolder().getData(NeoForgeDataMaps.FURNACE_FUELS);
-        return fuel == null ? 0 : fuel.burnTime();
+        return -1;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -73,15 +73,9 @@ public interface IItemStackExtension {
      * @return the fuel burn time for this itemStack in a furnace. Return 0 to make
      *         it not act as a fuel. Return -1 to let the default vanilla logic
      *         decide.
-     * @apiNote This method by default returns the {@code burn_time} specified in
-     *          the {@code furnace_fuels.json} file.
      */
     default int getBurnTime(@Nullable RecipeType<?> recipeType) {
-        int burnTime = self().getItem().getBurnTime(self(), recipeType);
-        if (self().isEmpty()) {
-            return 0;
-        }
-        return EventHooks.getItemBurnTime(self(), burnTime, recipeType);
+        return self().getItem().getBurnTime(self(), recipeType);
     }
 
     default InteractionResult onItemUseFirst(UseOnContext context) {


### PR DESCRIPTION
Reverts neoforged/NeoForge#699.

#699 introduces subtle breaking changes by moving the logic (e.g. return values of `-1` from the item are now nonsense). The PR should just have waited for 1.20.5.