### PR TITLE
Add an event fired when data maps are updated

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
@@ -32,12 +32,14 @@ import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.profiling.ProfilerFiller;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.registries.datamaps.AdvancedDataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapFile;
 import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueMerger;
+import net.neoforged.neoforge.registries.datamaps.DataMapsUpdatedEvent;
 import org.slf4j.Logger;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -71,6 +73,7 @@ public class DataMapLoader implements PreparableReloadListener {
         registry.dataMaps.clear();
         result.results().forEach((key, entries) -> registry.dataMaps.put(
                 key, this.buildDataMap(registry, key, (List) entries)));
+        NeoForge.EVENT_BUS.post(new DataMapsUpdatedEvent(registryAccess, registry, DataMapsUpdatedEvent.UpdateCause.SERVER_RELOAD));
     }
 
     private <T, R> Map<ResourceKey<R>, T> buildDataMap(Registry<R> registry, DataMapType<R, T> attachment, List<DataMapFile<T, R>> entries) {

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.registries.datamaps;
 import java.util.function.Consumer;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.Connection;
 import net.minecraft.resources.ResourceKey;
 import net.neoforged.bus.api.Event;
 import org.jetbrains.annotations.ApiStatus;
@@ -76,6 +77,8 @@ public class DataMapsUpdatedEvent extends Event {
     public enum UpdateCause {
         /**
          * The data maps have been synced to the client.
+         * 
+         * @implNote An event with this cause is <i>not</i> fired for the host of a single-player world, or for any {@linkplain Connection#isMemoryConnection() in-memory} connections.
          */
         CLIENT_SYNC,
         /**

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
@@ -11,6 +11,7 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.Connection;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.bus.api.Event;
 import org.jetbrains.annotations.ApiStatus;
@@ -86,7 +87,7 @@ public class DataMapsUpdatedEvent extends Event {
         /**
          * The data maps have been reloaded on the server.
          * 
-         * @implNote Events with this cause are fired during the {@linkplain net.minecraft.server.packs.resources.SimplePreparableReloadListener#apply(Object, ResourceManager, ProfilerFiller) apply phase}
+         * @implNote Events with this cause are fired during the {@linkplain SimplePreparableReloadListener#apply(Object, ResourceManager, ProfilerFiller) apply phase}
          *           of a reload listener, and <strong>not</strong> after the reload is complete.
          */
         SERVER_RELOAD

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.registries.datamaps;
+
+import java.util.function.Consumer;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
+import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Event fired on the {@link net.neoforged.neoforge.common.NeoForge#EVENT_BUS game event bus} when the data maps of
+ * a registry have either been {@linkplain UpdateCause#CLIENT_SYNC synced to the client} or {@linkplain UpdateCause#SERVER_RELOAD reloaded on the server}.
+ * <p>
+ * This event can be used to build caches (like weighed lists) or for post-processing the data map values. <br>
+ * Remember however that the data map values should <strong>not</strong> end up referencing their owner, as they're not copied when attached to tags.
+ */
+public class DataMapsUpdatedEvent extends Event {
+    private final RegistryAccess registryAccess;
+    private final Registry<?> registry;
+    private final UpdateCause cause;
+
+    @ApiStatus.Internal
+    public DataMapsUpdatedEvent(RegistryAccess registryAccess, Registry<?> registry, UpdateCause cause) {
+        this.registryAccess = registryAccess;
+        this.registry = registry;
+        this.cause = cause;
+    }
+
+    /**
+     * {@return a registry access}
+     */
+    public RegistryAccess getRegistries() {
+        return registryAccess;
+    }
+
+    /**
+     * {@return the registry that had its data maps updated}
+     */
+    public Registry<?> getRegistry() {
+        return registry;
+    }
+
+    /**
+     * {@return the key of the registry that had its data maps updated}
+     */
+    public ResourceKey<? extends Registry<?>> getRegistryKey() {
+        return registry.key();
+    }
+
+    /**
+     * Runs the given {@code consumer} if the registry is of the given {@code type}.
+     * 
+     * @param type     the registry key
+     * @param consumer the consumer
+     * @param <T>      the registry type
+     */
+    @SuppressWarnings("unchecked")
+    public <T> void ifRegistry(ResourceKey<Registry<T>> type, Consumer<Registry<T>> consumer) {
+        if (getRegistryKey() == type) {
+            consumer.accept((Registry<T>) registry);
+        }
+    }
+
+    /**
+     * {@return the reason for the update}
+     */
+    public UpdateCause getCause() {
+        return cause;
+    }
+
+    public enum UpdateCause {
+        /**
+         * The data maps have been synced to the client.
+         */
+        CLIENT_SYNC,
+        /**
+         * The data maps have been reloaded on the server.
+         */
+        SERVER_RELOAD
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapsUpdatedEvent.java
@@ -10,6 +10,8 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.Connection;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.bus.api.Event;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -83,6 +85,9 @@ public class DataMapsUpdatedEvent extends Event {
         CLIENT_SYNC,
         /**
          * The data maps have been reloaded on the server.
+         * 
+         * @implNote Events with this cause are fired during the {@linkplain net.minecraft.server.packs.resources.SimplePreparableReloadListener#apply(Object, ResourceManager, ProfilerFiller) apply phase}
+         *           of a reload listener, and <strong>not</strong> after the reload is complete.
          */
         SERVER_RELOAD
     }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/reg/RegistrationHelperImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/reg/RegistrationHelperImpl.java
@@ -49,6 +49,8 @@ import net.neoforged.neoforge.common.data.LanguageProvider;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.event.AddPackFindersEvent;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.datamaps.DataMapType;
+import net.neoforged.neoforge.registries.datamaps.RegisterDataMapTypesEvent;
 import net.neoforged.testframework.registration.DeferredAttachmentTypes;
 import net.neoforged.testframework.registration.DeferredBlocks;
 import net.neoforged.testframework.registration.DeferredEntityTypes;
@@ -165,6 +167,12 @@ public class RegistrationHelperImpl implements RegistrationHelper {
     @Override
     public DeferredAttachmentTypes attachments() {
         return attachments.get();
+    }
+
+    @Override
+    public <M extends DataMapType<?, ?>> M registerDataMap(M map) {
+        eventListeners().accept((final RegisterDataMapTypesEvent event) -> event.register((DataMapType) map));
+        return map;
     }
 
     @Override

--- a/testframework/src/main/java/net/neoforged/testframework/registration/RegistrationHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/RegistrationHelper.java
@@ -14,6 +14,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import net.neoforged.testframework.impl.reg.RegistrationHelperImpl;
 
 /**
@@ -44,6 +45,11 @@ public interface RegistrationHelper {
      * {@return a helper for attachment type registration}
      */
     DeferredAttachmentTypes attachments();
+
+    /**
+     * Registers a data map.
+     */
+    <M extends DataMapType<?, ?>> M registerDataMap(M map);
 
     /**
      * {@return the mod id of this helper}

--- a/tests/src/generated/resources/data/neotests_data_map_update_event_test/data_maps/item/weight.json
+++ b/tests/src/generated/resources/data/neotests_data_map_update_event_test/data_maps/item/weight.json
@@ -1,0 +1,6 @@
+{
+  "values": {
+    "minecraft:blue_orchid": 5,
+    "minecraft:ominous_trial_key": 10
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -5,15 +5,16 @@
 
 package net.neoforged.neoforge.debug.data;
 
-import com.google.common.collect.Iterators;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
@@ -338,10 +339,9 @@ public class DataMapTests {
         });
 
         test.onGameTest(helper -> {
-            helper.assertTrue(Iterators.elementsEqual(
-                    entries.get().iterator(), List.of(
-                            WeightedEntry.wrap(Items.BLUE_ORCHID, 5),
-                            WeightedEntry.wrap(Items.OMINOUS_TRIAL_KEY, 10)).iterator()),
+            helper.assertTrue(new HashSet<>(entries.get()).equals(Set.of(
+                    WeightedEntry.wrap(Items.BLUE_ORCHID, 5),
+                    WeightedEntry.wrap(Items.OMINOUS_TRIAL_KEY, 10)).iterator()),
                     "Cached entries are not as expected");
             helper.succeed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -341,7 +341,7 @@ public class DataMapTests {
         test.onGameTest(helper -> {
             helper.assertTrue(new HashSet<>(entries.get()).equals(Set.of(
                     WeightedEntry.wrap(Items.BLUE_ORCHID, 5),
-                    WeightedEntry.wrap(Items.OMINOUS_TRIAL_KEY, 10)).iterator()),
+                    WeightedEntry.wrap(Items.OMINOUS_TRIAL_KEY, 10))),
                     "Cached entries are not as expected");
             helper.succeed();
         });


### PR DESCRIPTION
This event can be used for caching purposes, or post-processing of the data.