### PR TITLE
Add getters for components patch size on ItemStack and FluidStack

### DIFF
--- a/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
@@ -8,3 +8,18 @@
          this.ensureMapOwnership();
          T t = this.prototype.get((DataComponentType<? extends T>)p_330791_);
          Optional<T> optional;
+@@ -192,6 +_,14 @@
+         }
+ 
+         return i;
++    }
++
++    public int patchSize() {
++        return this.patch.size();
++    }
++
++    public boolean isPatchEmpty() {
++        return this.patch.isEmpty();
+     }
+ 
+     public DataComponentPatch asPatch() {

--- a/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
@@ -8,14 +8,10 @@
          this.ensureMapOwnership();
          T t = this.prototype.get((DataComponentType<? extends T>)p_330791_);
          Optional<T> optional;
-@@ -192,6 +_,14 @@
+@@ -192,6 +_,10 @@
          }
  
          return i;
-+    }
-+
-+    public int patchSize() {
-+        return this.patch.size();
 +    }
 +
 +    public boolean isPatchEmpty() {

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -9,14 +9,10 @@
      public static final Codec<Holder<Item>> ITEM_NON_AIR_CODEC = BuiltInRegistries.ITEM
          .holderByNameCodec()
          .validate(
-@@ -234,6 +_,14 @@
+@@ -234,6 +_,10 @@
          return !this.isEmpty() ? this.components.asPatch() : DataComponentPatch.EMPTY;
      }
  
-+    public int getComponentsPatchSize() {
-+        return !this.isEmpty() ? this.components.patchSize() : 0;
-+    }
-+
 +    public boolean isComponentsPatchEmpty() {
 +        return !this.isEmpty() ? this.components.isPatchEmpty() : true;
 +    }

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -9,6 +9,21 @@
      public static final Codec<Holder<Item>> ITEM_NON_AIR_CODEC = BuiltInRegistries.ITEM
          .holderByNameCodec()
          .validate(
+@@ -234,6 +_,14 @@
+         return !this.isEmpty() ? this.components.asPatch() : DataComponentPatch.EMPTY;
+     }
+ 
++    public int getComponentsPatchSize() {
++        return !this.isEmpty() ? this.components.patchSize() : 0;
++    }
++
++    public boolean isComponentsPatchEmpty() {
++        return !this.isEmpty() ? this.components.isPatchEmpty() : true;
++    }
++
+     public ItemStack(ItemLike p_41599_) {
+         this(p_41599_, 1);
+     }
 @@ -327,7 +_,7 @@
      }
  

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -156,6 +156,14 @@ public final class FluidStack implements DataComponentHolder {
         return !this.isEmpty() ? this.components.asPatch() : DataComponentPatch.EMPTY;
     }
 
+    public int getComponentsPatchSize() {
+        return !this.isEmpty() ? this.components.patchSize() : 0;
+    }
+
+    public boolean isComponentsPatchEmpty() {
+        return !this.isEmpty() ? this.components.isPatchEmpty() : true;
+    }
+
     public FluidStack(Holder<Fluid> fluid, int amount, DataComponentPatch patch) {
         this(fluid.value(), amount, PatchedDataComponentMap.fromPatch(DataComponentMap.EMPTY, patch));
     }

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -156,10 +156,6 @@ public final class FluidStack implements DataComponentHolder {
         return !this.isEmpty() ? this.components.asPatch() : DataComponentPatch.EMPTY;
     }
 
-    public int getComponentsPatchSize() {
-        return !this.isEmpty() ? this.components.patchSize() : 0;
-    }
-
     public boolean isComponentsPatchEmpty() {
         return !this.isEmpty() ? this.components.isPatchEmpty() : true;
     }


### PR DESCRIPTION
This is useful in scenarios where we want to only deal with `Item`s instead of the full `ItemStack`s, and need to know whether the `ItemStack` can be reconstructed perfectly from only the `Item`.