### PR TITLE
[20.6] Add tooltip helper for data component types

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
@@ -5,9 +5,14 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentHolder;
 import net.minecraft.core.component.DataComponentType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipProvider;
 import org.jetbrains.annotations.Nullable;
 
 public interface IDataComponentHolderExtension {
@@ -26,5 +31,16 @@ public interface IDataComponentHolderExtension {
 
     default boolean has(Supplier<? extends DataComponentType<?>> type) {
         return self().has(type.get());
+    }
+
+    default <T extends TooltipProvider> void addToTooltip(DataComponentType<T> type, Item.TooltipContext context, Consumer<Component> adder, TooltipFlag flag) {
+        var value = self().get(type);
+
+        if (value != null)
+            value.addToTooltip(context, adder, flag);
+    }
+
+    default <T extends TooltipProvider> void addToTooltip(Supplier<? extends DataComponentType<T>> type, Item.TooltipContext context, Consumer<Component> adder, TooltipFlag flag) {
+        addToTooltip(type.get(), context, adder, flag);
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -541,3 +541,4 @@ public com.mojang.blaze3d.vertex.VertexFormatElement$Usage$SetupState
 public com.mojang.blaze3d.vertex.VertexFormatElement$Usage$ClearState
 public net.minecraft.world.level.block.LiquidBlock fluid
 public net.minecraft.world.item.BucketItem content
+public net.minecraft.world.item.ItemStack addToTooltip(Lnet/minecraft/core/component/DataComponentType;Lnet/minecraft/world/item/Item$TooltipContext;Ljava/util/function/Consumer;Lnet/minecraft/world/item/TooltipFlag;)V


### PR DESCRIPTION
Copies out the private tooltip helper from ItemStack to allow it to be used with any DataComponetHolder type

AT updated to make the ItemStack method public, this is needed as it is now overriding the super method from the interface