### PR TITLE
Entity attachment copy fix

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
@@ -401,6 +401,6 @@ public interface IEntityExtension extends INBTSerializable<CompoundTag> {
      *                if {@code false}, all serializable attachments are copied.
      */
     default void copyAttachmentsFrom(Entity other, boolean isDeath) {
-        AttachmentInternals.copyEntityAttachments(self(), other, isDeath);
+        AttachmentInternals.copyEntityAttachments(other, self(), isDeath);
     }
 }


### PR DESCRIPTION
There was a fault in `IEntityExtension.copyAttachmentsFrom(...)` which made it not work as intended. This PR fixes that.
Also adds a test that checks attachment copying mechanisms on player respawn, which fails without the fix.