### PR TITLE
Make StructureTemplate's Palette caches thread safe

### DIFF
--- a/patches/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
@@ -130,7 +130,7 @@
      public static final class Palette {
          private final List<StructureTemplate.StructureBlockInfo> blocks;
 -        private final Map<Block, List<StructureTemplate.StructureBlockInfo>> cache = Maps.newHashMap();
-+        private final Map<Block, List<StructureTemplate.StructureBlockInfo>> cache = Maps.newConcurrentMap(); // Neo: Make the global StructureTemplate's palette caches now thread safe for worldgen
++        private final Map<Block, List<StructureTemplate.StructureBlockInfo>> cache = Maps.newConcurrentMap(); // Neo: Fixes MC-271899 - Make the global StructureTemplate's palette caches now thread safe for worldgen
  
          Palette(List<StructureTemplate.StructureBlockInfo> p_74648_) {
              this.blocks = p_74648_;

--- a/patches/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
@@ -125,3 +125,12 @@
                          ((Mob)p_275190_).finalizeSpawn(p_74524_, p_74524_.getCurrentDifficultyAt(BlockPos.containing(vec31)), MobSpawnType.STRUCTURE, null);
                      }
  
+@@ -777,7 +_,7 @@
+ 
+     public static final class Palette {
+         private final List<StructureTemplate.StructureBlockInfo> blocks;
+-        private final Map<Block, List<StructureTemplate.StructureBlockInfo>> cache = Maps.newHashMap();
++        private final Map<Block, List<StructureTemplate.StructureBlockInfo>> cache = Maps.newConcurrentMap(); // Neo: Make the global StructureTemplate's palette caches now thread safe for worldgen
+ 
+         Palette(List<StructureTemplate.StructureBlockInfo> p_74648_) {
+             this.blocks = p_74648_;


### PR DESCRIPTION
The StructureTemplate is a global object that all threads access during the game. And during worldgen, chunks are created on different worldgen threads. The issue is in the StructureTemplate's Palette, it holds a cached field that is mutated on calls to Palette$blocks. If two threads calls that method and the hash map is mutated for one, it can cause a concurrent modification exception.

The reason there is no linked bug report is because reproducing this issue is unbelievably difficult in vanilla. I was not able to reproduce it in vanilla with this datapack: 
[test.zip](https://github.com/neoforged/NeoForge/files/15283323/test.zip)

However, another dev was making a world viewer mod that generates many more chunks much faster for viewing purposed and managed to get this cache to crash with a concurrent modification exception.

There's no real downside to making this map a concurrent hash map to ensure thread safety for players and modders that may be in a situation that triggers the crash more often.