### PR TITLE
Fix `ServerLifecycleHooks.getCurrentServer` being incorrectly marked non-null.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/util/LogicalSidedProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/LogicalSidedProvider.java
@@ -14,6 +14,7 @@ import net.minecraft.server.TickTask;
 import net.minecraft.util.thread.BlockableEventLoop;
 import net.minecraft.world.level.Level;
 import net.neoforged.fml.LogicalSide;
+import org.jetbrains.annotations.Nullable;
 
 public class LogicalSidedProvider<T> {
     public static final LogicalSidedProvider<BlockableEventLoop<? super TickTask>> WORKQUEUE = new LogicalSidedProvider<>(Supplier::get, Supplier::get);

--- a/src/main/java/net/neoforged/neoforge/common/util/LogicalSidedProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/LogicalSidedProvider.java
@@ -14,7 +14,6 @@ import net.minecraft.server.TickTask;
 import net.minecraft.util.thread.BlockableEventLoop;
 import net.minecraft.world.level.Level;
 import net.neoforged.fml.LogicalSide;
-import org.jetbrains.annotations.Nullable;
 
 public class LogicalSidedProvider<T> {
     public static final LogicalSidedProvider<BlockableEventLoop<? super TickTask>> WORKQUEUE = new LogicalSidedProvider<>(Supplier::get, Supplier::get);

--- a/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
@@ -5,6 +5,12 @@
 
 package net.neoforged.neoforge.server;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
@@ -19,7 +25,11 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.util.LogicalSidedProvider;
 import net.neoforged.neoforge.common.world.BiomeModifier;
 import net.neoforged.neoforge.common.world.StructureModifier;
-import net.neoforged.neoforge.event.server.*;
+import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import net.neoforged.neoforge.event.server.ServerStoppedEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.gametest.GameTestHooks;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.NeoForgeRegistries.Keys;
@@ -30,13 +40,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 public class ServerLifecycleHooks {
     private static final Logger LOGGER = LogManager.getLogger();

--- a/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
@@ -5,12 +5,6 @@
 
 package net.neoforged.neoforge.server;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
@@ -25,11 +19,7 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.util.LogicalSidedProvider;
 import net.neoforged.neoforge.common.world.BiomeModifier;
 import net.neoforged.neoforge.common.world.StructureModifier;
-import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
-import net.neoforged.neoforge.event.server.ServerStartedEvent;
-import net.neoforged.neoforge.event.server.ServerStartingEvent;
-import net.neoforged.neoforge.event.server.ServerStoppedEvent;
-import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.neoforge.event.server.*;
 import net.neoforged.neoforge.gametest.GameTestHooks;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.NeoForgeRegistries.Keys;
@@ -39,12 +29,22 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 public class ServerLifecycleHooks {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker SERVERHOOKS = MarkerManager.getMarker("SERVERHOOKS");
     private static final LevelResource SERVERCONFIG = new LevelResource("serverconfig");
+    @Nullable
     private static volatile CountDownLatch exitLatch = null;
+    @Nullable
     private static MinecraftServer currentServer;
 
     private static Path getServerConfigPath(final MinecraftServer server) {
@@ -117,6 +117,7 @@ public class ServerLifecycleHooks {
         ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SERVER);
     }
 
+    @Nullable
     public static MinecraftServer getCurrentServer() {
         return currentServer;
     }


### PR DESCRIPTION
Fixes #840