### PR TITLE
Fix more particle culling issues

### DIFF
--- a/patches/net/minecraft/client/particle/ItemPickupParticle.java.patch
+++ b/patches/net/minecraft/client/particle/ItemPickupParticle.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/client/particle/ItemPickupParticle.java
++++ b/net/minecraft/client/particle/ItemPickupParticle.java
+@@ -103,4 +_,11 @@
+         this.targetYOld = this.targetY;
+         this.targetZOld = this.targetZ;
+     }
++
++    // Neo: Computing a bounding box for the pickup animation is annoying to patch in, and probably slower than
++    // always rendering it
++    @Override
++    public net.minecraft.world.phys.AABB getRenderBoundingBox(float partialTicks) {
++        return net.minecraft.world.phys.AABB.INFINITE;
++    }
+ }

--- a/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -45,6 +45,8 @@ public final class ParticleBoundsDebugRenderer {
             }
         });
 
+        Minecraft.getInstance().renderBuffers().bufferSource().endBatch(RenderType.lines());
+
         poseStack.popPose();
     }
 


### PR DESCRIPTION
- Fix particle hitboxes not being shown by debug renderer in Fabulous by manually ending the line batch we use; this is necessary because it gets ended prior to the `AFTER_PARTICLES` stage being fired.
- Disable particle culling on item pickup particles since computing the proper bounding box requires a rather complex patched-in method, and these particles are so short-lived in practice that it isn't worth it.

Fixes #949 
Fixes #947
