### PR TITLE
[1.20.5] Fix getting kicked from vanilla servers when interacting with fireworks

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/IExtensibleEnum.java
+++ b/src/main/java/net/neoforged/neoforge/common/IExtensibleEnum.java
@@ -65,6 +65,6 @@ public interface IExtensibleEnum {
      * Use this instead of {@link ByteBufCodecs#idMapper(IntFunction, ToIntFunction)} for extensible enums because this not cache the enum values on construction
      */
     static <E extends Enum<E> & StringRepresentable> StreamCodec<ByteBuf, E> createStreamCodecForExtensibleEnum(Supplier<E[]> valuesSupplier) {
-        return ByteBufCodecs.INT.map(i -> valuesSupplier.get()[i], Enum::ordinal);
+        return ByteBufCodecs.VAR_INT.map(i -> valuesSupplier.get()[i], Enum::ordinal);
     }
 }


### PR DESCRIPTION
This PR fixes `IExtensibleEnum.createStreamCodecForExtensibleEnum()` encoding and decoding enum entries to and from a full integer instead of a varint like `ByteBufCodecs.idMapper()` (which it's supposed to replace on extensible enums) does.

Fixes #872 