### PR TITLE
[1.20.5] Refactor PacketDistributor to static helper methods

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -137,7 +137,7 @@ public class NeoForgeEventHandler {
             att.put(key, registry.getDataMap(attach));
         });
         if (!att.isEmpty()) {
-            PacketDistributor.PLAYER.with(player).send(new RegistryDataMapSyncPayload<>(registry.key(), att));
+            PacketDistributor.sendToPlayer(player, new RegistryDataMapSyncPayload<>(registry.key(), att));
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
+++ b/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
@@ -77,7 +77,7 @@ public final class PacketDistributor {
      * Send the given payload(s) to all players on the server
      */
     public static void sendToAllPlayers(CustomPacketPayload... payloads) {
-        MinecraftServer server = Objects.requireNonNull(getServer(), "Cannot send clientbound payloads on the client");
+        MinecraftServer server = Objects.requireNonNull(ServerLifecycleHooks.getCurrentServer(), "Cannot send clientbound payloads on the client");
         server.getPlayerList().broadcastAll(makeClientboundPacket(payloads));
     }
 
@@ -125,9 +125,5 @@ public final class PacketDistributor {
         } else {
             throw new IllegalArgumentException("Must provide at least one payload");
         }
-    }
-
-    private static MinecraftServer getServer() {
-        return ServerLifecycleHooks.getCurrentServer();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
+++ b/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
@@ -61,7 +61,7 @@ public final class PacketDistributor {
      */
     public static void sendToPlayersNear(TargetPoint target, CustomPacketPayload... payloads) {
         Packet<?> packet = makeClientboundPacket(payloads);
-        getServer().getPlayerList().broadcast(target.excluded, target.x, target.y, target.z, target.r2, target.dim, packet);
+        getServer().getPlayerList().broadcast(target.excluded, target.x, target.y, target.z, target.r, target.dim, packet);
     }
 
     /**
@@ -109,45 +109,28 @@ public final class PacketDistributor {
         }
     }
 
-    public static final class TargetPoint {
-        @Nullable
-        private final ServerPlayer excluded;
-        private final double x;
-        private final double y;
-        private final double z;
-        private final double r2;
-        private final ResourceKey<Level> dim;
-
-        /**
-         * A target point with excluded entity
-         *
-         * @param excluded Entity to exclude
-         * @param x        X
-         * @param y        Y
-         * @param z        Z
-         * @param r2       Radius
-         * @param dim      DimensionType
-         */
-        public TargetPoint(@Nullable ServerPlayer excluded, double x, double y, double z, double r2, ResourceKey<Level> dim) {
-            this.excluded = excluded;
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.r2 = r2;
-            this.dim = dim;
-        }
-
+    /**
+     * A target point with excluded entity
+     *
+     * @param excluded Entity to exclude
+     * @param x        X coordinate
+     * @param y        Y coordinate
+     * @param z        Z coordinate
+     * @param r        Radius
+     * @param dim      Target dimension
+     */
+    public record TargetPoint(@Nullable ServerPlayer excluded, double x, double y, double z, double r, ResourceKey<Level> dim) {
         /**
          * A target point without excluded entity
-         * 
-         * @param x   X
-         * @param y   Y
-         * @param z   Z
-         * @param r2  Radius
-         * @param dim DimensionType
+         *
+         * @param x   X coordinate
+         * @param y   Y coordinate
+         * @param z   Z coordinate
+         * @param r   Radius
+         * @param dim Target dimension
          */
-        public TargetPoint(double x, double y, double z, double r2, ResourceKey<Level> dim) {
-            this(null, x, y, z, r2, dim);
+        public TargetPoint(double x, double y, double z, double r, ResourceKey<Level> dim) {
+            this(null, x, y, z, r , dim);
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
+++ b/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
@@ -8,84 +8,109 @@ package net.neoforged.neoforge.network;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.network.protocol.Packet;
-import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
-import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBundlePacket;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.chunk.LevelChunk;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Means to distribute packets in various ways
  */
-public class PacketDistributor<T> {
-    /**
-     * Sends a client-bound payload to the specified player.
-     * <br/>
-     * {@link #with(Object)} Player
-     */
-    public static final PacketDistributor<ServerPlayer> PLAYER = new PacketDistributor<>(PacketDistributor::playerConsumer, PacketFlow.CLIENTBOUND);
+public final class PacketDistributor {
+    private PacketDistributor() {}
 
     /**
-     * Sends a client-bound payload to everyone in the specified dimension.
-     * <br/>
-     * {@link #with(Object)} DimensionType
+     * Send the given payload(s) to the server
      */
-    public static final PacketDistributor<ResourceKey<Level>> DIMENSION = new PacketDistributor<>(PacketDistributor::playerListDimConsumer, PacketFlow.CLIENTBOUND);
+    public static void sendToServer(CustomPacketPayload... payloads) {
+        ClientPacketListener listener = Objects.requireNonNull(Minecraft.getInstance().getConnection());
+        for (CustomPacketPayload payload : payloads) {
+            listener.send(payload);
+        }
+    }
 
     /**
-     * Sends a client-bound payload to everyone near the specified {@link TargetPoint}.
-     * <br/>
-     * {@link #with(Object)} TargetPoint
+     * Send the given payload(s) to the given player
      */
-    public static final PacketDistributor<TargetPoint> NEAR = new PacketDistributor<>(PacketDistributor::playerListPointConsumer, PacketFlow.CLIENTBOUND);
+    public static void sendToPlayer(ServerPlayer player, CustomPacketPayload... payloads) {
+        player.connection.send(makeClientboundPacket(payloads));
+    }
 
     /**
-     * Sends a client-bound payload to all players connected to the server.
+     * Send the given payload(s) to all players in the given dimension
      */
-    public static final NoArgDistributor ALL = new NoArgDistributor(PacketDistributor::playerListAll, PacketFlow.CLIENTBOUND);
+    public static void sendToPlayersInDimension(ResourceKey<Level> dimension, CustomPacketPayload... payloads) {
+        getServer().getPlayerList().broadcastAll(makeClientboundPacket(payloads), dimension);
+    }
 
     /**
-     * Sends a server-bound payload to the server.
+     * Send the given payload(s) to all players near the given {@link TargetPoint}
      */
-    public static final NoArgDistributor SERVER = new NoArgDistributor(PacketDistributor::clientToServer, PacketFlow.SERVERBOUND);
+    public static void sendToPlayersNear(TargetPoint target, CustomPacketPayload... payloads) {
+        Packet<?> packet = makeClientboundPacket(payloads);
+        getServer().getPlayerList().broadcast(target.excluded, target.x, target.y, target.z, target.r2, target.dim, packet);
+    }
 
     /**
-     * Sends a client-bound payload to all players tracking the entity.
-     * <br/>
-     * {@link #with(Object)} Entity
+     * Send the given payload(s) to all players on the server
      */
-    public static final PacketDistributor<Entity> TRACKING_ENTITY = new PacketDistributor<>(PacketDistributor::trackingEntity, PacketFlow.CLIENTBOUND);
+    public static void sendToAllPlayers(CustomPacketPayload... payloads) {
+        getServer().getPlayerList().broadcastAll(makeClientboundPacket(payloads));
+    }
 
     /**
-     * Sends a client-bound payload to all players tracking the entity, and the entity if it is a player.
-     * <br/>
-     * {@link #with(Object)} Entity
+     * Send the given payload(s) to all players tracking the given entity
      */
-    public static final PacketDistributor<Entity> TRACKING_ENTITY_AND_SELF = new PacketDistributor<>(PacketDistributor::trackingEntityAndSelf, PacketFlow.CLIENTBOUND);
+    public static void sendToPlayersTrackingEntity(Entity entity, CustomPacketPayload... payloads) {
+        ((ServerChunkCache) entity.level().getChunkSource()).broadcast(entity, makeClientboundPacket(payloads));
+    }
 
     /**
-     * Sends a client-bound payload to all players tracking the chunk
-     * <br/>
-     * {@link #with(Object)} Chunk
+     * Send the given payload(s) to all players tracking the given entity and the entity itself if it is a player
      */
-    public static final PacketDistributor<LevelChunk> TRACKING_CHUNK = new PacketDistributor<>(PacketDistributor::trackingChunk, PacketFlow.CLIENTBOUND);
+    public static void sendToPlayersTrackingEntityAndSelf(Entity entity, CustomPacketPayload... payloads) {
+        ((ServerChunkCache) entity.level().getChunkSource()).broadcastAndSend(entity, makeClientboundPacket(payloads));
+    }
+
+    /**
+     * Send the given payload(s) to all players tracking the chunk at the given position in the given level
+     */
+    public static void sendToPlayersTrackingChunk(ServerLevel level, ChunkPos chunkPos, CustomPacketPayload... payloads) {
+        Packet<?> packet = makeClientboundPacket(payloads);
+        for (ServerPlayer player : level.getChunkSource().chunkMap.getPlayers(chunkPos, false)) {
+            player.connection.send(packet);
+        }
+    }
+
+    private static Packet<?> makeClientboundPacket(CustomPacketPayload... payloads) {
+        if (payloads.length > 1) {
+            final List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
+            for (CustomPacketPayload payload : payloads) {
+                packets.add(new ClientboundCustomPayloadPacket(payload));
+            }
+            return new ClientboundBundlePacket(packets);
+        } else if (payloads.length == 1) {
+            return new ClientboundCustomPayloadPacket(payloads[0]);
+        } else {
+            throw new IllegalArgumentException("Must provide at least one payload");
+        }
+    }
 
     public static final class TargetPoint {
+        @Nullable
         private final ServerPlayer excluded;
         private final double x;
         private final double y;
@@ -103,7 +128,7 @@ public class PacketDistributor<T> {
          * @param r2       Radius
          * @param dim      DimensionType
          */
-        public TargetPoint(final ServerPlayer excluded, final double x, final double y, final double z, final double r2, final ResourceKey<Level> dim) {
+        public TargetPoint(@Nullable ServerPlayer excluded, double x, double y, double z, double r2, ResourceKey<Level> dim) {
             this.excluded = excluded;
             this.x = x;
             this.y = y;
@@ -121,161 +146,12 @@ public class PacketDistributor<T> {
          * @param r2  Radius
          * @param dim DimensionType
          */
-        public TargetPoint(final double x, final double y, final double z, final double r2, final ResourceKey<Level> dim) {
-            this.excluded = null;
-            this.x = x;
-            this.y = y;
-            this.z = z;
-            this.r2 = r2;
-            this.dim = dim;
-        }
-
-        /**
-         * Helper to build a TargetPoint without excluded Entity
-         * 
-         * @param x   X
-         * @param y   Y
-         * @param z   Z
-         * @param r2  Radius
-         * @param dim DimensionType
-         * @return A TargetPoint supplier
-         */
-        public static Supplier<TargetPoint> p(double x, double y, double z, double r2, ResourceKey<Level> dim) {
-            TargetPoint tp = new TargetPoint(x, y, z, r2, dim);
-            return () -> tp;
+        public TargetPoint(double x, double y, double z, double r2, ResourceKey<Level> dim) {
+            this(null, x, y, z, r2, dim);
         }
     }
 
-    /**
-     * A Distributor curried with a specific value instance, for actual dispatch
-     *
-     */
-    public static class PacketTarget {
-        private final Consumer<Packet<?>> packetConsumer;
-        private final PacketDistributor<?> distributor;
-
-        PacketTarget(final Consumer<Packet<?>> packetConsumer, final PacketDistributor<?> distributor) {
-            this.packetConsumer = packetConsumer;
-            this.distributor = distributor;
-        }
-
-        public void send(Packet<?> packet) {
-            packetConsumer.accept(packet);
-        }
-
-        public void send(CustomPacketPayload... payloads) {
-            if (flow().isClientbound()) {
-                if (payloads.length > 1) {
-                    final List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
-                    for (CustomPacketPayload payload : payloads) {
-                        packets.add(new ClientboundCustomPayloadPacket(payload));
-                    }
-                    this.send(new ClientboundBundlePacket(packets));
-                } else if (payloads.length == 1) {
-                    this.send(new ClientboundCustomPayloadPacket(payloads[0]));
-                }
-            } else {
-                for (CustomPacketPayload payload : payloads) {
-                    this.send(new ServerboundCustomPayloadPacket(payload));
-                }
-            }
-        }
-
-        public PacketFlow flow() {
-            return distributor.flow;
-        }
-    }
-
-    private final BiFunction<PacketDistributor<T>, T, Consumer<Packet<?>>> functor;
-    private final PacketFlow flow;
-
-    public PacketDistributor(BiFunction<PacketDistributor<T>, T, Consumer<Packet<?>>> functor, PacketFlow flow) {
-        this.functor = functor;
-        this.flow = flow;
-    }
-
-    public PacketDistributor(Function<PacketDistributor<T>, Consumer<Packet<?>>> functor, PacketFlow flow) {
-        this((d, t) -> functor.apply(d), flow);
-    }
-
-    /**
-     * Apply the supplied value to the specific distributor to generate an instance for sending packets to.
-     * 
-     * @param input The input to apply
-     * @return A curried instance
-     */
-    public PacketTarget with(T input) {
-        return new PacketTarget(functor.apply(this, input), this);
-    }
-
-    /**
-     * Apply a no argument value to a distributor to generate an instance for sending packets to.
-     *
-     * @see #ALL
-     * @see #SERVER
-     * @return A curried instance
-     */
-    public PacketTarget noArg() {
-        return new PacketTarget(functor.apply(this, null), this);
-    }
-
-    private Consumer<Packet<?>> playerConsumer(final ServerPlayer entityPlayerMP) {
-        return p -> entityPlayerMP.connection.send(p);
-    }
-
-    private Consumer<Packet<?>> playerListDimConsumer(final ResourceKey<Level> dimensionType) {
-        return p -> getServer().getPlayerList().broadcastAll(p, dimensionType);
-    }
-
-    private Consumer<Packet<?>> playerListAll() {
-        return p -> getServer().getPlayerList().broadcastAll(p);
-    }
-
-    private Consumer<Packet<?>> clientToServer() {
-        return p -> Objects.requireNonNull(Minecraft.getInstance().getConnection()).send(p);
-    }
-
-    private Consumer<Packet<?>> playerListPointConsumer(final TargetPoint targetPoint) {
-        return p -> {
-            final TargetPoint tp = targetPoint;
-            getServer().getPlayerList().broadcast(tp.excluded, tp.x, tp.y, tp.z, tp.r2, tp.dim, p);
-        };
-    }
-
-    private Consumer<Packet<?>> trackingEntity(final Entity entity) {
-        return p -> {
-            ((ServerChunkCache) entity.getCommandSenderWorld().getChunkSource()).broadcast(entity, p);
-        };
-    }
-
-    private Consumer<Packet<?>> trackingEntityAndSelf(final Entity entity) {
-        return p -> {
-            ((ServerChunkCache) entity.getCommandSenderWorld().getChunkSource()).broadcastAndSend(entity, p);
-        };
-    }
-
-    @SuppressWarnings("resource")
-    private Consumer<Packet<?>> trackingChunk(final LevelChunk chunkPos) {
-        return p -> {
-            ((ServerChunkCache) chunkPos.getLevel().getChunkSource()).chunkMap.getPlayers(chunkPos.getPos(), false).forEach(e -> e.connection.send(p));
-        };
-    }
-
-    private MinecraftServer getServer() {
+    private static MinecraftServer getServer() {
         return ServerLifecycleHooks.getCurrentServer();
-    }
-
-    public static class NoArgDistributor extends PacketDistributor<Void> {
-        public NoArgDistributor(Function<PacketDistributor<Void>, Consumer<Packet<?>>> functor, PacketFlow flow) {
-            super(functor, flow);
-        }
-
-        public void send(Packet<?> packet) {
-            noArg().send(packet);
-        }
-
-        public void send(CustomPacketPayload... payloads) {
-            noArg().send(payloads);
-        }
     }
 }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
@@ -305,8 +305,8 @@ public class TestFrameworkImpl implements MutableTestFramework {
 
         final ChangeStatusPayload packet = new ChangeStatusPayload(this, test.id(), newStatus);
         sendPacketIfOn(
-                () -> PacketDistributor.ALL.send(packet),
-                () -> PacketDistributor.SERVER.send(packet),
+                () -> PacketDistributor.sendToAllPlayers(packet),
+                () -> PacketDistributor.sendToServer(packet),
                 null);
     }
 
@@ -332,8 +332,8 @@ public class TestFrameworkImpl implements MutableTestFramework {
 
         final ChangeEnabledPayload packet = new ChangeEnabledPayload(TestFrameworkImpl.this, test.id(), enabled);
         sendPacketIfOn(
-                () -> PacketDistributor.ALL.send(packet),
-                () -> PacketDistributor.SERVER.send(packet),
+                () -> PacketDistributor.sendToAllPlayers(packet),
+                () -> PacketDistributor.sendToServer(packet),
                 null);
     }
 


### PR DESCRIPTION
This PR simplifies the `PacketDistributor` API down to a set of static helper methods for sending payloads.
I have omitted overloads for sending vanilla `Packet`s for now, but adding them would be trivial if desired.

Closes #801