### PR TITLE
[1.20.4] Render local player when the renderViewEntity is not the local player

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -45,7 +45,7 @@
                              || p_109604_.getEntity() instanceof LivingEntity && ((LivingEntity)p_109604_.getEntity()).isSleeping()
                      )
 -                    && (!(entity instanceof LocalPlayer) || p_109604_.getEntity() == entity)) {
-+                    && (!(entity instanceof LocalPlayer) || p_109604_.getEntity() == entity || (entity == minecraft.player && !minecraft.player.isSpectator()))) { //FORGE: render local player entity when it is not the renderViewEntity
++                    && (!(entity instanceof LocalPlayer) || p_109604_.getEntity() == entity || (entity == minecraft.player && !minecraft.player.isSpectator()))) { // NEO: render local player entity when it is not the camera entity
                      ++this.renderedEntities;
                      if (entity.tickCount == 0) {
                          entity.xOld = entity.getX();

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -40,6 +40,15 @@
          this.renderSectionLayer(RenderType.cutout(), p_109600_, d0, d1, d2, p_254120_);
          if (this.level.effects().constantAmbientLight()) {
              Lighting.setupNetherLevel(p_109600_.last().pose());
+@@ -1018,7 +_,7 @@
+                             || p_109604_.isDetached()
+                             || p_109604_.getEntity() instanceof LivingEntity && ((LivingEntity)p_109604_.getEntity()).isSleeping()
+                     )
+-                    && (!(entity instanceof LocalPlayer) || p_109604_.getEntity() == entity)) {
++                    && (!(entity instanceof LocalPlayer) || p_109604_.getEntity() == entity || (entity == minecraft.player && !minecraft.player.isSpectator()))) { //FORGE: render local player entity when it is not the renderViewEntity
+                     ++this.renderedEntities;
+                     if (entity.tickCount == 0) {
+                         entity.xOld = entity.getX();
 @@ -1034,6 +_,9 @@
                          int i = entity.getTeamColor();
                          outlinebuffersource.setColor(FastColor.ARGB32.red(i), FastColor.ARGB32.green(i), FastColor.ARGB32.blue(i), 255);


### PR DESCRIPTION
Hey there,
I noticed that NeoForge is missing the fix for not rendering the local player when a custom view entity has been set. The original fix can be found here: https://github.com/MinecraftForge/MinecraftForge/pull/7216

This pr readds the fix. Backport from https://github.com/neoforged/NeoForge/pull/859