### PR TITLE
[TestFramework] Add a config option to force all tests to have a description

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/conf/FrameworkConfiguration.java
+++ b/testframework/src/main/java/net/neoforged/testframework/conf/FrameworkConfiguration.java
@@ -29,7 +29,8 @@ public record FrameworkConfiguration(
         int commandRequiredPermission,
         List<String> enabledTests,
         @Nullable Supplier<ClientConfiguration> clientConfiguration,
-        List<SummaryDumper> dumpers) {
+        List<SummaryDumper> dumpers,
+        MissingDescriptionAction onMissingDescription) {
 
     public static Builder builder(ResourceLocation id) {
         return new Builder(id);
@@ -48,6 +49,7 @@ public record FrameworkConfiguration(
 
         private int commandRequiredPermission = Commands.LEVEL_GAMEMASTERS;
         private final List<String> enabledTests = new ArrayList<>();
+        private MissingDescriptionAction onMissingDescription = MissingDescriptionAction.WARNING;
         private final List<SummaryDumper> dumpers = new ArrayList<>();
 
         private @Nullable Supplier<ClientConfiguration> clientConfiguration;
@@ -97,8 +99,13 @@ public record FrameworkConfiguration(
             return dumpers(dumpers);
         }
 
+        public Builder onMissingDescription(MissingDescriptionAction onMissingDescription) {
+            this.onMissingDescription = onMissingDescription;
+            return this;
+        }
+
         public FrameworkConfiguration build() {
-            return new FrameworkConfiguration(id, features, commandRequiredPermission, enabledTests, clientConfiguration, dumpers);
+            return new FrameworkConfiguration(id, features, commandRequiredPermission, enabledTests, clientConfiguration, dumpers, onMissingDescription);
         }
     }
 }

--- a/testframework/src/main/java/net/neoforged/testframework/conf/MissingDescriptionAction.java
+++ b/testframework/src/main/java/net/neoforged/testframework/conf/MissingDescriptionAction.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.testframework.conf;
+
+public enum MissingDescriptionAction {
+    IGNORE,
+    WARNING,
+    ERROR
+}

--- a/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
@@ -53,6 +53,7 @@ import net.neoforged.testframework.annotation.OnInit;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.conf.Feature;
 import net.neoforged.testframework.conf.FrameworkConfiguration;
+import net.neoforged.testframework.conf.MissingDescriptionAction;
 import net.neoforged.testframework.gametest.DynamicStructureTemplates;
 import net.neoforged.testframework.gametest.GameTestData;
 import net.neoforged.testframework.group.Group;
@@ -426,6 +427,14 @@ public class TestFrameworkImpl implements MutableTestFramework {
         public void register(Test test) {
             if (tests.containsKey(test.id())) {
                 throw new UnsupportedOperationException("Duplicate test with ID: " + test.id());
+            }
+
+            if (test.visuals() == null || test.visuals().description() == null || test.visuals().description().isEmpty()) {
+                if (configuration.onMissingDescription() == MissingDescriptionAction.ERROR) {
+                    throw new IllegalStateException("Test '" + test.id() + "' has no description.");
+                } else if (configuration.onMissingDescription() == MissingDescriptionAction.WARNING) {
+                    logger.warn("Test '{}' has no description.", test.id());
+                }
             }
 
             tests.put(test.id(), test);

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/AbstractTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/AbstractTest.java
@@ -78,8 +78,6 @@ public abstract class AbstractTest implements Test {
                     Component.literal(marker.title().isBlank() ? TestFrameworkImpl.capitaliseWords(id(), "_") : marker.title()),
                     Stream.of(marker.description()).<Component>map(Component::literal).collect(Collectors.toCollection(ArrayList::new)));
             groups.addAll(List.of(marker.groups()));
-        } else {
-            visuals = new Visuals(Component.literal(TestFrameworkImpl.capitaliseWords(id(), "_")), List.of());
         }
 
         final WithListener withListener = holder.get(WithListener.class);

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/AbstractTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/AbstractTest.java
@@ -78,6 +78,8 @@ public abstract class AbstractTest implements Test {
                     Component.literal(marker.title().isBlank() ? TestFrameworkImpl.capitaliseWords(id(), "_") : marker.title()),
                     Stream.of(marker.description()).<Component>map(Component::literal).collect(Collectors.toCollection(ArrayList::new)));
             groups.addAll(List.of(marker.groups()));
+        } else {
+            visuals = new Visuals(Component.literal(TestFrameworkImpl.capitaliseWords(id(), "_")), List.of());
         }
 
         final WithListener withListener = holder.get(WithListener.class);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/level/LevelEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/level/LevelEventTests.java
@@ -55,7 +55,7 @@ public class LevelEventTests {
     }
 
     @GameTest
-    @TestHolder
+    @TestHolder(description = "Tests if the alter ground event is fired, replacing podzol with redstone blocks")
     static void alterGroundEvent(final DynamicTest test) {
         test.registerGameTestTemplate(StructureTemplateBuilder.withSize(16, 32, 16)
                 .fill(0, 0, 0, 15, 0, 15, Blocks.DIRT.defaultBlockState())

--- a/tests/src/main/java/net/neoforged/neoforge/eventtest/internal/TestsMod.java
+++ b/tests/src/main/java/net/neoforged/neoforge/eventtest/internal/TestsMod.java
@@ -21,6 +21,7 @@ import net.neoforged.testframework.annotation.RegisterStructureTemplate;
 import net.neoforged.testframework.conf.ClientConfiguration;
 import net.neoforged.testframework.conf.Feature;
 import net.neoforged.testframework.conf.FrameworkConfiguration;
+import net.neoforged.testframework.conf.MissingDescriptionAction;
 import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 import net.neoforged.testframework.impl.MutableTestFramework;
 import net.neoforged.testframework.summary.GitHubActionsStepSummaryDumper;
@@ -51,6 +52,7 @@ public class TestsMod {
                         .build())
                 .enable(Feature.CLIENT_SYNC, Feature.CLIENT_MODIFICATIONS, Feature.TEST_STORE)
                 .dumpers(new JUnitSummaryDumper(Path.of("tests/")), new GitHubActionsStepSummaryDumper())
+                .onMissingDescription(MissingDescriptionAction.ERROR)
                 .build().create();
 
         framework.init(modBus, container);


### PR DESCRIPTION
This PR adds a new config option (`onMissingDescription`) to force test to have a description, it can be configured to:
- ignore: don't do anything if a test doesn't have a description (current state)
- warning: log a warning message (default behavior)
- error: throws an exception if a test doesn't have a description (turned on for neotests)

I also made sure every test in neoforge have a description.