### PR TITLE
[1.20.5] Record a BlockSnapshot for client break predictions and cleanup break pipeline

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -17,11 +17,12 @@
  
      public void handleBlockChangedAck(int p_233652_) {
          this.blockStatePredictionHandler.endPredictionsUpTo(p_233652_, this);
-@@ -157,10 +_,14 @@
+@@ -157,10 +_,15 @@
      @Override
      public boolean setBlock(BlockPos p_233643_, BlockState p_233644_, int p_233645_, int p_233646_) {
          if (this.blockStatePredictionHandler.isPredicting()) {
 +            // Neo: Record and store a snapshot in the prediction so that BE data can be restored if the break is denied.
++            // Fixes MC-36093 and permits correct server-side only cancellation of block changes.
 +            var snapshot = net.neoforged.neoforge.common.util.BlockSnapshot.create(this.dimension(), this, p_233643_, p_233645_);
 +
              BlockState blockstate = this.getBlockState(p_233643_);

--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -22,7 +22,7 @@
      public boolean setBlock(BlockPos p_233643_, BlockState p_233644_, int p_233645_, int p_233646_) {
          if (this.blockStatePredictionHandler.isPredicting()) {
 +            // Neo: Record and store a snapshot in the prediction so that BE data can be restored if the break is denied.
-+            var snapshot = net.neoforged.neoforge.common.util.BlockSnapshot.create(this.dimension(), this, p_233643_);
++            var snapshot = net.neoforged.neoforge.common.util.BlockSnapshot.create(this.dimension(), this, p_233643_, p_233645_);
 +
              BlockState blockstate = this.getBlockState(p_233643_);
              boolean flag = super.setBlock(p_233643_, p_233644_, p_233645_, p_233646_);

--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -17,6 +17,21 @@
  
      public void handleBlockChangedAck(int p_233652_) {
          this.blockStatePredictionHandler.endPredictionsUpTo(p_233652_, this);
+@@ -157,10 +_,14 @@
+     @Override
+     public boolean setBlock(BlockPos p_233643_, BlockState p_233644_, int p_233645_, int p_233646_) {
+         if (this.blockStatePredictionHandler.isPredicting()) {
++            // Neo: Record and store a snapshot in the prediction so that BE data can be restored if the break is denied.
++            var snapshot = net.neoforged.neoforge.common.util.BlockSnapshot.create(this.dimension(), this, p_233643_);
++
+             BlockState blockstate = this.getBlockState(p_233643_);
+             boolean flag = super.setBlock(p_233643_, p_233644_, p_233645_, p_233646_);
+             if (flag) {
+                 this.blockStatePredictionHandler.retainKnownServerState(p_233643_, blockstate, this.minecraft.player);
++                this.blockStatePredictionHandler.retainSnapshot(p_233643_, snapshot);
+             }
+ 
+             return flag;
 @@ -192,6 +_,7 @@
          this.serverSimulationDistance = p_205510_;
          this.updateSkyBrightness();

--- a/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/client/multiplayer/MultiPlayerGameMode.java
 +++ b/net/minecraft/client/multiplayer/MultiPlayerGameMode.java
-@@ -106,6 +_,7 @@
-     }
- 
-     public boolean destroyBlock(BlockPos p_105268_) {
-+        if (minecraft.player.getMainHandItem().onBlockStartBreak(p_105268_, minecraft.player)) return false;
-         if (this.minecraft.player.blockActionRestricted(this.minecraft.level, p_105268_, this.localPlayerMode)) {
-             return false;
-         } else {
 @@ -120,9 +_,8 @@
                  } else if (blockstate.isAir()) {
                      return false;

--- a/patches/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java.patch
+++ b/patches/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java
++++ b/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java
+@@ -49,6 +_,14 @@
+                 p_233858_.syncBlockState(
+                     blockpos, blockstatepredictionhandler$serververifiedstate.blockState, blockstatepredictionhandler$serververifiedstate.playerPos
+                 );
++                // Neo: Restore the BlockEntity if one was present before the break was cancelled. Fixes MC-270804
++                if (blockstatepredictionhandler$serververifiedstate.snapshot != null &&
++                        blockstatepredictionhandler$serververifiedstate.blockState == blockstatepredictionhandler$serververifiedstate.snapshot.getReplacedBlock()) {
++                    if (blockstatepredictionhandler$serververifiedstate.snapshot.restoreBlockEntity(p_233858_, blockpos)) {
++                        // Attempt a re-render if BE data was loaded, since some blocks may depend on it.
++                        p_233858_.sendBlockUpdated(blockpos, blockstatepredictionhandler$serververifiedstate.blockState, blockstatepredictionhandler$serververifiedstate.blockState, 3);
++                    }
++                }
+             }
+         }
+     }
+@@ -72,8 +_,20 @@
+         return this.isPredicting;
+     }
+ 
++    /**
++     * Sets the stored BlockSnapshot on the ServerVerifiedState for the given position.
++     * This method is only called after {@link #retainKnownServerState}, so we are certain a map entry exists.
++     */
++    public void retainSnapshot(BlockPos pos, net.neoforged.neoforge.common.util.BlockSnapshot snapshot) {
++        this.serverVerifiedStates.get(pos.asLong()).snapshot = snapshot;
++    }
++
+     @OnlyIn(Dist.CLIENT)
+     static class ServerVerifiedState {
++        /**
++         * Neo: Used to hold all data necessary for clientside restoration during break denial.
++         */
++        net.neoforged.neoforge.common.util.BlockSnapshot snapshot;
+         final Vec3 playerPos;
+         int sequence;
+         BlockState blockState;

--- a/patches/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java.patch
+++ b/patches/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java
 +++ b/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java
-@@ -49,6 +_,14 @@
+@@ -49,6 +_,15 @@
                  p_233858_.syncBlockState(
                      blockpos, blockstatepredictionhandler$serververifiedstate.blockState, blockstatepredictionhandler$serververifiedstate.playerPos
                  );
-+                // Neo: Restore the BlockEntity if one was present before the break was cancelled. Fixes MC-270804
++                // Neo: Restore the BlockEntity if one was present before the break was cancelled.
++                // Fixes MC-36093 and permits correct server-side only cancellation of block changes.
 +                var verifiedState = blockstatepredictionhandler$serververifiedstate;
 +                if (verifiedState.snapshot != null && verifiedState.blockState == verifiedState.snapshot.getState()) {
 +                    if (verifiedState.snapshot.restoreBlockEntity(p_233858_, blockpos)) {

--- a/patches/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java.patch
+++ b/patches/net/minecraft/client/multiplayer/prediction/BlockStatePredictionHandler.java.patch
@@ -5,11 +5,11 @@
                      blockpos, blockstatepredictionhandler$serververifiedstate.blockState, blockstatepredictionhandler$serververifiedstate.playerPos
                  );
 +                // Neo: Restore the BlockEntity if one was present before the break was cancelled. Fixes MC-270804
-+                if (blockstatepredictionhandler$serververifiedstate.snapshot != null &&
-+                        blockstatepredictionhandler$serververifiedstate.blockState == blockstatepredictionhandler$serververifiedstate.snapshot.getReplacedBlock()) {
-+                    if (blockstatepredictionhandler$serververifiedstate.snapshot.restoreBlockEntity(p_233858_, blockpos)) {
++                var verifiedState = blockstatepredictionhandler$serververifiedstate;
++                if (verifiedState.snapshot != null && verifiedState.blockState == verifiedState.snapshot.getState()) {
++                    if (verifiedState.snapshot.restoreBlockEntity(p_233858_, blockpos)) {
 +                        // Attempt a re-render if BE data was loaded, since some blocks may depend on it.
-+                        p_233858_.sendBlockUpdated(blockpos, blockstatepredictionhandler$serververifiedstate.blockState, blockstatepredictionhandler$serververifiedstate.blockState, 3);
++                        p_233858_.sendBlockUpdated(blockpos, verifiedState.blockState, verifiedState.blockState, 3);
 +                    }
 +                }
              }

--- a/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -35,17 +35,12 @@
      public boolean destroyBlock(BlockPos p_9281_) {
          BlockState blockstate1 = this.level.getBlockState(p_9281_);
 -        if (!this.player.getMainHandItem().getItem().canAttackBlock(blockstate1, this.level, p_9281_, this.player)) {
-+        int exp = net.neoforged.neoforge.common.CommonHooks.onBlockBreakEvent(level, gameModeForPlayer, player, p_9281_);
++        int exp = net.neoforged.neoforge.common.CommonHooks.fireBlockBreak(level, gameModeForPlayer, player, p_9281_, blockstate1);
 +        if (exp == -1) {
              return false;
          } else {
              BlockEntity blockentity = this.level.getBlockEntity(p_9281_);
-@@ -232,30 +_,44 @@
-             if (block instanceof GameMasterBlock && !this.player.canUseGameMasterBlocks()) {
-                 this.level.sendBlockUpdated(p_9281_, blockstate1, blockstate1, 3);
-                 return false;
-+            } else if (player.getMainHandItem().onBlockStartBreak(p_9281_, player)) {
-+                return false;
+@@ -235,27 +_,46 @@
              } else if (this.player.blockActionRestricted(this.level, p_9281_, this.gameModeForPlayer)) {
                  return false;
              } else {
@@ -57,7 +52,7 @@
 +                BlockState blockstate = blockstate1;
  
                  if (this.isCreative()) {
-+                    removeBlock(p_9281_, false);
++                    removeBlock(p_9281_, blockstate, false);
                      return true;
                  } else {
                      ItemStack itemstack = this.player.getMainHandItem();
@@ -67,7 +62,7 @@
                      itemstack.mineBlock(this.level, blockstate, p_9281_, this.player);
 +                    if (itemstack.isEmpty() && !itemstack1.isEmpty())
 +                        net.neoforged.neoforge.event.EventHooks.onPlayerDestroyItem(this.player, itemstack1, InteractionHand.MAIN_HAND);
-+                    boolean flag = removeBlock(p_9281_, flag1);
++                    boolean flag = removeBlock(p_9281_, blockstate, flag1);
 +
                      if (flag1 && flag) {
                          block.playerDestroy(this.level, this.player, p_9281_, blockstate, blockentity, itemstack1);
@@ -82,11 +77,18 @@
          }
 +    }
 +
-+    private boolean removeBlock(BlockPos p_180235_1_, boolean canHarvest) {
-+        BlockState state = this.level.getBlockState(p_180235_1_);
-+        boolean removed = state.onDestroyedByPlayer(this.level, p_180235_1_, this.player, canHarvest, this.level.getFluidState(p_180235_1_));
++    /**
++     * Patched-in method that handles actual removal of blocks for {@link #destroyBlock(BlockPos)}.
++     *
++     * @param pos The block pos of the destroyed block
++     * @param state The state of the destroyed block
++     * @param canHarvest If the player breaking the block can harvest the drops of the block
++     * @return If the block was removed, as reported by {@link BlockState#onDestroyedByPlayer}.
++     */
++    private boolean removeBlock(BlockPos pos, BlockState state, boolean canHarvest) {
++        boolean removed = state.onDestroyedByPlayer(this.level, pos, this.player, canHarvest, this.level.getFluidState(pos));
 +        if (removed)
-+            state.getBlock().destroy(this.level, p_180235_1_, state);
++            state.getBlock().destroy(this.level, pos, state);
 +        return removed;
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -55,7 +55,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.PlainTextContents;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.network.syncher.EntityDataSerializer;
@@ -122,7 +121,6 @@ import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.level.gameevent.GameEvent;
@@ -486,19 +484,9 @@ public class CommonHooks {
         event.setCanceled(preCancelEvent);
         NeoForge.EVENT_BUS.post(event);
 
-        // Handle if the event is canceled
+        // If the event is canceled, let the client know the block still exists
         if (event.isCanceled()) {
-            // Let the client know the block still exists
             entityPlayer.connection.send(new ClientboundBlockUpdatePacket(level, pos));
-
-            // Update any tile entity data for this block
-            BlockEntity blockEntity = level.getBlockEntity(pos);
-            if (blockEntity != null) {
-                Packet<?> pkt = blockEntity.getUpdatePacket();
-                if (pkt != null) {
-                    entityPlayer.connection.send(pkt);
-                }
-            }
         }
         return event.isCanceled() ? -1 : event.getExpToDrop();
     }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -555,7 +555,7 @@ public class CommonHooks {
                 // revert back all captured blocks
                 for (BlockSnapshot blocksnapshot : Lists.reverse(blockSnapshots)) {
                     level.restoringBlockSnapshots = true;
-                    blocksnapshot.restore(true, false);
+                    blocksnapshot.restore(blocksnapshot.getFlags() | Block.UPDATE_CLIENTS);
                     level.restoringBlockSnapshots = false;
                 }
             } else {
@@ -564,8 +564,8 @@ public class CommonHooks {
                 //itemstack.setTag(newNBT);
 
                 for (BlockSnapshot snap : blockSnapshots) {
-                    int updateFlag = snap.getFlag();
-                    BlockState oldBlock = snap.getReplacedBlock();
+                    int updateFlag = snap.getFlags();
+                    BlockState oldBlock = snap.getState();
                     BlockState newBlock = level.getBlockState(snap.getPos());
                     newBlock.onPlace(level, snap.getPos(), oldBlock, false);
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -138,21 +138,6 @@ public interface IItemExtension {
     }
 
     /**
-     * Called before a block is broken. Return true to prevent default block
-     * harvesting.
-     *
-     * Note: In SMP, this is called on both client and server sides!
-     *
-     * @param itemstack The current ItemStack
-     * @param pos       Block's position in world
-     * @param player    The Player that is wielding the item
-     * @return True to prevent harvesting, false to continue as normal
-     */
-    default boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, Player player) {
-        return false;
-    }
-
-    /**
      * Called when an entity stops using an item for any reason, notably when selecting another item without releasing or finishing.
      * This method is called in addition to any other hooks called when an item is finished using; when another hook is also called it will be called before this method.
      *

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -122,20 +122,6 @@ public interface IItemStackExtension {
     }
 
     /**
-     * Called before a block is broken. Return true to prevent default block
-     * harvesting.
-     *
-     * Note: In SMP, this is called on both client and server sides!
-     *
-     * @param pos    Block's position in world
-     * @param player The Player that is wielding the item
-     * @return True to prevent harvesting, false to continue as normal
-     */
-    default boolean onBlockStartBreak(BlockPos pos, Player player) {
-        return !self().isEmpty() && self().getItem().onBlockStartBreak(self(), pos, player);
-    }
-
-    /**
      * Called when the player is mining a block and the item in his hand changes.
      * Allows to not reset blockbreaking if only NBT or similar changes.
      *

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockSnapshot.java
@@ -120,18 +120,29 @@ public class BlockSnapshot {
         if (world instanceof Level)
             ((Level) world).sendBlockUpdated(pos, current, replaced, flags);
 
+        restoreBlockEntity(world, pos);
+
+        if (DEBUG)
+            System.out.println("Restored " + this.toString());
+        return true;
+    }
+
+    /**
+     * Loads the stored {@link BlockEntity} data if one exists at the given position.
+     * 
+     * @return true if any data was loaded
+     */
+    public boolean restoreBlockEntity(LevelAccessor world, BlockPos pos) {
         BlockEntity te = null;
         if (getTag() != null) {
             te = world.getBlockEntity(pos);
             if (te != null) {
                 te.loadWithComponents(getTag(), world.registryAccess());
                 te.setChanged();
+                return true;
             }
         }
-
-        if (DEBUG)
-            System.out.println("Restored " + this.toString());
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockSnapshot.java
@@ -17,114 +17,173 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a captured snapshot of a block which will not change
- * automatically.
+ * Represents a captured snapshot of a block, including the level, position, state, BE data, and setBlock flags.
  * <p>
- * Unlike Block, which only one object can exist per coordinate, BlockSnapshot
- * can exist multiple times for any given Block.
+ * Used to record the prior state and unwind changes if the change was denied, such as during {@link BlockEvent.BreakEvent}.
  */
 public class BlockSnapshot {
     private static final boolean DEBUG = Boolean.parseBoolean(System.getProperty("neoforge.debugBlockSnapshot", "false"));
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private final ResourceKey<Level> dim;
     private final BlockPos pos;
     private final int flags;
-    private final BlockState block;
+    private final BlockState state;
     @Nullable
     private final CompoundTag nbt;
 
-    @Nullable
     private WeakReference<LevelAccessor> level;
+    @Nullable
     private String toString = null;
 
     private BlockSnapshot(ResourceKey<Level> dim, LevelAccessor level, BlockPos pos, BlockState state, @Nullable CompoundTag nbt, int flags) {
         this.dim = dim;
         this.pos = pos.immutable();
-        this.block = state;
+        this.state = state;
         this.flags = flags;
         this.nbt = nbt;
 
         this.level = new WeakReference<>(level);
 
-        if (DEBUG)
-            System.out.println("Created " + this.toString());
+        if (DEBUG) {
+            LOGGER.debug("Created " + this.toString());
+        }
     }
 
-    public static BlockSnapshot create(ResourceKey<Level> dim, LevelAccessor world, BlockPos pos) {
-        return create(dim, world, pos, 3);
+    /**
+     * Creates a new snapshot of the data at the given position.
+     * 
+     * @param dim   The dimension of the changed block
+     * @param level The level of the changed block
+     * @param pos   The position of the changed block
+     * @param flag  The {@link Level#setBlock(BlockPos, BlockState, int)} flags that the block was changed with.
+     * @return A captured block snapshot, containing the state and BE data from the given position.
+     */
+    public static BlockSnapshot create(ResourceKey<Level> dim, LevelAccessor level, BlockPos pos, int flag) {
+        return new BlockSnapshot(dim, level, pos, level.getBlockState(pos), getBlockEntityTag(level, pos), flag);
     }
 
-    public static BlockSnapshot create(ResourceKey<Level> dim, LevelAccessor world, BlockPos pos, int flag) {
-        return new BlockSnapshot(dim, world, pos, world.getBlockState(pos), getBlockEntityTag(world.getBlockEntity(pos), world.registryAccess()), flag);
+    /**
+     * Creates a new snapshot with the default block flags ({@link Block#UPDATE_NEIGHBORS and Block#UPDATE_CLIENTS}.
+     * 
+     * @see #create(ResourceKey, LevelAccessor, BlockPos, int)
+     */
+    public static BlockSnapshot create(ResourceKey<Level> dim, LevelAccessor level, BlockPos pos) {
+        return create(dim, level, pos, 3);
     }
 
+    /**
+     * {@return the recorded dimension key}
+     */
+    public ResourceKey<Level> getDimension() {
+        return this.dim;
+    }
+
+    /**
+     * {@return the recorded position}
+     */
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    /**
+     * @return the recorded {@link Level#setBlock(BlockPos, BlockState, int)} flags
+     */
+    public int getFlags() {
+        return flags;
+    }
+
+    /**
+     * {@return the recorded block entity NBT data, if one was present}
+     */
     @Nullable
-    private static CompoundTag getBlockEntityTag(@Nullable BlockEntity te, HolderLookup.Provider provider) {
-        return te == null ? null : te.saveWithFullMetadata(provider);
+    public CompoundTag getTag() {
+        return nbt;
     }
 
-    public BlockState getCurrentBlock() {
-        LevelAccessor world = getLevel();
-        return world == null ? Blocks.AIR.defaultBlockState() : world.getBlockState(this.pos);
+    /**
+     * {@return the snapshot's recorded block state}
+     */
+    public BlockState getState() {
+        return this.state;
     }
 
+    /**
+     * {@return the stored level, attempting to resolve it from the current server if it has gone out of scope}
+     */
     @Nullable
     public LevelAccessor getLevel() {
-        LevelAccessor world = this.level != null ? this.level.get() : null;
-        if (world == null) {
-            world = ServerLifecycleHooks.getCurrentServer().getLevel(this.dim);
-            this.level = new WeakReference<LevelAccessor>(world);
+        LevelAccessor level = this.level.get();
+        if (level == null) {
+            level = ServerLifecycleHooks.getCurrentServer().getLevel(this.dim);
+            this.level = new WeakReference<LevelAccessor>(level);
         }
-        return world;
+        return level;
     }
 
-    public BlockState getReplacedBlock() {
-        return this.block;
+    /**
+     * {@return the current (live) block state at the recorded position, not the snapshot's recorded state}
+     */
+    public BlockState getCurrentState() {
+        LevelAccessor level = this.getLevel();
+        return level == null ? Blocks.AIR.defaultBlockState() : level.getBlockState(this.pos);
     }
 
+    /**
+     * Recreates a block entity from the stored data (pos/state/NBT) of this block snapshot.
+     * 
+     * @return The newly created block entity, or null if no NBT data was present, or it was invalid.
+     */
     @Nullable
-    public BlockEntity getBlockEntity(HolderLookup.Provider provider) {
-        return getTag() != null ? BlockEntity.loadStatic(getPos(), getReplacedBlock(), getTag(), provider) : null;
+    public BlockEntity recreateBlockEntity(HolderLookup.Provider provider) {
+        return getTag() != null ? BlockEntity.loadStatic(getPos(), getState(), getTag(), provider) : null;
     }
 
-    public boolean restore() {
-        return restore(false);
-    }
+    /**
+     * Restores this block snapshot to the target level and position with the specified flags.
+     * 
+     * @return true if the block was successfully updated, false otherwise.
+     */
+    public boolean restoreToLocation(LevelAccessor level, BlockPos pos, int flags) {
+        BlockState replaced = getState();
 
-    public boolean restore(boolean force) {
-        return restore(force, true);
-    }
-
-    public boolean restore(boolean force, boolean notifyNeighbors) {
-        return restoreToLocation(getLevel(), getPos(), force, notifyNeighbors);
-    }
-
-    public boolean restoreToLocation(LevelAccessor world, BlockPos pos, boolean force, boolean notifyNeighbors) {
-        BlockState current = getCurrentBlock();
-        BlockState replaced = getReplacedBlock();
-
-        int flags = notifyNeighbors ? Block.UPDATE_ALL : Block.UPDATE_CLIENTS;
-
-        if (current != replaced) {
-            if (force)
-                world.setBlock(pos, replaced, flags);
-            else
-                return false;
+        if (!level.setBlock(pos, replaced, flags)) {
+            return false;
         }
 
-        world.setBlock(pos, replaced, flags);
-        if (world instanceof Level)
-            ((Level) world).sendBlockUpdated(pos, current, replaced, flags);
+        if (level instanceof Level realLevel) {
+            BlockState current = getCurrentState();
+            realLevel.sendBlockUpdated(pos, current, replaced, flags);
+        }
 
-        restoreBlockEntity(world, pos);
+        restoreBlockEntity(level, pos);
 
-        if (DEBUG)
-            System.out.println("Restored " + this.toString());
+        if (DEBUG) {
+            LOGGER.debug("Restored " + this.toString());
+        }
+
         return true;
+    }
+
+    /**
+     * Calls {@link #restoreToLocation} with the stored level, position, but custom block flags.
+     */
+    public boolean restore(int flags) {
+        return restoreToLocation(getLevel(), getPos(), flags);
+    }
+
+    /**
+     * Calls {@link #restoreToLocation} with the stored level, position, and block flags.
+     */
+    public boolean restore() {
+        return restore(this.getFlags());
     }
 
     /**
@@ -132,13 +191,13 @@ public class BlockSnapshot {
      * 
      * @return true if any data was loaded
      */
-    public boolean restoreBlockEntity(LevelAccessor world, BlockPos pos) {
-        BlockEntity te = null;
+    public boolean restoreBlockEntity(LevelAccessor level, BlockPos pos) {
+        BlockEntity be = null;
         if (getTag() != null) {
-            te = world.getBlockEntity(pos);
-            if (te != null) {
-                te.loadWithComponents(getTag(), world.registryAccess());
-                te.setChanged();
+            be = level.getBlockEntity(pos);
+            if (be != null) {
+                be.loadWithComponents(getTag(), level.registryAccess());
+                be.setChanged();
                 return true;
             }
         }
@@ -155,7 +214,7 @@ public class BlockSnapshot {
         final BlockSnapshot other = (BlockSnapshot) obj;
         return this.dim.equals(other.dim) &&
                 this.pos.equals(other.pos) &&
-                this.block == other.block &&
+                this.state == other.state &&
                 this.flags == other.flags &&
                 Objects.equals(this.nbt, other.nbt);
     }
@@ -165,7 +224,7 @@ public class BlockSnapshot {
         int hash = 7;
         hash = 73 * hash + this.dim.hashCode();
         hash = 73 * hash + this.pos.hashCode();
-        hash = 73 * hash + this.block.hashCode();
+        hash = 73 * hash + this.state.hashCode();
         hash = 73 * hash + this.flags;
         hash = 73 * hash + Objects.hashCode(this.getTag());
         return hash;
@@ -175,9 +234,9 @@ public class BlockSnapshot {
     public String toString() {
         if (toString == null) {
             this.toString = "BlockSnapshot[" +
-                    "World:" + this.dim.location() + ',' +
+                    "Level:" + this.dim.location() + ',' +
                     "Pos: " + this.pos + ',' +
-                    "State: " + this.block + ',' +
+                    "State: " + this.state + ',' +
                     "Flags: " + this.flags + ',' +
                     "NBT: " + (this.nbt == null ? "null" : this.nbt.toString()) +
                     ']';
@@ -185,16 +244,12 @@ public class BlockSnapshot {
         return this.toString;
     }
 
-    public BlockPos getPos() {
-        return pos;
-    }
-
-    public int getFlag() {
-        return flags;
-    }
-
+    /**
+     * Checks for a block entity at a given position, and saves it to NBT with full metadata if it exists.
+     */
     @Nullable
-    public CompoundTag getTag() {
-        return nbt;
+    private static CompoundTag getBlockEntityTag(LevelAccessor level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        return be == null ? null : be.saveWithFullMetadata(level.registryAccess());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -111,10 +111,10 @@ public abstract class BlockEvent extends Event {
         private final BlockState placedAgainst;
 
         public EntityPlaceEvent(BlockSnapshot blockSnapshot, BlockState placedAgainst, @Nullable Entity entity) {
-            super(blockSnapshot.getLevel(), blockSnapshot.getPos(), !(entity instanceof Player) ? blockSnapshot.getReplacedBlock() : blockSnapshot.getCurrentBlock());
+            super(blockSnapshot.getLevel(), blockSnapshot.getPos(), !(entity instanceof Player) ? blockSnapshot.getState() : blockSnapshot.getCurrentState());
             this.entity = entity;
             this.blockSnapshot = blockSnapshot;
-            this.placedBlock = !(entity instanceof Player) ? blockSnapshot.getReplacedBlock() : blockSnapshot.getCurrentBlock();
+            this.placedBlock = !(entity instanceof Player) ? blockSnapshot.getState() : blockSnapshot.getCurrentState();
             this.placedAgainst = placedAgainst;
 
             if (DEBUG) {


### PR DESCRIPTION
## Overview
### Clientside Break Predictions
This PR fixes #808 by attaching a `BlockSnapshot` to the `ServerVerifiedState` stored by vanilla for recording staged client block break actions. If the client restores the same block that was previously broken (meaning the break action was denied by the server), the BE data is restored to the snapshot. This prevents desyncs from occuring.

It also removes the code that sends a BE update packet from `CommonHooks.onBlockBreakEvent`.  Due to the same issue, this packet is always discarded, as the client state is set to air.
### Block Break Cleanup
Unrelated to the above, this PR removes the method `IItemExtension#onBlockStartBreak`.  This method had an incorrect hook spot (meaning it is not usable and was not previously usable for its intended purpose), and provides no unique functionality that cannot be accomplished by using `BreakEvent` or other methods on Item.

Finally, it updates the javadocs and fixes some logic in `CommonHooks.fireBlockBreak` (renamed from `onBlockBreakEvent`).

## Future Work
We should consider firing `BlockEvent.BreakEvent` on the client to prevent the desync before it can possibly occur; this patch will still be necessary to support pure server-side operations, and prevent desyncs in cases where vanilla blocks the break action (until vanilla fixes the bug).

Additionally, we need to re-assess `IBlockExtension#onDestroyedByPlayer` to see if it still provides and unique functionality, since the maintenance cost for this method is fairly high due to how much logic it subverts.

In other break-event related changes, the XP modification code can finally be moved out of `BreakEvent` and into `BlockDropsEvent` when #788 is rebased to 1.20.5