### PR TITLE
[Test Framework] Add a check in `StructureTemplateBuilder#set` to prevent placing block outside template bondaries

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/gametest/StructureTemplateBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/StructureTemplateBuilder.java
@@ -79,6 +79,9 @@ public class StructureTemplateBuilder implements TemplateBuilderHelper<Structure
 
     @Override
     public StructureTemplateBuilder set(int x, int y, int z, BlockState state, @Nullable CompoundTag nbt) {
+        if (x < 0 || y < 0 || z < 0 || x >= size.getX() || y >= size.getY() || z >= size.getZ()) {
+            throw new IllegalArgumentException("Block position is out of template bounds");
+        }
         blocks.put(new BlockPos(x, y, z), new StructureTemplate.StructureBlockInfo(new BlockPos(x, y, z), state, nbt));
         return this;
     }


### PR DESCRIPTION
Title, I ran into this issue because I missed typed a block coord and didn't understood why my test was failing.