### PR TITLE
Hide demo timer when debug overlay is open

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -242,7 +242,7 @@
  
      private void renderDemoOverlay(GuiGraphics p_281825_, float p_316211_) {
 -        if (this.minecraft.isDemo()) {
-+        if (this.minecraft.isDemo() && !this.getDebugOverlay().showDebugScreen()) { // NEO: Hide demo timer when F3 debug overlay is open
++        if (this.minecraft.isDemo() && !this.getDebugOverlay().showDebugScreen()) { // NEO: Hide demo timer when F3 debug overlay is open; fixes MC-271166
              this.minecraft.getProfiler().push("demo");
              Component component;
              if (this.minecraft.level.getGameTime() >= 120500L) {

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -237,6 +237,15 @@
              }
          }
  
+@@ -664,7 +_,7 @@
+     }
+ 
+     private void renderDemoOverlay(GuiGraphics p_281825_, float p_316211_) {
+-        if (this.minecraft.isDemo()) {
++        if (this.minecraft.isDemo() && !this.getDebugOverlay().showDebugScreen()) { // NEO: Hide demo timer when F3 debug overlay is open
+             this.minecraft.getProfiler().push("demo");
+             Component component;
+             if (this.minecraft.level.getGameTime() >= 120500L) {
 @@ -777,7 +_,15 @@
          return (int)Math.ceil((double)p_93013_ / 10.0);
      }


### PR DESCRIPTION
This PR fixes #863 by hiding the demo timer (on the player HUD) when the (F3) debug overlay is visible, to avoid overlap between the demo timer and the debug overlay.

The demo timer is visible as the first line on the right side of the debug overlay (as added by #357), so the information is always available to the user.