### PR TITLE
[20.5] Pass along tooltip context to ItemTooltipEvent

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -125,7 +125,7 @@
                  list.add(DISABLED_ITEM_TOOLTIP);
              }
  
-+            net.neoforged.neoforge.event.EventHooks.onItemTooltip(this, p_41652_, list, p_41653_);
++            net.neoforged.neoforge.event.EventHooks.onItemTooltip(this, p_41652_, list, p_41653_, p_339637_);
              return list;
          }
      }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -63,6 +63,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Projectile;
 import net.minecraft.world.entity.projectile.ThrownEnderpearl;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemStackLinkedSet;
 import net.minecraft.world.item.TooltipFlag;
@@ -360,8 +361,8 @@ public class EventHooks {
         return event.getNewState();
     }
 
-    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags) {
-        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, list, flags);
+    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags, Item.TooltipContext context) {
+        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, list, flags, context);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ItemTooltipEvent.java
@@ -9,6 +9,7 @@ import java.util.List;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import org.jetbrains.annotations.Nullable;
@@ -17,16 +18,18 @@ public class ItemTooltipEvent extends PlayerEvent {
     private final TooltipFlag flags;
     private final ItemStack itemStack;
     private final List<Component> toolTip;
+    private final TooltipContext context;
 
     /**
-     * This event is fired in {@link ItemStack#getTooltipLines(Player, TooltipFlag)}, which in turn is called from its respective GUIContainer.
+     * This event is fired in {@link ItemStack#getTooltipLines(TooltipContext, Player, TooltipFlag)}, which in turn is called from its respective GUIContainer.
      * Tooltips are also gathered with a null player during startup by {@link Minecraft#createSearchTrees()}.
      */
-    public ItemTooltipEvent(ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags) {
+    public ItemTooltipEvent(ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags, TooltipContext context) {
         super(player);
         this.itemStack = itemStack;
         this.toolTip = list;
         this.flags = flags;
+        this.context = context;
     }
 
     /**
@@ -57,5 +60,12 @@ public class ItemTooltipEvent extends PlayerEvent {
     @Nullable
     public Player getEntity() {
         return super.getEntity();
+    }
+
+    /**
+     * The {@link TooltipContext tooltip context}.
+     */
+    public TooltipContext getContext() {
+        return context;
     }
 }


### PR DESCRIPTION
Passes along the new `TooltipContext` instance from `ItemStack#getTooltipLines` into `ItemTooltipEvent`