### PR TITLE
Make hasChannel callable from payload context

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -65,7 +65,7 @@
          LOGGER.warn("Client disconnected with reason: {}", p_295485_.getString());
      }
  
-@@ -354,5 +_,15 @@
+@@ -354,5 +_,10 @@
          @OnlyIn(Dist.CLIENT)
          static record PendingRequest(UUID id, URL url, String hash) {
          }
@@ -74,10 +74,5 @@
 +    @Override
 +    public Connection getConnection() {
 +        return connection;
-+    }
-+
-+    @Override
-+    public Minecraft getMinecraft() {
-+        return minecraft;
      }
  }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IClientCommonPacketListenerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IClientCommonPacketListenerExtension.java
@@ -6,93 +6,37 @@
 package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.Connection;
-import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientCommonPacketListener;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.thread.ReentrantBlockableEventLoop;
-import net.neoforged.neoforge.network.connection.ConnectionType;
-import net.neoforged.neoforge.network.registration.NetworkRegistry;
 
 /**
- * This interface is used to extend the {@link ClientCommonPacketListener} interface.
- * <p>
- * Its primary purpose is to expose sending logic, for transmitting packets to the server.
- * </p>
+ * Extension interface for {@link ClientCommonPacketListener}
  */
-public interface IClientCommonPacketListenerExtension {
+public interface IClientCommonPacketListenerExtension extends ICommonPacketListener {
     /**
-     * {@return the ClientCommonPacketListener this extension is attached to}
+     * {@inheritDoc}
      */
-    private ClientCommonPacketListener self() {
-        return (ClientCommonPacketListener) this;
-    }
-
-    /**
-     * Sends a packet to the server.
-     * 
-     * @param packet The packet to send.
-     */
-    void send(Packet<?> packet);
-
-    /**
-     * Sends a custom payload to the server.
-     *
-     * @param payload The payload to send.
-     */
+    @Override
     default void send(CustomPacketPayload payload) {
-        send(new ServerboundCustomPayloadPacket(payload));
+        this.send(new ServerboundCustomPayloadPacket(payload));
     }
 
     /**
-     * Exposes the raw underlying connection.
-     *
-     * @return The raw underlying connection.
+     * {@inheritDoc}
      */
-    Connection getConnection();
+    @Override
+    default void disconnect(Component reason) {
+        this.getConnection().disconnect(reason);
+    }
 
     /**
-     * Exposes the raw underlying connection event loop that can be used to schedule tasks on the main thread.
-     *
-     * @return The raw underlying connection event loop.
+     * {@inheritDoc}
      */
+    @Override
     default ReentrantBlockableEventLoop<?> getMainThreadEventLoop() {
-        return getMinecraft();
+        return Minecraft.getInstance();
     }
-
-    /**
-     * Checks if the connection has negotiated and opened a channel for the payload.
-     *
-     * @param payloadId The payload id to check
-     * @returns true if a payload with this id may be sent over this connection.
-     */
-    default boolean hasChannel(final ResourceLocation payloadId) {
-        return NetworkRegistry.hasChannel(self(), payloadId);
-    }
-
-    /**
-     * @see {@link #hasChannel(ResourceLocation)}
-     */
-    default boolean hasChannel(final CustomPacketPayload.Type<?> type) {
-        return hasChannel(type.id());
-    }
-
-    /**
-     * @see {@link #hasChannel(ResourceLocation)}
-     */
-    default boolean hasChannel(final CustomPacketPayload payload) {
-        return hasChannel(payload.type());
-    }
-
-    /**
-     * {@return the minecraft instance}
-     */
-    Minecraft getMinecraft();
-
-    /**
-     * {@return the connection type}
-     */
-    ConnectionType getConnectionType();
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommonPacketListener.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommonPacketListener.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import net.minecraft.network.Connection;
+import net.minecraft.network.PacketListener;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.common.ClientCommonPacketListener;
+import net.minecraft.network.protocol.common.ServerCommonPacketListener;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.thread.ReentrantBlockableEventLoop;
+import net.neoforged.neoforge.network.connection.ConnectionType;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
+
+/**
+ * Extension interface and functionality hoist for both {@link ServerCommonPacketListener}
+ * and {@link ClientCommonPacketListener}.
+ */
+public interface ICommonPacketListener extends PacketListener {
+    /**
+     * Sends a packet to the target of this listener.
+     */
+    void send(Packet<?> packet);
+
+    /**
+     * Sends a payload to the target of this listener.
+     */
+    void send(CustomPacketPayload payload);
+
+    /**
+     * Triggers a disconnection with the given reason.
+     *
+     * @param reason The reason for the disconnection
+     */
+    void disconnect(Component reason);
+
+    /**
+     * {@return the connection this listener is attached to}
+     */
+    Connection getConnection();
+
+    /**
+     * {@return the main thread event loop}
+     */
+    ReentrantBlockableEventLoop<?> getMainThreadEventLoop();
+
+    /**
+     * Checks if the connection has negotiated and opened a channel for the payload.
+     *
+     * @param payloadId The payload id to check
+     * @returns true if a payload with this id may be sent over this connection.
+     */
+    default boolean hasChannel(final ResourceLocation payloadId) {
+        return NetworkRegistry.hasChannel(this.getConnection(), this.protocol(), payloadId);
+    }
+
+    /**
+     * @see {@link #hasChannel(ResourceLocation)}
+     */
+    default boolean hasChannel(final CustomPacketPayload.Type<?> type) {
+        return hasChannel(type.id());
+    }
+
+    /**
+     * @see {@link #hasChannel(ResourceLocation)}
+     */
+    default boolean hasChannel(final CustomPacketPayload payload) {
+        return hasChannel(payload.type());
+    }
+
+    /**
+     * {@return the connection type of this packet listener}
+     */
+    ConnectionType getConnectionType();
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IServerCommonPacketListenerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IServerCommonPacketListenerExtension.java
@@ -6,109 +6,37 @@
 package net.neoforged.neoforge.common.extensions;
 
 import javax.annotation.Nullable;
-import net.minecraft.network.Connection;
 import net.minecraft.network.PacketSendListener;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.ServerCommonPacketListener;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.thread.ReentrantBlockableEventLoop;
-import net.neoforged.neoforge.network.connection.ConnectionType;
-import net.neoforged.neoforge.network.registration.NetworkRegistry;
 
 /**
- * Extension class for {@link net.minecraft.network.protocol.common.ServerCommonPacketListener}
- * <p>
- * This interface and its default methods is used to make sending custom payloads easier.
- * </p>
+ * Extension interface for {@link ServerCommonPacketListener}
  */
-public interface IServerCommonPacketListenerExtension {
+public interface IServerCommonPacketListenerExtension extends ICommonPacketListener {
     /**
-     * {@return the {@link ServerCommonPacketListener} that the extensions is attached to}
+     * {@inheritDoc}
      */
-    private ServerCommonPacketListener self() {
-        return (ServerCommonPacketListener) this;
+    @Override
+    default void send(CustomPacketPayload payload) {
+        this.send(new ClientboundCustomPayloadPacket(payload));
     }
 
     /**
-     * Sends a packet to the client which this listener is attached to.
+     * Sends a packet to the client of this listener.
      *
-     * @param packet The packet to send
+     * @param listener An optional callback for when the payload is sent
      */
-    void send(Packet<?> packet);
+    void send(Packet<?> packet, @Nullable PacketSendListener listener);
 
     /**
-     * Sends a custom payload to the client which this listener is attached to.
+     * Sends a payload to the client of this listener.
      *
-     * @param packetPayload The payload to send
+     * @param listener An optional callback for when the payload is sent
      */
-    default void send(CustomPacketPayload packetPayload) {
-        this.send(new ClientboundCustomPayloadPacket(packetPayload));
+    default void send(CustomPacketPayload payload, @Nullable PacketSendListener listener) {
+        this.send(new ClientboundCustomPayloadPacket(payload), listener);
     }
-
-    /**
-     * Sends a packet to the client which this listener is attached to.
-     *
-     * @param packet             The packet to send
-     * @param packetSendListener The listener to call when the packet is sent
-     */
-    void send(Packet<?> packet, @Nullable PacketSendListener packetSendListener);
-
-    /**
-     * Sends a custom payload to the client which this listener is attached to.
-     *
-     * @param packetPayload The payload to send
-     * @param listener      The listener to call when the packet is sent
-     */
-    default void send(CustomPacketPayload packetPayload, @Nullable PacketSendListener listener) {
-        this.send(new ClientboundCustomPayloadPacket(packetPayload), listener);
-    }
-
-    /**
-     * Triggers a disconnection with the given reason.
-     *
-     * @param reason The reason for the disconnection
-     */
-    void disconnect(Component reason);
-
-    /**
-     * {@return the connection this listener is attached to}
-     */
-    Connection getConnection();
-
-    /**
-     * {@return the main thread event loop}
-     */
-    ReentrantBlockableEventLoop<?> getMainThreadEventLoop();
-
-    /**
-     * Checks if the connection has negotiated and opened a channel for the payload.
-     *
-     * @param payloadId The payload id to check
-     * @returns true if a payload with this id may be sent over this connection.
-     */
-    default boolean hasChannel(final ResourceLocation payloadId) {
-        return NetworkRegistry.hasChannel(self(), payloadId);
-    }
-
-    /**
-     * @see {@link #hasChannel(ResourceLocation)}
-     */
-    default boolean hasChannel(final CustomPacketPayload.Type<?> type) {
-        return hasChannel(type.id());
-    }
-
-    /**
-     * @see {@link #hasChannel(ResourceLocation)}
-     */
-    default boolean hasChannel(final CustomPacketPayload payload) {
-        return hasChannel(payload.type());
-    }
-
-    /**
-     * {@return the connection type of the connection}
-     */
-    ConnectionType getConnectionType();
 }

--- a/src/main/java/net/neoforged/neoforge/network/filters/GenericPacketSplitter.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/GenericPacketSplitter.java
@@ -150,7 +150,7 @@ public class GenericPacketSplitter extends MessageToMessageEncoder<Packet<?>> im
             FriendlyByteBuf full = new FriendlyByteBuf(Unpooled.wrappedBuffer(buffers));
 
             try {
-                Packet<?> packet = context.protocolInfo().codec().decode(full);
+                Packet<?> packet = context.connection().getInboundProtocol().codec().decode(full);
                 context.enqueueWork(() -> context.handle(packet));
             } finally {
                 receivedBuffers.clear();

--- a/src/main/java/net/neoforged/neoforge/network/handling/ClientPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ClientPayloadContext.java
@@ -5,14 +5,9 @@
 
 package net.neoforged.neoforge.network.handling;
 
-import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import net.minecraft.network.Connection;
-import net.minecraft.network.ConnectionProtocol;
-import net.minecraft.network.ProtocolInfo;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.Packet;
+import net.minecraft.client.Minecraft;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.ClientCommonPacketListener;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
@@ -25,21 +20,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public record ClientPayloadContext(ClientCommonPacketListener listener, ResourceLocation payloadId) implements IPayloadContext {
-    @Override
-    public void reply(CustomPacketPayload payload) {
-        listener.send(payload);
-    }
-
-    @Override
-    public void disconnect(Component reason) {
-        listener.getConnection().disconnect(reason);
-    }
-
-    @Override
-    public void handle(Packet<?> packet) {
-        NetworkRegistry.handlePacketUnchecked(packet, listener);
-    }
-
     @Override
     public void handle(CustomPacketPayload payload) {
         handle(new ClientboundCustomPayloadPacket(payload));
@@ -68,33 +48,13 @@ public record ClientPayloadContext(ClientCommonPacketListener listener, Resource
     }
 
     @Override
-    public ProtocolInfo<?> protocolInfo() {
-        return listener.getConnection().getInboundProtocol();
-    }
-
-    @Override
     public PacketFlow flow() {
         return PacketFlow.CLIENTBOUND;
     }
 
     @Override
-    public ConnectionProtocol protocol() {
-        return listener.protocol();
-    }
-
-    @Override
     @SuppressWarnings("resource")
     public Player player() {
-        return listener.getMinecraft().player;
-    }
-
-    @Override
-    public ChannelHandlerContext channelHandlerContext() {
-        return listener.getConnection().channel().pipeline().lastContext();
-    }
-
-    @Override
-    public Connection connection() {
-        return listener.getConnection();
+        return Minecraft.getInstance().player;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handling/ClientPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ClientPayloadContext.java
@@ -55,6 +55,9 @@ public record ClientPayloadContext(ClientCommonPacketListener listener, Resource
     @Override
     @SuppressWarnings("resource")
     public Player player() {
-        return Minecraft.getInstance().player;
+        if (Minecraft.getInstance().player != null) {
+            return Minecraft.getInstance().player;
+        }
+        throw new UnsupportedOperationException("Cannot retrieve the client player during the configuration phase.");
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handling/IPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IPayloadContext.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.network.handling;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.Connection;
 import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.chat.Component;
@@ -41,11 +42,11 @@ public interface IPayloadContext {
     }
 
     /**
-     * Retrieves the player relevant to this payload, which has a different meaning based on the protocol and flow.
+     * Retrieves the player relevant to this payload. Players are only available in the {@link ConnectionProtocol#CONFIGURATION} phase.
      * <p>
-     * For server-bound play payloads, retrieves the sending player. This case can safely be cast to {@link ServerPlayer}.
+     * For server-bound payloads, retrieves the sending {@link ServerPlayer}.
      * <p>
-     * For client-bound payloads, retrieves the client player.
+     * For client-bound payloads, retrieves the receiving {@link LocalPlayer}.
      * 
      * @throws UnsupportedOperationException when called on the server during the configuration phase.
      */

--- a/src/main/java/net/neoforged/neoforge/network/handling/IPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IPayloadContext.java
@@ -48,7 +48,7 @@ public interface IPayloadContext {
      * <p>
      * For client-bound payloads, retrieves the receiving {@link LocalPlayer}.
      * 
-     * @throws UnsupportedOperationException when called on the server during the configuration phase.
+     * @throws UnsupportedOperationException when called during the configuration phase.
      */
     Player player();
 

--- a/src/main/java/net/neoforged/neoforge/network/handling/IPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/IPayloadContext.java
@@ -42,7 +42,7 @@ public interface IPayloadContext {
     }
 
     /**
-     * Retrieves the player relevant to this payload. Players are only available in the {@link ConnectionProtocol#CONFIGURATION} phase.
+     * Retrieves the player relevant to this payload. Players are only available in the {@link ConnectionProtocol#PLAY} phase.
      * <p>
      * For server-bound payloads, retrieves the sending {@link ServerPlayer}.
      * <p>

--- a/src/main/java/net/neoforged/neoforge/network/handling/ServerPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ServerPayloadContext.java
@@ -5,14 +5,8 @@
 
 package net.neoforged.neoforge.network.handling;
 
-import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import net.minecraft.network.Connection;
-import net.minecraft.network.ConnectionProtocol;
-import net.minecraft.network.ProtocolInfo;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.ServerCommonPacketListener;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
@@ -27,21 +21,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public record ServerPayloadContext(ServerCommonPacketListener listener, ResourceLocation payloadId) implements IPayloadContext {
-    @Override
-    public void reply(CustomPacketPayload payload) {
-        listener.send(payload);
-    }
-
-    @Override
-    public void disconnect(Component reason) {
-        listener.disconnect(reason);
-    }
-
-    @Override
-    public void handle(Packet<?> packet) {
-        NetworkRegistry.handlePacketUnchecked(packet, listener);
-    }
-
     @Override
     public void handle(CustomPacketPayload payload) {
         handle(new ServerboundCustomPayloadPacket(payload));
@@ -74,23 +53,8 @@ public record ServerPayloadContext(ServerCommonPacketListener listener, Resource
     }
 
     @Override
-    public ProtocolInfo<?> protocolInfo() {
-        return listener.getConnection().getInboundProtocol();
-    }
-
-    @Override
     public PacketFlow flow() {
         return PacketFlow.SERVERBOUND;
-    }
-
-    @Override
-    public ConnectionProtocol protocol() {
-        return listener.protocol();
-    }
-
-    @Override
-    public ChannelHandlerContext channelHandlerContext() {
-        return listener.getConnection().channel().pipeline().lastContext();
     }
 
     @Override
@@ -99,10 +63,5 @@ public record ServerPayloadContext(ServerCommonPacketListener listener, Resource
             return spc.getPlayer();
         }
         throw new UnsupportedOperationException("Cannot retrieve a sending player during the configuration phase.");
-    }
-
-    @Override
-    public Connection connection() {
-        return listener.getConnection();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handling/ServerPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ServerPayloadContext.java
@@ -62,6 +62,6 @@ public record ServerPayloadContext(ServerCommonPacketListener listener, Resource
         if (this.listener instanceof ServerPlayerConnection spc) {
             return spc.getPlayer();
         }
-        throw new UnsupportedOperationException("Cannot retrieve a sending player during the configuration phase.");
+        throw new UnsupportedOperationException("Cannot retrieve the sending player during the configuration phase.");
     }
 }


### PR DESCRIPTION
Currently the only surface to invoke `hasChannel` from payload handling is via `NetworkRegistry` (which is internal API).  To solve this, I have hoisted the functionality of `IClientCommonPacketListenerExtension` and `IServerCommonPacketListenerExtension` into `ICommonPacketListener`, and made the `ICommonPacketListener` available via `IPayloadContext`.

This shared definition also allowed many functions to be hoisted to `IPayloadContext` instead of requiring implementation-specific overloads in the child classes.  Due to that, some methods were reorganized within `IPayloadContext`, attempting to place the most relevant methods at the top of the class.

This is binary breaking due to the interface reshuffling, but is unlikely to cause a source break.  The only code that can potentially cause a source-level break was the removal of `protocolInfo` from `IPayloadContext`, since it is generally not applicable and is available from the `Connection`.