### PR TITLE
[1.20.5] Mark additional built-in registries as synced

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -49,7 +49,8 @@ public class NeoForgeRegistriesSetup {
             BuiltInRegistries.FROG_VARIANT, // Required for EntityDataSerializers
             BuiltInRegistries.DATA_COMPONENT_TYPE, // Required for itemstack sync
             BuiltInRegistries.RECIPE_SERIALIZER, // Required for Recipe sync
-            BuiltInRegistries.ATTRIBUTE // Required for ClientboundUpdateAttributesPacket
+            BuiltInRegistries.ATTRIBUTE, // Required for ClientboundUpdateAttributesPacket
+            BuiltInRegistries.POTION // Required for DataComponents (DataComponents.POTION_CONTENTS)
     );
 
     private static void registerRegistries(NewRegistryEvent event) {

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -50,7 +50,14 @@ public class NeoForgeRegistriesSetup {
             BuiltInRegistries.DATA_COMPONENT_TYPE, // Required for itemstack sync
             BuiltInRegistries.RECIPE_SERIALIZER, // Required for Recipe sync
             BuiltInRegistries.ATTRIBUTE, // Required for ClientboundUpdateAttributesPacket
-            BuiltInRegistries.POTION // Required for DataComponents (DataComponents.POTION_CONTENTS)
+
+            // Required due to appearing in usages of ByteBufCodecs#registry
+            BuiltInRegistries.POTION, // PotionContents#STREAM_CODEC
+            BuiltInRegistries.NUMBER_FORMAT_TYPE, // NumberFormatTypes#STREAM_CODEC
+            BuiltInRegistries.CUSTOM_STAT, // StatType creates a registry StreamCodec using the provided stat registry
+            BuiltInRegistries.POSITION_SOURCE_TYPE, // PositionSource#STREAM_CODEC
+            BuiltInRegistries.ARMOR_MATERIAL, // TrimMaterial#DIRECT_STREAM_CODEC
+            BuiltInRegistries.MAP_DECORATION_TYPE // MapDecorationType#STREAM_CODEC
     );
 
     private static void registerRegistries(NewRegistryEvent event) {


### PR DESCRIPTION
Marks additional built-in registries as being synced to clients due to being used within various `StreamCodec`s, merging this PR would also fix #813 .

I am not 100% on if all the newly marked registries should be synced or not, they just all appear in usages of `StreamCodecs#registry` and so I assumed would cause similar issue as the potion registry currently. (throw exception as not marked synced and kick the player)