### PR TITLE
Fix writing empty ingredients

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.common.crafting;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import java.util.Arrays;
 import java.util.List;
@@ -17,9 +16,14 @@ import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
 
 /** Ingredient that matches if any of the child ingredients match */
 public record CompoundIngredient(List<Ingredient> children) implements ICustomIngredient {
+    public CompoundIngredient {
+        if (children.isEmpty()) {
+            // Empty ingredients are always represented as Ingredient.EMPTY.
+            throw new IllegalArgumentException("Compound ingredient must have at least one child");
+        }
+    }
+
     public static final MapCodec<CompoundIngredient> CODEC = NeoForgeExtraCodecs.aliasedFieldOf(Ingredient.LIST_CODEC_NONEMPTY, "children", "ingredients").xmap(CompoundIngredient::new, CompoundIngredient::children);
-    public static final Codec<CompoundIngredient> DIRECT_CODEC = Ingredient.LIST_CODEC.xmap(CompoundIngredient::new, CompoundIngredient::children);
-    public static final Codec<CompoundIngredient> DIRECT_CODEC_NONEMPTY = Ingredient.LIST_CODEC_NONEMPTY.xmap(CompoundIngredient::new, CompoundIngredient::children);
 
     /** Creates a compound ingredient from the given list of ingredients */
     public static Ingredient of(Ingredient... children) {

--- a/src/main/java/net/neoforged/neoforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CraftingHelper.java
@@ -37,7 +37,8 @@ public class CraftingHelper {
     private static Ingredient convertToCompoundIngredient(Ingredient ingredient) {
         if (!ingredient.isCustom() && ingredient.getValues().length != 1) {
             // Convert vanilla ingredient to custom CompoundIngredient
-            return CompoundIngredient.of(Stream.of(ingredient.getValues()).map(v -> Ingredient.fromValues(Stream.of(v))).toArray(Ingredient[]::new));
+            // Do not use CompoundIngredient.of(...) as it will convert empty ingredients back to Ingredient.EMPTY
+            return new CompoundIngredient(Stream.of(ingredient.getValues()).map(v -> Ingredient.fromValues(Stream.of(v))).toList()).toVanilla();
         }
         return ingredient;
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
@@ -177,6 +177,8 @@ public class IngredientTests {
         helper.assertTrue(ingredient.isEmpty(), "empty ingredient should return true from isEmpty()");
         helper.assertValueEqual(Ingredient.EMPTY, ingredient, "empty ingredient");
         helper.assertTrue(Ingredient.EMPTY == ingredient, "Reference equality with Ingredient.EMPTY");
+
+        helper.succeed();
     }
 
     @GameTest

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
@@ -169,6 +169,7 @@ public class IngredientTests {
         // Make sure that [] deserializes to an empty ingredient
         var result = Ingredient.CODEC.parse(JsonOps.INSTANCE, new JsonArray());
         var ingredient = result.resultOrPartial(error -> helper.fail("Failed to deserialize empty ingredient: " + error)).orElseThrow();
+        helper.assertTrue(ingredient.isEmpty(), "empty ingredient should return true from isEmpty()");
         helper.assertValueEqual(Ingredient.EMPTY, ingredient, "empty ingredient");
         helper.assertTrue(Ingredient.EMPTY == ingredient, "Reference equality with Ingredient.EMPTY");
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.crafting;
 
+import com.google.gson.JsonArray;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
@@ -25,7 +26,6 @@ import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.data.recipes.ShapedRecipeBuilder;
 import net.minecraft.data.recipes.ShapelessRecipeBuilder;
-import net.minecraft.data.recipes.SmithingTransformRecipeBuilder;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -163,8 +163,14 @@ public class IngredientTests {
     static void emptyIngredientSerialization(ExtendedGameTestHelper helper) {
         // Make sure that empty ingredients serialize to []
         var emptyResult = Ingredient.CODEC.encodeStart(JsonOps.INSTANCE, Ingredient.EMPTY);
-        var result = emptyResult.resultOrPartial(error -> helper.fail("Failed to serialize empty ingredient: " + error)).orElseThrow();
-        helper.assertValueEqual("[]", result.toString(), "empty ingredient");
+        var emptyJson = emptyResult.resultOrPartial(error -> helper.fail("Failed to serialize empty ingredient: " + error)).orElseThrow();
+        helper.assertValueEqual("[]", emptyJson.toString(), "empty ingredient");
+
+        // Make sure that [] deserializes to an empty ingredient
+        var result = Ingredient.CODEC.parse(JsonOps.INSTANCE, new JsonArray());
+        var ingredient = result.resultOrPartial(error -> helper.fail("Failed to deserialize empty ingredient: " + error)).orElseThrow();
+        helper.assertValueEqual(Ingredient.EMPTY, ingredient, "empty ingredient");
+        helper.assertTrue(Ingredient.EMPTY == ingredient, "Reference equality with Ingredient.EMPTY");
 
         helper.succeed();
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.debug.crafting;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.data.recipes.ShapedRecipeBuilder;
 import net.minecraft.data.recipes.ShapelessRecipeBuilder;
+import net.minecraft.data.recipes.SmithingTransformRecipeBuilder;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -53,6 +55,7 @@ import net.neoforged.testframework.annotation.OnInit;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.condition.TestEnabledIngredient;
 import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.registration.RegistrationHelper;
 import org.jetbrains.annotations.Nullable;
 
@@ -152,6 +155,18 @@ public class IngredientTests {
                 .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.ACACIA_BOAT))
 
                 .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Serialization tests for empty ingredients")
+    static void emptyIngredientSerialization(ExtendedGameTestHelper helper) {
+        // Make sure that empty ingredients serialize to []
+        var emptyResult = Ingredient.CODEC.encodeStart(JsonOps.INSTANCE, Ingredient.EMPTY);
+        var result = emptyResult.resultOrPartial(error -> helper.fail("Failed to serialize empty ingredient: " + error)).orElseThrow();
+        helper.assertValueEqual("[]", result.toString(), "empty ingredient");
+
+        helper.succeed();
     }
 
     private static final RegistrationHelper REG_HELPER = RegistrationHelper.create("neotests_ingredients");


### PR DESCRIPTION
This cleans up the ingredient handling by ensuring that empty ingredients are always `Ingredient.EMPTY`, and to make sure that a `CompoundIngredient` can never be empty.