### PR TITLE
Remove Unnecessary Stitcher patch

### DIFF
--- a/patches/net/minecraft/client/renderer/texture/Stitcher.java.patch
+++ b/patches/net/minecraft/client/renderer/texture/Stitcher.java.patch
@@ -24,12 +24,3 @@
                  throw new StitcherException(holder.entry, list.stream().map(p_247946_ -> p_247946_.entry).collect(ImmutableList.toImmutableList()));
              }
          }
-@@ -87,7 +_,7 @@
-             boolean flag4 = flag2 && j != l;
-             boolean flag;
-             if (flag3 ^ flag4) {
--                flag = flag3;
-+                flag = !flag3 && flag1; // Forge: Fix stitcher not expanding entire height before growing width, and (potentially) growing larger then the max size.
-             } else {
-                 flag = flag1 && i <= j;
-             }


### PR DESCRIPTION
In Vanilla 1.19.3+, the vanilla logic was changed in a way that the patch will no longer produce a better result than vanilla. So this patch has become tech debt that can be removed safely. See the original issue report for more details.

Closes https://github.com/neoforged/NeoForge/issues/705