### PR TITLE
Fix dedicated server GUI never showing up

### DIFF
--- a/patches/net/minecraft/server/Main.java.patch
+++ b/patches/net/minecraft/server/Main.java.patch
@@ -126,7 +126,7 @@
                      boolean flag2 = !optionset.has(optionspec) && !optionset.valuesOf(optionspec15).contains("nogui");
 -                    if (flag2 && !GraphicsEnvironment.isHeadless()) {
 -                        dedicatedserver1.showGui();
-+                    if (dedicatedserver1 instanceof DedicatedServer dedicatedServer && flag1 && !GraphicsEnvironment.isHeadless()) {
++                    if (dedicatedserver1 instanceof DedicatedServer dedicatedServer && flag2 && !GraphicsEnvironment.isHeadless()) {
 +                        dedicatedServer.showGui();
                      }
  


### PR DESCRIPTION
This PR fixes the dedicated server GUI never showing up, whether `--nogui` is present or not, by fixing a broken patch to use the correct boolean variable.

During the porting to 1.20.5-pre3, the variable which controlled the appearance of the dedicated server GUI changed from `flag1` to `flag2` (because a boolean variable was introduced somewhere earlier in the method), but the patch which used the variable went unchanged.

Tested by launcing the server from my dev environment, and seeing the server GUI appear as expected.