### PR TITLE
[1.20.4] "override" field for solving overlaps in recipe ingredients and patterns.

### DIFF
--- a/patches/net/minecraft/data/recipes/ShapedRecipeBuilder.java.patch
+++ b/patches/net/minecraft/data/recipes/ShapedRecipeBuilder.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/recipes/ShapedRecipeBuilder.java
 +++ b/net/minecraft/data/recipes/ShapedRecipeBuilder.java
-@@ -25,6 +_,7 @@
+@@ -25,17 +_,25 @@
      private final RecipeCategory category;
      private final Item result;
      private final int count;
@@ -8,7 +8,10 @@
      private final List<String> rows = Lists.newArrayList();
      private final Map<Character, Ingredient> key = Maps.newLinkedHashMap();
      private final Map<String, Criterion<?>> criteria = new LinkedHashMap<>();
-@@ -33,9 +_,14 @@
+     @Nullable
+     private String group;
++    @Nullable
++    private String override;
      private boolean showNotification = true;
  
      public ShapedRecipeBuilder(RecipeCategory p_249996_, ItemLike p_251475_, int p_248948_) {
@@ -36,12 +39,27 @@
      public ShapedRecipeBuilder define(Character p_206417_, TagKey<Item> p_206418_) {
          return this.define(p_206417_, Ingredient.of(p_206418_));
      }
-@@ -106,7 +_,7 @@
+@@ -79,6 +_,11 @@
+         return this;
+     }
+ 
++    public ShapedRecipeBuilder override(@Nullable String override) {
++        this.override = override;
++        return this;
++    }
++
+     public ShapedRecipeBuilder group(@Nullable String p_126146_) {
+         this.group = p_126146_;
+         return this;
+@@ -106,8 +_,9 @@
              Objects.requireNonNullElse(this.group, ""),
              RecipeBuilder.determineBookCategory(this.category),
              shapedrecipepattern,
 -            new ItemStack(this.result, this.count),
+-            this.showNotification
 +            this.resultStack,
-             this.showNotification
++            this.showNotification,
++            Objects.requireNonNullElse(this.override, "")
          );
          p_301098_.accept(p_126142_, shapedrecipe, advancement$builder.build(p_126142_.withPrefix("recipes/" + this.category.getFolderName() + "/")));
+     }

--- a/patches/net/minecraft/data/recipes/ShapelessRecipeBuilder.java.patch
+++ b/patches/net/minecraft/data/recipes/ShapelessRecipeBuilder.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/recipes/ShapelessRecipeBuilder.java
 +++ b/net/minecraft/data/recipes/ShapelessRecipeBuilder.java
-@@ -22,15 +_,21 @@
+@@ -22,15 +_,23 @@
      private final RecipeCategory category;
      private final Item result;
      private final int count;
@@ -9,6 +9,8 @@
      private final Map<String, Criterion<?>> criteria = new LinkedHashMap<>();
      @Nullable
      private String group;
++    @Nullable
++    private String override;
  
      public ShapelessRecipeBuilder(RecipeCategory p_250837_, ItemLike p_251897_, int p_252227_) {
 +        this(p_250837_, new ItemStack(p_251897_, p_252227_));
@@ -35,12 +37,27 @@
      public ShapelessRecipeBuilder requires(TagKey<Item> p_206420_) {
          return this.requires(Ingredient.of(p_206420_));
      }
-@@ -95,7 +_,7 @@
+@@ -74,6 +_,11 @@
+         return this;
+     }
+ 
++    public ShapelessRecipeBuilder override(@Nullable String override) {
++        this.override = override;
++        return this;
++    }
++
+     public ShapelessRecipeBuilder group(@Nullable String p_126195_) {
+         this.group = p_126195_;
+         return this;
+@@ -95,8 +_,9 @@
          ShapelessRecipe shapelessrecipe = new ShapelessRecipe(
              Objects.requireNonNullElse(this.group, ""),
              RecipeBuilder.determineBookCategory(this.category),
 -            new ItemStack(this.result, this.count),
+-            this.ingredients
 +            this.resultStack,
-             this.ingredients
++            this.ingredients,
++            Objects.requireNonNullElse(this.override, "")
          );
          p_301215_.accept(p_126206_, shapelessrecipe, advancement$builder.build(p_126206_.withPrefix("recipes/" + this.category.getFolderName() + "/")));
+     }

--- a/patches/net/minecraft/data/recipes/SimpleCookingRecipeBuilder.java.patch
+++ b/patches/net/minecraft/data/recipes/SimpleCookingRecipeBuilder.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/recipes/SimpleCookingRecipeBuilder.java
 +++ b/net/minecraft/data/recipes/SimpleCookingRecipeBuilder.java
-@@ -27,6 +_,7 @@
+@@ -27,13 +_,18 @@
      private final RecipeCategory category;
      private final CookingBookCategory bookCategory;
      private final Item result;
@@ -8,10 +8,28 @@
      private final Ingredient ingredient;
      private final float experience;
      private final int cookingTime;
-@@ -44,9 +_,22 @@
+     private final Map<String, Criterion<?>> criteria = new LinkedHashMap<>();
+     @Nullable
+     private String group;
++    @Nullable
++    private String override;
+     private final AbstractCookingRecipe.Factory<?> factory;
++    @Nullable
++    private final AbstractCookingRecipe.NeoForgeFactory<?> neoForgeFactory;
+ 
+     private SimpleCookingRecipeBuilder(
+         RecipeCategory p_251345_,
+@@ -44,13 +_,59 @@
          int p_250189_,
          AbstractCookingRecipe.Factory<?> p_311960_
      ) {
+-        this.category = p_251345_;
+-        this.bookCategory = p_251607_;
+-        this.result = p_252112_.asItem();
+-        this.ingredient = p_250362_;
+-        this.experience = p_251204_;
+-        this.cookingTime = p_250189_;
+-        this.factory = p_311960_;
 +        this(p_251345_, p_251607_, new ItemStack(p_252112_), p_250362_, p_251204_, p_250189_, p_311960_);
 +    }
 +
@@ -24,15 +42,51 @@
 +            int p_250189_,
 +            AbstractCookingRecipe.Factory<?> p_311960_
 +    ) {
-         this.category = p_251345_;
-         this.bookCategory = p_251607_;
--        this.result = p_252112_.asItem();
++        this.category = p_251345_;
++        this.bookCategory = p_251607_;
 +        this.result = result.getItem();
 +        this.stackResult = result;
-         this.ingredient = p_250362_;
-         this.experience = p_251204_;
-         this.cookingTime = p_250189_;
-@@ -85,6 +_,38 @@
++        this.ingredient = p_250362_;
++        this.experience = p_251204_;
++        this.cookingTime = p_250189_;
++        this.factory = p_311960_;
++        this.neoForgeFactory = null;
++    }
++
++    private SimpleCookingRecipeBuilder(
++            RecipeCategory p_251345_,
++            CookingBookCategory p_251607_,
++            ItemLike p_252112_,
++            Ingredient p_250362_,
++            float p_251204_,
++            int p_250189_,
++            AbstractCookingRecipe.NeoForgeFactory<?> p_311960_
++    ) {
++        this(p_251345_, p_251607_, new ItemStack(p_252112_), p_250362_, p_251204_, p_250189_, p_311960_);
++    }
++
++    private SimpleCookingRecipeBuilder(
++            RecipeCategory p_251345_,
++            CookingBookCategory p_251607_,
++            ItemStack result,
++            Ingredient p_250362_,
++            float p_251204_,
++            int p_250189_,
++            AbstractCookingRecipe.NeoForgeFactory<?> p_311960_
++    ) {
++        this.category = p_251345_;
++        this.bookCategory = p_251607_;
++        this.result = result.getItem();
++        this.stackResult = result;
++        this.ingredient = p_250362_;
++        this.experience = p_251204_;
++        this.cookingTime = p_250189_;
++        this.factory = p_311960_;
++        this.neoForgeFactory = p_311960_;
+     }
+ 
+     public static <T extends AbstractCookingRecipe> SimpleCookingRecipeBuilder generic(
+@@ -85,11 +_,48 @@
          return new SimpleCookingRecipeBuilder(p_250319_, CookingBookCategory.FOOD, p_250377_, p_248930_, p_252329_, p_250482_, SmokingRecipe::new);
      }
  
@@ -71,12 +125,38 @@
      public SimpleCookingRecipeBuilder unlockedBy(String p_176792_, Criterion<?> p_300970_) {
          this.criteria.put(p_176792_, p_300970_);
          return this;
-@@ -110,7 +_,7 @@
+     }
+ 
++    public SimpleCookingRecipeBuilder override(@Nullable String override) {
++        this.override = override;
++        return this;
++    }
++
+     public SimpleCookingRecipeBuilder group(@Nullable String p_176795_) {
+         this.group = p_176795_;
+         return this;
+@@ -108,10 +_,20 @@
+             .rewards(AdvancementRewards.Builder.recipe(p_126264_))
+             .requirements(AdvancementRequirements.Strategy.OR);
          this.criteria.forEach(advancement$builder::addCriterion);
-         AbstractCookingRecipe abstractcookingrecipe = this.factory
-             .create(
+-        AbstractCookingRecipe abstractcookingrecipe = this.factory
+-            .create(
 -                Objects.requireNonNullElse(this.group, ""), this.bookCategory, this.ingredient, new ItemStack(this.result), this.experience, this.cookingTime
-+                Objects.requireNonNullElse(this.group, ""), this.bookCategory, this.ingredient, this.stackResult, this.experience, this.cookingTime
-             );
+-            );
++        AbstractCookingRecipe abstractcookingrecipe;
++        if (this.neoForgeFactory != null) {
++            abstractcookingrecipe = this.neoForgeFactory
++                    .create(
++                            Objects.requireNonNullElse(this.group, ""), this.bookCategory, this.ingredient, this.stackResult, this.experience, this.cookingTime, Objects.requireNonNullElse(this.override, "")
++                    );
++        } else {
++            abstractcookingrecipe = this.factory
++                    .create(
++                            Objects.requireNonNullElse(this.group, ""), this.bookCategory, this.ingredient, this.stackResult, this.experience, this.cookingTime
++                    );
++        }
++
++
          p_301266_.accept(p_126264_, abstractcookingrecipe, advancement$builder.build(p_126264_.withPrefix("recipes/" + this.category.getFolderName() + "/")));
      }
+ 

--- a/patches/net/minecraft/world/item/crafting/AbstractCookingRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/AbstractCookingRecipe.java.patch
@@ -1,0 +1,48 @@
+--- a/net/minecraft/world/item/crafting/AbstractCookingRecipe.java
++++ b/net/minecraft/world/item/crafting/AbstractCookingRecipe.java
+@@ -14,6 +_,7 @@
+     protected final ItemStack result;
+     protected final float experience;
+     protected final int cookingTime;
++    String override;
+ 
+     public AbstractCookingRecipe(
+         RecipeType<?> p_250197_, String p_249518_, CookingBookCategory p_250891_, Ingredient p_251354_, ItemStack p_252185_, float p_252165_, int p_250256_
+@@ -27,6 +_,14 @@
+         this.cookingTime = p_250256_;
+     }
+ 
++    public AbstractCookingRecipe(
++            RecipeType<?> type, String group, CookingBookCategory category, Ingredient ingredient, ItemStack result, float experience, int cookingTime, String override
++    ) {
++        this(type, group, category, ingredient, result, experience, cookingTime);
++        this.override = override;
++
++    }
++
+     @Override
+     public boolean matches(Container p_43748_, Level p_43749_) {
+         return this.ingredient.test(p_43748_.getItem(0));
+@@ -59,6 +_,11 @@
+     }
+ 
+     @Override
++    public String getOverride() {
++        return this.override;
++    }
++
++    @Override
+     public String getGroup() {
+         return this.group;
+     }
+@@ -74,6 +_,10 @@
+ 
+     public CookingBookCategory category() {
+         return this.category;
++    }
++
++    public interface NeoForgeFactory<T extends AbstractCookingRecipe> extends Factory<T> {
++        T create(String p_312581_, CookingBookCategory p_312220_, Ingredient p_312282_, ItemStack p_311868_, float p_312803_, int p_312165_, String override);
+     }
+ 
+     public interface Factory<T extends AbstractCookingRecipe> {

--- a/patches/net/minecraft/world/item/crafting/BlastingRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/BlastingRecipe.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/crafting/BlastingRecipe.java
++++ b/net/minecraft/world/item/crafting/BlastingRecipe.java
+@@ -8,6 +_,10 @@
+         super(RecipeType.BLASTING, p_251053_, p_249936_, p_251550_, p_251027_, p_250843_, p_249841_);
+     }
+ 
++    public BlastingRecipe(String p_251053_, CookingBookCategory p_249936_, Ingredient p_251550_, ItemStack p_251027_, float p_250843_, int p_249841_, String override) {
++        super(RecipeType.BLASTING, p_251053_, p_249936_, p_251550_, p_251027_, p_250843_, p_249841_, override);
++    }
++
+     @Override
+     public ItemStack getToastSymbol() {
+         return new ItemStack(Blocks.BLAST_FURNACE);

--- a/patches/net/minecraft/world/item/crafting/CampfireCookingRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/CampfireCookingRecipe.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/crafting/CampfireCookingRecipe.java
++++ b/net/minecraft/world/item/crafting/CampfireCookingRecipe.java
+@@ -8,6 +_,10 @@
+         super(RecipeType.CAMPFIRE_COOKING, p_250140_, p_251808_, p_249826_, p_251839_, p_251432_, p_251471_);
+     }
+ 
++    public CampfireCookingRecipe(String p_250140_, CookingBookCategory p_251808_, Ingredient p_249826_, ItemStack p_251839_, float p_251432_, int p_251471_, String override) {
++        super(RecipeType.CAMPFIRE_COOKING, p_250140_, p_251808_, p_249826_, p_251839_, p_251432_, p_251471_, override);
++    }
++
+     @Override
+     public ItemStack getToastSymbol() {
+         return new ItemStack(Blocks.CAMPFIRE);

--- a/patches/net/minecraft/world/item/crafting/Recipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Recipe.java.patch
@@ -20,6 +20,17 @@
              }
          }
  
+@@ -46,6 +_,10 @@
+         return true;
+     }
+ 
++    default String getOverride() {
++        return "";
++    }
++
+     default String getGroup() {
+         return "";
+     }
 @@ -60,6 +_,6 @@
  
      default boolean isIncomplete() {

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -1,12 +1,14 @@
 --- a/net/minecraft/world/item/crafting/RecipeManager.java
 +++ b/net/minecraft/world/item/crafting/RecipeManager.java
-@@ -45,17 +_,23 @@
+@@ -45,23 +_,40 @@
      }
  
      protected void apply(Map<ResourceLocation, JsonElement> p_44037_, ResourceManager p_44038_, ProfilerFiller p_44039_) {
 +        var ops = this.makeConditionalOps();
          this.hasErrors = false;
-         Map<RecipeType<?>, Builder<ResourceLocation, RecipeHolder<?>>> map = Maps.newHashMap();
+-        Map<RecipeType<?>, Builder<ResourceLocation, RecipeHolder<?>>> map = Maps.newHashMap();
++        Map<RecipeType<?>, net.neoforged.neoforge.common.util.MutableHashedLinkedMap<ResourceLocation, RecipeHolder<?>>> map = Maps.newLinkedHashMap();
++        Map<RecipeType<?>, List<RecipeHolder<?>>> overrides = Maps.newLinkedHashMap();
          Builder<ResourceLocation, RecipeHolder<?>> builder = ImmutableMap.builder();
  
          for(Entry<ResourceLocation, JsonElement> entry : p_44037_.entrySet()) {
@@ -19,7 +21,11 @@
 -                builder.put(resourcelocation, recipeholder);
 +                Optional<RecipeHolder<?>> recipeHolderOptional = fromJson(resourcelocation, GsonHelper.convertToJsonObject(entry.getValue(), "top element"), ops);
 +                recipeHolderOptional.ifPresentOrElse(recipeholder -> {
-+                    map.computeIfAbsent(recipeholder.value().getType(), p_44075_ -> ImmutableMap.builder()).put(resourcelocation, recipeholder);
++                    if (recipeholder.value().getOverride() == null || recipeholder.value().getOverride().isEmpty()) {
++                        map.computeIfAbsent(recipeholder.value().getType(), p_44075_ -> new net.neoforged.neoforge.common.util.MutableHashedLinkedMap<>()).put(resourcelocation, recipeholder);
++                    } else {
++                        overrides.computeIfAbsent(recipeholder.value().getType(), p_44075_ -> new java.util.ArrayList<>()).add(recipeholder);
++                    }
 +                    builder.put(resourcelocation, recipeholder);
 +                }, () -> {
 +                    LOGGER.debug("Skipping loading recipe {} as it's conditions were not met", resourcelocation);
@@ -27,6 +33,19 @@
              } catch (IllegalArgumentException | JsonParseException jsonparseexception) {
                  LOGGER.error("Parsing error loading recipe {}", resourcelocation, jsonparseexception);
              }
+         }
+ 
+-        this.recipes = map.entrySet().stream().collect(ImmutableMap.toImmutableMap(Entry::getKey, p_44033_ -> ((Builder)p_44033_.getValue()).build()));
++        overrides.forEach((key, value) -> value.forEach((entry) -> { //todo safety checks
++            if (map.containsKey(key) && map.get(key).contains(new ResourceLocation(entry.value().getOverride()))) {
++                map.get(key).putBefore(new ResourceLocation(entry.value().getOverride()), entry.id(), entry);
++            }
++        }));
++
++        this.recipes = map.entrySet().stream().collect(ImmutableMap.toImmutableMap((e) -> e.getKey(), (e) -> ImmutableMap.copyOf(e.getValue())));
+         this.byName = builder.build();
+         LOGGER.info("Loaded {} recipes", map.size());
+     }
 @@ -136,9 +_,15 @@
          return this.recipes.values().stream().flatMap(p_220258_ -> p_220258_.keySet().stream());
      }

--- a/patches/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/crafting/ShapedRecipe.java
 +++ b/net/minecraft/world/item/crafting/ShapedRecipe.java
-@@ -11,7 +_,7 @@
+@@ -11,12 +_,13 @@
  import net.minecraft.world.item.ItemStack;
  import net.minecraft.world.level.Level;
  
@@ -9,7 +9,34 @@
      final ShapedRecipePattern pattern;
      final ItemStack result;
      final String group;
-@@ -41,11 +_,21 @@
+     final CraftingBookCategory category;
+     final boolean showNotification;
++    String override;
+ 
+     public ShapedRecipe(String p_272759_, CraftingBookCategory p_273506_, ShapedRecipePattern p_312827_, ItemStack p_272852_, boolean p_312010_) {
+         this.group = p_272759_;
+@@ -30,22 +_,42 @@
+         this(p_250221_, p_250716_, p_312814_, p_248581_, true);
+     }
+ 
++    public ShapedRecipe(String group, CraftingBookCategory category, ShapedRecipePattern pattern, ItemStack result, boolean showNotification, String override) {
++        this(group, category, pattern, result, showNotification);
++        this.override = override;
++    }
++
+     @Override
+     public RecipeSerializer<?> getSerializer() {
+         return RecipeSerializer.SHAPED_RECIPE;
+     }
+ 
+     @Override
++    public String getOverride() {
++        return this.override;
++    }
++
++    @Override
+     public String getGroup() {
+         return this.group;
      }
  
      @Override
@@ -40,3 +67,31 @@
      }
  
      public static class Serializer implements RecipeSerializer<ShapedRecipe> {
+@@ -94,7 +_,8 @@
+                         CraftingBookCategory.CODEC.fieldOf("category").orElse(CraftingBookCategory.MISC).forGetter(p_311732_ -> p_311732_.category),
+                         ShapedRecipePattern.MAP_CODEC.forGetter(p_311733_ -> p_311733_.pattern),
+                         ItemStack.ITEM_WITH_COUNT_CODEC.fieldOf("result").forGetter(p_311730_ -> p_311730_.result),
+-                        ExtraCodecs.strictOptionalField(Codec.BOOL, "show_notification", true).forGetter(p_311731_ -> p_311731_.showNotification)
++                        ExtraCodecs.strictOptionalField(Codec.BOOL, "show_notification", true).forGetter(p_311731_ -> p_311731_.showNotification),
++                        ExtraCodecs.strictOptionalField(Codec.STRING, "override", "").forGetter(p_311729_ -> p_311729_.override)
+                     )
+                     .apply(p_311728_, ShapedRecipe::new)
+         );
+@@ -110,7 +_,8 @@
+             ShapedRecipePattern shapedrecipepattern = ShapedRecipePattern.fromNetwork(p_44240_);
+             ItemStack itemstack = p_44240_.readItem();
+             boolean flag = p_44240_.readBoolean();
+-            return new ShapedRecipe(s, craftingbookcategory, shapedrecipepattern, itemstack, flag);
++            String override = p_44240_.readUtf();
++            return new ShapedRecipe(s, craftingbookcategory, shapedrecipepattern, itemstack, flag, override);
+         }
+ 
+         public void toNetwork(FriendlyByteBuf p_44227_, ShapedRecipe p_44228_) {
+@@ -119,6 +_,7 @@
+             p_44228_.pattern.toNetwork(p_44227_);
+             p_44227_.writeItem(p_44228_.result);
+             p_44227_.writeBoolean(p_44228_.showNotification);
++            p_44227_.writeUtf(p_44228_.override);
+         }
+     }
+ }

--- a/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/world/item/crafting/ShapelessRecipe.java
 +++ b/net/minecraft/world/item/crafting/ShapelessRecipe.java
-@@ -19,12 +_,14 @@
+@@ -19,12 +_,20 @@
      final CraftingBookCategory category;
      final ItemStack result;
      final NonNullList<Ingredient> ingredients;
 +    private final boolean isSimple;
++    String override;
  
      public ShapelessRecipe(String p_249640_, CraftingBookCategory p_249390_, ItemStack p_252071_, NonNullList<Ingredient> p_250689_) {
          this.group = p_249640_;
@@ -12,9 +13,26 @@
          this.result = p_252071_;
          this.ingredients = p_250689_;
 +        this.isSimple = p_250689_.stream().allMatch(Ingredient::isSimple);
++    }
++
++    public ShapelessRecipe(String group, CraftingBookCategory category, ItemStack result, NonNullList<Ingredient> ingredients, String override) {
++        this(group, category, result, ingredients);
++        this.override = override;
      }
  
      @Override
+@@ -33,6 +_,11 @@
+     }
+ 
+     @Override
++    public String getOverride() {
++        return this.override;
++    }
++
++    @Override
+     public String getGroup() {
+         return this.group;
+     }
 @@ -54,17 +_,20 @@
  
      public boolean matches(CraftingContainer p_44262_, Level p_44263_) {
@@ -45,7 +63,7 @@
          private static final Codec<ShapelessRecipe> CODEC = RecordCodecBuilder.create(
              p_311734_ -> p_311734_.group(
                          ExtraCodecs.strictOptionalField(Codec.STRING, "group", "").forGetter(p_301127_ -> p_301127_.group),
-@@ -87,14 +_,13 @@
+@@ -87,20 +_,20 @@
                              .fieldOf("ingredients")
                              .flatXmap(
                                  p_301021_ -> {
@@ -64,3 +82,29 @@
                                              : DataResult.success(NonNullList.of(Ingredient.EMPTY, aingredient));
                                      }
                                  },
+                                 DataResult::success
+                             )
+-                            .forGetter(p_300975_ -> p_300975_.ingredients)
++                            .forGetter(p_300975_ -> p_300975_.ingredients),
++                            ExtraCodecs.strictOptionalField(Codec.STRING, "override", "").forGetter(p_311729_ -> p_311729_.override)
+                     )
+                     .apply(p_311734_, ShapelessRecipe::new)
+         );
+@@ -121,7 +_,8 @@
+             }
+ 
+             ItemStack itemstack = p_44294_.readItem();
+-            return new ShapelessRecipe(s, craftingbookcategory, itemstack, nonnulllist);
++            String override = p_44294_.readUtf();
++            return new ShapelessRecipe(s, craftingbookcategory, itemstack, nonnulllist, override);
+         }
+ 
+         public void toNetwork(FriendlyByteBuf p_44281_, ShapelessRecipe p_44282_) {
+@@ -134,6 +_,7 @@
+             }
+ 
+             p_44281_.writeItem(p_44282_.result);
++            p_44281_.writeUtf(p_44282_.override);
+         }
+     }
+ }

--- a/patches/net/minecraft/world/item/crafting/SimpleCookingSerializer.java.patch
+++ b/patches/net/minecraft/world/item/crafting/SimpleCookingSerializer.java.patch
@@ -1,6 +1,18 @@
 --- a/net/minecraft/world/item/crafting/SimpleCookingSerializer.java
 +++ b/net/minecraft/world/item/crafting/SimpleCookingSerializer.java
-@@ -19,11 +_,7 @@
+@@ -10,20 +_,19 @@
+ 
+ public class SimpleCookingSerializer<T extends AbstractCookingRecipe> implements RecipeSerializer<T> {
+     private final AbstractCookingRecipe.Factory<T> factory;
++    @javax.annotation.Nullable
++    private final AbstractCookingRecipe.NeoForgeFactory<?> neoForgeFactory;
+     private final Codec<T> codec;
+ 
+     public SimpleCookingSerializer(AbstractCookingRecipe.Factory<T> p_312065_, int p_44331_) {
+         this.factory = p_312065_;
++        this.neoForgeFactory = null;
+         this.codec = RecordCodecBuilder.create(
+             p_300831_ -> p_300831_.group(
                          ExtraCodecs.strictOptionalField(Codec.STRING, "group", "").forGetter(p_300832_ -> p_300832_.group),
                          CookingBookCategory.CODEC.fieldOf("category").orElse(CookingBookCategory.MISC).forGetter(p_300828_ -> p_300828_.category),
                          Ingredient.CODEC_NONEMPTY.fieldOf("ingredient").forGetter(p_300833_ -> p_300833_.ingredient),
@@ -13,3 +25,66 @@
                          Codec.FLOAT.fieldOf("experience").orElse(0.0F).forGetter(p_300826_ -> p_300826_.experience),
                          Codec.INT.fieldOf("cookingtime").orElse(p_44331_).forGetter(p_300834_ -> p_300834_.cookingTime)
                      )
+@@ -31,6 +_,23 @@
+         );
+     }
+ 
++    public SimpleCookingSerializer(AbstractCookingRecipe.NeoForgeFactory<T> p_312065_, int p_44331_) {
++        this.factory = p_312065_;
++        this.neoForgeFactory = p_312065_;
++        this.codec = RecordCodecBuilder.create(
++                p_300831_ -> p_300831_.group(
++                                ExtraCodecs.strictOptionalField(Codec.STRING, "group", "").forGetter(p_300832_ -> p_300832_.group),
++                                CookingBookCategory.CODEC.fieldOf("category").orElse(CookingBookCategory.MISC).forGetter(p_300828_ -> p_300828_.category),
++                                Ingredient.CODEC_NONEMPTY.fieldOf("ingredient").forGetter(p_300833_ -> p_300833_.ingredient),
++                                net.neoforged.neoforge.common.crafting.CraftingHelper.smeltingResultCodec().fieldOf("result").forGetter(p_300827_ -> p_300827_.result),
++                                Codec.FLOAT.fieldOf("experience").orElse(0.0F).forGetter(p_300826_ -> p_300826_.experience),
++                                Codec.INT.fieldOf("cookingtime").orElse(p_44331_).forGetter(p_300834_ -> p_300834_.cookingTime),
++                                ExtraCodecs.strictOptionalField(Codec.STRING, "override", "").forGetter(p_311729_ -> p_311729_.override)
++                        )
++                        .apply(p_300831_, p_312065_::create)
++        );
++    }
++
+     @Override
+     public Codec<T> codec() {
+         return this.codec;
+@@ -43,7 +_,12 @@
+         ItemStack itemstack = p_44345_.readItem();
+         float f = p_44345_.readFloat();
+         int i = p_44345_.readVarInt();
+-        return this.factory.create(s, cookingbookcategory, ingredient, itemstack, f, i);
++        if (this.neoForgeFactory != null) {
++            String override = p_44345_.readUtf();
++            return (T) this.neoForgeFactory.create(s, cookingbookcategory, ingredient, itemstack, f, i, override);
++        } else {
++            return this.factory.create(s, cookingbookcategory, ingredient, itemstack, f, i);
++        }
+     }
+ 
+     public void toNetwork(FriendlyByteBuf p_44335_, T p_44336_) {
+@@ -53,11 +_,24 @@
+         p_44335_.writeItem(p_44336_.result);
+         p_44335_.writeFloat(p_44336_.experience);
+         p_44335_.writeVarInt(p_44336_.cookingTime);
++        if (this.neoForgeFactory != null) {
++            p_44335_.writeUtf(p_44336_.override);
++        }
+     }
+ 
+     public AbstractCookingRecipe create(
+         String p_312671_, CookingBookCategory p_312067_, Ingredient p_312327_, ItemStack p_311758_, float p_312386_, int p_311986_
+     ) {
+         return this.factory.create(p_312671_, p_312067_, p_312327_, p_311758_, p_312386_, p_311986_);
++    }
++
++    public AbstractCookingRecipe create(
++            String p_312671_, CookingBookCategory p_312067_, Ingredient p_312327_, ItemStack p_311758_, float p_312386_, int p_311986_, String override
++    ) {
++        if (this.neoForgeFactory != null) {
++            return this.neoForgeFactory.create(p_312671_, p_312067_, p_312327_, p_311758_, p_312386_, p_311986_, override);
++        } else {
++            return this.factory.create(p_312671_, p_312067_, p_312327_, p_311758_, p_312386_, p_311986_);
++        }
+     }
+ }

--- a/patches/net/minecraft/world/item/crafting/SmeltingRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/SmeltingRecipe.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/crafting/SmeltingRecipe.java
++++ b/net/minecraft/world/item/crafting/SmeltingRecipe.java
+@@ -8,6 +_,10 @@
+         super(RecipeType.SMELTING, p_250200_, p_251114_, p_250340_, p_250306_, p_249577_, p_250030_);
+     }
+ 
++    public SmeltingRecipe(String p_250200_, CookingBookCategory p_251114_, Ingredient p_250340_, ItemStack p_250306_, float p_249577_, int p_250030_, String override) {
++        super(RecipeType.SMELTING, p_250200_, p_251114_, p_250340_, p_250306_, p_249577_, p_250030_, override);
++    }
++
+     @Override
+     public ItemStack getToastSymbol() {
+         return new ItemStack(Blocks.FURNACE);

--- a/patches/net/minecraft/world/item/crafting/SmokingRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/SmokingRecipe.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/crafting/SmokingRecipe.java
++++ b/net/minecraft/world/item/crafting/SmokingRecipe.java
+@@ -8,6 +_,10 @@
+         super(RecipeType.SMOKING, p_249312_, p_251017_, p_252345_, p_250002_, p_250535_, p_251222_);
+     }
+ 
++    public SmokingRecipe(String p_249312_, CookingBookCategory p_251017_, Ingredient p_252345_, ItemStack p_250002_, float p_250535_, int p_251222_, String override) {
++        super(RecipeType.SMOKING, p_249312_, p_251017_, p_252345_, p_250002_, p_250535_, p_251222_, override);
++    }
++
+     @Override
+     public ItemStack getToastSymbol() {
+         return new ItemStack(Blocks.SMOKER);


### PR DESCRIPTION
This PR adds a new field called `'override"` to Crafting and Smelting recipes that allows for specifying a `String` that correlates to another recipe's ID. The recipe with the `override` field will then be prioritized over the recipe with the given ID. This is different from overriding by file in datapacks because it is intended as a way of solving problems caused by a recipe using a broad tag and a modder needing to make a recipe with the same pattern and only one ingredient of that tag.

For example, a modder may be trying to make a Chest for a specific wood type, but in Vanilla, crafting Chests uses the `#planks` tag, so all wood types are normally going to give the default Chest block. Using this, a modder could specify `"override": "minecraft:chest"` in their recipe and it would make their recipe take priority only if using the specific wood block that the chest uses.

Attached is a datapack that demonstrates this system in action.
![2024-05-05_11 53 43](https://github.com/neoforged/NeoForge/assets/67203206/fad35765-c896-4edb-be65-b7d4e1378c23)
![2024-05-05_11 53 54](https://github.com/neoforged/NeoForge/assets/67203206/ef46e211-5e32-4f1a-ac60-9ce9ac99eaeb)
[Recipe Override Test.zip](https://github.com/neoforged/NeoForge/files/15214167/Recipe.Override.Test.zip)

_This PR changes some of the data structures used in first constructing the recipe map in `RecipeManager` to allow for this, as in Vanilla it uses a HashMap that can't be ordered. The changes in this PR have the side effect of also making recipes now be ordered logically by their `ResourceLocation`, which is mostly alphabetical._