### PR TITLE
Fixes ModMismatchEvent crash

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/ModMismatchEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModMismatchEvent.java
@@ -83,18 +83,16 @@ public class ModMismatchEvent extends Event implements IModBusEvent {
      */
     @Nullable
     public ArtifactVersion getPreviousVersion(String modId) {
-        if (this.versionDifferences.containsKey(modId))
-            return this.versionDifferences.get(modId).oldVersion();
+        var versionDifference = this.versionDifferences.get(modId);
 
-        return null;
+        return versionDifference != null ? versionDifference.oldVersion() : null;
     }
 
     @Nullable
-    public ArtifactVersion getCurrentVersion(String modid) {
-        if (this.versionDifferences.containsKey(modid))
-            return this.versionDifferences.get(modid).newVersion();
+    public ArtifactVersion getCurrentVersion(String modId) {
+        var versionDifference = this.versionDifferences.get(modId);
 
-        return null;
+        return versionDifference != null ? versionDifference.newVersion() : null;
     }
 
     /**
@@ -137,6 +135,7 @@ public class ModMismatchEvent extends Event implements IModBusEvent {
 
     public Stream<MismatchResolutionResult> getResolved() {
         return resolved.keySet().stream()
+                .filter(versionDifferences::containsKey)
                 .map(modid -> new MismatchResolutionResult(modid, versionDifferences.get(modid), resolved.get(modid)))
                 .sorted(Comparator.comparing(MismatchResolutionResult::modid));
     }


### PR DESCRIPTION
Fix crash when a mod marks a modid as resolved, which didn't have a version difference to begin with.

Example from an actual mod:

```
    @SubscribeEvent
    public static void onModMismatch(final ModMismatchEvent event)
    {
        // there are no world data and rest is mod compat anyway
        event.markResolved(ModClass.MOD_ID);
    }
```
