### PR TITLE
Add more accurate culling for single quad particles

### DIFF
--- a/patches/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/net/minecraft/client/particle/Particle.java.patch
@@ -1,15 +1,14 @@
 --- a/net/minecraft/client/particle/Particle.java
 +++ b/net/minecraft/client/particle/Particle.java
-@@ -245,6 +_,18 @@
+@@ -245,6 +_,17 @@
          return Optional.empty();
      }
  
 +    /**
-+     * Forge added method that controls if a particle should be culled to it's bounding box.
-+     * Default behaviour is culling enabled
++     * Returns the bounding box that should be used for particle culling.
 +     */
-+    public boolean shouldCull() {
-+        return true;
++    public AABB getRenderBoundingBox(float partialTicks) {
++        return getBoundingBox().inflate(1.0);
 +    }
 +
 +    public Vec3 getPos() {

--- a/patches/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/net/minecraft/client/particle/Particle.java.patch
@@ -1,11 +1,22 @@
 --- a/net/minecraft/client/particle/Particle.java
 +++ b/net/minecraft/client/particle/Particle.java
-@@ -245,6 +_,17 @@
-         return Optional.empty();
-     }
+@@ -19,6 +_,7 @@
+ @OnlyIn(Dist.CLIENT)
+ public abstract class Particle {
+     private static final AABB INITIAL_AABB = new AABB(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
++    public static final AABB INFINITE_EXTENT_AABB = net.neoforged.neoforge.client.extensions.IBlockEntityRendererExtension.INFINITE_EXTENT_AABB;
+     private static final double MAXIMUM_COLLISION_VELOCITY_SQUARED = Mth.square(100.0);
+     protected final ClientLevel level;
+     protected double xo;
+@@ -243,6 +_,18 @@
  
+     public Optional<ParticleGroup> getParticleGroup() {
+         return Optional.empty();
++    }
++
 +    /**
-+     * Returns the bounding box that should be used for particle culling.
++     * Returns the bounding box that should be used for particle culling. {@link Particle#INFINITE_EXTENT_AABB} can be
++     * returned for particles that should not be called.
 +     */
 +    public AABB getRenderBoundingBox(float partialTicks) {
 +        return getBoundingBox().inflate(1.0);
@@ -13,8 +24,6 @@
 +
 +    public Vec3 getPos() {
 +        return new Vec3(this.x, this.y, this.z);
-+    }
-+
+     }
+ 
      @OnlyIn(Dist.CLIENT)
-     public static record LifetimeAlpha(float startAlpha, float endAlpha, float startAtNormalizedAge, float endAtNormalizedAge) {
-         public static final Particle.LifetimeAlpha ALWAYS_OPAQUE = new Particle.LifetimeAlpha(1.0F, 1.0F, 0.0F, 1.0F);

--- a/patches/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/net/minecraft/client/particle/Particle.java.patch
@@ -6,7 +6,7 @@
  
 +    /**
 +     * Returns the bounding box that should be used for particle culling. {@link AABB#INFINITE} can be
-+     * returned for particles that should not be called.
++     * returned for particles that should not be culled.
 +     */
 +    public AABB getRenderBoundingBox(float partialTicks) {
 +        return getBoundingBox().inflate(1.0);

--- a/patches/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/net/minecraft/client/particle/Particle.java.patch
@@ -1,21 +1,11 @@
 --- a/net/minecraft/client/particle/Particle.java
 +++ b/net/minecraft/client/particle/Particle.java
-@@ -19,6 +_,7 @@
- @OnlyIn(Dist.CLIENT)
- public abstract class Particle {
-     private static final AABB INITIAL_AABB = new AABB(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-+    public static final AABB INFINITE_EXTENT_AABB = net.neoforged.neoforge.client.extensions.IBlockEntityRendererExtension.INFINITE_EXTENT_AABB;
-     private static final double MAXIMUM_COLLISION_VELOCITY_SQUARED = Mth.square(100.0);
-     protected final ClientLevel level;
-     protected double xo;
-@@ -243,6 +_,18 @@
- 
-     public Optional<ParticleGroup> getParticleGroup() {
+@@ -245,6 +_,18 @@
          return Optional.empty();
-+    }
-+
+     }
+ 
 +    /**
-+     * Returns the bounding box that should be used for particle culling. {@link Particle#INFINITE_EXTENT_AABB} can be
++     * Returns the bounding box that should be used for particle culling. {@link AABB#INFINITE} can be
 +     * returned for particles that should not be called.
 +     */
 +    public AABB getRenderBoundingBox(float partialTicks) {
@@ -24,6 +14,8 @@
 +
 +    public Vec3 getPos() {
 +        return new Vec3(this.x, this.y, this.z);
-     }
- 
++    }
++
      @OnlyIn(Dist.CLIENT)
+     public static record LifetimeAlpha(float startAlpha, float endAlpha, float startAtNormalizedAge, float endAtNormalizedAge) {
+         public static final Particle.LifetimeAlpha ALWAYS_OPAQUE = new Particle.LifetimeAlpha(1.0F, 1.0F, 0.0F, 1.0F);

--- a/patches/net/minecraft/client/particle/ParticleEngine.java.patch
+++ b/patches/net/minecraft/client/particle/ParticleEngine.java.patch
@@ -80,7 +80,7 @@
                  particlerendertype.begin(bufferbuilder, this.textureManager);
  
                  for (Particle particle : iterable) {
-+                    if (frustum != null && particle.shouldCull() && !frustum.isVisible(particle.getBoundingBox().inflate(1.0))) continue;
++                    if (frustum != null && !frustum.isVisible(particle.getRenderBoundingBox(p_107341_))) continue;
                      try {
                          particle.render(bufferbuilder, p_107340_, p_107341_);
                      } catch (Throwable throwable) {
@@ -102,7 +102,7 @@
                                  );
                              }
                          }
-@@ -556,12 +_,18 @@
+@@ -556,12 +_,28 @@
                  d0 = (double)i + aabb.maxX + 0.1F;
              }
  
@@ -113,6 +113,16 @@
  
      public String countParticles() {
          return String.valueOf(this.particles.values().stream().mapToInt(Collection::size).sum());
++    }
++
++    public void iterateParticles(java.util.function.Consumer<Particle> consumer) {
++        for (ParticleRenderType particlerendertype : this.particles.keySet()) {
++            if (particlerendertype == ParticleRenderType.NO_RENDER) continue;
++            Iterable<Particle> iterable = this.particles.get(particlerendertype);
++            if (iterable != null) {
++                iterable.forEach(consumer);
++            }
++        }
 +    }
 +
 +    public void addBlockHitEffects(BlockPos pos, net.minecraft.world.phys.BlockHitResult target) {

--- a/patches/net/minecraft/client/particle/SingleQuadParticle.java.patch
+++ b/patches/net/minecraft/client/particle/SingleQuadParticle.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/client/particle/SingleQuadParticle.java
++++ b/net/minecraft/client/particle/SingleQuadParticle.java
+@@ -81,6 +_,12 @@
+             .endVertex();
+     }
+ 
++    @Override
++    public net.minecraft.world.phys.AABB getRenderBoundingBox(float partialTicks) {
++        float size = getQuadSize(partialTicks);
++        return new net.minecraft.world.phys.AABB(this.x - size, this.y - size, this.z - size, this.x + size, this.y + size, this.z + size);
++    }
++
+     public float getQuadSize(float p_107681_) {
+         return this.quadSize;
+     }

--- a/patches/net/minecraft/client/renderer/blockentity/PistonHeadRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/blockentity/PistonHeadRenderer.java.patch
@@ -19,6 +19,6 @@
 +
 +    @Override
 +    public net.minecraft.world.phys.AABB getRenderBoundingBox(PistonMovingBlockEntity blockEntity) {
-+        return INFINITE_EXTENT_AABB;
++        return net.minecraft.world.phys.AABB.INFINITE;
      }
  }

--- a/patches/net/minecraft/client/renderer/blockentity/StructureBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/blockentity/StructureBlockRenderer.java.patch
@@ -7,6 +7,6 @@
 +
 +    @Override
 +    public net.minecraft.world.phys.AABB getRenderBoundingBox(StructureBlockEntity blockEntity) {
-+        return INFINITE_EXTENT_AABB;
++        return net.minecraft.world.phys.AABB.INFINITE;
 +    }
  }

--- a/patches/net/minecraft/client/renderer/blockentity/TheEndGatewayRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/blockentity/TheEndGatewayRenderer.java.patch
@@ -7,6 +7,6 @@
 +
 +    @Override
 +    public net.minecraft.world.phys.AABB getRenderBoundingBox(TheEndGatewayBlockEntity blockEntity) {
-+        return blockEntity.isSpawning() || blockEntity.isCoolingDown() ? INFINITE_EXTENT_AABB : super.getRenderBoundingBox(blockEntity);
++        return blockEntity.isSpawning() || blockEntity.isCoolingDown() ? net.minecraft.world.phys.AABB.INFINITE : super.getRenderBoundingBox(blockEntity);
 +    }
  }

--- a/patches/net/minecraft/client/renderer/culling/Frustum.java.patch
+++ b/patches/net/minecraft/client/renderer/culling/Frustum.java.patch
@@ -5,7 +5,7 @@
  
      public boolean isVisible(AABB p_113030_) {
 +        // FORGE: exit early for infinite bounds, these would otherwise fail in the intersection test at certain camera angles (GH-9321)
-+        if (p_113030_.equals(AABB.INFINITE)) return true;
++        if (p_113030_.isInfinite()) return true;
          return this.cubeInFrustum(p_113030_.minX, p_113030_.minY, p_113030_.minZ, p_113030_.maxX, p_113030_.maxY, p_113030_.maxZ);
      }
  

--- a/patches/net/minecraft/client/renderer/culling/Frustum.java.patch
+++ b/patches/net/minecraft/client/renderer/culling/Frustum.java.patch
@@ -5,7 +5,7 @@
  
      public boolean isVisible(AABB p_113030_) {
 +        // FORGE: exit early for infinite bounds, these would otherwise fail in the intersection test at certain camera angles (GH-9321)
-+        if (p_113030_.equals(net.neoforged.neoforge.client.extensions.IBlockEntityRendererExtension.INFINITE_EXTENT_AABB)) return true;
++        if (p_113030_.equals(AABB.INFINITE)) return true;
          return this.cubeInFrustum(p_113030_.minX, p_113030_.minY, p_113030_.minZ, p_113030_.maxX, p_113030_.maxY, p_113030_.maxZ);
      }
  

--- a/patches/net/minecraft/world/phys/AABB.java.patch
+++ b/patches/net/minecraft/world/phys/AABB.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/phys/AABB.java
++++ b/net/minecraft/world/phys/AABB.java
+@@ -9,6 +_,7 @@
+ 
+ public class AABB {
+     private static final double EPSILON = 1.0E-7;
++    public static final AABB INFINITE = new AABB(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+     public final double minX;
+     public final double minY;
+     public final double minZ;

--- a/patches/net/minecraft/world/phys/AABB.java.patch
+++ b/patches/net/minecraft/world/phys/AABB.java.patch
@@ -8,3 +8,17 @@
      public final double minX;
      public final double minY;
      public final double minZ;
+@@ -511,5 +_,13 @@
+             p_165883_.y + p_165885_ / 2.0,
+             p_165883_.z + p_165886_ / 2.0
+         );
++    }
++
++    /**
++     * {@return true if this AABB is infinite in all directions}
++     */
++    public boolean isInfinite() {
++        return this == INFINITE || (Double.isInfinite(this.minX) && Double.isInfinite(this.minY) && Double.isInfinite(this.minZ)
++                && Double.isInfinite(this.maxX) && Double.isInfinite(this.maxY) && Double.isInfinite(this.maxZ));
+     }
+ }

--- a/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.commands.Commands;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.neoforged.neoforge.client.extensions.IBlockEntityRendererExtension;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+
+@EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME, modid = NeoForgeVersion.MOD_ID)
+public final class ParticleBoundsDebugRenderer {
+    private static boolean enabled = false;
+
+    @SubscribeEvent
+    public static void onRenderLevelStage(RenderLevelStageEvent event) {
+        if (!enabled || event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES) {
+            return;
+        }
+
+        var camPos = event.getCamera().getPosition();
+
+        PoseStack poseStack = event.getPoseStack();
+        poseStack.pushPose();
+        poseStack.translate(-camPos.x, -camPos.y, -camPos.z);
+
+        VertexConsumer consumer = Minecraft.getInstance().renderBuffers().bufferSource().getBuffer(RenderType.lines());
+
+        Minecraft.getInstance().particleEngine.iterateParticles(particle -> {
+            var bb = particle.getRenderBoundingBox(event.getPartialTick());
+            if (bb != IBlockEntityRendererExtension.INFINITE_EXTENT_AABB && event.getFrustum().isVisible(bb)) {
+                LevelRenderer.renderLineBox(poseStack, consumer, bb, 1F, 0F, 0F, 1F);
+            }
+        });
+
+        poseStack.popPose();
+    }
+
+    @SubscribeEvent
+    public static void onRegisterClientCommands(RegisterClientCommandsEvent event) {
+        event.getDispatcher().register(
+                Commands.literal("neoforge")
+                        .then(Commands.literal("debug_particle_renderbounds")
+                                .requires(src -> src.hasPermission(Commands.LEVEL_ADMINS))
+                                .then(Commands.argument("enable", BoolArgumentType.bool())
+                                        .executes(ctx -> {
+                                            enabled = BoolArgumentType.getBool(ctx, "enable");
+                                            return Command.SINGLE_SUCCESS;
+                                        }))));
+    }
+
+    private ParticleBoundsDebugRenderer() {}
+}

--- a/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -41,7 +41,7 @@ public final class ParticleBoundsDebugRenderer {
 
         Minecraft.getInstance().particleEngine.iterateParticles(particle -> {
             var bb = particle.getRenderBoundingBox(event.getPartialTick());
-            if (bb != AABB.INFINITE && event.getFrustum().isVisible(bb)) {
+            if (!bb.isInfinite() && event.getFrustum().isVisible(bb)) {
                 LevelRenderer.renderLineBox(poseStack, consumer, bb, 1F, 0F, 0F, 1F);
             }
         });

--- a/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -13,12 +13,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.commands.Commands;
+import net.minecraft.world.phys.AABB;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
-import net.neoforged.neoforge.client.extensions.IBlockEntityRendererExtension;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
 @EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME, modid = NeoForgeVersion.MOD_ID)
@@ -41,7 +41,7 @@ public final class ParticleBoundsDebugRenderer {
 
         Minecraft.getInstance().particleEngine.iterateParticles(particle -> {
             var bb = particle.getRenderBoundingBox(event.getPartialTick());
-            if (bb != IBlockEntityRendererExtension.INFINITE_EXTENT_AABB && event.getFrustum().isVisible(bb)) {
+            if (bb != AABB.INFINITE && event.getFrustum().isVisible(bb)) {
                 LevelRenderer.renderLineBox(poseStack, consumer, bb, 1F, 0F, 0F, 1F);
             }
         });

--- a/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -13,7 +13,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.commands.Commands;
-import net.minecraft.world.phys.AABB;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IBlockEntityRendererExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IBlockEntityRendererExtension.java
@@ -11,14 +11,9 @@ import net.minecraft.world.phys.AABB;
 
 public interface IBlockEntityRendererExtension<T extends BlockEntity> {
     /**
-     * Bounding box with infinite scope. Used as the render bounding box for blocks with dynamic render bounds which
-     * can't be trivially determined
-     */
-    AABB INFINITE_EXTENT_AABB = new AABB(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
-
-    /**
      * Return an {@link AABB} that controls the visible scope of this {@link BlockEntityRenderer}.
-     * Defaults to the unit cube at the given position.
+     * Defaults to the unit cube at the given position. {@link AABB#INFINITE} can be used to declare the BER
+     * should be visible everywhere.
      *
      * @return an appropriately sized {@link AABB} for the {@link BlockEntityRenderer}
      */


### PR DESCRIPTION
This PR refactors particle culling to work more similarly to BE culling, using a `getRenderBoundingBox` method rather than assuming the particle's vanilla bounding box matches its visual extents. This allows implementing a more accurate bounding box for `SingleQuadParticle` based on the quad's size, which fixes #874. Other particles continue to be culled using the same simple heuristic as before (expand bounding box by 1 block in each direction).

I also added a visualizer for particle bounding boxes, like we did for block entities previously. 

This is a breaking change because `shouldCull` was removed (`getRenderBoundingBox` allows doing the same thing and is more flexible), and the infinite AABB was moved out of `IBlockEntityRendererExtension` and onto `AABB` directly.