### PR TITLE
Fix incorrect parameter patch in LevelSettings

### DIFF
--- a/patches/net/minecraft/world/level/LevelSettings.java.patch
+++ b/patches/net/minecraft/world/level/LevelSettings.java.patch
@@ -49,7 +49,7 @@
  
      public LevelSettings withDataConfiguration(WorldDataConfiguration p_250867_) {
 -        return new LevelSettings(this.levelName, this.gameType, this.hardcore, this.difficulty, this.allowCommands, this.gameRules, p_250867_);
-+        return new LevelSettings(this.levelName, this.gameType, this.hardcore, this.difficulty, this.allowCommands, this.gameRules, dataConfiguration, this.lifecycle);
++        return new LevelSettings(this.levelName, this.gameType, this.hardcore, this.difficulty, this.allowCommands, this.gameRules, p_250867_, this.lifecycle);
      }
  
      public LevelSettings copy() {


### PR DESCRIPTION
This PR fixes #857 by fixing an incorrect patch to `LevelSettings` which was causing a field to be used rather than the parameter in the `withDataConfiguration` method, meaning the method had no effect.

