### PR TITLE
[1.20.5] ModelDataManager cleanup

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -13,7 +13,7 @@
      private final BlockStatePredictionHandler blockStatePredictionHandler = new BlockStatePredictionHandler();
      private static final Set<Item> MARKER_PARTICLE_ITEMS = Set.of(Items.BARRIER, Items.LIGHT);
 +    private final it.unimi.dsi.fastutil.ints.Int2ObjectMap<net.neoforged.neoforge.entity.PartEntity<?>> partEntities = new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>();
-+    private final net.neoforged.neoforge.client.model.data.ModelDataManager.Active modelDataManager = new net.neoforged.neoforge.client.model.data.ModelDataManager.Active(this);
++    private final net.neoforged.neoforge.client.model.data.ModelDataManager modelDataManager = new net.neoforged.neoforge.client.model.data.ModelDataManager(this);
  
      public void handleBlockChangedAck(int p_233652_) {
          this.blockStatePredictionHandler.endPredictionsUpTo(p_233652_, this);
@@ -79,7 +79,7 @@
              this.difficulty = p_104852_;
          }
  
-@@ -1069,14 +_,46 @@
+@@ -1069,14 +_,51 @@
              if (p_171712_ instanceof AbstractClientPlayer) {
                  ClientLevel.this.players.add((AbstractClientPlayer)p_171712_);
              }
@@ -114,8 +114,13 @@
 +    }
 +
 +    @Override
-+    public net.neoforged.neoforge.client.model.data.ModelDataManager.Active getModelDataManager() {
++    public net.neoforged.neoforge.client.model.data.ModelDataManager getModelDataManager() {
 +        return modelDataManager;
++    }
++
++    @Override
++    public net.neoforged.neoforge.client.model.data.ModelData getModelData(BlockPos pos) {
++        return modelDataManager.getAt(pos);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -101,7 +101,7 @@
                      VertexConsumer vertexconsumer1 = new SheetedDecalTextureGenerator(
                          this.renderBuffers.crumblingBufferSource().getBuffer(ModelBakery.DESTROY_TYPES.get(k)), posestack$pose1, 1.0F
                      );
-+                    net.neoforged.neoforge.client.model.data.ModelData modelData = level.getModelDataManager().getAtOrEmpty(blockpos2);
++                    net.neoforged.neoforge.client.model.data.ModelData modelData = level.getModelData(blockpos2);
                      this.minecraft
                          .getBlockRenderer()
 -                        .renderBreakingTexture(this.level.getBlockState(blockpos2), blockpos2, this.level, posestack, vertexconsumer1);

--- a/patches/net/minecraft/client/renderer/block/BlockModelShaper.java.patch
+++ b/patches/net/minecraft/client/renderer/block/BlockModelShaper.java.patch
@@ -11,7 +11,7 @@
 +    }
 +
 +    public TextureAtlasSprite getTexture(BlockState p_110883_, net.minecraft.world.level.Level level, net.minecraft.core.BlockPos pos) {
-+        var data = level.getModelDataManager().getAtOrEmpty(pos);
++        var data = level.getModelData(pos);
 +        BakedModel model = this.getBlockModel(p_110883_);
 +        return model.getParticleIcon(model.getModelData(level, pos, p_110883_, data));
      }

--- a/patches/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
@@ -1,22 +1,21 @@
 --- a/net/minecraft/client/renderer/chunk/RenderChunkRegion.java
 +++ b/net/minecraft/client/renderer/chunk/RenderChunkRegion.java
-@@ -20,12 +_,19 @@
+@@ -20,12 +_,18 @@
      private final int centerZ;
      protected final RenderChunk[][] chunks;
      protected final Level level;
-+    @Nullable
-+    private final net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot modelDataManager;
++    private final it.unimi.dsi.fastutil.longs.Long2ObjectFunction<net.neoforged.neoforge.client.model.data.ModelData> modelDataSnapshot;
  
 +    @Deprecated
      RenderChunkRegion(Level p_200456_, int p_200457_, int p_200458_, RenderChunk[][] p_200459_) {
-+        this(p_200456_, p_200457_, p_200458_, p_200459_, null);
++        this(p_200456_, p_200457_, p_200458_, p_200459_, net.neoforged.neoforge.client.model.data.ModelDataManager.EMPTY_SNAPSHOT);
 +    }
-+    RenderChunkRegion(Level p_200456_, int p_200457_, int p_200458_, RenderChunk[][] p_200459_, @Nullable net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot modelDataManager) {
++    RenderChunkRegion(Level p_200456_, int p_200457_, int p_200458_, RenderChunk[][] p_200459_, it.unimi.dsi.fastutil.longs.Long2ObjectFunction<net.neoforged.neoforge.client.model.data.ModelData> modelDataSnapshot) {
          this.level = p_200456_;
          this.centerX = p_200457_;
          this.centerZ = p_200458_;
          this.chunks = p_200459_;
-+        this.modelDataManager = modelDataManager;
++        this.modelDataSnapshot = modelDataSnapshot;
      }
  
      @Override
@@ -33,7 +32,7 @@
 +
 +    @Override
 +    public net.neoforged.neoforge.client.model.data.ModelData getModelData(BlockPos pos) {
-+        return modelDataManager != null ? modelDataManager.getAt(pos) : net.neoforged.neoforge.client.model.data.ModelData.EMPTY;
++        return modelDataSnapshot.get(pos.asLong());
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/RenderChunkRegion.java.patch
@@ -20,7 +20,7 @@
      }
  
      @Override
-@@ -73,5 +_,23 @@
+@@ -73,5 +_,22 @@
      @Override
      public int getHeight() {
          return this.level.getHeight();
@@ -32,9 +32,8 @@
 +    }
 +
 +    @Override
-+    @Nullable
-+    public net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot getModelDataManager() {
-+        return modelDataManager;
++    public net.neoforged.neoforge.client.model.data.ModelData getModelData(BlockPos pos) {
++        return modelDataManager != null ? modelDataManager.getAt(pos) : net.neoforged.neoforge.client.model.data.ModelData.EMPTY;
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
@@ -20,11 +20,10 @@
              );
              return this.lastRebuildTask;
          }
-@@ -501,10 +_,20 @@
+@@ -501,10 +_,17 @@
          class RebuildTask extends SectionRenderDispatcher.RenderSection.CompileTask {
              @Nullable
              protected RenderChunkRegion region;
-+            private final net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot modelData;
 +            private final List<net.neoforged.neoforge.client.event.AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers;
  
 +            @Deprecated
@@ -35,8 +34,6 @@
 +            public RebuildTask(double p_294400_, @Nullable RenderChunkRegion p_294382_, boolean p_295207_, List<net.neoforged.neoforge.client.event.AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers) {
                  super(RenderSection.this, p_294400_, p_295207_);
                  this.region = p_294382_;
-+                var manager = p_294382_ != null ? p_294382_.getModelDataManager() : null;
-+                this.modelData = manager != null ? manager : net.neoforged.neoforge.client.model.data.ModelDataManager.Snapshot.EMPTY;
 +                this.additionalRenderers = additionalRenderers;
              }
  
@@ -47,7 +44,7 @@
                          if (blockstate.getRenderShape() != RenderShape.INVISIBLE) {
 -                            RenderType rendertype2 = ItemBlockRenderTypes.getChunkRenderType(blockstate);
 +                            var model = blockrenderdispatcher.getBlockModel(blockstate);
-+                            var modelData = this.modelData.getAtOrEmpty(blockpos2);
++                            var modelData = renderchunkregion.getModelData(blockpos2);
 +                            modelData = model.getModelData(renderchunkregion, blockpos2, blockstate, modelData);
 +                            randomsource.setSeed(blockstate.getSeed(blockpos2));
 +                            for (RenderType rendertype2 : model.getRenderTypes(blockstate, randomsource, modelData)) {

--- a/patches/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/net/minecraft/server/level/ChunkMap.java.patch
@@ -43,7 +43,7 @@
  
                  this.level.getProfiler().incrementCounter("chunkSave");
                  CompoundTag compoundtag = ChunkSerializer.write(this.level, p_140259_);
-+                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.ChunkDataEvent.Save(p_140259_, p_140259_.getWorldForge() != null ? p_140259_.getWorldForge() : this.level, compoundtag));
++                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.ChunkDataEvent.Save(p_140259_, p_140259_.getLevel() != null ? p_140259_.getLevel() : this.level, compoundtag));
                  this.write(chunkpos, compoundtag).exceptionallyAsync(p_329914_ -> {
                      this.level.getServer().reportChunkSaveFailure(chunkpos);
                      return null;

--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -219,7 +219,7 @@
                          this.neighborChanged(blockstate, blockpos, p_46719_, p_46718_, false);
                      }
                  }
-@@ -1062,6 +_,24 @@
+@@ -1062,6 +_,18 @@
      @Override
      public BiomeManager getBiomeManager() {
          return this.biomeManager;
@@ -235,12 +235,6 @@
 +        if (value > maxEntityRadius)
 +            maxEntityRadius = value;
 +        return maxEntityRadius;
-+    }
-+
-+    @Override
-+    @Nullable
-+    public net.neoforged.neoforge.client.model.data.ModelDataManager.Active getModelDataManager() {
-+        return null;
      }
  
      public final boolean isDebug() {

--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -111,5 +111,5 @@
 +        return attachmentHolder;
 +    }
 +    @Nullable
-+    public net.minecraft.world.level.LevelAccessor getWorldForge() { return null; }
++    public net.minecraft.world.level.Level getWorldForge() { return null; }
  }

--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -111,5 +111,5 @@
 +        return attachmentHolder;
 +    }
 +    @Nullable
-+    public net.minecraft.world.level.Level getWorldForge() { return null; }
++    public net.minecraft.world.level.Level getLevel() { return null; }
  }

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -156,15 +156,3 @@
                          throw new ReportedException(crashreport);
                      }
                  }
-@@ -709,6 +_,11 @@
-         IMMEDIATE,
-         QUEUED,
-         CHECK;
-+    }
-+
-+    @Override
-+    public Level getWorldForge() {
-+        return getLevel();
-     }
- 
-     @FunctionalInterface

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -11,12 +11,14 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod.EventBusSubscriber;
@@ -131,6 +133,11 @@ public class ModelDataManager {
                 // Query the BE for new model data if it exists
                 if (toUpdate != null && !toUpdate.isRemoved()) {
                     newData = toUpdate.getModelData();
+                    // Sanity check so that mods cannot cause impossible-to-trace NPEs in other code later
+                    //noinspection ConstantValue
+                    if (newData == null) {
+                        throw new NullPointerException("Null ModelData provided by " + BlockEntityType.getKey(toUpdate.getType()) + " @ " + pos);
+                    }
                 }
                 // Make sure we don't bother storing empty data in the map
                 if (newData != ModelData.EMPTY) {

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -23,6 +23,7 @@ import net.neoforged.fml.common.Mod.EventBusSubscriber;
 import net.neoforged.fml.common.Mod.EventBusSubscriber.Bus;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 /**
  * A manager for the lifecycle of all the {@link ModelData} instances in a {@link Level}.
@@ -67,6 +68,7 @@ public class ModelDataManager {
      * @param pos the section to query
      * @return an (unmodifiable) map containing the {@link ModelData} stored for the given chunk section
      */
+    @UnmodifiableView
     public Long2ObjectMap<ModelData> getAt(SectionPos pos) {
         long sectionKey = pos.asLong();
         refreshAt(sectionKey);

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -11,7 +11,6 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -62,8 +62,8 @@ public class ModelDataManager {
     /**
      * Provides all the model data for a given chunk section. This is useful for mods which wish to retrieve
      * a fast view of the model data for a single section in a level.
-     * <p></p>
-     * The returned map must be copied if it needs to be accessed from another thread, as it may be modified
+     *
+     * <p>The returned map must be copied if it needs to be accessed from another thread, as it may be modified
      * by this data manager.
      *
      * @param pos the section to query

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -23,7 +23,6 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod.EventBusSubscriber;
 import net.neoforged.fml.common.Mod.EventBusSubscriber.Bus;
 import net.neoforged.neoforge.event.level.ChunkEvent;
-import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
 
 /**
@@ -98,7 +97,6 @@ public class ModelDataManager {
      * Snapshot the state of this manager for all sections in the volume specified by the given section coordinates.
      * The snapshot will return {@link ModelData#EMPTY} for nonexistent keys.
      */
-    @Unmodifiable
     public Long2ObjectFunction<ModelData> snapshotSectionRegion(int sectionMinX, int sectionMinY, int sectionMinZ, int sectionMaxX, int sectionMaxY, int sectionMaxZ) {
         if (isOtherThread()) {
             throw new UnsupportedOperationException("Cannot snapshot active manager outside the owning thread: " + owningThread);

--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelDataManager.java
@@ -152,7 +152,7 @@ public class ModelDataManager {
 
     @SubscribeEvent
     public static void onChunkUnload(ChunkEvent.Unload event) {
-        var level = event.getChunk().getWorldForge();
+        var level = event.getChunk().getLevel();
         if (level == null)
             return;
 

--- a/src/main/java/net/neoforged/neoforge/common/FarmlandWaterManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/FarmlandWaterManager.java
@@ -123,7 +123,7 @@ public class FarmlandWaterManager {
     }
 
     static void removeTickets(ChunkAccess chunk) {
-        ChunkTicketManager<Vec3> ticketManager = getTicketManager(chunk.getPos(), chunk.getWorldForge());
+        ChunkTicketManager<Vec3> ticketManager = getTicketManager(chunk.getPos(), chunk.getLevel());
         if (ticketManager != null) {
             if (DEBUG)
                 LOGGER.info("FarmlandWaterManager: got tickets {} at {} before", ticketManager.getTickets().size(), ticketManager.pos);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -852,7 +852,7 @@ public interface IBlockExtension {
      * As such, if you need any data from your {@link BlockEntity}, you should put it in {@link ModelData} to guarantee
      * safe concurrent access to it on the client.<br/>
      * {@link ModelDataManager#getAt(BlockPos)} will return the {@link ModelData} for the queried block,
-     * or {@code null} if none is present.
+     * or {@link ModelData#EMPTY} if none is present.
      *
      * @param level         The world
      * @param pos           The blocks position in the world
@@ -932,9 +932,9 @@ public interface IBlockExtension {
      * <b>Note that this method may be called on the server, or on any of the client's meshing threads.</b><br/>
      * As such, if you need any data from your {@link BlockEntity}, you should put it in {@link ModelData} to guarantee
      * safe concurrent access to it on the client.<br/>
-     * Calling {@link BlockGetter#getModelDataManager()} will return {@code null} if in a server context, where it is
+     * Calling {@link ILevelExtension#getModelDataManager()} will return {@code null} if in a server context, where it is
      * safe to query your {@link BlockEntity} directly. Otherwise, {@link ModelDataManager#getAt(BlockPos)} will return
-     * the {@link ModelData} for the queried block, or {@code null} if none is present.
+     * the {@link ModelData} for the queried block, or {@link ModelData#EMPTY} if none is present.
      *
      * @param state      The state of this block
      * @param level      The level this block is in

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -71,7 +71,6 @@ import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.client.model.data.ModelData;
-import net.neoforged.neoforge.client.model.data.ModelDataManager;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.IPlantable;
 import net.neoforged.neoforge.common.ToolAction;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -851,7 +851,7 @@ public interface IBlockExtension {
      * <b>Note that this method may be called on any of the client's meshing threads.</b><br/>
      * As such, if you need any data from your {@link BlockEntity}, you should put it in {@link ModelData} to guarantee
      * safe concurrent access to it on the client.<br/>
-     * {@link ModelDataManager#getAt(BlockPos)} will return the {@link ModelData} for the queried block,
+     * {@link IBlockGetterExtension#getModelData(BlockPos)} will return the {@link ModelData} for the queried block,
      * or {@link ModelData#EMPTY} if none is present.
      *
      * @param level         The world
@@ -933,7 +933,7 @@ public interface IBlockExtension {
      * As such, if you need any data from your {@link BlockEntity}, you should put it in {@link ModelData} to guarantee
      * safe concurrent access to it on the client.<br/>
      * Calling {@link ILevelExtension#getModelDataManager()} will return {@code null} if in a server context, where it is
-     * safe to query your {@link BlockEntity} directly. Otherwise, {@link ModelDataManager#getAt(BlockPos)} will return
+     * safe to query your {@link BlockEntity} directly. Otherwise, {@link IBlockGetterExtension#getModelData(BlockPos)} will return
      * the {@link ModelData} for the queried block, or {@link ModelData#EMPTY} if none is present.
      *
      * @param state      The state of this block

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockGetterExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockGetterExtension.java
@@ -13,7 +13,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.ChunkSource;
 import net.minecraft.world.level.chunk.ImposterProtoChunk;
 import net.minecraft.world.level.chunk.LightChunk;
-import net.neoforged.neoforge.client.model.data.ModelDataManager;
+import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -59,11 +59,12 @@ public interface IBlockGetterExtension {
     }
 
     /**
-     * Retrieves the model data manager for this level.
-     * This will be {@code null} on a server level.
+     * Retrieves model data for a block at the given position.
+     *
+     * @param pos the position to query
+     * @return the model data at this position, or {@link ModelData#EMPTY} if none exists
      */
-    @Nullable
-    default ModelDataManager getModelDataManager() {
-        return null;
+    default ModelData getModelData(BlockPos pos) {
+        return ModelData.EMPTY;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.client.model.data.ModelDataManager;
 import net.neoforged.neoforge.entity.PartEntity;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,6 +44,17 @@ public interface ILevelExtension {
      */
     public default Collection<PartEntity<?>> getPartEntities() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Retrieves the model data manager for the given level. May be null on a server level.
+     *
+     * <p>For model data retrieval, prefer calling {@link IBlockGetterExtension#getModelData(BlockPos)} rather than this method,
+     * as it works on more than just a level.
+     */
+    @Nullable
+    default ModelDataManager getModelDataManager() {
+        return null;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkEvent.java
@@ -26,7 +26,7 @@ public abstract class ChunkEvent extends LevelEvent {
     private final ChunkAccess chunk;
 
     public ChunkEvent(ChunkAccess chunk) {
-        super(chunk.getWorldForge());
+        super(chunk.getLevel());
         this.chunk = chunk;
     }
 


### PR DESCRIPTION
This PR is largely based on design changes suggested by @PepperCode1 (from whom I would appreciate a review, if they have time/interest).

There are several goals that I aim to address. I list them below with the corresponding changes.

1. Remove the requirement for custom `BlockGetter`s to provide a full `ModelDataManager`. To do this, `getModelData(BlockPos)` was introduced on our BlockGetter extension and `getModelDataManager()` was moved down the inheritance chain to our Level extension.
2. Allow mods to snapshot the state of the model data manager for a given section without needing to rely on internal API. This was done by adding a `getAt(SectionPos)` method to the `ModelDataManager`. This API was designed to give mods the utmost flexibility. It returns an unmodifiable reference to the map for a given section. Mods may iterate over this and assemble a larger map (as NeoForge does in its own `Snapshot`) or clone the map as-is if they just want a snapshot for the single section.
3. With (1) and (2) implemented, the inheritance chain of `ModelDataManager` can be simplified. I removed the `Active` subclass and refactored all its contents into the parent class. The `Snapshot` static class remains, but it is marked as internal as we only use it in our patches to `RenderChunkRegion`. Mods shouldn't need to use it, as they can implement a snapshot tailored to their own purposes with the changes in (2).
4. To simplify the API surface, I made getters return `ModelData.EMPTY` when model data does not exist, rather than `null`. This means `getAtOrEmpty` is no longer required. If a mod *absolutely* needs to know that the empty model data was provided by a block entity as opposed to being the default return value, it can use `containsKey` on the map returned by (2). I don't see this as a very likely scenario, and it makes the API more ergonomic to remove the nullability.

(N.B.: The change to the `ChunkAccess` patch was done so that the model data manager could be accessed from `getWorldForge()` without requiring a cast to `Level`. The only override of this method returns a `Level`, anyways.)

I'm happy to adjust the design in response to feedback. Obviously, this PR is targeted at 1.20.5 due to the breaking changes.