### PR TITLE
Mark ResourceKeys as being valid component classes

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1316,6 +1316,9 @@ public class CommonHooks {
         markComponentClassAsValid(BlockState.class);
         markComponentClassAsValid(FluidState.class);
         // Block, Fluid, Item, etc. are handled via the registry check further down
+
+        // Mark common interned classes as valid
+        markComponentClassAsValid(ResourceKey.class);
     }
 
     /**


### PR DESCRIPTION
While I could manually mark ResourceKeys as being valid from my mod so that they don't cause a crash, given they are an interned vanilla class I figured it made more sense to add them here as valid.