### PR TITLE
[20.6] Add tick level extension method to expose the client/server method for common usage

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -7,6 +7,8 @@ package net.neoforged.neoforge.common.extensions;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.BooleanSupplier;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
@@ -16,6 +18,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.client.model.data.ModelDataManager;
 import net.neoforged.neoforge.entity.PartEntity;
+import net.neoforged.neoforge.event.tick.LevelTickEvent;
 import org.jetbrains.annotations.Nullable;
 
 public interface ILevelExtension {
@@ -105,4 +108,17 @@ public interface ILevelExtension {
      * but it is safe to call on any {@link Level}, without the need for an {@code instanceof} check.
      */
     default void invalidateCapabilities(ChunkPos pos) {}
+
+    /**
+     * Run a full single level tick.
+     *
+     * Wrapper method to expose the common method from {@linkplain ClientLevel} and {@linkplain ServerLevel},
+     * useful for ticking fake levels to update block/entity render animations.
+     *
+     * This method does not post the {@linkplain LevelTickEvent.Pre} or {@linkplain LevelTickEvent.Post} events,
+     * modders should post these events themselves before and after invoking this method.
+     */
+    default void tick(BooleanSupplier hasTime) {
+        // No-op default impl
+    }
 }


### PR DESCRIPTION
Adds a simple tick method to `ILevelExtensions` that exposes the server/client level implementation. This allows modders to easily tick levels without requiring a full `ClientLevel` or `ServerLevel`. The method is particularly useful for rendering fake levels, where it ticks all the blocks/entities and updates animations.

Note that the default implementation does nothing, as `ClientLevel` and `ServerLevel` override the method to correctly handle level ticking.

If you’re using this method, keep in mind that level tick events are not posted during its invocation; they occur right before or after the method call in vanilla code.
For modded fake levels, consider posting the events accordingly.