### PR TITLE
Fire Villager/Wandering Trader trade events on /reload

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
@@ -34,8 +34,10 @@ public class VillagerTradingManager {
     }
 
     static void loadTrades(TagsUpdatedEvent e) {
-        postWandererEvent();
-        postVillagerEvents();
+        if (e.getUpdateCause() == TagsUpdatedEvent.UpdateCause.SERVER_DATA_LOAD) {
+            postWandererEvent();
+            postVillagerEvents();
+        }
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
@@ -16,7 +16,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.npc.VillagerProfession;
 import net.minecraft.world.entity.npc.VillagerTrades;
 import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
-import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
+import net.neoforged.neoforge.event.TagsUpdatedEvent;
 import net.neoforged.neoforge.event.village.VillagerTradesEvent;
 import net.neoforged.neoforge.event.village.WandererTradesEvent;
 
@@ -33,7 +33,7 @@ public class VillagerTradingManager {
         VillagerTrades.WANDERING_TRADER_TRADES.int2ObjectEntrySet().forEach(e -> WANDERER_TRADES.put(e.getIntKey(), Arrays.copyOf(e.getValue(), e.getValue().length)));
     }
 
-    static void loadTrades(ServerAboutToStartEvent e) {
+    static void loadTrades(TagsUpdatedEvent e) {
         postWandererEvent();
         postVillagerEvents();
     }
@@ -62,7 +62,7 @@ public class VillagerTradingManager {
                 mutableTrades.put(i, NonNullList.create());
             }
             trades.int2ObjectEntrySet().forEach(e -> {
-                Arrays.stream(e.getValue()).forEach(mutableTrades.get(e.getIntKey())::add);
+               Arrays.stream(e.getValue()).forEach(mutableTrades.get(e.getIntKey())::add);
             });
             NeoForge.EVENT_BUS.post(new VillagerTradesEvent(mutableTrades, prof));
             Int2ObjectMap<ItemListing[]> newTrades = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/VillagerTradingManager.java
@@ -62,7 +62,7 @@ public class VillagerTradingManager {
                 mutableTrades.put(i, NonNullList.create());
             }
             trades.int2ObjectEntrySet().forEach(e -> {
-               Arrays.stream(e.getValue()).forEach(mutableTrades.get(e.getIntKey())::add);
+                Arrays.stream(e.getValue()).forEach(mutableTrades.get(e.getIntKey())::add);
             });
             NeoForge.EVENT_BUS.post(new VillagerTradesEvent(mutableTrades, prof));
             Int2ObjectMap<ItemListing[]> newTrades = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/net/neoforged/neoforge/event/village/VillagerTradesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/VillagerTradesEvent.java
@@ -13,10 +13,11 @@ import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
 import net.neoforged.bus.api.Event;
 import net.neoforged.neoforge.common.BasicItemListing;
 import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.TagsUpdatedEvent;
 import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 
 /**
- * VillagerTradesEvent is fired during the {@link ServerAboutToStartEvent}. It is used to gather the trade lists for each profession.
+ * VillagerTradesEvent is fired during reload by {@link TagsUpdatedEvent}. It is used to gather the trade lists for each profession.
  * It is fired on the {@link NeoForge#EVENT_BUS}.
  * It is fired once for each registered villager profession.
  * Villagers pick two trades from their trade map, based on their level.

--- a/src/main/java/net/neoforged/neoforge/event/village/VillagerTradesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/VillagerTradesEvent.java
@@ -14,7 +14,6 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.neoforge.common.BasicItemListing;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
-import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 
 /**
  * VillagerTradesEvent is fired during reload by {@link TagsUpdatedEvent}. It is used to gather the trade lists for each profession.

--- a/src/main/java/net/neoforged/neoforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/WandererTradesEvent.java
@@ -10,10 +10,11 @@ import net.minecraft.world.entity.npc.VillagerTrades.ItemListing;
 import net.neoforged.bus.api.Event;
 import net.neoforged.neoforge.common.BasicItemListing;
 import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.TagsUpdatedEvent;
 import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 
 /**
- * WandererTradesEvent is fired during the {@link ServerAboutToStartEvent}. It is used to gather the trade lists for the wandering merchant.
+ * WandererTradesEvent is fired during reload by {@link TagsUpdatedEvent}. It is used to gather the trade lists for the wandering merchant.
  * It is fired on the {@link NeoForge#EVENT_BUS}.
  * The wandering merchant picks a few trades from {@code generic} and a single trade from {@code rare}.
  * To add trades to the merchant, simply add new trades to the list. {@link BasicItemListing} provides a default implementation.

--- a/src/main/java/net/neoforged/neoforge/event/village/WandererTradesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/WandererTradesEvent.java
@@ -11,7 +11,6 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.neoforge.common.BasicItemListing;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
-import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 
 /**
  * WandererTradesEvent is fired during reload by {@link TagsUpdatedEvent}. It is used to gather the trade lists for the wandering merchant.


### PR DESCRIPTION
Fixes https://github.com/neoforged/NeoForge/issues/721

Fired on tag updated event to make sure all tags are ready for use in case modders are using tags in their trade events.