### PR TITLE
Add level and pos context to `PlayerEvent.HarvestCheck`

### DIFF
--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -97,7 +97,7 @@
          float f = this.inventory.getDestroySpeed(p_36282_);
          if (f > 1.0F) {
              int i = EnchantmentHelper.getBlockEfficiency(this);
-@@ -748,11 +_,12 @@
+@@ -748,13 +_,19 @@
              f /= 5.0F;
          }
  
@@ -105,12 +105,18 @@
          return f;
      }
  
++    @Deprecated // Neo: use position sensitive version below
      public boolean hasCorrectToolForDrops(BlockState p_36299_) {
--        return !p_36299_.requiresCorrectToolForDrops() || this.inventory.getSelected().isCorrectToolForDrops(p_36299_);
-+        return net.neoforged.neoforge.event.EventHooks.doPlayerHarvestCheck(this, p_36299_, !p_36299_.requiresCorrectToolForDrops() || this.inventory.getSelected().isCorrectToolForDrops(p_36299_));
+         return !p_36299_.requiresCorrectToolForDrops() || this.inventory.getSelected().isCorrectToolForDrops(p_36299_);
      }
  
++    public boolean hasCorrectToolForDrops(BlockState state, Level level, BlockPos pos) {
++        return net.neoforged.neoforge.event.EventHooks.doPlayerHarvestCheck(this, state, level, pos);
++    }
++
      @Override
+     public void readAdditionalSaveData(CompoundTag p_36215_) {
+         super.readAdditionalSaveData(p_36215_);
 @@ -851,6 +_,7 @@
  
      @Override

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/DoorBlock.java
++++ b/net/minecraft/world/level/block/DoorBlock.java
+@@ -120,7 +_,7 @@
+ 
+     @Override
+     public BlockState playerWillDestroy(Level p_52755_, BlockPos p_52756_, BlockState p_52757_, Player p_52758_) {
+-        if (!p_52755_.isClientSide && (p_52758_.isCreative() || !p_52758_.hasCorrectToolForDrops(p_52757_))) {
++        if (!p_52755_.isClientSide && (p_52758_.isCreative() || !p_52758_.hasCorrectToolForDrops(p_52757_, p_52755_, p_52756_))) {
+             DoublePlantBlock.preventDropFromBottomPart(p_52755_, p_52756_, p_52757_, p_52758_);
+         }
+ 

--- a/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -52,7 +52,7 @@
          } else {
 -            int i = p_60467_.hasCorrectToolForDrops(p_60466_) ? 30 : 100;
 -            return p_60467_.getDestroySpeed(p_60466_) / f / (float)i;
-+            int i = net.neoforged.neoforge.common.CommonHooks.isCorrectToolForDrops(p_60466_, p_60467_) ? 30 : 100;
++            int i = net.neoforged.neoforge.event.EventHooks.doPlayerHarvestCheck(p_60467_, p_60466_, p_60468_, p_60469_) ? 30 : 100;
 +            return p_60467_.getDigSpeed(p_60466_, p_60469_) / f / (float)i;
          }
      }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -212,13 +212,6 @@ public class CommonHooks {
         return false;
     }
 
-    public static boolean isCorrectToolForDrops(BlockState state, Player player) {
-        if (!state.requiresCorrectToolForDrops())
-            return EventHooks.doPlayerHarvestCheck(player, state, true);
-
-        return player.hasCorrectToolForDrops(state);
-    }
-
     public static boolean onItemStackedOn(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess) {
         return NeoForge.EVENT_BUS.post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess)).isCanceled();
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -71,11 +71,11 @@ import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.client.model.data.ModelData;
-import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.IPlantable;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
+import net.neoforged.neoforge.event.EventHooks;
 import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("deprecation")
@@ -193,7 +193,7 @@ public interface IBlockExtension {
      * @return True to spawn the drops
      */
     default public boolean canHarvestBlock(BlockState state, BlockGetter level, BlockPos pos, Player player) {
-        return CommonHooks.isCorrectToolForDrops(state, player);
+        return EventHooks.doPlayerHarvestCheck(player, state, level, pos);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -185,6 +185,7 @@ public class EventHooks {
     }
 
     public static boolean doPlayerHarvestCheck(Player player, BlockState state, BlockGetter level, BlockPos pos) {
+        // Call deprecated hasCorrectToolForDrops overload for a fallback value, in turn the non-deprecated overload calls this method
         boolean vanillaValue = player.hasCorrectToolForDrops(state);
         PlayerEvent.HarvestCheck event = NeoForge.EVENT_BUS.post(new PlayerEvent.HarvestCheck(player, state, level, pos, vanillaValue));
         return event.canHarvest();

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -72,6 +72,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.BaseSpawner;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.GameRules;
@@ -183,9 +184,9 @@ public class EventHooks {
         return event;
     }
 
-    public static boolean doPlayerHarvestCheck(Player player, BlockState state, boolean success) {
-        PlayerEvent.HarvestCheck event = new PlayerEvent.HarvestCheck(player, state, success);
-        NeoForge.EVENT_BUS.post(event);
+    public static boolean doPlayerHarvestCheck(Player player, BlockState state, BlockGetter level, BlockPos pos) {
+        boolean vanillaValue = player.hasCorrectToolForDrops(state);
+        PlayerEvent.HarvestCheck event = NeoForge.EVENT_BUS.post(new PlayerEvent.HarvestCheck(player, state, level, pos, vanillaValue));
         return event.canHarvest();
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -16,6 +16,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -51,7 +52,7 @@ public abstract class PlayerEvent extends LivingEvent {
      * This event is fired whenever a player attempts to harvest a block in
      * {@link Player#hasCorrectToolForDrops(BlockState)}.<br>
      * <br>
-     * This event is fired via the {@link EventHooks#doPlayerHarvestCheck(Player, BlockState, boolean)}.<br>
+     * This event is fired via the {@link EventHooks#doPlayerHarvestCheck(Player, BlockState, BlockGetter, BlockPos)}.<br>
      * <br>
      * {@link #state} contains the {@link BlockState} that is being checked for harvesting. <br>
      * {@link #success} contains the boolean value for whether the Block will be successfully harvested. <br>
@@ -64,16 +65,28 @@ public abstract class PlayerEvent extends LivingEvent {
      **/
     public static class HarvestCheck extends PlayerEvent {
         private final BlockState state;
+        private final BlockGetter level;
+        private final BlockPos pos;
         private boolean success;
 
-        public HarvestCheck(Player player, BlockState state, boolean success) {
+        public HarvestCheck(Player player, BlockState state, BlockGetter level, BlockPos pos, boolean success) {
             super(player);
             this.state = state;
+            this.level = level;
+            this.pos = pos;
             this.success = success;
         }
 
         public BlockState getTargetBlock() {
             return this.state;
+        }
+
+        public BlockGetter getLevel() {
+            return level;
+        }
+
+        public BlockPos getPos() {
+            return pos;
         }
 
         public boolean canHarvest() {

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -22,10 +22,10 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.PortalShape;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
-import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
 import net.neoforged.neoforge.common.util.BlockSnapshot;
+import net.neoforged.neoforge.event.EventHooks;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class BlockEvent extends Event {
@@ -66,7 +66,7 @@ public abstract class BlockEvent extends Event {
             super(level, pos, state);
             this.player = player;
 
-            if (state == null || !CommonHooks.isCorrectToolForDrops(state, player)) // Handle empty block or player unable to break block scenario
+            if (state == null || !EventHooks.doPlayerHarvestCheck(player, state, level, pos)) // Handle empty block or player unable to break block scenario
             {
                 this.exp = 0;
             } else {


### PR DESCRIPTION
Reimplementation of #526 on 1.20.5, hopefully without a messed up Git tree this time.

Simply adds `BlockGetter` and `BlockPos` fields to `PlayerEvent.HarvestCheck`, and passes the `BlockGetter` and `BlockPos` into methods that subsequently need them. Most notably, this creates a new overload for `Player#hasCorrectToolForDrops`.

The PR also removes `CommonHooks#isCorrectToolForDrops` in favor of directly calling `EventHooks#doPlayerHarvestCheck`.