### PR TITLE
Mark ingredient serializer registry as synced

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
@@ -42,7 +42,7 @@ public class NeoForgeRegistries {
             .maxId(128 * 2) // 0 -> 127 gets positive ID, 128 -> 256 gets negative ID
             .defaultKey(new ResourceLocation("none"))
             .create();
-    public static final Registry<IngredientType<?>> INGREDIENT_TYPES = new RegistryBuilder<>(Keys.INGREDIENT_TYPES).create();
+    public static final Registry<IngredientType<?>> INGREDIENT_TYPES = new RegistryBuilder<>(Keys.INGREDIENT_TYPES).sync(true).create();
     public static final Registry<MapCodec<? extends ICondition>> CONDITION_SERIALIZERS = new RegistryBuilder<>(Keys.CONDITION_CODECS).create();
     public static final Registry<AttachmentType<?>> ATTACHMENT_TYPES = new RegistryBuilder<>(Keys.ATTACHMENT_TYPES).create();
 


### PR DESCRIPTION
Without this, the tests fail when serializing a recipe packet with `Cannot use ID syncing for non-synced built-in registry: ResourceKey[minecraft:root / neoforge:ingredient_serializer]`.