### PR TITLE
Fix FinalizeSpawnEvent for trial spawners

### DIFF
--- a/patches/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/net/minecraft/world/entity/Mob.java.patch
@@ -84,15 +84,12 @@
              if (entity != null) {
                  double d0 = entity.distanceToSqr(this);
                  int i = this.getType().getCategory().getDespawnDistance();
-@@ -1135,6 +_,14 @@
+@@ -1135,6 +_,11 @@
          }
      }
  
 +    /**
-+     * Forge: Override-Only, call via EventHooks.onFinalizeSpawn.<br>
-+     * Overrides are allowed. Do not wrap super calls within override (as that will cause stack overflows).<br>
-+     * Vanilla calls are replaced with a transformer, and are not visible in source.<br>
-+     * <p>
++     * @deprecated Override-Only. External callers should call via {@link net.neoforged.neoforge.event.EventHooks#finalizeMobSpawn}.
 +     */
 +    @Deprecated
 +    @org.jetbrains.annotations.ApiStatus.OverrideOnly

--- a/patches/net/minecraft/world/entity/vehicle/MinecartSpawner.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/MinecartSpawner.java.patch
@@ -1,14 +1,13 @@
 --- a/net/minecraft/world/entity/vehicle/MinecartSpawner.java
 +++ b/net/minecraft/world/entity/vehicle/MinecartSpawner.java
-@@ -17,6 +_,12 @@
+@@ -17,6 +_,11 @@
          public void broadcastEvent(Level p_150342_, BlockPos p_150343_, int p_150344_) {
              p_150342_.broadcastEntityEvent(MinecartSpawner.this, (byte)p_150344_);
          }
 +
 +        @Override
-+        @org.jetbrains.annotations.Nullable
-+        public net.minecraft.world.entity.Entity getSpawnerEntity() {
-+            return MinecartSpawner.this;
++        public com.mojang.datafixers.util.Either<net.minecraft.world.level.block.entity.BlockEntity, net.minecraft.world.entity.Entity> getOwner() {
++            return com.mojang.datafixers.util.Either.right(MinecartSpawner.this);
 +        }
      };
      private final Runnable ticker;

--- a/patches/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/patches/net/minecraft/world/level/BaseSpawner.java.patch
@@ -1,6 +1,15 @@
 --- a/net/minecraft/world/level/BaseSpawner.java
 +++ b/net/minecraft/world/level/BaseSpawner.java
-@@ -151,14 +_,14 @@
+@@ -26,7 +_,7 @@
+ import net.minecraft.world.phys.AABB;
+ import org.slf4j.Logger;
+ 
+-public abstract class BaseSpawner {
++public abstract class BaseSpawner implements net.neoforged.neoforge.common.extensions.IOwnedSpawner {
+     public static final String SPAWN_DATA_TAG = "SpawnData";
+     private static final Logger LOGGER = LogUtils.getLogger();
+     private static final int EVENT_SPAWN = 1;
+@@ -151,15 +_,14 @@
  
                          entity.moveTo(entity.getX(), entity.getY(), entity.getZ(), randomsource.nextFloat() * 360.0F, 0.0F);
                          if (entity instanceof Mob mob) {
@@ -10,26 +19,26 @@
                                  continue;
                              }
  
--                            boolean flag1 = spawndata.getEntityToSpawn().size() == 1 && spawndata.getEntityToSpawn().contains("id", 8);
+                             boolean flag1 = spawndata.getEntityToSpawn().size() == 1 && spawndata.getEntityToSpawn().contains("id", 8);
 -                            if (flag1) {
 -                                ((Mob)entity).finalizeSpawn(p_151312_, p_151312_.getCurrentDifficultyAt(entity.blockPosition()), MobSpawnType.SPAWNER, null);
-+                            // Forge: Patch in FinalizeSpawn for spawners so it may be fired unconditionally, instead of only when vanilla normally would trigger it.
-+                            var event = net.neoforged.neoforge.event.EventHooks.onFinalizeSpawnSpawner(mob, p_151312_, p_151312_.getCurrentDifficultyAt(entity.blockPosition()), null, this);
-+                            if (event != null && spawndata.getEntityToSpawn().size() == 1 && spawndata.getEntityToSpawn().contains("id", 8)) {
-+                                ((Mob)entity).finalizeSpawn(p_151312_, event.getDifficulty(), event.getSpawnType(), event.getSpawnData());
-                             }
+-                            }
++                            // Neo: Patch in FinalizeSpawn for spawners so it may be fired unconditionally, instead of only when vanilla would normally call it.
++                            // The local flag1 is the conditions under which the spawner will normally call Mob#finalizeSpawn.
++                            net.neoforged.neoforge.event.EventHooks.finalizeMobSpawnSpawner(mob, p_151312_, p_151312_.getCurrentDifficultyAt(entity.blockPosition()), MobSpawnType.SPAWNER, null, this, flag1);
  
                              spawndata.getEquipment().ifPresent(mob::equip);
-@@ -309,4 +_,12 @@
+                         }
+@@ -308,5 +_,12 @@
+ 
      public double getoSpin() {
          return this.oSpin;
-     }
-+
-+    @Nullable
-+    public Entity getSpawnerEntity() {
-+        return null;
 +    }
 +
-+    @Nullable
-+    public net.minecraft.world.level.block.entity.BlockEntity getSpawnerBlockEntity(){ return null; }
++    @Override
++    @org.jetbrains.annotations.Nullable
++    public com.mojang.datafixers.util.Either<net.minecraft.world.level.block.entity.BlockEntity, Entity> getOwner() {
++        // The vanilla anonymous classes have proper overrides, but we return null here for compatibility.
++        return null;
+     }
  }

--- a/patches/net/minecraft/world/level/block/entity/SpawnerBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/SpawnerBlockEntity.java.patch
@@ -1,11 +1,14 @@
 --- a/net/minecraft/world/level/block/entity/SpawnerBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/SpawnerBlockEntity.java
-@@ -30,6 +_,8 @@
+@@ -30,6 +_,11 @@
                  p_155771_.sendBlockUpdated(p_155772_, blockstate, blockstate, 4);
              }
          }
 +
-+        public net.minecraft.world.level.block.entity.BlockEntity getSpawnerBlockEntity() { return SpawnerBlockEntity.this; }
++        @Override
++        public com.mojang.datafixers.util.Either<net.minecraft.world.level.block.entity.BlockEntity, net.minecraft.world.entity.Entity> getOwner() {
++            return com.mojang.datafixers.util.Either.left(SpawnerBlockEntity.this);
++        }
      };
  
      public SpawnerBlockEntity(BlockPos p_155752_, BlockState p_155753_) {

--- a/patches/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java.patch
@@ -1,0 +1,39 @@
+--- a/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
++++ b/net/minecraft/world/level/block/entity/trialspawner/TrialSpawner.java
+@@ -43,7 +_,7 @@
+ import net.minecraft.world.phys.Vec3;
+ import net.minecraft.world.phys.shapes.CollisionContext;
+ 
+-public final class TrialSpawner {
++public final class TrialSpawner implements net.neoforged.neoforge.common.extensions.IOwnedSpawner {
+     public static final String NORMAL_CONFIG_TAG_NAME = "normal_config";
+     public static final String OMINOUS_CONFIG_TAG_NAME = "ominous_config";
+     public static final int DETECT_PLAYER_SPAWN_BUFFER = 40;
+@@ -229,9 +_,9 @@
+                                 }
+ 
+                                 boolean flag = spawndata.getEntityToSpawn().size() == 1 && spawndata.getEntityToSpawn().contains("id", 8);
+-                                if (flag) {
+-                                    mob.finalizeSpawn(p_312582_, p_312582_.getCurrentDifficultyAt(mob.blockPosition()), MobSpawnType.TRIAL_SPAWNER, null);
+-                                }
++                                // Neo: Patch in FinalizeSpawn for spawners so it may be fired unconditionally, instead of only when vanilla would normally call it.
++                                // The local flag is the conditions under which the spawner will normally call Mob#finalizeSpawn.
++                                net.neoforged.neoforge.event.EventHooks.finalizeMobSpawnSpawner(mob, p_312582_, p_312582_.getCurrentDifficultyAt(mob.blockPosition()), MobSpawnType.TRIAL_SPAWNER, null, this, flag);
+ 
+                                 mob.setPersistenceRequired();
+                                 spawndata.getEquipment().ifPresent(mob::equip);
+@@ -416,5 +_,14 @@
+         TrialSpawnerState getState();
+ 
+         void markUpdated();
++    }
++
++    @Override
++    @org.jetbrains.annotations.Nullable
++    public com.mojang.datafixers.util.Either<net.minecraft.world.level.block.entity.BlockEntity, Entity> getOwner() {
++        if (this.stateAccessor instanceof net.minecraft.world.level.block.entity.TrialSpawnerBlockEntity be) {
++            return com.mojang.datafixers.util.Either.left(be);
++        }
++        return null;
+     }
+ }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IOwnedSpawner.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IOwnedSpawner.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import com.mojang.datafixers.util.Either;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.vehicle.MinecartSpawner;
+import net.minecraft.world.level.BaseSpawner;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.TrialSpawnerBlockEntity;
+import net.minecraft.world.level.block.entity.trialspawner.TrialSpawner;
+import org.jetbrains.annotations.Nullable;
+
+public interface IOwnedSpawner {
+    /**
+     * Returns the block entity or entity which owns this spawner object.
+     * <p>
+     * For a {@link BaseSpawner}, this is the {@link MobSpawnerBlockEntity} or {@link MinecartSpawner}.
+     * <p>
+     * For a {@link TrialSpawner}, this is the {@link TrialSpawnerBlockEntity}.
+     */
+    @Nullable
+    Either<BlockEntity, Entity> getOwner();
+}

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -98,6 +98,7 @@ import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.common.EffectCure;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.ToolAction;
+import net.neoforged.neoforge.common.extensions.IOwnedSpawner;
 import net.neoforged.neoforge.common.util.BlockSnapshot;
 import net.neoforged.neoforge.common.util.MutableHashedLinkedMap;
 import net.neoforged.neoforge.event.brewing.PlayerBrewedPotionEvent;
@@ -112,6 +113,7 @@ import net.neoforged.neoforge.event.entity.EntityTeleportEvent;
 import net.neoforged.neoforge.event.entity.ProjectileImpactEvent;
 import net.neoforged.neoforge.event.entity.item.ItemExpireEvent;
 import net.neoforged.neoforge.event.entity.living.AnimalTameEvent;
+import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
 import net.neoforged.neoforge.event.entity.living.LivingConversionEvent;
 import net.neoforged.neoforge.event.entity.living.LivingDestroyBlockEvent;
 import net.neoforged.neoforge.event.entity.living.LivingEntityUseItemEvent;
@@ -119,7 +121,6 @@ import net.neoforged.neoforge.event.entity.living.LivingExperienceDropEvent;
 import net.neoforged.neoforge.event.entity.living.LivingHealEvent;
 import net.neoforged.neoforge.event.entity.living.LivingPackSizeEvent;
 import net.neoforged.neoforge.event.entity.living.MobEffectEvent;
-import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent.AllowDespawn;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent.PositionCheck;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent.SpawnPlacementCheck;
@@ -250,8 +251,10 @@ public class EventHooks {
     }
 
     /**
-     * Vanilla calls to {@link Mob#finalizeSpawn} are replaced with calls to this method via coremod.<br>
-     * Mods should call this method in place of calling {@link Mob#finalizeSpawn}. Super calls (from within overrides) should not be wrapped.
+     * Finalizes the spawn of a mob by firing the {@link FinalizeSpawnEvent} and calling {@link Mob#finalizeSpawn} with the result.
+     * <p>
+     * Mods should call this method in place of calling {@link Mob#finalizeSpawn}, unless calling super from within an override.
+     * Vanilla calls to {@link Mob#finalizeSpawn} are replaced with calls to this method via coremod, so calls to this method will not show in an IDE.
      * <p>
      * When interfacing with this event, write all code as normal, and replace the call to {@link Mob#finalizeSpawn} with a call to this method.<p>
      * As an example, the following code block:
@@ -272,7 +275,7 @@ public class EventHooks {
      * 
      * <pre>
      * var zombie = new Zombie(level);
-     * EventHook.onFinalizeSpawn(zombie, level, difficulty, spawnType, spawnData);
+     * EventHooks.finalizeMobSpawn(zombie, level, difficulty, spawnType, spawnData);
      * level.tryAddFreshEntityWithPassengers(zombie);
      * if (zombie.isAddedToWorld()) {
      *     // Do stuff with your new zombie
@@ -282,16 +285,24 @@ public class EventHooks {
      * </code>
      * The only code that changes is the {@link Mob#finalizeSpawn} call.
      * 
-     * @return The SpawnGroupData from this event, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned.
-     * @see MobSpawnEvent.FinalizeSpawn
+     * @param mob        The mob whose spawn is being finalized
+     * @param level      The level the mob will be spawned in
+     * @param difficulty The local difficulty at the position of the mob
+     * @param spawnType  The type of spawn that is occuring
+     * @param spawnData  Optional spawn data relevant to the mob being spawned
+     * @return The SpawnGroupData from this event, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned
+     * 
+     * @see FinalizeSpawnEvent
      * @see Mob#finalizeSpawn(ServerLevelAccessor, DifficultyInstance, MobSpawnType, SpawnGroupData)
+     * 
      * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
+     * 
      * @implNote Changes to the signature of this method must be reflected in the method redirector coremod.
      */
     @Nullable
     @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
-    public static SpawnGroupData onFinalizeSpawn(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData) {
-        var event = new MobSpawnEvent.FinalizeSpawn(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, null);
+    public static SpawnGroupData finalizeMobSpawn(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData) {
+        var event = new FinalizeSpawnEvent(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, null);
         boolean cancel = NeoForge.EVENT_BUS.post(event).isCanceled();
 
         if (!cancel) {
@@ -302,17 +313,31 @@ public class EventHooks {
     }
 
     /**
-     * Returns the FinalizeSpawn event instance, or null if it was canceled.<br>
-     * This is separate since mob spawners perform special finalizeSpawn handling when NBT data is present, but we still want to fire the event.<br>
-     * This overload is also the only way to pass through a {@link BaseSpawner} instance.
+     * Finalizes the spawn of a mob by firing the {@link FinalizeSpawnEvent} and calling {@link Mob#finalizeSpawn} with the result.
+     * <p>
+     * This method is separate since mob spawners perform special finalizeSpawn handling when NBT data is present, but we still want to fire the event.
+     * <p>
+     * This overload is also the only way to pass through an {@link IOwnedSpawner} instance.
      * 
-     * @see #onFinalizeSpawn
+     * @param mob        The mob whose spawn is being finalized
+     * @param level      The level the mob will be spawned in
+     * @param difficulty The local difficulty at the position of the mob
+     * @param spawnType  The type of spawn that is occuring
+     * @param spawnData  Optional spawn data relevant to the mob being spawned
+     * @param spawner    The spawner that is attempting to spawn the mob
+     * @param def        If the spawner would normally call finalizeSpawn, regardless of the event
      */
-    @Nullable
-    public static MobSpawnEvent.FinalizeSpawn onFinalizeSpawnSpawner(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, @Nullable SpawnGroupData spawnData, BaseSpawner spawner) {
-        var event = new MobSpawnEvent.FinalizeSpawn(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, MobSpawnType.SPAWNER, spawnData, spawner);
+    @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
+    public static FinalizeSpawnEvent finalizeMobSpawnSpawner(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData, IOwnedSpawner spawner, boolean def) {
+        var event = new FinalizeSpawnEvent(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, spawner.getOwner());
         boolean cancel = NeoForge.EVENT_BUS.post(event).isCanceled();
-        return cancel ? null : event;
+
+        if (!cancel && def) {
+            // Spawners only call finalizeSpawn under certain conditions, which are passed through as def.
+            mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData());
+        }
+
+        return event;
     }
 
     public static PlayerSpawnPhantomsEvent onPhantomSpawn(ServerPlayer player, int phantomsToSpawn) {

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -290,7 +290,7 @@ public class EventHooks {
      * @param difficulty The local difficulty at the position of the mob
      * @param spawnType  The type of spawn that is occuring
      * @param spawnData  Optional spawn data relevant to the mob being spawned
-     * @return The SpawnGroupData from this event, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned
+     * @return The SpawnGroupData from the finalize, or null if it was canceled. The return value of this method has no bearing on if the entity will be spawned
      * 
      * @see FinalizeSpawnEvent
      * @see Mob#finalizeSpawn(ServerLevelAccessor, DifficultyInstance, MobSpawnType, SpawnGroupData)
@@ -303,13 +303,13 @@ public class EventHooks {
     @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
     public static SpawnGroupData finalizeMobSpawn(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData) {
         var event = new FinalizeSpawnEvent(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, null);
-        boolean cancel = NeoForge.EVENT_BUS.post(event).isCanceled();
+        NeoForge.EVENT_BUS.post(event);
 
-        if (!cancel) {
-            mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData());
+        if (!event.isCanceled()) {
+            return mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData());
         }
 
-        return cancel ? null : event.getSpawnData();
+        return null;
     }
 
     /**
@@ -330,10 +330,11 @@ public class EventHooks {
     @SuppressWarnings("deprecation") // Call to deprecated Mob#finalizeSpawn is expected.
     public static FinalizeSpawnEvent finalizeMobSpawnSpawner(Mob mob, ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData, IOwnedSpawner spawner, boolean def) {
         var event = new FinalizeSpawnEvent(mob, level, mob.getX(), mob.getY(), mob.getZ(), difficulty, spawnType, spawnData, spawner.getOwner());
-        boolean cancel = NeoForge.EVENT_BUS.post(event).isCanceled();
+        NeoForge.EVENT_BUS.post(event);
 
-        if (!cancel && def) {
+        if (!event.isCanceled() && def) {
             // Spawners only call finalizeSpawn under certain conditions, which are passed through as def.
+            // Spawners also do not propagate the SpawnGroupData between spawns, so we ignore the result of Mob#finalizeSpawn
             mob.finalizeSpawn(level, event.getDifficulty(), event.getSpawnType(), event.getSpawnData());
         }
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/FinalizeSpawnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/FinalizeSpawnEvent.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.living;
+
+import com.mojang.datafixers.util.Either;
+import net.minecraft.server.level.WorldGenRegion;
+import net.minecraft.world.DifficultyInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.world.entity.SpawnGroupData;
+import net.minecraft.world.entity.vehicle.MinecartSpawner;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
+import net.minecraft.world.level.block.entity.TrialSpawnerBlockEntity;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.common.NeoForgeEventHandler;
+import net.neoforged.neoforge.event.EventHooks;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This event is fired before {@link Mob#finalizeSpawn} is called.<br>
+ * This allows mods to control mob initialization.<br>
+ * In vanilla code, this event is injected by a transformer and not via patch, so calls cannot be traced via call hierarchy (it is not source-visible).
+ * <p>
+ * Canceling this event will result in {@link Mob#finalizeSpawn} not being called, and the returned value always being null, instead of propagating the SpawnGroupData.<br>
+ * The entity will still be spawned. If you want to prevent the spawn, use {@link FinalizeSpawnEvent#setSpawnCancelled}, which will cause Forge to prevent the spawn.
+ * <p>
+ * This event is fired on {@link NeoForge#EVENT_BUS}, and is only fired on the logical server.
+ * 
+ * @see EventHooks#onFinalizeSpawn
+ * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
+ */
+public class FinalizeSpawnEvent extends MobSpawnEvent implements ICancellableEvent {
+    private final MobSpawnType spawnType;
+
+    @Nullable
+    private final Either<BlockEntity, Entity> spawner;
+
+    private DifficultyInstance difficulty;
+
+    @Nullable
+    private SpawnGroupData spawnData;
+
+    /**
+     * @apiNote Fire via {@link EventHooks#onFinalizeSpawn} / {@link EventHooks#onFinalizeSpawnSpawner}.
+     */
+    @ApiStatus.Internal
+    public FinalizeSpawnEvent(Mob entity, ServerLevelAccessor level, double x, double y, double z, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData, @Nullable Either<BlockEntity, Entity> spawner) {
+        super(entity, level, x, y, z);
+        this.difficulty = difficulty;
+        this.spawnType = spawnType;
+        this.spawnData = spawnData;
+        this.spawner = spawner;
+    }
+
+    /**
+     * Retrieves the {@link DifficultyInstance} for the chunk where the mob is about to be spawned.
+     * 
+     * @return The local difficulty instance
+     */
+    public DifficultyInstance getDifficulty() {
+        return this.difficulty;
+    }
+
+    /**
+     * Sets the difficulty instance for this event, which will be propagated to {@link Mob#finalizeSpawn} unless cancelled.
+     * The difficulty instance controls how likely certain random effects are to occur, or if certain mob abilities are enabled.
+     * 
+     * @param inst The new difficulty instance.
+     */
+    public void setDifficulty(DifficultyInstance inst) {
+        this.difficulty = inst;
+    }
+
+    /**
+     * Retrieves the type of mob spawn that happened (the event that caused the spawn). The enum names are self-explanatory.
+     * 
+     * @return The mob spawn type.
+     * @see MobSpawnType
+     */
+    public MobSpawnType getSpawnType() {
+        return this.spawnType;
+    }
+
+    /**
+     * Retrieves the {@link SpawnGroupData} for this entity. When spawning mobs in a loop, this group data is used for the entire group and impacts future spawns.
+     * This is how entities like horses ensure that the whole group spawns as a single variant. How this is used varies on a per-entity basis.
+     * 
+     * @return The spawn group data.
+     */
+    @Nullable
+    public SpawnGroupData getSpawnData() {
+        return this.spawnData;
+    }
+
+    /**
+     * Sets the spawn data for this entity. If this event is cancelled, this value is not used, since {@link Mob#finalizeSpawn} will not be called.
+     * 
+     * @param data The new spawn data
+     * @see FinalizeSpawnEvent#getSpawnData
+     */
+    public void setSpawnData(@Nullable SpawnGroupData data) {
+        this.spawnData = data;
+    }
+
+    /**
+     * Retrieves the underlying {@link BlockEntity} or {@link Entity} that performed the spawn. This may be a {@link SpawnerBlockEntity},
+     * {@link TrialSpawnerBlockEntity}, {@link MinecartSpawner}, or similar modded object.
+     * <p>
+     * This is usually null unless the {@link #getSpawnType() spawn type} is a {@link MobSpawnType#isSpawner spawner type}, and may still be null even then.
+     * 
+     * @return The spawner responsible for triggering the spawn, or null if none is available.
+     */
+    @Nullable
+    public Either<BlockEntity, Entity> getSpawner() {
+        return this.spawner;
+    }
+
+    /**
+     * This method can be used to cancel the spawn of this mob.<p>
+     * This method must be used if you want to block the spawn, as canceling the event only blocks the call to {@link Mob#finalizeSpawn}.<p>
+     * Note that if the spawn is cancelled, but the event is not, then {@link Mob#finalizeSpawn} will still be called, but the entity will not be spawned.
+     * Usually that has no side effects, but callers should be aware.
+     * 
+     * @param cancel If the spawn should be cancelled (or not).
+     */
+    public void setSpawnCancelled(boolean cancel) {
+        this.getEntity().setSpawnCancelled(cancel);
+    }
+
+    /**
+     * Returns the current spawn cancellation status, which can be changed via {@link FinalizeSpawnEvent#setSpawnCancelled(boolean)}.
+     * 
+     * @return If this mob's spawn is cancelled or not.
+     * @implNote This is enforced in {@link NeoForgeEventHandler#builtinMobSpawnBlocker} and a patch in {@link WorldGenRegion#addEntity}
+     */
+    public boolean isSpawnCancelled() {
+        return this.getEntity().isSpawnCancelled();
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/MobSpawnEvent.java
@@ -6,14 +6,11 @@
 package net.neoforged.neoforge.event.entity.living;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobSpawnType;
-import net.minecraft.world.entity.SpawnGroupData;
 import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.ServerLevelAccessor;
@@ -21,8 +18,6 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.NeoForgeEventHandler;
-import net.neoforged.neoforge.event.EventHooks;
 import net.neoforged.neoforge.event.entity.EntityEvent;
 import net.neoforged.neoforge.event.entity.SpawnPlacementRegisterEvent;
 import org.jetbrains.annotations.ApiStatus;
@@ -239,124 +234,6 @@ public abstract class MobSpawnEvent extends EntityEvent {
          */
         public MobSpawnType getSpawnType() {
             return this.spawnType;
-        }
-    }
-
-    /**
-     * This event is fired before {@link Mob#finalizeSpawn} is called.<br>
-     * This allows mods to control mob initialization.<br>
-     * In vanilla code, this event is injected by a transformer and not via patch, so calls cannot be traced via call hierarchy (it is not source-visible).
-     * <p>
-     * Canceling this event will result in {@link Mob#finalizeSpawn} not being called, and the returned value always being null, instead of propagating the SpawnGroupData.<br>
-     * The entity will still be spawned. If you want to prevent the spawn, use {@link FinalizeSpawn#setSpawnCancelled}, which will cause Forge to prevent the spawn.
-     * <p>
-     * This event is fired on {@link NeoForge#EVENT_BUS}, and is only fired on the logical server.
-     * 
-     * @see EventHooks#onFinalizeSpawn
-     * @apiNote Callers do not need to check if the entity's spawn was cancelled, as the spawn will be blocked by Forge.
-     */
-    public static class FinalizeSpawn extends MobSpawnEvent implements ICancellableEvent {
-        private final MobSpawnType spawnType;
-        @Nullable
-        private final BaseSpawner spawner;
-
-        private DifficultyInstance difficulty;
-        @Nullable
-        private SpawnGroupData spawnData;
-
-        /**
-         * @apiNote Do not construct directly. Access via {@link EventHooks#onFinalizeSpawn} / {@link EventHooks#onFinalizeSpawnSpawner}.
-         */
-        @ApiStatus.Internal
-        public FinalizeSpawn(Mob entity, ServerLevelAccessor level, double x, double y, double z, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnData, @Nullable BaseSpawner spawner) {
-            super(entity, level, x, y, z);
-            this.difficulty = difficulty;
-            this.spawnType = spawnType;
-            this.spawnData = spawnData;
-            this.spawner = spawner;
-        }
-
-        /**
-         * Retrieves the {@link DifficultyInstance} for the chunk where the mob is about to be spawned.
-         * 
-         * @return The local difficulty instance
-         */
-        public DifficultyInstance getDifficulty() {
-            return this.difficulty;
-        }
-
-        /**
-         * Sets the difficulty instance for this event, which will be propagated to {@link Mob#finalizeSpawn} unless cancelled.
-         * The difficulty instance controls how likely certain random effects are to occur, or if certain mob abilities are enabled.
-         * 
-         * @param inst The new difficulty instance.
-         */
-        public void setDifficulty(DifficultyInstance inst) {
-            this.difficulty = inst;
-        }
-
-        /**
-         * Retrieves the type of mob spawn that happened (the event that caused the spawn). The enum names are self-explanatory.
-         * 
-         * @return The mob spawn type.
-         * @see MobSpawnType
-         */
-        public MobSpawnType getSpawnType() {
-            return this.spawnType;
-        }
-
-        /**
-         * Retrieves the {@link SpawnGroupData} for this entity. When spawning mobs in a loop, this group data is used for the entire group and impacts future spawns.
-         * This is how entities like horses ensure that the whole group spawns as a single variant. How this is used varies on a per-entity basis.
-         * 
-         * @return The spawn group data.
-         */
-        @Nullable
-        public SpawnGroupData getSpawnData() {
-            return this.spawnData;
-        }
-
-        /**
-         * Sets the spawn data for this entity. If this event is cancelled, this value is not used, since {@link Mob#finalizeSpawn} will not be called.
-         * 
-         * @param data The new spawn data
-         * @see FinalizeSpawn#getSpawnData
-         */
-        public void setSpawnData(@Nullable SpawnGroupData data) {
-            this.spawnData = data;
-        }
-
-        /**
-         * Retrieves the underlying {@link BaseSpawner} instance if this mob was created by a Mob Spawner of some form.
-         * This is always null unless {@link #getSpawnType()} is {@link MobSpawnType#SPAWNER}, and may still be null even then.
-         * 
-         * @return The BaseSpawner responsible for triggering the spawn, or null if none is available.
-         */
-        @Nullable
-        public BaseSpawner getSpawner() {
-            return spawner;
-        }
-
-        /**
-         * This method can be used to cancel the spawn of this mob.<p>
-         * This method must be used if you want to block the spawn, as canceling the event only blocks the call to {@link Mob#finalizeSpawn}.<p>
-         * Note that if the spawn is cancelled, but the event is not, then {@link Mob#finalizeSpawn} will still be called, but the entity will not be spawned.
-         * Usually that has no side effects, but callers should be aware.
-         * 
-         * @param cancel If the spawn should be cancelled (or not).
-         */
-        public void setSpawnCancelled(boolean cancel) {
-            this.getEntity().setSpawnCancelled(cancel);
-        }
-
-        /**
-         * Returns the current spawn cancellation status, which can be changed via {@link FinalizeSpawn#setSpawnCancelled(boolean)}.
-         * 
-         * @return If this mob's spawn is cancelled or not.
-         * @implNote This is enforced in {@link NeoForgeEventHandler#builtinMobSpawnBlocker} and a patch in {@link WorldGenRegion#addEntity}
-         */
-        public boolean isSpawnCancelled() {
-            return this.getEntity().isSpawnCancelled();
         }
     }
 

--- a/src/main/resources/coremods/method_redirector.js
+++ b/src/main/resources/coremods/method_redirector.js
@@ -7,7 +7,7 @@ function finalizeSpawnNode(node){
     return new MethodInsnNode(
         Opcodes.INVOKESTATIC, 
         "net/neoforged/neoforge/event/EventHooks",
-        "onFinalizeSpawn", 
+        "finalizeMobSpawn", 
         "(Lnet/minecraft/world/entity/Mob;Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/world/DifficultyInstance;Lnet/minecraft/world/entity/MobSpawnType;Lnet/minecraft/world/entity/SpawnGroupData;)Lnet/minecraft/world/entity/SpawnGroupData;",
         false);
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/FinalizeSpawnTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/FinalizeSpawnTest.java
@@ -9,7 +9,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.EntityType;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.event.entity.living.MobSpawnEvent;
+import net.neoforged.neoforge.event.entity.living.FinalizeSpawnEvent;
 
 @Mod(FinalizeSpawnTest.ID)
 public class FinalizeSpawnTest {
@@ -17,7 +17,7 @@ public class FinalizeSpawnTest {
     public static final boolean ENABLED = false;
 
     public FinalizeSpawnTest() {
-        NeoForge.EVENT_BUS.addListener(MobSpawnEvent.FinalizeSpawn.class, event -> {
+        NeoForge.EVENT_BUS.addListener(FinalizeSpawnEvent.class, event -> {
             var entityType = EntityType.WANDERING_TRADER;
             var entity = event.getEntity();
 


### PR DESCRIPTION
This PR allows the finalize spawn event to be fired with the proper context for Trial Spawners.  This was a bit annoying since `BaseSpawner` and `TrialSpawner` are totally disjoint objects, so we're left with `Either<BlockEntity, Entity>` as the "spawner" object.

This also moves the event from an inner class to a full class (`MobSpawnEvent.FinalizeSpawn` -> `FinalizeSpawnEvent`) and updates the documentation on related areas since it had been remarked as confusing.

Closes #783
Closes #939 