### PR TITLE
[1.20.6] Use extensible enum codec and streamcodec for rarity enum

### DIFF
--- a/patches/net/minecraft/world/item/Rarity.java.patch
+++ b/patches/net/minecraft/world/item/Rarity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/Rarity.java
 +++ b/net/minecraft/world/item/Rarity.java
-@@ -9,7 +_,7 @@
+@@ -9,31 +_,69 @@
  import net.minecraft.util.ByIdMap;
  import net.minecraft.util.StringRepresentable;
  
@@ -9,7 +9,14 @@
      COMMON(0, "common", ChatFormatting.WHITE),
      UNCOMMON(1, "uncommon", ChatFormatting.YELLOW),
      RARE(2, "rare", ChatFormatting.AQUA),
-@@ -21,19 +_,46 @@
+     EPIC(3, "epic", ChatFormatting.LIGHT_PURPLE);
+ 
+-    public static final Codec<Rarity> CODEC = StringRepresentable.fromValues(Rarity::values);
++    private static final java.util.Map<String, Rarity> BY_NAME = java.util.Arrays.stream(values()).collect(java.util.stream.Collectors.toMap(rarity -> rarity.name, rarity -> rarity));
++    public static final Codec<Rarity> CODEC = net.neoforged.neoforge.common.IExtensibleEnum.createCodecForExtensibleEnum(Rarity::values, Rarity::byName);
+     public static final IntFunction<Rarity> BY_ID = ByIdMap.continuous(p_335877_ -> p_335877_.id, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
+-    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = ByteBufCodecs.idMapper(BY_ID, p_335484_ -> p_335484_.id);
++    public static final StreamCodec<ByteBuf, Rarity> STREAM_CODEC = net.neoforged.neoforge.common.IExtensibleEnum.createStreamCodecForExtensibleEnum(Rarity::values);
      private final int id;
      private final String name;
      private final ChatFormatting color;
@@ -48,6 +55,16 @@
      @Override
      public String getSerializedName() {
          return this.name;
++    }
++
++    @Override
++    @Deprecated
++    public void init() {
++        BY_NAME.put(this.name, this);
++    }
++
++    public static Rarity byName(String name) {
++        return BY_NAME.get(name);
 +    }
 +
 +    public static Rarity create(String name, net.minecraft.resources.ResourceLocation serializedName, ChatFormatting color) {


### PR DESCRIPTION
This PR fixes the `Rarity` enum (which is made extensible by NeoForge) using the wrong `Codec` and `StreamCodec` and crashing when a non-vanilla rarity is encountered.