### PR TITLE
Add method to blocks to allow hiding neighboring fluid overlay

### DIFF
--- a/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/LiquidBlockRenderer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/block/LiquidBlockRenderer.java
 +++ b/net/minecraft/client/renderer/block/LiquidBlockRenderer.java
-@@ -38,6 +_,7 @@
+@@ -38,12 +_,17 @@
          this.waterIcons[0] = Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(Blocks.WATER.defaultBlockState()).getParticleIcon();
          this.waterIcons[1] = ModelBakery.WATER_FLOW.sprite();
          this.waterOverlay = ModelBakery.WATER_OVERLAY.sprite();
@@ -8,8 +8,33 @@
      }
  
      private static boolean isNeighborSameFluid(FluidState p_203186_, FluidState p_203187_) {
-@@ -70,8 +_,9 @@
+         return p_203187_.getType().isSame(p_203186_.getType());
+     }
  
++    private static boolean isNeighborStateCompatibleWithFluid(FluidState selfState, BlockState otherState) {
++        return otherState.isCompatibleWithFluid(selfState);
++    }
++
+     private static boolean isFaceOccludedByState(BlockGetter p_110979_, Direction p_110980_, float p_110981_, BlockPos p_110982_, BlockState p_110983_) {
+         if (p_110983_.canOcclude()) {
+             VoxelShape voxelshape = Shapes.box(0.0, 0.0, 0.0, 1.0, (double)p_110981_, 1.0);
+@@ -62,16 +_,24 @@
+         return isFaceOccludedByState(p_110960_, p_110963_.getOpposite(), 1.0F, p_110961_, p_110962_);
+     }
+ 
++    @Deprecated // Neo: use overload that accepts BlockState
+     public static boolean shouldRenderFace(
+         BlockAndTintGetter p_203167_, BlockPos p_203168_, FluidState p_203169_, BlockState p_203170_, Direction p_203171_, FluidState p_203172_
+     ) {
+         return !isFaceOccludedBySelf(p_203167_, p_203168_, p_203170_, p_203171_) && !isNeighborSameFluid(p_203169_, p_203172_);
+     }
+ 
++    public static boolean shouldRenderFace(
++            BlockAndTintGetter p_203167_, BlockPos p_203168_, FluidState p_203169_, BlockState p_203170_, Direction p_203171_, BlockState otherState
++    ) {
++        return !isFaceOccludedBySelf(p_203167_, p_203168_, p_203170_, p_203171_) && !isNeighborStateCompatibleWithFluid(p_203169_, otherState);
++    }
++
      public void tesselate(BlockAndTintGetter p_234370_, BlockPos p_234371_, VertexConsumer p_234372_, BlockState p_234373_, FluidState p_234374_) {
          boolean flag = p_234374_.is(FluidTags.LAVA);
 -        TextureAtlasSprite[] atextureatlassprite = flag ? this.lavaIcons : this.waterIcons;
@@ -20,6 +45,26 @@
          float f = (float)(i >> 16 & 0xFF) / 255.0F;
          float f1 = (float)(i >> 8 & 0xFF) / 255.0F;
          float f2 = (float)(i & 0xFF) / 255.0F;
+@@ -87,13 +_,13 @@
+         FluidState fluidstate4 = blockstate4.getFluidState();
+         BlockState blockstate5 = p_234370_.getBlockState(p_234371_.relative(Direction.EAST));
+         FluidState fluidstate5 = blockstate5.getFluidState();
+-        boolean flag1 = !isNeighborSameFluid(p_234374_, fluidstate1);
+-        boolean flag2 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.DOWN, fluidstate)
++        boolean flag1 = !isNeighborStateCompatibleWithFluid(p_234374_, blockstate1);
++        boolean flag2 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.DOWN, blockstate)
+             && !isFaceOccludedByNeighbor(p_234370_, p_234371_, Direction.DOWN, 0.8888889F, blockstate);
+-        boolean flag3 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.NORTH, fluidstate2);
+-        boolean flag4 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.SOUTH, fluidstate3);
+-        boolean flag5 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.WEST, fluidstate4);
+-        boolean flag6 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.EAST, fluidstate5);
++        boolean flag3 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.NORTH, blockstate2);
++        boolean flag4 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.SOUTH, blockstate3);
++        boolean flag5 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.WEST, blockstate4);
++        boolean flag6 = shouldRenderFace(p_234370_, p_234371_, p_234374_, p_234373_, Direction.EAST, blockstate5);
+         if (flag1 || flag2 || flag6 || flag5 || flag3 || flag4) {
+             float f3 = p_234370_.getShade(Direction.DOWN, true);
+             float f4 = p_234370_.getShade(Direction.UP, true);
 @@ -181,15 +_,15 @@
                  float f52 = f4 * f;
                  float f30 = f4 * f1;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -976,4 +976,8 @@ public interface IBlockExtension {
     default boolean isEmpty(BlockState state) {
         return state.is(Blocks.AIR) || state.is(Blocks.CAVE_AIR) || state.is(Blocks.VOID_AIR);
     }
+
+    default boolean isCompatibleWithFluid(BlockState state, FluidState adjacentFluid) {
+        return state.getFluidState().getType().isSame(adjacentFluid.getType());
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -746,4 +746,11 @@ public interface IBlockStateExtension {
     default boolean isEmpty() {
         return self().getBlock().isEmpty(self());
     }
+
+    /**
+     * Return true if this block should cause an adjacent face of the given fluid to not render.
+     */
+    default boolean isCompatibleWithFluid(FluidState adjacentFluid) {
+        return self().getBlock().isCompatibleWithFluid(self(), adjacentFluid);
+    }
 }

--- a/tests/src/generated/resources/assets/neotests_test_water_glass_face_removal/blockstates/water_glass.json
+++ b/tests/src/generated/resources/assets/neotests_test_water_glass_face_removal/blockstates/water_glass.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "neotests_test_water_glass_face_removal:block/water_glass"
+    }
+  }
+}

--- a/tests/src/generated/resources/assets/neotests_test_water_glass_face_removal/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_test_water_glass_face_removal/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "block.neotests_test_water_glass_face_removal.water_glass": "Water Glass"
+}

--- a/tests/src/generated/resources/assets/neotests_test_water_glass_face_removal/models/block/water_glass.json
+++ b/tests/src/generated/resources/assets/neotests_test_water_glass_face_removal/models/block/water_glass.json
@@ -1,0 +1,7 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "render_type": "minecraft:cutout",
+  "textures": {
+    "all": "minecraft:block/glass"
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/fluid/FluidTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/fluid/FluidTests.java
@@ -5,9 +5,62 @@
 
 package net.neoforged.neoforge.debug.fluid;
 
+import net.minecraft.client.renderer.block.LiquidBlockRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.TransparentBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
+import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.registration.RegistrationHelper;
 
 @ForEachTest(groups = FluidTests.GROUP)
 public class FluidTests {
     public static final String GROUP = "level.fluid";
+
+    static class WaterGlassBlock extends TransparentBlock {
+        WaterGlassBlock() {
+            super(BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS));
+        }
+
+        @Override
+        public boolean isCompatibleWithFluid(BlockState state, FluidState adjacentFluid) {
+            // Hide water faces
+            return adjacentFluid.getFluidType() == Fluids.WATER.getFluidType();
+        }
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if blocks can prevent neighboring fluids from rendering against them")
+    static void testWaterGlassFaceRemoval(final DynamicTest test, final RegistrationHelper reg) {
+        final var glass = reg.blocks().register("water_glass", WaterGlassBlock::new).withLang("Water Glass").withBlockItem();
+        reg.provider(BlockStateProvider.class, prov -> prov.simpleBlock(glass.get(), prov.models()
+                .cubeAll("water_glass", new ResourceLocation("block/glass"))
+                .renderType("cutout")));
+        final var waterPosition = new BlockPos(1, 1, 2);
+        final var glassDirection = Direction.NORTH;
+        final var glassPosition = waterPosition.relative(glassDirection);
+        test.onGameTest(helper -> helper.startSequence()
+                .thenExecute(() -> helper.setBlock(glassPosition, glass.get().defaultBlockState()))
+                .thenExecute(() -> helper.setBlock(waterPosition, Blocks.WATER.defaultBlockState()))
+                // Check that the north side of the water is not rendered
+                .thenExecute(() -> helper.assertFalse(
+                        LiquidBlockRenderer.shouldRenderFace(helper.getLevel(), waterPosition,
+                                helper.getBlockState(waterPosition).getFluidState(),
+                                helper.getBlockState(waterPosition),
+                                glassDirection,
+                                helper.getBlockState(glassPosition)),
+                        "Fluid face rendering is not skipped"))
+                .thenSucceed());
+    }
 }


### PR DESCRIPTION
This PR introduces a new method `isCompatibleWithFluid` on blocks (not super happy with name) that may be overridden to customize the logic for determining when the fluid is visually "compatible" with a neighbor (which stops the water overlay from rendering on a given face). The default implementation matches vanilla behavior.

This can be used to tweak the rendering of transparent blocks underwater (e.g. to implement the "depth glass" effect from Alex's Caves, see photo below for an example). That mod currently uses a mixin to implement the same effect; the goal of this PR is to remove the need for such a mixin.

![277799947-8a0c467c-0251-4269-b323-86d44e5a7d34](https://github.com/neoforged/NeoForge/assets/42941056/5ff26acc-792d-41e1-a271-d1d36eced540)
