### PR TITLE
Remove ability to translate mod names

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -88,8 +88,8 @@ public class ModListScreen extends Screen {
 
         @Override
         public int compare(IModInfo o1, IModInfo o2) {
-            String name1 = StringUtils.toLowerCase(stripControlCodes(I18nExtension.getDisplayName(o1)));
-            String name2 = StringUtils.toLowerCase(stripControlCodes(I18nExtension.getDisplayName(o2)));
+            String name1 = StringUtils.toLowerCase(stripControlCodes(o1.getDisplayName()));
+            String name2 = StringUtils.toLowerCase(stripControlCodes(o2.getDisplayName()));
             return compare(name1, name2);
         }
 
@@ -248,7 +248,7 @@ public class ModListScreen extends Screen {
     @Override
     public void init() {
         for (IModInfo mod : mods) {
-            listWidth = Math.max(listWidth, getFontRenderer().width(I18nExtension.getDisplayName(mod)) + 10);
+            listWidth = Math.max(listWidth, getFontRenderer().width(mod.getDisplayName()) + 10);
             listWidth = Math.max(listWidth, getFontRenderer().width(MavenVersionStringHelper.artifactVersionToString(mod.getVersion())) + 5);
         }
         listWidth = Math.max(Math.min(listWidth, width / 3), 100);
@@ -327,7 +327,7 @@ public class ModListScreen extends Screen {
     }
 
     private void reloadMods() {
-        this.mods = this.unsortedMods.stream().filter(mi -> StringUtils.toLowerCase(stripControlCodes(I18nExtension.getDisplayName(mi))).contains(StringUtils.toLowerCase(search.getValue()))).collect(Collectors.toList());
+        this.mods = this.unsortedMods.stream().filter(mi -> StringUtils.toLowerCase(stripControlCodes(mi.getDisplayName())).contains(StringUtils.toLowerCase(search.getValue()))).collect(Collectors.toList());
         lastFilterText = search.getValue();
     }
 
@@ -399,7 +399,7 @@ public class ModListScreen extends Screen {
             return Pair.<ResourceLocation, Size2i>of(null, new Size2i(0, 0));
         }).orElse(Pair.of(null, new Size2i(0, 0)));
 
-        lines.add(I18nExtension.getDisplayName(selectedMod));
+        lines.add(selectedMod.getDisplayName());
         lines.add(I18nExtension.parseMessage("fml.menu.mods.info.version", MavenVersionStringHelper.artifactVersionToString(selectedMod.getVersion())));
         lines.add(I18nExtension.parseMessage("fml.menu.mods.info.idstate", selectedMod.getModId(), "LOADED")); // TODO: remove mod loading stages from here too
 
@@ -409,7 +409,7 @@ public class ModListScreen extends Screen {
         if (selectedMod.getOwningFile() == null || selectedMod.getOwningFile().getMods().size() == 1)
             lines.add(I18nExtension.parseMessage("fml.menu.mods.info.nochildmods"));
         else
-            lines.add(I18nExtension.parseMessage("fml.menu.mods.info.childmods", selectedMod.getOwningFile().getMods().stream().map(I18nExtension::getDisplayName).collect(Collectors.joining(","))));
+            lines.add(I18nExtension.parseMessage("fml.menu.mods.info.childmods", selectedMod.getOwningFile().getMods().stream().map(IModInfo::getDisplayName).collect(Collectors.joining(","))));
 
         if (vercheck.status() == VersionChecker.Status.OUTDATED || vercheck.status() == VersionChecker.Status.BETA_OUTDATED)
             lines.add(I18nExtension.parseMessage("fml.menu.mods.info.updateavailable", vercheck.url() == null ? "" : vercheck.url()));

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -15,7 +15,6 @@ import net.minecraft.network.chat.FormattedText;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.fml.VersionChecker;
 import net.neoforged.neoforge.client.gui.ModListScreen;
-import net.neoforged.neoforge.common.I18nExtension;
 import net.neoforged.neoforge.common.util.MavenVersionStringHelper;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforgespi.language.IModInfo;
@@ -64,12 +63,12 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
 
         @Override
         public Component getNarration() {
-            return Component.translatable("narrator.select", I18nExtension.getDisplayName(modInfo));
+            return Component.translatable("narrator.select", modInfo.getDisplayName());
         }
 
         @Override
         public void render(GuiGraphics guiGraphics, int entryIdx, int top, int left, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean isMouseOver, float partialTick) {
-            Component name = Component.literal(stripControlCodes(I18nExtension.getDisplayName(modInfo)));
+            Component name = Component.literal(stripControlCodes(modInfo.getDisplayName()));
             Component version = Component.literal(stripControlCodes(MavenVersionStringHelper.artifactVersionToString(modInfo.getVersion())));
             VersionChecker.CheckResult vercheck = VersionChecker.getResult(modInfo);
             Font font = this.parent.getFontRenderer();

--- a/src/main/java/net/neoforged/neoforge/common/I18nExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/I18nExtension.java
@@ -74,7 +74,7 @@ public class I18nExtension {
         if (Objects.equals(formatString, "id")) {
             stringBuffer.append(info.getModId());
         } else if (Objects.equals(formatString, "name")) {
-            stringBuffer.append(getDisplayName(info));
+            stringBuffer.append(info.getDisplayName());
         }
     }
 
@@ -108,10 +108,6 @@ public class I18nExtension {
     public static String parseFormat(final String format, final Object... args) {
         final ExtendedMessageFormat extendedMessageFormat = new ExtendedMessageFormat(format, customFactories);
         return extendedMessageFormat.format(args);
-    }
-
-    public static String getDisplayName(final IModInfo modInfo) {
-        return parseMessageWithFallback("fml.menu.mods.info.displayname." + modInfo.getModId(), modInfo::getDisplayName);
     }
 
     public static String getDescription(final IModInfo modInfo) {

--- a/tests/src/main/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/main/resources/META-INF/neoforge.mods.toml
@@ -7,6 +7,7 @@ license="LGPL v2.1"
 
 [[mods]]
     modId="neotests"
+    description="NeoForge tests. Change the language to fr_fr and the description should change too."
 [[mods]]
     modId="client_command_test"
 [[mods]]

--- a/tests/src/main/resources/assets/neotests/lang/fr_fr.json
+++ b/tests/src/main/resources/assets/neotests/lang/fr_fr.json
@@ -1,0 +1,3 @@
+{
+  "fml.menu.mods.info.description.neotests": "Le mod de test de NeoForge oh la la !"
+}


### PR DESCRIPTION
And the new test for translatable descriptions:
![image](https://github.com/neoforged/NeoForge/assets/13494793/61668b55-9723-4a8e-a7fe-99490e0a2c37)
