### PR TITLE
[1.20.5] Fix custom spawn eggs using DeferredSpawnEggItem being invisible

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/DeferredSpawnEggItem.java
+++ b/src/main/java/net/neoforged/neoforge/common/DeferredSpawnEggItem.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import net.minecraft.core.Direction;
 import net.minecraft.core.dispenser.DispenseItemBehavior;
+import net.minecraft.util.FastColor;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
@@ -93,7 +94,7 @@ public class DeferredSpawnEggItem extends SpawnEggItem {
     private static class ColorRegisterHandler {
         @SubscribeEvent(priority = EventPriority.HIGHEST)
         public static void registerSpawnEggColors(RegisterColorHandlersEvent.Item event) {
-            MOD_EGGS.forEach(egg -> event.register((stack, layer) -> egg.getColor(layer), egg));
+            MOD_EGGS.forEach(egg -> event.register((stack, layer) -> FastColor.ARGB32.opaque(egg.getColor(layer)), egg));
         }
     }
 }


### PR DESCRIPTION
This PR fixes custom spawn eggs items using `DeferredSpawnEggItem` being invisible.

Before 1.20.5, `BlockColor` and `ItemColor` did not support the alpha channel and everyone defined their colors without alpha channel. In 1.20.5, the alpha channel of the color returned by `BlockColor` and `ItemColor` is taken into account, meaning any color definition without alpha channel is now fully transparent. To avoid having to redefine all spawn egg colors, vanilla's spawn egg `ItemColor` implementation forces the egg's color to opaque with `FastColor.ARGB32.opaque()`. The fix is to replicate this in the `ItemColor` implementation of Neo's custom spawn egg.

Fixes #855 