### PR TITLE
Allow multiple of same itemstack for BuildCreativeModeTabContentsEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -66,7 +66,6 @@ import net.minecraft.world.entity.projectile.ThrownEnderpearl;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackLinkedSet;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -989,13 +989,7 @@ public class EventHooks {
      */
     @ApiStatus.Internal
     public static void onCreativeModeTabBuildContents(CreativeModeTab tab, ResourceKey<CreativeModeTab> tabKey, CreativeModeTab.DisplayItemsGenerator originalGenerator, CreativeModeTab.ItemDisplayParameters params, CreativeModeTab.Output output) {
-        final var entries = new MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility>(ItemStackLinkedSet.TYPE_AND_TAG,
-                (key, left, right) -> {
-                    //throw new IllegalStateException("Accidentally adding the same item stack twice " + key.getDisplayName().getString() + " to a Creative Mode Tab: " + tab.getDisplayName().getString());
-                    // Vanilla adds enchanting books twice in both visibilities.
-                    // This is just code cleanliness for them. For us lets just increase the visibility and merge the entries.
-                    return CreativeModeTab.TabVisibility.PARENT_AND_SEARCH_TABS;
-                });
+        final var entries = new MutableHashedLinkedMap<ItemStack, CreativeModeTab.TabVisibility>();
 
         originalGenerator.accept(params, (stack, vis) -> {
             if (stack.getCount() != 1)


### PR DESCRIPTION
Fixes https://github.com/neoforged/NeoForge/issues/886

The issue is vanilla adds the max level enchanting books twice. The first time, it adds all max level enchantments for the main creative menu as PARENT_TAB_ONLY. Then it adds all levels of the enchanting books (including the max level again) for the search as SEARCH_TAB_ONLY. It is done this way so that the max level shows in main tab and in search, every enchanting book shows up in increasing level order for same enchantment. 

To support this, the itemstack type/tag merging in the backing map for BuildCreativeModeTabContentsEvent has to be removed. This also allows modders to do similar setup like vanilla does for ordering for specific tabs using same itemstack.