### PR TITLE
[1.20.6] Miscellaneous network cleanup

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -36,7 +36,7 @@
 +        }
 +
 +        // Neo: Handle modded payloads. Vanilla payloads do not get sent to the modded handling pass. Additional payloads cannot be registered in the minecraft domain.
-+        if (!"minecraft".equals(p_295727_.payload().type().id().getNamespace())) {
++        if (net.neoforged.neoforge.network.registration.NetworkRegistry.isModdedPayload(p_295727_.payload())) {
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.handleModdedPayload(this, p_295727_);
 +            return;
 +        }

--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -7,7 +7,7 @@
 +    /**
 +     * Holds the current connection type, based on the types of payloads that have been received so far.
 +     */
-+    protected net.neoforged.neoforge.network.connection.ConnectionType connectionType = net.neoforged.neoforge.network.connection.ConnectionType.VANILLA;
++    protected net.neoforged.neoforge.network.connection.ConnectionType connectionType = net.neoforged.neoforge.network.connection.ConnectionType.OTHER;
  
      protected ClientCommonPacketListenerImpl(Minecraft p_295454_, Connection p_294773_, CommonListenerCookie p_294647_) {
          this.minecraft = p_295454_;
@@ -20,25 +20,23 @@
      }
  
      @Override
-@@ -116,6 +_,25 @@
+@@ -116,6 +_,23 @@
  
      @Override
      public void handleCustomPayload(ClientboundCustomPayloadPacket p_295727_) {
-+        // Neo: Unconditionally handle register/unregister payloads and update the connection type accordingly.
++        // Neo: Unconditionally handle register/unregister payloads.
 +        if (p_295727_.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftRegisterPayload minecraftRegisterPayload) {
-+            this.connectionType = this.connectionType.withMinecraftRegisterPayload();
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.onMinecraftRegister(this.getConnection(), minecraftRegisterPayload.newChannels());
 +            return;
 +        }
 +
 +        if (p_295727_.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftUnregisterPayload minecraftUnregisterPayload) {
-+            this.connectionType = this.connectionType.withMinecraftRegisterPayload();
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.onMinecraftUnregister(this.getConnection(), minecraftUnregisterPayload.forgottenChannels());
 +            return;
 +        }
 +
-+        // Neo: Handle modded payloads on modded connections. Vanilla payloads do not get sent to the modded handling pass.
-+        if (this.connectionType.isNotVanilla() && !"minecraft".equals(p_295727_.payload().type().id().getNamespace())) {
++        // Neo: Handle modded payloads. Vanilla payloads do not get sent to the modded handling pass. Additional payloads cannot be registered in the minecraft domain.
++        if (!"minecraft".equals(p_295727_.payload().type().id().getNamespace())) {
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.handleModdedPayload(this, p_295727_);
 +            return;
 +        }

--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -59,7 +59,7 @@
 +        // Receiving a modded network payload implies a successful negotiation by the server.
 +        if (packet.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkPayload moddedNetworkPayload) {
 +            this.initializedConnection = true;
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoforgeConnection(this, moddedNetworkPayload.setup());
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoForgeConnection(this, moddedNetworkPayload.setup());
 +            return;
 +        }
 +

--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -4,7 +4,7 @@
      private KnownPacksManager knownPacks;
      @Nullable
      protected ChatComponent.State chatState;
-+    private net.neoforged.neoforge.network.connection.ConnectionType connectionType = net.neoforged.neoforge.network.connection.ConnectionType.VANILLA;
++    private net.neoforged.neoforge.network.connection.ConnectionType connectionType = net.neoforged.neoforge.network.connection.ConnectionType.OTHER;
 +    private boolean initializedConnection = false;
 +    private java.util.Map<net.minecraft.resources.ResourceLocation, net.minecraft.network.chat.Component> failureReasons = new java.util.HashMap<>();
  
@@ -14,10 +14,10 @@
      @Override
      public void handleEnabledFeatures(ClientboundUpdateEnabledFeaturesPacket p_294410_) {
          this.enabledFeatures = FeatureFlags.REGISTRY.fromNames(p_294410_.features());
-+        //Fallback detection layer for vanilla servers
-+        if (!this.connectionType.isNeoForge()) {
++        // Neo: Fallback detection layer for vanilla servers
++        if (this.connectionType.isOther()) {
 +            this.initializedConnection = true;
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNonModdedConnection(this);
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeOtherConnection(this);
 +        }
      }
  
@@ -33,9 +33,9 @@
                  )
              );
 +        // Packets can only be sent after the outbound protocol is set up again
-+        if (!this.initializedConnection && !this.connectionType.isNeoForge()) {
-+            //Fallback detection for servers with a delayed brand payload (BungeeCord)
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNonModdedConnection(this);
++        if (!this.initializedConnection && this.connectionType.isOther()) {
++            // Neo: Fallback detection for servers with a delayed brand payload (BungeeCord)
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeOtherConnection(this);
 +        }
 +        net.neoforged.neoforge.network.registration.NetworkRegistry.onConfigurationFinished(this);
          this.connection.send(ServerboundFinishConfigurationPacket.INSTANCE);
@@ -51,7 +51,7 @@
 +    public void handleCustomPayload(net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket packet) {
 +        // Handle the query payload by responding with the client's network channels. Update the connection type accordingly.
 +        if (packet.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload) {
-+            this.connectionType = this.connectionType.withNeoForgeQueryPayload();
++            this.connectionType = net.neoforged.neoforge.network.connection.ConnectionType.NEOFORGE;
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.onNetworkQuery(this);
 +            return;
 +        }
@@ -59,7 +59,7 @@
 +        // Receiving a modded network payload implies a successful negotiation by the server.
 +        if (packet.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkPayload moddedNetworkPayload) {
 +            this.initializedConnection = true;
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.onModdedNetworkConnectionEstablished(this, moddedNetworkPayload.setup());
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoforgeConnection(this, moddedNetworkPayload.setup());
 +            return;
 +        }
 +
@@ -70,9 +70,9 @@
 +        }
 +
 +        // Receiving a brand payload without having transitioned to a Neo connection implies a non-modded connection has begun.
-+        if (!this.connectionType.isNeoForge() && packet.payload() instanceof net.minecraft.network.protocol.common.custom.BrandPayload) {
++        if (this.connectionType.isOther() && packet.payload() instanceof net.minecraft.network.protocol.common.custom.BrandPayload) {
 +            this.initializedConnection = true;
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNonModdedConnection(this);
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeOtherConnection(this);
 +            // Continue processing the brand payload
 +        }
 +

--- a/patches/net/minecraft/client/multiplayer/CommonListenerCookie.java.patch
+++ b/patches/net/minecraft/client/multiplayer/CommonListenerCookie.java.patch
@@ -25,6 +25,6 @@
 +            @Nullable ChatComponent.State chatState,
 +            @Deprecated(forRemoval = true) boolean strictErrorHandling
 +    ) {
-+        this(localGameProfile, telemetryManager, receivedRegistries, enabledFeatures, serverBrand, serverData, postDisconnectScreen, serverCookies, chatState, strictErrorHandling, net.neoforged.neoforge.network.connection.ConnectionType.VANILLA);
++        this(localGameProfile, telemetryManager, receivedRegistries, enabledFeatures, serverBrand, serverData, postDisconnectScreen, serverCookies, chatState, strictErrorHandling, net.neoforged.neoforge.network.connection.ConnectionType.OTHER);
 +    }
  }

--- a/patches/net/minecraft/server/network/CommonListenerCookie.java.patch
+++ b/patches/net/minecraft/server/network/CommonListenerCookie.java.patch
@@ -11,7 +11,7 @@
 +     */
 +    @Deprecated
 +    public CommonListenerCookie(GameProfile gameProfile, int latency, ClientInformation clientInformation, boolean transferred) {
-+        this(gameProfile, latency, clientInformation, transferred, net.neoforged.neoforge.network.connection.ConnectionType.VANILLA);
++        this(gameProfile, latency, clientInformation, transferred, net.neoforged.neoforge.network.connection.ConnectionType.OTHER);
 +    }
 +
      public static CommonListenerCookie createInitial(GameProfile p_302024_, boolean p_320180_) {

--- a/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -36,7 +36,7 @@
 +        }
 +
 +        // Neo: Handle modded payloads. Vanilla payloads do not get sent to the modded handling pass. Additional payloads cannot be registered in the minecraft domain.
-+        if (!"minecraft".equals(p_294276_.payload().type().id().getNamespace())) {
++        if (net.neoforged.neoforge.network.registration.NetworkRegistry.isModdedPayload(p_294276_.payload())) {
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.handleModdedPayload(this, p_294276_);
 +            return;
 +        }

--- a/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -20,25 +20,23 @@
      }
  
      private void close() {
-@@ -82,6 +_,24 @@
+@@ -82,6 +_,22 @@
  
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket p_294276_) {
-+        // Neo: Unconditionally handle register/unregister payloads and update the connection type accordingly.
++        // Neo: Unconditionally handle register/unregister payloads.
 +        if (p_294276_.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftRegisterPayload minecraftRegisterPayload) {
-+            this.connectionType = this.connectionType.withMinecraftRegisterPayload();
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.onMinecraftRegister(this.getConnection(), minecraftRegisterPayload.newChannels());
 +            return;
 +        }
 +
 +        if (p_294276_.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftUnregisterPayload minecraftUnregisterPayload) {
-+            this.connectionType = this.connectionType.withMinecraftRegisterPayload();
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.onMinecraftUnregister(this.getConnection(), minecraftUnregisterPayload.forgottenChannels());
 +            return;
 +        }
 +
-+        // Neo: Handle modded payloads on modded connections. Vanilla payloads do not get sent to the modded handling pass.
-+        if (this.connectionType.isNotVanilla() && !"minecraft".equals(p_294276_.payload().type().id().getNamespace())) {
++        // Neo: Handle modded payloads. Vanilla payloads do not get sent to the modded handling pass. Additional payloads cannot be registered in the minecraft domain.
++        if (!"minecraft".equals(p_294276_.payload().type().id().getNamespace())) {
 +            net.neoforged.neoforge.network.registration.NetworkRegistry.handleModdedPayload(this, p_294276_);
 +            return;
 +        }

--- a/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -34,8 +34,8 @@
 +    public void handleCustomPayload(net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket p_294276_) {
 +        // Neo: Perform modded network initialization when the client sends their channel list.
 +        if (p_294276_.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload moddedEnvironmentPayload) {
-+            this.connectionType = this.connectionType.withNeoForgeQueryPayload();
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeModdedConnection(this, moddedEnvironmentPayload.queries());
++            this.connectionType = net.neoforged.neoforge.network.connection.ConnectionType.NEOFORGE;
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoforgeConnection(this, moddedEnvironmentPayload.queries());
 +            return;
 +        }
 +
@@ -47,7 +47,7 @@
 +        super.handlePong(p_295142_);
 +        // During startConfiguration() we send a ping with id 0, if we get a pong back, we initiate the connection.
 +        if (p_295142_.getId() == 0) {
-+            if (!this.connectionType.isNeoForge() && !net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNonModdedConnection(this)) {
++            if (!this.connectionType.isNeoForge() && !net.neoforged.neoforge.network.registration.NetworkRegistry.initializeOtherConnection(this)) {
 +                return;
 +            }
 +
@@ -63,7 +63,7 @@
 +        // Packets can only be sent after the outbound protocol is set up again
 +        if (this.connectionType == net.neoforged.neoforge.network.connection.ConnectionType.OTHER) {
 +            //We need to also initialize this here, as the client may have sent the packet before we have finished our configuration.
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeModdedConnection(this, java.util.Map.of());
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoforgeConnection(this, java.util.Map.of());
 +        }
 +        net.neoforged.neoforge.network.registration.NetworkRegistry.onConfigurationFinished(this);
  

--- a/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -6,7 +6,7 @@
      public void startConfiguration() {
 +        // Neo: Before starting vanilla configuration, reset ad-hoc channels and run modded channel negotiation.
 +        this.send(new net.neoforged.neoforge.network.payload.MinecraftUnregisterPayload(net.neoforged.neoforge.network.registration.NetworkRegistry.getInitialServerUnregisterChannels()));
-+        this.send(new net.neoforged.neoforge.network.payload.MinecraftRegisterPayload(net.neoforged.neoforge.network.registration.NetworkRegistry.getInitialServerListeningChannels()));
++        this.send(new net.neoforged.neoforge.network.payload.MinecraftRegisterPayload(net.neoforged.neoforge.network.registration.NetworkRegistry.getInitialListeningChannels(this.flow())));
 +        this.send(new net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload(java.util.Map.of()));
 +        this.send(new net.minecraft.network.protocol.common.ClientboundPingPacket(0));
 +    }
@@ -35,7 +35,7 @@
 +        // Neo: Perform modded network initialization when the client sends their channel list.
 +        if (p_294276_.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload moddedEnvironmentPayload) {
 +            this.connectionType = net.neoforged.neoforge.network.connection.ConnectionType.NEOFORGE;
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoforgeConnection(this, moddedEnvironmentPayload.queries());
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoForgeConnection(this, moddedEnvironmentPayload.queries());
 +            return;
 +        }
 +
@@ -63,7 +63,7 @@
 +        // Packets can only be sent after the outbound protocol is set up again
 +        if (this.connectionType == net.neoforged.neoforge.network.connection.ConnectionType.OTHER) {
 +            //We need to also initialize this here, as the client may have sent the packet before we have finished our configuration.
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoforgeConnection(this, java.util.Map.of());
++            net.neoforged.neoforge.network.registration.NetworkRegistry.initializeNeoForgeConnection(this, java.util.Map.of());
 +        }
 +        net.neoforged.neoforge.network.registration.NetworkRegistry.onConfigurationFinished(this);
  

--- a/src/main/java/net/neoforged/neoforge/network/connection/ConnectionType.java
+++ b/src/main/java/net/neoforged/neoforge/network/connection/ConnectionType.java
@@ -5,26 +5,24 @@
 
 package net.neoforged.neoforge.network.connection;
 
+import net.neoforged.neoforge.network.payload.MinecraftRegisterPayload;
+import net.neoforged.neoforge.network.payload.ModdedNetworkPayload;
+
+/**
+ * Declares categories of connections based on the other side.
+ */
 public enum ConnectionType {
-    VANILLA,
-    OTHER,
-    NEOFORGE;
+    /**
+     * Indicates that the other end is Neo.
+     * Modded channels will be negotiated via {@link ModdedNetworkPayload}.
+     */
+    NEOFORGE,
 
-    public ConnectionType withMinecraftRegisterPayload() {
-        return this == VANILLA ? OTHER : this;
-    }
-
-    public ConnectionType withNeoForgeQueryPayload() {
-        return NEOFORGE;
-    }
-
-    public boolean isVanilla() {
-        return this == VANILLA;
-    }
-
-    public boolean isNotVanilla() {
-        return !isVanilla();
-    }
+    /**
+     * Indicates that the other end of the connection is not Neo. This may be a Vanilla connection, or another modded platform (such as Fabric or Bukkit).
+     * Modded channels will be negotiated via {@link MinecraftRegisterPayload}.
+     */
+    OTHER;
 
     public boolean isOther() {
         return this == OTHER;

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -40,6 +40,7 @@ import net.minecraft.network.protocol.common.ServerCommonPacketListener;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.BrandPayload;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.common.custom.DiscardedPayload;
 import net.minecraft.network.protocol.configuration.ClientConfigurationPacketListener;
 import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
 import net.minecraft.resources.ResourceLocation;
@@ -219,6 +220,17 @@ public class NetworkRegistry {
             dumpStackToLog();
             return null;
         }
+    }
+
+    /**
+     * Checks if a payload is a modded payload. A modded payload is any payload that does not have `minecraft` as the domain, and is not a discarded payload.
+     * <p>
+     * The special handling for {@link DiscardedPayload} is because it falsely reports its type as the type that failed to decode.
+     * 
+     * @return True if the payload is modded, and modded payload handling should be invoked for it.
+     */
+    public static boolean isModdedPayload(CustomPacketPayload payload) {
+        return !(payload instanceof DiscardedPayload) && !"minecraft".equals(payload.type().id().getNamespace());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -325,7 +325,7 @@ public class NetworkRegistry {
      * <p>
      * Invoked on the network thread.
      *
-     * @param listener        The listener which completed the negotiation.
+     * @param listener      The listener which completed the negotiation.
      * @param configuration The configuration channels that the client has available.
      * @param play          The play channels that the client has available.
      */

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -329,7 +329,7 @@ public class NetworkRegistry {
      * @param configuration The configuration channels that the client has available.
      * @param play          The play channels that the client has available.
      */
-    public static void initializeNeoforgeConnection(ServerConfigurationPacketListener listener, Map<ConnectionProtocol, Set<ModdedNetworkQueryComponent>> clientChannels) {
+    public static void initializeNeoForgeConnection(ServerConfigurationPacketListener listener, Map<ConnectionProtocol, Set<ModdedNetworkQueryComponent>> clientChannels) {
         listener.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(listener.getConnectionType());
         listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
         listener.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.SERVERBOUND);
@@ -503,7 +503,7 @@ public class NetworkRegistry {
      * @param configuration The configuration channels that were negotiated.
      * @param play          The play channels that were negotiated.
      */
-    public static void initializeNeoforgeConnection(ClientConfigurationPacketListener listener, NetworkPayloadSetup setup) {
+    public static void initializeNeoForgeConnection(ClientConfigurationPacketListener listener, NetworkPayloadSetup setup) {
         listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(setup);
         listener.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(listener.getConnectionType());
         listener.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.CLIENTBOUND);
@@ -691,7 +691,7 @@ public class NetworkRegistry {
     /**
      * {@return the initial channels for the configuration phase.}
      */
-    private static Set<ResourceLocation> getInitialListeningChannels(PacketFlow flow) {
+    public static Set<ResourceLocation> getInitialListeningChannels(PacketFlow flow) {
         // TODO: Separate builtins by flow and return them appropriately here.
         return BUILTIN_PAYLOADS.keySet();
     }

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -46,6 +46,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.network.ServerConfigurationPacketListenerImpl;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.config.ConfigTracker;
+import net.neoforged.neoforge.common.extensions.ICommonPacketListener;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
@@ -65,6 +66,7 @@ import net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload;
 import net.neoforged.neoforge.network.payload.ModdedNetworkSetupFailedPayload;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 
 /**
@@ -171,7 +173,7 @@ public class NetworkRegistry {
     }
 
     /**
-     * Attempst to retrieve the {@link StreamCodec} for a non-vanilla payload.
+     * Attempts to retrieve the {@link StreamCodec} for a non-vanilla payload.
      * <p>
      * This method hardcodes NeoForge custom packets, stored in {@link #BUILTIN_PAYLOADS}, which may be sent before negotiation.
      * <p>
@@ -184,7 +186,7 @@ public class NetworkRegistry {
      * @param flow     The flow of the connection.
      * @return A codec for the payload, or null if the payload should be discarded on receipt.
      * 
-     * @see #hasChannel(Connection, ConnectionProtocol, ResourceLocation) to check if a packet can be sent/received.
+     * @see {@link #hasChannel(Connection, ConnectionProtocol, ResourceLocation)} to check if a packet can be sent/received.
      * @apiNote This method must not throw exceptions, as it is called within another codec on the network thread.
      */
     @Nullable
@@ -319,18 +321,18 @@ public class NetworkRegistry {
      * If the negotiation fails, a custom packet is sent to the client to inform it of the failure, and which will allow the client to disconnect gracefully with an indicative error screen.
      * <p>
      * This method should only be invoked for modded connections.
-     * Use {@link #onVanillaOrOtherConnectionDetectedAtServer} to indicate that during the configuration phase of the network handshake between a client and the server, a vanilla connection was detected.
+     * Use {@link #initializeOtherConnection(ServerConfigurationPacketListener)} to indicate that during the configuration phase of the network handshake between a client and the server, a vanilla connection was detected.
      * <p>
      * Invoked on the network thread.
      *
-     * @param sender        The listener which completed the negotiation.
+     * @param listener        The listener which completed the negotiation.
      * @param configuration The configuration channels that the client has available.
      * @param play          The play channels that the client has available.
      */
-    public static void initializeModdedConnection(ServerConfigurationPacketListener sender, Map<ConnectionProtocol, Set<ModdedNetworkQueryComponent>> clientChannels) {
-        sender.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(sender.getConnectionType());
-        sender.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
-        sender.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.SERVERBOUND);
+    public static void initializeNeoforgeConnection(ServerConfigurationPacketListener listener, Map<ConnectionProtocol, Set<ModdedNetworkQueryComponent>> clientChannels) {
+        listener.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(listener.getConnectionType());
+        listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
+        listener.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.SERVERBOUND);
 
         Map<ConnectionProtocol, NegotiationResult> results = new IdentityHashMap<>();
 
@@ -342,10 +344,10 @@ public class NetworkRegistry {
             // Negotiation failed. Disconnect the client.
             if (!negotiationResult.success()) {
                 if (!negotiationResult.failureReasons().isEmpty()) {
-                    sender.send(new ModdedNetworkSetupFailedPayload(negotiationResult.failureReasons()));
+                    listener.send(new ModdedNetworkSetupFailedPayload(negotiationResult.failureReasons()));
                 }
 
-                sender.disconnect(Component.translatable("multiplayer.disconnect.incompatible", "NeoForge %s".formatted(NeoForgeVersion.getVersion())));
+                listener.disconnect(Component.translatable("multiplayer.disconnect.incompatible", "NeoForge %s".formatted(NeoForgeVersion.getVersion())));
                 return;
             }
             results.put(protocol, negotiationResult);
@@ -353,30 +355,30 @@ public class NetworkRegistry {
 
         NetworkPayloadSetup setup = NetworkPayloadSetup.from(results);
 
-        sender.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(setup);
+        listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(setup);
 
-        NetworkFilters.injectIfNecessary(sender.getConnection());
+        NetworkFilters.injectIfNecessary(listener.getConnection());
 
-        sender.send(new ModdedNetworkPayload(setup));
+        listener.send(new ModdedNetworkPayload(setup));
         ImmutableSet.Builder<ResourceLocation> nowListeningOn = ImmutableSet.builder();
-        nowListeningOn.addAll(getInitialServerListeningChannels());
+        nowListeningOn.addAll(getInitialListeningChannels(listener.flow()));
         nowListeningOn.addAll(setup.getChannels(ConnectionProtocol.CONFIGURATION).keySet());
-        sender.send(new MinecraftRegisterPayload(nowListeningOn.build()));
+        listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
     }
 
     /**
      * Invoked by the {@link ServerConfigurationPacketListenerImpl} when a vanilla or other connection is detected.
      *
-     * @param sender The listener which detected the vanilla connection during the configuration phase.
+     * @param listener The listener which detected the vanilla connection during the configuration phase.
      * @return True if the vanilla connection should be handled by the server, false otherwise.
      */
-    public static boolean initializeNonModdedConnection(ServerConfigurationPacketListener sender) {
-        NetworkFilters.cleanIfNecessary(sender.getConnection());
+    public static boolean initializeOtherConnection(ServerConfigurationPacketListener listener) {
+        NetworkFilters.cleanIfNecessary(listener.getConnection());
 
         // Because we are in vanilla land, no matter what we are not able to support any custom channels.
-        sender.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(sender.getConnectionType());
-        sender.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
-        sender.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.SERVERBOUND);
+        listener.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(listener.getConnectionType());
+        listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
+        listener.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.SERVERBOUND);
 
         for (ConnectionProtocol protocol : PAYLOAD_REGISTRATIONS.keySet()) {
             NegotiationResult negotiationResult = NetworkComponentNegotiator.negotiate(
@@ -387,21 +389,21 @@ public class NetworkRegistry {
 
             //Negotiation failed. Disconnect the client.
             if (!negotiationResult.success()) {
-                sender.disconnect(Component.translatableWithFallback("neoforge.network.negotiation.failure.vanilla.client.not_supported",
+                listener.disconnect(Component.translatableWithFallback("neoforge.network.negotiation.failure.vanilla.client.not_supported",
                         "You are trying to connect to a server that is running NeoForge, but you are not. Please install NeoForge Version: %s to connect to this server.", NeoForgeVersion.getVersion()));
                 return false;
             }
         }
 
-        NetworkFilters.injectIfNecessary(sender.getConnection());
+        NetworkFilters.injectIfNecessary(listener.getConnection());
 
         ImmutableSet.Builder<ResourceLocation> nowListeningOn = ImmutableSet.builder();
-        nowListeningOn.addAll(getInitialClientListeningChannels());
+        nowListeningOn.addAll(getInitialListeningChannels(listener.flow()));
         PAYLOAD_REGISTRATIONS.get(ConnectionProtocol.CONFIGURATION).entrySet().stream()
-                .filter(registration -> registration.getValue().flow().isEmpty() || registration.getValue().flow().get() == PacketFlow.SERVERBOUND)
+                .filter(registration -> registration.getValue().matchesFlow(listener.flow()))
                 .filter(registration -> registration.getValue().optional())
                 .forEach(registration -> nowListeningOn.add(registration.getKey()));
-        sender.send(new MinecraftRegisterPayload(nowListeningOn.build()));
+        listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
 
         return true;
     }
@@ -475,7 +477,7 @@ public class NetworkRegistry {
      */
     private static boolean hasAdhocChannel(ConnectionProtocol protocol, ResourceLocation id, PacketFlow flow) {
         PayloadRegistration<?> reg = PAYLOAD_REGISTRATIONS.getOrDefault(protocol, Collections.emptyMap()).get(id);
-        return reg != null && reg.optional() && (reg.flow().isEmpty() || reg.flow().get() == flow);
+        return reg != null && reg.optional() && reg.matchesFlow(flow);
     }
 
     /**
@@ -501,7 +503,7 @@ public class NetworkRegistry {
      * @param configuration The configuration channels that were negotiated.
      * @param play          The play channels that were negotiated.
      */
-    public static void onModdedNetworkConnectionEstablished(ClientConfigurationPacketListener listener, NetworkPayloadSetup setup) {
+    public static void initializeNeoforgeConnection(ClientConfigurationPacketListener listener, NetworkPayloadSetup setup) {
         listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(setup);
         listener.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(listener.getConnectionType());
         listener.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.CLIENTBOUND);
@@ -510,7 +512,7 @@ public class NetworkRegistry {
         NetworkFilters.injectIfNecessary(listener.getConnection());
 
         final ImmutableSet.Builder<ResourceLocation> nowListeningOn = ImmutableSet.builder();
-        nowListeningOn.addAll(getInitialClientListeningChannels());
+        nowListeningOn.addAll(getInitialListeningChannels(listener.flow()));
         nowListeningOn.addAll(setup.getChannels(ConnectionProtocol.CONFIGURATION).keySet());
         listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
     }
@@ -521,18 +523,18 @@ public class NetworkRegistry {
      * If this happens then the client will do a negotiation of its own internal channel configuration, to check if any mods are installed that require a modded connection to the server.
      * If those are found then the connection is aborted and the client disconnects from the server.
      * <p>
-     * This method should never be invoked on a connection where the server is modded.
+     * This method should never be invoked on a connection where the server is {@link ConnectionType#NEOFORGE}.
      * <p>
      * Invoked on the network thread.
      *
-     * @param sender The listener which received the brand payload.
+     * @param listener The listener which received the brand payload.
      * @return True if the vanilla connection should be handled by the client, false otherwise.
      */
-    public static void initializeNonModdedConnection(ClientConfigurationPacketListener sender) {
+    public static void initializeOtherConnection(ClientConfigurationPacketListener listener) {
         // Because we are in vanilla land, no matter what we are not able to support any custom channels.
-        sender.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
-        sender.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(sender.getConnectionType());
-        sender.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.CLIENTBOUND);
+        listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).set(NetworkPayloadSetup.empty());
+        listener.getConnection().channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(listener.getConnectionType());
+        listener.getConnection().channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.CLIENTBOUND);
 
         for (ConnectionProtocol protocol : PAYLOAD_REGISTRATIONS.keySet()) {
             NegotiationResult negotiationResult = NetworkComponentNegotiator.negotiate(
@@ -543,7 +545,7 @@ public class NetworkRegistry {
 
             // Negotiation failed. Disconnect the client.
             if (!negotiationResult.success()) {
-                sender.getConnection().disconnect(Component.translatableWithFallback("neoforge.network.negotiation.failure.vanilla.server.not_supported",
+                listener.getConnection().disconnect(Component.translatableWithFallback("neoforge.network.negotiation.failure.vanilla.server.not_supported",
                         "You are trying to connect to a server that is not running NeoForge, but you have mods that require it. A connection could not be established.", NeoForgeVersion.getVersion()));
                 return;
             }
@@ -552,36 +554,25 @@ public class NetworkRegistry {
         // We are on the client, connected to a vanilla server, We have to load the default configs.
         ConfigTracker.INSTANCE.loadDefaultServerConfigs();
 
-        NetworkFilters.injectIfNecessary(sender.getConnection());
+        NetworkFilters.injectIfNecessary(listener.getConnection());
 
         ImmutableSet.Builder<ResourceLocation> nowListeningOn = ImmutableSet.builder();
-        nowListeningOn.addAll(getInitialClientListeningChannels());
+        nowListeningOn.addAll(getInitialListeningChannels(listener.flow()));
         PAYLOAD_REGISTRATIONS.get(ConnectionProtocol.CONFIGURATION).entrySet().stream()
-                .filter(registration -> registration.getValue().flow().isEmpty() || registration.getValue().flow().get() == PacketFlow.CLIENTBOUND)
+                .filter(registration -> registration.getValue().matchesFlow(listener.flow()))
                 .filter(registration -> registration.getValue().optional())
                 .forEach(registration -> nowListeningOn.add(registration.getKey()));
-        sender.send(new MinecraftRegisterPayload(nowListeningOn.build()));
+        listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
     }
 
     /**
-     * Indicates whether the server listener has a connection setup that can transmit the given payload id.
+     * Checks if the packet listener's connection can send/receive the given payload.
      *
      * @param listener  The listener to check.
      * @param payloadId The payload id to check.
      * @return True if the listener has a connection setup that can transmit the given payload id, false otherwise.
      */
-    public static boolean hasChannel(ServerCommonPacketListener listener, ResourceLocation payloadId) {
-        return hasChannel(listener.getConnection(), listener.protocol(), payloadId);
-    }
-
-    /**
-     * Indicates whether the client listener has a connection setup that can transmit the given payload id.
-     *
-     * @param listener  The listener to check.
-     * @param payloadId The payload id to check.
-     * @return True if the listener has a connection setup that can transmit the given payload id, false otherwise.
-     */
-    public static boolean hasChannel(ClientCommonPacketListener listener, ResourceLocation payloadId) {
+    public static boolean hasChannel(ICommonPacketListener listener, ResourceLocation payloadId) {
         return hasChannel(listener.getConnection(), listener.protocol(), payloadId);
     }
 
@@ -652,10 +643,11 @@ public class NetworkRegistry {
     }
 
     /**
-     * Configures a mock connection.
+     * Configures a mock connection for use in game tests. The mock connection will act as if the server and client are fully compatible and both NeoForge.
      *
      * @param connection The connection to configure.
      */
+    @VisibleForTesting
     public static void configureMockConnection(final Connection connection) {
         connection.channel().attr(ATTRIBUTE_CONNECTION_TYPE).set(ConnectionType.NEOFORGE);
         connection.channel().attr(ATTRIBUTE_FLOW).set(PacketFlow.SERVERBOUND);
@@ -697,9 +689,10 @@ public class NetworkRegistry {
     }
 
     /**
-     * {@return the initial channels that the server listens on during the configuration phase.}
+     * {@return the initial channels for the configuration phase.}
      */
-    public static Set<ResourceLocation> getInitialServerListeningChannels() {
+    private static Set<ResourceLocation> getInitialListeningChannels(PacketFlow flow) {
+        // TODO: Separate builtins by flow and return them appropriately here.
         return BUILTIN_PAYLOADS.keySet();
     }
 
@@ -714,56 +707,34 @@ public class NetworkRegistry {
         return nowForgottenChannels.build();
     }
 
-    private static Set<ResourceLocation> getInitialClientListeningChannels() {
-        return BUILTIN_PAYLOADS.keySet();
-    }
-
-    public static void onConfigurationFinished(ServerConfigurationPacketListener serverConfigurationPacketListener) {
-        final NetworkPayloadSetup setup = serverConfigurationPacketListener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).get();
-        if (setup == null) {
-            LOGGER.error("Somebody tried to finish the configuration phase of a connection that has not negotiated with the client. Not finishing configuration.");
-            return;
-        }
-
-        final ImmutableSet.Builder<ResourceLocation> notListeningAnymoreOn = ImmutableSet.builder();
-        notListeningAnymoreOn.addAll(getInitialServerListeningChannels());
-        notListeningAnymoreOn.addAll(setup.getChannels(ConnectionProtocol.CONFIGURATION).keySet());
-        serverConfigurationPacketListener.send(new MinecraftUnregisterPayload(notListeningAnymoreOn.build()));
-
-        final ImmutableSet.Builder<ResourceLocation> nowListeningOn = ImmutableSet.builder();
-        nowListeningOn.add(MinecraftRegisterPayload.ID);
-        nowListeningOn.add(MinecraftUnregisterPayload.ID);
-        if (serverConfigurationPacketListener.getConnectionType().isNotVanilla()) {
-            nowListeningOn.add(ModdedNetworkQueryPayload.ID);
-        } else {
-            PAYLOAD_REGISTRATIONS.get(ConnectionProtocol.PLAY).entrySet().stream()
-                    .filter(registration -> registration.getValue().flow().isEmpty() || registration.getValue().flow().get() == PacketFlow.SERVERBOUND)
-                    .filter(registration -> registration.getValue().optional())
-                    .forEach(registration -> nowListeningOn.add(registration.getKey()));
-        }
-        serverConfigurationPacketListener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
-    }
-
-    public static void onConfigurationFinished(ClientConfigurationPacketListener listener) {
+    /**
+     * Invoked when the configuration phase of a connection is completed.
+     * <p>
+     * Updates the ad-hoc channels to prepare for the game phase by removing the initial channels and building a new list based on the connection type.
+     * 
+     * @param listener
+     */
+    public static void onConfigurationFinished(ICommonPacketListener listener) {
         final NetworkPayloadSetup setup = listener.getConnection().channel().attr(ATTRIBUTE_PAYLOAD_SETUP).get();
         if (setup == null) {
-            LOGGER.error("Somebody tried to finish the configuration phase of a connection that has not negotiated with the server. Not finishing configuration.");
+            LOGGER.error("Somebody tried to finish the configuration phase of a connection that has not performed channel negotiation. Not finishing configuration.");
             return;
         }
 
         final ImmutableSet.Builder<ResourceLocation> notListeningAnymoreOn = ImmutableSet.builder();
-        notListeningAnymoreOn.addAll(getInitialClientListeningChannels());
+        notListeningAnymoreOn.addAll(getInitialListeningChannels(listener.flow()));
         notListeningAnymoreOn.addAll(setup.getChannels(ConnectionProtocol.CONFIGURATION).keySet());
         listener.send(new MinecraftUnregisterPayload(notListeningAnymoreOn.build()));
 
         final ImmutableSet.Builder<ResourceLocation> nowListeningOn = ImmutableSet.builder();
         nowListeningOn.add(MinecraftRegisterPayload.ID);
         nowListeningOn.add(MinecraftUnregisterPayload.ID);
-        if (listener.getConnectionType().isNotVanilla()) {
+        if (listener.getConnectionType().isNeoForge()) {
             nowListeningOn.add(ModdedNetworkQueryPayload.ID);
         } else {
+            // For non-Neo connections, send the registered channels
             PAYLOAD_REGISTRATIONS.get(ConnectionProtocol.PLAY).entrySet().stream()
-                    .filter(registration -> registration.getValue().flow().isEmpty() || registration.getValue().flow().get() == PacketFlow.CLIENTBOUND)
+                    .filter(registration -> registration.getValue().matchesFlow(listener.flow()))
                     .filter(registration -> registration.getValue().optional())
                     .forEach(registration -> nowListeningOn.add(registration.getKey()));
         }

--- a/src/main/java/net/neoforged/neoforge/network/registration/PayloadRegistration.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/PayloadRegistration.java
@@ -40,4 +40,11 @@ public record PayloadRegistration<T extends CustomPacketPayload>(
     public ResourceLocation id() {
         return this.type().id();
     }
+
+    /**
+     * {@return true if the registered flow is compatible with the passed flow}
+     */
+    public boolean matchesFlow(PacketFlow flow) {
+        return this.flow.isEmpty() || this.flow.get() == flow;
+    }
 }


### PR DESCRIPTION
This PR further simplifies some logic in the network paths. This was done by flattening some more identical code paths in `NetworkRegistry` (by using the new `ICommonPacketListener` interface), and removing `ConnectionType.VANILLA`.

The latter change requires further explanation:

Prior to this change, there are three possible connection types: `VANILLA`, `OTHER`, and `NEOFORGE`.  A connection is considered to be vanilla if a `minecraft:register` payload is not sent, but this is not an accurate representation. The other end may _not_ be vanilla, and still not send a `minecraft:register` payload, so having a separate `VANILLA` connection type is misleading.  There was no logic that depended on the vanilla state, so collapsing the handling logic to "Neo vs non-Neo" makes it easier to understand (and is more representable of the actual scenario).

Further, treating all non-Neo connections as "Other" allows us to enter the modded payload processing step for any non-`minecraft` payloads, which provides better error messages, and permits functionality to execute as _expected_ if the other side has a poor implementation of `minecraft:register`, permitting primitive one-way communication.