### PR TITLE
Force ArmorMaterial registry event to fire before Items.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -120,6 +120,7 @@ public class GameData {
         Set<ResourceLocation> ordered = new LinkedHashSet<>();
         ordered.add(Registries.ATTRIBUTE.location()); // Vanilla order is incorrect, both Item and MobEffect depend on Attribute at construction time.
         ordered.add(Registries.DATA_COMPONENT_TYPE.location()); // Vanilla order is incorrect, Item depends on data components at construction time.
+        ordered.add(Registries.ARMOR_MATERIAL.location()); // Vanilla order is incorrect, ArmorItem depends on armor materials at construction time.
         ordered.addAll(BuiltInRegistries.getVanillaRegistrationOrder());
         ordered.addAll(BuiltInRegistries.REGISTRY.keySet().stream().sorted(ResourceLocation::compareNamespaced).toList());
         return ordered;


### PR DESCRIPTION
It's a bit of a corner case, but I need to have ArmorMaterials available while registering items, for Json Things purposes.

The alternative for me would be painful and ugly, while this is nice and simple, and technically more correct than what we have now.