### PR TITLE
[1.20.5] Add supplier based component methods

### DIFF
--- a/patches/net/minecraft/core/component/DataComponentHolder.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentHolder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/core/component/DataComponentHolder.java
++++ b/net/minecraft/core/component/DataComponentHolder.java
+@@ -2,7 +_,7 @@
+ 
+ import javax.annotation.Nullable;
+ 
+-public interface DataComponentHolder {
++public interface DataComponentHolder extends net.neoforged.neoforge.common.extensions.IDataComponentHolderExtension {
+     DataComponentMap getComponents();
+ 
+     @Nullable

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import java.util.function.Supplier;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.core.component.DataComponentType;
+import org.jetbrains.annotations.Nullable;
+
+public interface IDataComponentHolderExtension {
+    private DataComponentHolder self() {
+        return (DataComponentHolder) this;
+    }
+
+    @Nullable
+    default <T> T get(Supplier<? extends DataComponentType<? extends T>> type) {
+        return self().get(type.get());
+    }
+
+    @Nullable
+    default <T> T getOrDefault(Supplier<? extends DataComponentType<? extends T>> type, T defaultValue) {
+        return self().getOrDefault(type.get(), defaultValue);
+    }
+
+    default boolean has(Supplier<? extends DataComponentType<?>> type) {
+        return self().has(type.get());
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -5,7 +5,11 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.stats.Stats;
@@ -506,5 +510,37 @@ public interface IItemStackExtension {
     @Nullable
     default <T> T getCapability(ItemCapability<T, Void> capability) {
         return capability.getCapability(self(), null);
+    }
+
+    /**
+     * Sets a data component.
+     */
+    @Nullable
+    default <T> T set(Supplier<? extends DataComponentType<T>> type, @Nullable T component) {
+        return self().set(type.get(), component);
+    }
+
+    /**
+     * Updates a data component if it exists, using an additional {@code updateContext}.
+     */
+    @Nullable
+    default <T, U> T update(Supplier<? extends DataComponentType<T>> type, T component, U updateContext, BiFunction<T, U, T> updater) {
+        return self().update(type.get(), component, updateContext, updater);
+    }
+
+    /**
+     * Updates a data component if it exists.
+     */
+    @Nullable
+    default <T> T update(Supplier<? extends DataComponentType<T>> type, T component, UnaryOperator<T> updater) {
+        return self().update(type.get(), component, updater);
+    }
+
+    /**
+     * Removes a data component.
+     */
+    @Nullable
+    default <T> T remove(Supplier<? extends DataComponentType<? extends T>> type) {
+        return self().remove(type.get());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import net.minecraft.core.Holder;
@@ -392,12 +393,25 @@ public final class FluidStack implements DataComponentHolder {
         return this.components.set(type, component);
     }
 
+    @Nullable
+    public <T> T set(Supplier<? extends DataComponentType<T>> type, @Nullable T value) {
+        return set(type.get(), value);
+    }
+
     /**
      * Updates a data component if it exists, using an additional {@code updateContext}.
      */
     @Nullable
     public <T, U> T update(DataComponentType<T> type, T component, U updateContext, BiFunction<T, U, T> updater) {
         return this.set(type, updater.apply(this.getOrDefault(type, component), updateContext));
+    }
+
+    /**
+     * Updates a data component if it exists, using an additional {@code updateContext}.
+     */
+    @Nullable
+    public <T, U> T update(Supplier<? extends DataComponentType<T>> type, T component, U updateContext, BiFunction<T, U, T> updater) {
+        return update(type.get(), component, updateContext, updater);
     }
 
     /**
@@ -410,11 +424,27 @@ public final class FluidStack implements DataComponentHolder {
     }
 
     /**
+     * Updates a data component if it exists.
+     */
+    @Nullable
+    public <T> T update(Supplier<? extends DataComponentType<T>> type, T component, UnaryOperator<T> updater) {
+        return update(type.get(), component, updater);
+    }
+
+    /**
      * Removes a data component.
      */
     @Nullable
     public <T> T remove(DataComponentType<? extends T> type) {
         return this.components.remove(type);
+    }
+
+    /**
+     * Removes a data component.
+     */
+    @Nullable
+    public <T> T remove(Supplier<? extends DataComponentType<? extends T>> type) {
+        return remove(type.get());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.fluids.capability.templates;
 
+import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -21,7 +22,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
  * fluid containers with different empty and full items (see {@link SwapEmpty},
  */
 public class FluidHandlerItemStack implements IFluidHandlerItem {
-    protected final DataComponentType<SimpleFluidContent> componentType;
+    protected final Supplier<DataComponentType<SimpleFluidContent>> componentType;
     protected ItemStack container;
     protected int capacity;
 
@@ -30,7 +31,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
      * @param container     The container itemStack, data is stored on it directly under a component.
      * @param capacity      The maximum capacity of this fluid tank.
      */
-    public FluidHandlerItemStack(DataComponentType<SimpleFluidContent> componentType, ItemStack container, int capacity) {
+    public FluidHandlerItemStack(Supplier<DataComponentType<SimpleFluidContent>> componentType, ItemStack container, int capacity) {
         this.componentType = componentType;
         this.container = container;
         this.capacity = capacity;
@@ -155,7 +156,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
      * Destroys the container item when it's emptied.
      */
     public static class Consumable extends FluidHandlerItemStack {
-        public Consumable(DataComponentType<SimpleFluidContent> componentType, ItemStack container, int capacity) {
+        public Consumable(Supplier<DataComponentType<SimpleFluidContent>> componentType, ItemStack container, int capacity) {
             super(componentType, container, capacity);
         }
 
@@ -172,7 +173,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
     public static class SwapEmpty extends FluidHandlerItemStack {
         protected final ItemStack emptyContainer;
 
-        public SwapEmpty(DataComponentType<SimpleFluidContent> componentType, ItemStack container, ItemStack emptyContainer, int capacity) {
+        public SwapEmpty(Supplier<DataComponentType<SimpleFluidContent>> componentType, ItemStack container, ItemStack emptyContainer, int capacity) {
             super(componentType, container, capacity);
             this.emptyContainer = emptyContainer;
         }

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.fluids.capability.templates;
 
+import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -18,7 +19,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
  * <p>This implementation only allows item containers to be fully filled or emptied, similar to vanilla buckets.
  */
 public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
-    protected final DataComponentType<SimpleFluidContent> componentType;
+    protected final Supplier<DataComponentType<SimpleFluidContent>> componentType;
     protected ItemStack container;
     protected int capacity;
 
@@ -27,7 +28,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
      * @param container     The container itemStack, data is stored on it directly as NBT.
      * @param capacity      The maximum capacity of this fluid tank.
      */
-    public FluidHandlerItemStackSimple(DataComponentType<SimpleFluidContent> componentType, ItemStack container, int capacity) {
+    public FluidHandlerItemStackSimple(Supplier<DataComponentType<SimpleFluidContent>> componentType, ItemStack container, int capacity) {
         this.componentType = componentType;
         this.container = container;
         this.capacity = capacity;
@@ -141,7 +142,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
      * Destroys the container item when it's emptied.
      */
     public static class Consumable extends FluidHandlerItemStackSimple {
-        public Consumable(DataComponentType<SimpleFluidContent> componentType, ItemStack container, int capacity) {
+        public Consumable(Supplier<DataComponentType<SimpleFluidContent>> componentType, ItemStack container, int capacity) {
             super(componentType, container, capacity);
         }
 
@@ -158,7 +159,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem {
     public static class SwapEmpty extends FluidHandlerItemStackSimple {
         protected final ItemStack emptyContainer;
 
-        public SwapEmpty(DataComponentType<SimpleFluidContent> componentType, ItemStack container, ItemStack emptyContainer, int capacity) {
+        public SwapEmpty(Supplier<DataComponentType<SimpleFluidContent>> componentType, ItemStack container, ItemStack emptyContainer, int capacity) {
             super(componentType, container, capacity);
             this.emptyContainer = emptyContainer;
         }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/FluidTemplatesTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/FluidTemplatesTests.java
@@ -45,7 +45,7 @@ public class FluidTemplatesTests {
     public static void testFluidHandlerItemStack(ExtendedGameTestHelper helper) {
         ItemStack stack = Items.APPLE.getDefaultInstance();
         int capacity = 2 * FluidType.BUCKET_VOLUME;
-        var fluidHandler = new FluidHandlerItemStack(SIMPLE_FLUID_CONTENT.get(), stack, capacity);
+        var fluidHandler = new FluidHandlerItemStack(SIMPLE_FLUID_CONTENT, stack, capacity);
 
         if (fluidHandler.getTanks() != 1) {
             helper.fail("Expected a single tank");
@@ -56,7 +56,7 @@ public class FluidTemplatesTests {
         if (fluidHandler.getFluidInTank(0).getAmount() != 0) {
             helper.fail("Expected empty tank");
         }
-        if (stack.has(SIMPLE_FLUID_CONTENT.get())) {
+        if (stack.has(SIMPLE_FLUID_CONTENT)) {
             helper.fail("Expected no fluid stack component");
         }
 
@@ -64,7 +64,7 @@ public class FluidTemplatesTests {
         if (fluidHandler.fill(waterStack, IFluidHandler.FluidAction.EXECUTE) != FluidType.BUCKET_VOLUME) {
             helper.fail("Expected to be able to fill a bucket of water");
         }
-        if (!stack.has(SIMPLE_FLUID_CONTENT.get())) {
+        if (!stack.has(SIMPLE_FLUID_CONTENT)) {
             helper.fail("Expected fluid stack component");
         }
         if (fluidHandler.getFluidInTank(0).getAmount() != FluidType.BUCKET_VOLUME) {
@@ -78,7 +78,7 @@ public class FluidTemplatesTests {
         if (fluidHandler.getFluidInTank(0).getAmount() != 0) {
             helper.fail("Expected empty tank");
         }
-        if (stack.has(SIMPLE_FLUID_CONTENT.get())) {
+        if (stack.has(SIMPLE_FLUID_CONTENT)) {
             helper.fail("Expected no fluid stack component");
         }
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -38,11 +38,11 @@ public class ItemComponentTests {
             ItemStack stack = Items.DIAMOND.getDefaultInstance();
 
             ItemStack stack1 = stack.copy();
-            stack1.set(blockHolderComponent.get(), Blocks.DIAMOND_BLOCK.builtInRegistryHolder());
+            stack1.set(blockHolderComponent, Blocks.DIAMOND_BLOCK.builtInRegistryHolder());
 
             ItemStack stack2 = stack.copy();
             var diamondDh = DeferredBlock.createBlock(BuiltInRegistries.BLOCK.getKey(Blocks.DIAMOND_BLOCK));
-            stack2.set(blockHolderComponent.get(), diamondDh);
+            stack2.set(blockHolderComponent, diamondDh);
 
             if (!ItemStack.matches(stack1, stack2)) {
                 helper.fail("Expected the same item stacks");

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -62,7 +62,7 @@ public class CustomFluidContainerTest {
     }
 
     private void registerCaps(RegisterCapabilitiesEvent event) {
-        event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidHandlerItemStackSimple(SIMPLE_FLUID_CONTENT.get(), stack, FluidType.BUCKET_VOLUME), CUSTOM_FLUID_CONTAINER.get());
+        event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidHandlerItemStackSimple(SIMPLE_FLUID_CONTENT, stack, FluidType.BUCKET_VOLUME), CUSTOM_FLUID_CONTAINER.get());
     }
 
     /**


### PR DESCRIPTION
Patches in supplier based component methods to make using modded components easier.

This change brings them more in line with how attachment types currently work, where theres a method taking in the attachment type directly and a supplier based overload for passing in lazily registered types.

The following code snippet
`itemStack.set(MyComponents.MY_COMPONENT.value(), new MyComponent(0));`

would become
`itemStack.set(MyComponents.MY_COMPONENT, new MyComponent(0));`

---

The component based fluid handler templates have been modified to now take in supplier rather than the component type directly.