### PR TITLE
[1.20.4] Add `BlockDropsEvent`

### DIFF
--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -39,7 +39,30 @@
          } else if (blockstate.canOcclude()) {
              Block.BlockStatePairKey block$blockstatepairkey = new Block.BlockStatePairKey(p_152445_, blockstate, p_152448_);
              Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey> object2bytelinkedopenhashmap = OCCLUSION_CACHE.get();
-@@ -305,9 +_,12 @@
+@@ -290,24 +_,33 @@
+ 
+     public static void dropResources(BlockState p_49951_, Level p_49952_, BlockPos p_49953_) {
+         if (p_49952_ instanceof ServerLevel) {
+-            getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null).forEach(p_152406_ -> popResource(p_49952_, p_49953_, p_152406_));
+-            p_49951_.spawnAfterBreak((ServerLevel)p_49952_, p_49953_, ItemStack.EMPTY, true);
++            net.neoforged.neoforge.common.CommonHooks.interceptBlockDrops(
++                    p_49952_, p_49953_, p_49951_,
++                    getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null),
++                    null, ItemStack.EMPTY, true);
+         }
+     }
+ 
+     public static void dropResources(BlockState p_49893_, LevelAccessor p_49894_, BlockPos p_49895_, @Nullable BlockEntity p_49896_) {
+         if (p_49894_ instanceof ServerLevel) {
+-            getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_).forEach(p_49859_ -> popResource((ServerLevel)p_49894_, p_49895_, p_49859_));
+-            p_49893_.spawnAfterBreak((ServerLevel)p_49894_, p_49895_, ItemStack.EMPTY, true);
++            net.neoforged.neoforge.common.CommonHooks.interceptBlockDrops(
++                    (ServerLevel)p_49894_, p_49895_, p_49893_,
++                    getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_),
++                    null, ItemStack.EMPTY, true);
+         }
+     }
+ 
      public static void dropResources(
          BlockState p_49882_, Level p_49883_, BlockPos p_49884_, @Nullable BlockEntity p_49885_, @Nullable Entity p_49886_, ItemStack p_49887_
      ) {
@@ -47,9 +70,12 @@
 +    }
 +    public static void dropResources(BlockState p_49882_, Level p_49883_, BlockPos p_49884_, @Nullable BlockEntity p_49885_, @Nullable Entity p_49886_, ItemStack p_49887_, boolean dropXp) {
          if (p_49883_ instanceof ServerLevel) {
-             getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
+-            getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
 -            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, true);
-+            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, dropXp);
++            net.neoforged.neoforge.common.CommonHooks.interceptBlockDrops(
++                    p_49883_, p_49884_, p_49882_,
++                    getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_),
++                    p_49886_, p_49887_, dropXp);
          }
      }
  

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -39,27 +39,25 @@
          } else if (blockstate.canOcclude()) {
              Block.BlockStatePairKey block$blockstatepairkey = new Block.BlockStatePairKey(p_152445_, blockstate, p_152448_);
              Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey> object2bytelinkedopenhashmap = OCCLUSION_CACHE.get();
-@@ -290,24 +_,33 @@
+@@ -290,24 +_,34 @@
  
      public static void dropResources(BlockState p_49951_, Level p_49952_, BlockPos p_49953_) {
          if (p_49952_ instanceof ServerLevel) {
--            getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null).forEach(p_152406_ -> popResource(p_49952_, p_49953_, p_152406_));
++            beginCapturingDrops();
+             getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null).forEach(p_152406_ -> popResource(p_49952_, p_49953_, p_152406_));
 -            p_49951_.spawnAfterBreak((ServerLevel)p_49952_, p_49953_, ItemStack.EMPTY, true);
-+            net.neoforged.neoforge.common.CommonHooks.interceptBlockDrops(
-+                    p_49952_, p_49953_, p_49951_,
-+                    getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null),
-+                    null, ItemStack.EMPTY, true);
++            List<ItemEntity> captured = stopCapturingDrops();
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49952_, p_49953_, p_49951_, null, captured, null, ItemStack.EMPTY, true);
          }
      }
  
      public static void dropResources(BlockState p_49893_, LevelAccessor p_49894_, BlockPos p_49895_, @Nullable BlockEntity p_49896_) {
          if (p_49894_ instanceof ServerLevel) {
--            getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_).forEach(p_49859_ -> popResource((ServerLevel)p_49894_, p_49895_, p_49859_));
++            beginCapturingDrops();
+             getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_).forEach(p_49859_ -> popResource((ServerLevel)p_49894_, p_49895_, p_49859_));
 -            p_49893_.spawnAfterBreak((ServerLevel)p_49894_, p_49895_, ItemStack.EMPTY, true);
-+            net.neoforged.neoforge.common.CommonHooks.interceptBlockDrops(
-+                    (ServerLevel)p_49894_, p_49895_, p_49893_,
-+                    getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_),
-+                    null, ItemStack.EMPTY, true);
++            List<ItemEntity> captured = stopCapturingDrops();
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49894_, p_49895_, p_49893_, p_49896_, captured, null, ItemStack.EMPTY, true);
          }
      }
  
@@ -68,18 +66,18 @@
      ) {
 +        dropResources(p_49882_, p_49883_, p_49884_, p_49885_, p_49886_, p_49887_, true);
 +    }
++    // TODO 1.20.5+: Remove this patched-in override and remove XP control logic from BlockEvent.BreakEvent.
 +    public static void dropResources(BlockState p_49882_, Level p_49883_, BlockPos p_49884_, @Nullable BlockEntity p_49885_, @Nullable Entity p_49886_, ItemStack p_49887_, boolean dropXp) {
          if (p_49883_ instanceof ServerLevel) {
--            getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
++            beginCapturingDrops();
+             getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
 -            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, true);
-+            net.neoforged.neoforge.common.CommonHooks.interceptBlockDrops(
-+                    p_49883_, p_49884_, p_49882_,
-+                    getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_),
-+                    p_49886_, p_49887_, dropXp);
++            List<ItemEntity> captured = stopCapturingDrops();
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49883_, p_49884_, p_49882_, p_49885_, captured, p_49886_, p_49887_, dropXp);
          }
      }
  
-@@ -335,7 +_,7 @@
+@@ -335,19 +_,26 @@
      }
  
      private static void popResource(Level p_152441_, Supplier<ItemEntity> p_152442_, ItemStack p_152443_) {
@@ -87,8 +85,15 @@
 +        if (!p_152441_.isClientSide && !p_152443_.isEmpty() && p_152441_.getGameRules().getBoolean(GameRules.RULE_DOBLOCKDROPS) && !p_152441_.restoringBlockSnapshots) {
              ItemEntity itementity = p_152442_.get();
              itementity.setDefaultPickUpDelay();
-             p_152441_.addFreshEntity(itementity);
-@@ -343,11 +_,12 @@
+-            p_152441_.addFreshEntity(itementity);
++            // Neo: Add drops to the captured list if capturing is enabled.
++            if (capturedDrops != null) {
++                capturedDrops.add(itementity);
++            }
++            else {
++                p_152441_.addFreshEntity(itementity);
++            }
+         }
      }
  
      public void popExperience(ServerLevel p_49806_, BlockPos p_49807_, int p_49808_) {
@@ -139,11 +144,40 @@
      public SoundType getSoundType(BlockState p_49963_) {
          return this.soundType;
      }
-@@ -498,6 +_,75 @@
+@@ -498,6 +_,104 @@
          return this.stateDefinition.getPossibleStates().stream().collect(ImmutableMap.toImmutableMap(Function.identity(), p_152459_));
      }
  
 +    /* ======================================== FORGE START =====================================*/
++
++    /**
++     * Short-lived holder of dropped item entities.
++     * 
++     * When not null, records all item entities from {@link #popResource(Level, Supplier, ItemStack)} instead of adding them to the world.
++     */
++    @Nullable
++    private static List<ItemEntity> capturedDrops = null;
++
++    /**
++     * Initializes {@link #capturedDrops}, starting the drop capture process.
++     * 
++     * Must only be called on the server thread.
++     */
++    private static void beginCapturingDrops() {
++        capturedDrops = new java.util.ArrayList<>();
++    }
++
++    /**
++     * Ends the drop capture process by setting {@link #capturedDrops} to null and returning the old list.
++     *
++     * Must only be called on the server thread.
++     */
++    private static List<ItemEntity> stopCapturingDrops() {
++        List<ItemEntity> drops = capturedDrops;
++        capturedDrops = null;
++        return drops;
++    }
++
 +    private Object renderProperties;
 +
 +    /*

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -152,7 +152,7 @@
 +
 +    /**
 +     * Short-lived holder of dropped item entities.
-+     * 
++     *
 +     * When not null, records all item entities from {@link #popResource(Level, Supplier, ItemStack)} instead of adding them to the world.
 +     */
 +    @Nullable
@@ -160,7 +160,7 @@
 +
 +    /**
 +     * Initializes {@link #capturedDrops}, starting the drop capture process.
-+     * 
++     *
 +     * Must only be called on the server thread.
 +     */
 +    private static void beginCapturingDrops() {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -107,6 +107,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
@@ -452,7 +453,12 @@ public class CommonHooks {
         BlockDropsEvent event = new BlockDropsEvent(level, pos, state, List.copyOf(drops), breaker, breakerTool);
         NeoForge.EVENT_BUS.post(event);
         if (!event.isCanceled()) {
-            drops.forEach(item -> Block.popResource(level, pos, item));
+            event.getDrops().forEach(i -> {
+                if (!level.isClientSide && !i.getItem().isEmpty() && level.getGameRules().getBoolean(GameRules.RULE_DOBLOCKDROPS)) {
+                    i.setDefaultPickUpDelay();
+                    level.addFreshEntity(i);
+                }
+            });
             state.spawnAfterBreak((ServerLevel) level, pos, breakerTool, dropXp);
         } else if (event.isDropXpWhenCancelled()) {
             net.neoforged.neoforge.common.CommonHooks.dropXpForBlock(state, (ServerLevel) level, pos, breakerTool);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -447,6 +447,17 @@ public class CommonHooks {
             state.getBlock().popExperience(level, pos, exp);
     }
 
+    public static void interceptBlockDrops(Level level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity breaker, ItemStack breakerTool, boolean dropXp) {
+        BlockEvent.DestroyedEvent event = new BlockEvent.DestroyedEvent(level, pos, state, List.copyOf(drops), breaker, breakerTool);
+        NeoForge.EVENT_BUS.post(event);
+        if (!event.isCanceled()) {
+            drops.forEach(item -> Block.popResource(level, pos, item));
+            state.spawnAfterBreak((ServerLevel) level, pos, breakerTool, dropXp);
+        } else if (event.isDropXpWhenCancelled()) {
+            net.neoforged.neoforge.common.CommonHooks.dropXpForBlock(state, (ServerLevel) level, pos, breakerTool);
+        }
+    }
+
     public static int onBlockBreakEvent(Level level, GameType gameType, ServerPlayer entityPlayer, BlockPos pos) {
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -177,6 +177,7 @@ import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
 import net.neoforged.neoforge.event.entity.player.CriticalHitEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.NoteBlockEvent;
 import net.neoforged.neoforge.fluids.FluidType;
@@ -448,7 +449,7 @@ public class CommonHooks {
     }
 
     public static void interceptBlockDrops(Level level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity breaker, ItemStack breakerTool, boolean dropXp) {
-        BlockEvent.DestroyedEvent event = new BlockEvent.DestroyedEvent(level, pos, state, List.copyOf(drops), breaker, breakerTool);
+        BlockDropsEvent event = new BlockDropsEvent(level, pos, state, List.copyOf(drops), breaker, breakerTool);
         NeoForge.EVENT_BUS.post(event);
         if (!event.isCanceled()) {
             drops.forEach(item -> Block.popResource(level, pos, item));

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.event.level;
 
+import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
@@ -8,15 +14,11 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.ICancellableEvent;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-
-
 /**
  * Fired when a block is destroyed AFTER drops have been determined, but have not yet spawned.
  * It is safe to modify the Block in this event, as it has already been replaced.
  */
 public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
-
     private final List<ItemStack> drops;
     private final Entity destroyingEntity;
     private final ItemStack tool;
@@ -36,6 +38,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
 
     /**
      * Sets whether XP Orb Entities should still be spawned when the event is cancelled.
+     * 
      * @param shouldDrop Whether XP should be spawned.
      */
     public void setDropXpWhenCancelled(boolean shouldDrop) {
@@ -44,6 +47,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
 
     /**
      * Returns a list of drops determined for this broken block.
+     * 
      * @return An immutable list of ItemStacks.
      */
     public List<ItemStack> getDrops() {
@@ -52,6 +56,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
 
     /**
      * Returns the entity associated with this broken block. Might be null.
+     * 
      * @return The entity responsible for the breaking of this block, or null.
      */
     public @Nullable Entity getDestroyingEntity() {
@@ -60,6 +65,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
 
     /**
      * Returns the tool associated with this broken block.
+     * 
      * @return The used tool as ItemStack, or ItemStack.EMPTY
      */
     public ItemStack getTool() {

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -10,12 +10,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
+
 /**
  * Fired when a block is destroyed AFTER drops have been determined, but have not yet spawned.
- * - Cancellation will result in the drops not being spawned.
- * - Breaker may be null if the block was not destroyed by an entity.
- * - The drops list is immutable and cannot be modified. Use LootTableModifiers instead
- * - It is safe to modify the Block in this event, as it has already been replaced.
+ * It is safe to modify the Block in this event, as it has already been replaced.
  */
 public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
 
@@ -25,6 +23,9 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
 
     private boolean dropXpWhenCancelled;
 
+    /**
+     * Cancellation will result in the drops not being spawned.
+     */
     public BlockDropsEvent(LevelAccessor level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity destroyer, ItemStack tool) {
         super(level, pos, state);
         this.drops = drops;
@@ -33,18 +34,34 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
         this.dropXpWhenCancelled = true;
     }
 
+    /**
+     * Sets whether XP Orb Entities should still be spawned when the event is cancelled.
+     * @param shouldDrop Whether XP should be spawned.
+     */
     public void setDropXpWhenCancelled(boolean shouldDrop) {
         this.dropXpWhenCancelled = shouldDrop;
     }
 
+    /**
+     * Returns a list of drops determined for this broken block.
+     * @return An immutable list of ItemStacks.
+     */
     public List<ItemStack> getDrops() {
         return drops;
     }
 
-    public Entity getDestroyingEntity() {
+    /**
+     * Returns the entity associated with this broken block. Might be null.
+     * @return The entity responsible for the breaking of this block, or null.
+     */
+    public @Nullable Entity getDestroyingEntity() {
         return destroyingEntity;
     }
 
+    /**
+     * Returns the tool associated with this broken block.
+     * @return The used tool as ItemStack, or ItemStack.EMPTY
+     */
     public ItemStack getTool() {
         return tool;
     }

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -1,0 +1,55 @@
+package net.neoforged.neoforge.event.level;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.ICancellableEvent;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Fired when a block is destroyed AFTER drops have been determined, but have not yet spawned.
+ * - Cancellation will result in the drops not being spawned.
+ * - Breaker may be null if the block was not destroyed by an entity.
+ * - The drops list is immutable and cannot be modified. Use LootTableModifiers instead
+ * - It is safe to modify the Block in this event, as it has already been replaced.
+ */
+public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
+
+    private final List<ItemStack> drops;
+    private final Entity destroyingEntity;
+    private final ItemStack tool;
+
+    private boolean dropXpWhenCancelled;
+
+    public BlockDropsEvent(LevelAccessor level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity destroyer, ItemStack tool) {
+        super(level, pos, state);
+        this.drops = drops;
+        this.destroyingEntity = destroyer;
+        this.tool = tool;
+        this.dropXpWhenCancelled = true;
+    }
+
+    public void setDropXpWhenCancelled(boolean shouldDrop) {
+        this.dropXpWhenCancelled = shouldDrop;
+    }
+
+    public List<ItemStack> getDrops() {
+        return drops;
+    }
+
+    public Entity getDestroyingEntity() {
+        return destroyingEntity;
+    }
+
+    public ItemStack getTool() {
+        return tool;
+    }
+
+    public boolean isDropXpWhenCancelled() {
+        return dropXpWhenCancelled;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
  * It is safe to modify the Block in this event, as it has already been replaced.
  */
 public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
-
     private final List<ItemEntity> dropEntities;
     private final Entity destroyingEntity;
     private final ItemStack tool;
@@ -42,12 +41,12 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
         this.tool = tool;
         this.dropXpWhenCancelled = true;
 
-        for(ItemStack drop : drops) {
+        for (ItemStack drop : drops) {
             Vec3 offset = pos.getCenter().add(
                     Mth.nextDouble(level.getRandom(), -0.25, 0.25),
-                    Mth.nextDouble(level.getRandom(), -0.25, 0.25) - (double)EntityType.ITEM.getHeight() / 2.0,
+                    Mth.nextDouble(level.getRandom(), -0.25, 0.25) - (double) EntityType.ITEM.getHeight() / 2.0,
                     Mth.nextDouble(level.getRandom(), -0.25, 0.25));
-            dropEntities.add(new ItemEntity((ServerLevel)level, offset.x(), offset.y(), offset.z(), drop));
+            dropEntities.add(new ItemEntity((ServerLevel) level, offset.x(), offset.y(), offset.z(), drop));
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -5,88 +5,87 @@
 
 package net.neoforged.neoforge.event.level;
 
-import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.loot.LootModifier;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Fired when a block is destroyed AFTER drops have been determined, but have not yet spawned.
- * It is safe to modify the Block in this event, as it has already been replaced.
+ * Fired when a block is broken and the drops have been determined, but before they have been added to the world. This event can be used to manipulate the dropped item entities.
+ * <p>
+ * No guarantees can be made about the block. It will either have already been removed from the world, or will be removed after the event terminates.
+ * <p>
+ * If you wish to edit the state of the block in-world, use {@link BreakEvent}.
  */
 public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
-    private final List<ItemEntity> dropEntities;
-    private final Entity destroyingEntity;
+    @Nullable
+    private final BlockEntity blockEntity;
+    private final List<ItemEntity> drops;
+    @Nullable
+    private final Entity breaker;
     private final ItemStack tool;
 
-    private boolean dropXpWhenCancelled;
-
-    /**
-     * Cancellation will result in the drops not being spawned.
-     */
-    public BlockDropsEvent(LevelAccessor level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity destroyer, ItemStack tool) {
+    public BlockDropsEvent(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool) {
         super(level, pos, state);
-        this.dropEntities = new ArrayList<>();
-        this.destroyingEntity = destroyer;
+        this.blockEntity = blockEntity;
+        this.drops = drops;
+        this.breaker = breaker;
         this.tool = tool;
-        this.dropXpWhenCancelled = true;
-
-        for (ItemStack drop : drops) {
-            Vec3 offset = pos.getCenter().add(
-                    Mth.nextDouble(level.getRandom(), -0.25, 0.25),
-                    Mth.nextDouble(level.getRandom(), -0.25, 0.25) - (double) EntityType.ITEM.getHeight() / 2.0,
-                    Mth.nextDouble(level.getRandom(), -0.25, 0.25));
-            dropEntities.add(new ItemEntity((ServerLevel) level, offset.x(), offset.y(), offset.z(), drop));
-        }
     }
 
     /**
-     * Sets whether XP Orb Entities should still be spawned when the event is cancelled.
+     * Returns a mutable list of item entities that will be dropped by this block.
+     * <p>
+     * When this event completes successfully, all entities in this list will be added to the world.
      * 
-     * @param shouldDrop Whether XP should be spawned.
-     */
-    public void setDropXpWhenCancelled(boolean shouldDrop) {
-        this.dropXpWhenCancelled = shouldDrop;
-    }
-
-    /**
-     * Returns a list of ItemEntities determined for this broken block.
-     * 
-     * @return A modifiable list of ItemStacks.
+     * @return A mutable list of item entities.
+     * @apiNote Prefer using {@link LootModifier}s to add additional loot drops.
      */
     public List<ItemEntity> getDrops() {
-        return dropEntities;
+        return this.drops;
     }
 
     /**
-     * Returns the entity associated with this broken block. Might be null.
-     * 
-     * @return The entity responsible for the breaking of this block, or null.
+     * {@return the block entity from the current position, if available}
      */
-    public @Nullable Entity getDestroyingEntity() {
-        return destroyingEntity;
+    @Nullable
+    public BlockEntity getBlockEntity() {
+        return blockEntity;
     }
 
     /**
-     * Returns the tool associated with this broken block.
-     * 
-     * @return The used tool as ItemStack, or ItemStack.EMPTY
+     * {@return the entity that broke the block, or null if unknown}
+     */
+    @Nullable
+    public Entity getBreaker() {
+        return this.breaker;
+    }
+
+    /**
+     * {@return the tool used when breaking this block; may be empty}
      */
     public ItemStack getTool() {
-        return tool;
+        return this.tool;
     }
 
-    public boolean isDropXpWhenCancelled() {
-        return dropXpWhenCancelled;
+    /**
+     * Cancels this event, preventing any drops from being spawned and preventing {@link Block#spawnAfterBreak} from being called.
+     */
+    @Override
+    public void setCanceled(boolean canceled) {
+        ICancellableEvent.super.setCanceled(canceled);
+    }
+
+    @Override
+    public ServerLevel getLevel() {
+        return (ServerLevel) super.getLevel();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -54,7 +54,7 @@ public abstract class BlockEvent extends Event {
     }
 
     /**
-     * Event that is fired when an Block is about to be broken by a player
+     * Event that is fired when a Block is about to be broken by a player
      * Canceling this event will prevent the Block from being broken.
      */
     public static class BreakEvent extends BlockEvent implements ICancellableEvent {
@@ -96,6 +96,49 @@ public abstract class BlockEvent extends Event {
          */
         public void setExpToDrop(int exp) {
             this.exp = exp;
+        }
+    }
+
+    /**
+     * Fired when a block is destroyed AFTER drops have been determined, but have not yet spawned.
+     * - Cancellation will result in the drops not being spawned.
+     * - Breaker may be null if the block was not destroyed by an entity.
+     * - The drops list is immutable and cannot be modified. Use LootTableModifiers instead
+     * - It is safe to modify the Block in this event, as it has already been replaced.
+     */
+    public static class DestroyedEvent extends BlockEvent implements ICancellableEvent {
+        private final List<ItemStack> drops;
+        private final Entity destroyingEntity;
+        private final ItemStack tool;
+
+        private boolean dropXpWhenCancelled;
+
+        public DestroyedEvent(LevelAccessor level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity destroyer, ItemStack tool) {
+            super(level, pos, state);
+            this.drops = drops;
+            this.destroyingEntity = destroyer;
+            this.tool = tool;
+            this.dropXpWhenCancelled = true;
+        }
+
+        public void setDropXpWhenCancelled(boolean shouldDrop) {
+            this.dropXpWhenCancelled = shouldDrop;
+        }
+
+        public List<ItemStack> getDrops() {
+            return drops;
+        }
+
+        public Entity getDestroyingEntity() {
+            return destroyingEntity;
+        }
+
+        public ItemStack getTool() {
+            return tool;
+        }
+
+        public boolean isDropXpWhenCancelled() {
+            return dropXpWhenCancelled;
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -100,49 +100,6 @@ public abstract class BlockEvent extends Event {
     }
 
     /**
-     * Fired when a block is destroyed AFTER drops have been determined, but have not yet spawned.
-     * - Cancellation will result in the drops not being spawned.
-     * - Breaker may be null if the block was not destroyed by an entity.
-     * - The drops list is immutable and cannot be modified. Use LootTableModifiers instead
-     * - It is safe to modify the Block in this event, as it has already been replaced.
-     */
-    public static class DestroyedEvent extends BlockEvent implements ICancellableEvent {
-        private final List<ItemStack> drops;
-        private final Entity destroyingEntity;
-        private final ItemStack tool;
-
-        private boolean dropXpWhenCancelled;
-
-        public DestroyedEvent(LevelAccessor level, BlockPos pos, BlockState state, List<ItemStack> drops, @Nullable Entity destroyer, ItemStack tool) {
-            super(level, pos, state);
-            this.drops = drops;
-            this.destroyingEntity = destroyer;
-            this.tool = tool;
-            this.dropXpWhenCancelled = true;
-        }
-
-        public void setDropXpWhenCancelled(boolean shouldDrop) {
-            this.dropXpWhenCancelled = shouldDrop;
-        }
-
-        public List<ItemStack> getDrops() {
-            return drops;
-        }
-
-        public Entity getDestroyingEntity() {
-            return destroyingEntity;
-        }
-
-        public ItemStack getTool() {
-            return tool;
-        }
-
-        public boolean isDropXpWhenCancelled() {
-            return dropXpWhenCancelled;
-        }
-    }
-
-    /**
      * Called when a block is placed.
      *
      * If a Block Place event is cancelled, the block will not be placed.

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -42,6 +42,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -231,6 +232,14 @@ public class ExtendedGameTestHelper extends GameTestHelper {
                     pos,
                     this.getTick());
         }
+    }
+
+    public void breakBlock(BlockPos relativePos, ItemStack tool, @Nullable Entity breakingEntity) {
+        BlockState state = getBlockState(relativePos);
+        BlockPos absolutePos = absolutePos(relativePos);
+        BlockEntity blockEntity = state.hasBlockEntity() ? getLevel().getBlockEntity(absolutePos) : null;
+        Block.dropResources(state, getLevel(), absolutePos, blockEntity, breakingEntity, tool);
+        getLevel().destroyBlock(absolutePos, false);
     }
 
     public void boneMeal(BlockPos pos, Player player) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ToolActions;
+import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.eventtest.internal.TestsMod;
 import net.neoforged.testframework.DynamicTest;
@@ -34,7 +35,7 @@ public class BlockEventTests {
     @GameTest(template = TestsMod.TEMPLATE_3x3)
     @TestHolder(description = "Tests if the BlockDestroyed event is fired and works properly.")
     public static void blockDestroyedEvent(final DynamicTest test) {
-        test.whenEnabled(listeners -> listeners.forge().addListener((final BlockEvent.DestroyedEvent event) -> {
+        test.whenEnabled(listeners -> listeners.forge().addListener((final BlockDropsEvent event) -> {
             if (event.getState().getBlock() == Blocks.DIRT && !event.getTool().is(ItemTags.SHOVELS)) {
                 event.setCanceled(true); // Make dirt not drop unless it was broken by a shovel to test cancellation as a whole.
             }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.debug.block;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.animal.Sheep;
@@ -30,6 +31,37 @@ import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 
 @ForEachTest(groups = { BlockTests.GROUP + ".event", "event" })
 public class BlockEventTests {
+    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @TestHolder(description = "Tests if the BlockDestroyed event is fired and works properly.")
+    public static void blockDestroyedEvent(final DynamicTest test) {
+        test.whenEnabled(listeners -> listeners.forge().addListener((final BlockEvent.DestroyedEvent event) -> {
+            if (event.getState().getBlock() == Blocks.DIRT && !event.getTool().is(ItemTags.SHOVELS)) {
+                event.setCanceled(true); // Make dirt not drop unless it was broken by a shovel to test cancellation as a whole.
+            }
+            if (event.getState().getBlock() == Blocks.NETHER_QUARTZ_ORE && event.getTool().is(Items.IRON_PICKAXE)) {
+                event.setDropXpWhenCancelled(true);
+                event.setCanceled(true); // Make Nether Quartz only drop XP and no items when broken with an Iron Pickaxe.
+            }
+            test.pass();
+        }));
+
+        BlockPos pos = new BlockPos(1, 1, 1);
+
+        test.onGameTest(helper -> helper
+                .startSequence() // Dirt Test
+                .thenExecute(() -> helper.setBlock(pos, Blocks.DIRT))
+                .thenExecute(() -> helper.breakBlock(pos, new ItemStack(Items.DIAMOND_HOE), helper.makeMockSurvivalPlayer()))
+                .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DIRT, pos))
+                .thenExecute(() -> helper.assertItemEntityNotPresent(Items.DIRT))
+                .thenIdle(5) // Quartz Test
+                .thenExecute(() -> helper.setBlock(pos, Blocks.NETHER_QUARTZ_ORE))
+                .thenExecute(() -> helper.breakBlock(pos, new ItemStack(Items.IRON_PICKAXE), helper.makeMockSurvivalPlayer()))
+                .thenExecute(() -> helper.assertBlockNotPresent(Blocks.NETHER_QUARTZ_ORE, pos))
+                .thenExecute(() -> helper.assertItemEntityNotPresent(Items.QUARTZ))
+                .thenExecute(() -> helper.assertEntityPresent(EntityType.EXPERIENCE_ORB))
+                .thenSucceed());
+    }
+
     @GameTest(template = TestsMod.TEMPLATE_3x3)
     @TestHolder(description = "Tests if the entity place event is fired")
     public static void entityPlacedEvent(final DynamicTest test) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -40,8 +40,7 @@ public class BlockEventTests {
                 event.setCanceled(true); // Make dirt not drop unless it was broken by a shovel to test cancellation as a whole.
             }
             if (event.getState().getBlock() == Blocks.NETHER_QUARTZ_ORE && event.getTool().is(Items.IRON_PICKAXE)) {
-                event.setDropXpWhenCancelled(true);
-                event.setCanceled(true); // Make Nether Quartz only drop XP and no items when broken with an Iron Pickaxe.
+                event.setCanceled(true); // Make Nether Quartz drop no items when broken with an Iron Pickaxe.
             }
             test.pass();
         }));
@@ -59,7 +58,6 @@ public class BlockEventTests {
                 .thenExecute(() -> helper.breakBlock(pos, new ItemStack(Items.IRON_PICKAXE), helper.makeMockSurvivalPlayer()))
                 .thenExecute(() -> helper.assertBlockNotPresent(Blocks.NETHER_QUARTZ_ORE, pos))
                 .thenExecute(() -> helper.assertItemEntityNotPresent(Items.QUARTZ))
-                .thenExecute(() -> helper.assertEntityPresent(EntityType.EXPERIENCE_ORB))
                 .thenSucceed());
     }
 


### PR DESCRIPTION
This PR adds the `BlockDropsEvent`, which fires after the drops for a block have been determined but before they have been added to the world.
This allows for manipulation of the item entities, which is not possible when using loot modifiers (they can only change the list of item stacks).

Cancellation of the event causes no items to be dropped, but the block will remain destroyed/replaced by air.  During the next breaking change window, we can also migrate the XP logic from `BreakEvent` to this event, as this is hooked in where XP is normally dropped, which will reduce patch overhead.

This PR also adds a `breakBlock` method to the GameTest helper to simulate breaking blocks with an entity and tool within a game test.