### PR TITLE
Avoid calling getDimensions in Entity constructor

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -33,7 +33,7 @@
          this.entityData = synchedentitydata$builder.build();
          this.setPos(0.0, 0.0, 0.0);
 -        this.eyeHeight = this.dimensions.eyeHeight();
-+        net.neoforged.neoforge.event.entity.EntityEvent.Size sizeEvent = net.neoforged.neoforge.event.EventHooks.getEntitySizeForge(this, Pose.STANDING, this.dimensions, this.getEyeHeight(Pose.STANDING));
++        net.neoforged.neoforge.event.entity.EntityEvent.Size sizeEvent = net.neoforged.neoforge.event.EventHooks.getEntitySizeForge(this, Pose.STANDING, this.dimensions, this.dimensions.eyeHeight());
 +        this.dimensions = sizeEvent.getNewSize();
 +        this.eyeHeight = sizeEvent.getNewEyeHeight();
 +        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.EntityEvent.EntityConstructing(this));


### PR DESCRIPTION
During the 20.5 update cycle, the `getEyeHeight(Pose, EntityDimensions)` method was removed by Mojang, and our patch was updated to use the remaining `getEyeHeight(Pose)` method rather than passing in `this.dimensions` to the old method. However, this has the side effect of calling `getDimensions`, which is not safe to call from an entity constructor since it may be overriden by subclasses with behavior that depends on their constructor. 

This PR addresses the issue by calling the `eyeHeight()` helper on `this.dimensions`, which from my reading of the code is closest to the behavior of the original patch in 20.4 (which used `this.dimensions` rather than calling `getDimensions`).

Tested that this fixes #819.