### PR TITLE
[1.20.5] Fix data component nullability issue

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
@@ -20,7 +20,6 @@ public interface IDataComponentHolderExtension {
         return self().get(type.get());
     }
 
-    @Nullable
     default <T> T getOrDefault(Supplier<? extends DataComponentType<? extends T>> type, T defaultValue) {
         return self().getOrDefault(type.get(), defaultValue);
     }


### PR DESCRIPTION
Removes the `@Nullable` annotation from `getOrDefault` in `IDataComponentHolderExtension`, this method shouldn't be nullable