### PR TITLE
Continue processing server brand after configuration listener

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -73,7 +73,7 @@
 +        if (!this.connectionType.isNeoForge() && packet.payload() instanceof net.minecraft.network.protocol.common.custom.BrandPayload) {
 +            this.initializedConnection = true;
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNonModdedConnection(this);
-+            return;
++            // Continue processing the brand payload
 +        }
 +
 +        // Fallback to super for un/register, modded, and vanilla payloads.


### PR DESCRIPTION
This PR fixes #849 by continuing the processing of the `BrandPayload` from within `ClientConfigurationPacketListenerImpl` to `ClientCommonPacketListenerImpl`, where the server brand is set based on the contents of the payload.

Tested to work; to confirm, run this as a client, connect to a vanilla server, and look at the F3 debug menu. The third line on the left should indicate `"vanilla" server`.

Note that this happens for any server other than a NeoForge server (i.e., servers that don't do the NeoForge handshake to establish the connection as a NeoForge one); the simplest test case here is the vanilla server. A NeoForge server is unaffected, as the brand payload is not captured by the `if`-branch as seen in this PR.