### PR TITLE
[1.20.5] Remove deprecated IBakedModelExtension#useAmbientOcclusion overloads

### DIFF
--- a/patches/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/MultiPartBakedModel.java.patch
@@ -67,20 +67,10 @@
          }
      }
  
-@@ -79,6 +_,26 @@
+@@ -79,6 +_,16 @@
      }
  
      @Override
-+    public boolean useAmbientOcclusion(BlockState state) {
-+        return this.defaultModel.useAmbientOcclusion(state);
-+    }
-+
-+    @Override
-+    public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
-+        return this.defaultModel.useAmbientOcclusion(state, renderType);
-+    }
-+
-+    @Override
 +    public net.neoforged.neoforge.common.util.TriState useAmbientOcclusion(BlockState state, net.neoforged.neoforge.client.model.data.ModelData modelData, net.minecraft.client.renderer.RenderType renderType) {
 +        return this.defaultModel.useAmbientOcclusion(state, modelData, renderType);
 +    }

--- a/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
@@ -22,20 +22,10 @@
              .orElse(Collections.emptyList());
      }
  
-@@ -41,6 +_,21 @@
+@@ -41,6 +_,11 @@
      }
  
      @Override
-+    public boolean useAmbientOcclusion(BlockState state) {
-+        return this.wrapped.useAmbientOcclusion(state);
-+    }
-+
-+    @Override
-+    public boolean useAmbientOcclusion(BlockState state, net.minecraft.client.renderer.RenderType renderType) {
-+        return this.wrapped.useAmbientOcclusion(state, renderType);
-+    }
-+
-+    @Override
 +    public net.neoforged.neoforge.common.util.TriState useAmbientOcclusion(BlockState state, net.neoforged.neoforge.client.model.data.ModelData modelData, net.minecraft.client.renderer.RenderType renderType) {
 +        return this.wrapped.useAmbientOcclusion(state, modelData, renderType);
 +    }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
@@ -42,22 +42,6 @@ public interface IBakedModelExtension {
     }
 
     /**
-     * @deprecated Use {@link #useAmbientOcclusion(BlockState, ModelData, RenderType)} instead
-     */
-    @Deprecated(forRemoval = true, since = "1.20.4")
-    default boolean useAmbientOcclusion(BlockState state) {
-        return self().useAmbientOcclusion();
-    }
-
-    /**
-     * @deprecated Use {@link #useAmbientOcclusion(BlockState, ModelData, RenderType)} instead
-     */
-    @Deprecated(forRemoval = true, since = "1.20.4")
-    default boolean useAmbientOcclusion(BlockState state, RenderType renderType) {
-        return self().useAmbientOcclusion(state);
-    }
-
-    /**
      * Controls the AO behavior for all quads of this model. The default behavior is to use AO unless the block emits light,
      * {@link TriState#TRUE} and {@link TriState#FALSE} force AO to be enabled and disabled respectively, regardless of
      * the block emitting light or not. {@link BakedQuad#hasAmbientOcclusion()} can be used to disable AO for a specific
@@ -71,7 +55,7 @@ public interface IBakedModelExtension {
      * @return {@link TriState#TRUE} to force-enable AO, {@link TriState#FALSE} to force-disable AO or {@link TriState#DEFAULT} to use vanilla AO behavior
      */
     default TriState useAmbientOcclusion(BlockState state, ModelData data, RenderType renderType) {
-        return useAmbientOcclusion(state, renderType) ? TriState.DEFAULT : TriState.FALSE;
+        return self().useAmbientOcclusion() ? TriState.DEFAULT : TriState.FALSE;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/model/BakedModelWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/BakedModelWrapper.java
@@ -48,16 +48,6 @@ public abstract class BakedModelWrapper<T extends BakedModel> implements BakedMo
     }
 
     @Override
-    public boolean useAmbientOcclusion(BlockState state) {
-        return originalModel.useAmbientOcclusion(state);
-    }
-
-    @Override
-    public boolean useAmbientOcclusion(BlockState state, RenderType renderType) {
-        return originalModel.useAmbientOcclusion(state, renderType);
-    }
-
-    @Override
     public TriState useAmbientOcclusion(BlockState state, ModelData data, RenderType renderType) {
         return originalModel.useAmbientOcclusion(state, data, renderType);
     }


### PR DESCRIPTION
The new hook receives a superset of the original context, so it can do everything the old hooks could.