### PR TITLE
Publishing extended Gradle Module Metadata for Tooling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,22 @@ allprojects {
     group 'net.neoforged'
     repositories {
         mavenLocal()
+
+        maven {
+            name 'Maven for PR #10' // https://github.com/neoforged/NeoForm/pull/10
+            url 'https://prmaven.neoforged.net/NeoForm/pr10'
+            content {
+                includeModule('net.neoforged', 'neoform')
+            }
+        }
+
+        maven {
+            name 'Maven for PR #1' // https://github.com/neoforged/GradleMinecraftDependencies/pull/1
+            url 'https://prmaven.neoforged.net/GradleMinecraftDependencies/pr1'
+            content {
+                includeModule('net.neoforged', 'minecraft-dependencies')
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,6 @@ if (isPreReleaseVersion) {
         }
     }
 
-    changelog {
-        from '20.6'
-        disableAutomaticPublicationRegistration()
-    }
-
     project.version = gradleutils.version.toString()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,22 +43,6 @@ allprojects {
     group 'net.neoforged'
     repositories {
         mavenLocal()
-
-        maven {
-            name 'Maven for PR #10' // https://github.com/neoforged/NeoForm/pull/10
-            url 'https://prmaven.neoforged.net/NeoForm/pr10'
-            content {
-                includeModule('net.neoforged', 'neoform')
-            }
-        }
-
-        maven {
-            name 'Maven for PR #1' // https://github.com/neoforged/GradleMinecraftDependencies/pull/1
-            url 'https://prmaven.neoforged.net/GradleMinecraftDependencies/pr1'
-            content {
-                includeModule('net.neoforged', 'minecraft-dependencies')
-            }
-        }
     }
 }
 

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -411,7 +411,6 @@ afterEvaluate {
             builtBy(signInstallerJar)
             setClassifier("installer")
         }
-        // Only publish a changelog for releases
         changelog(createChangelog.outputFile) {
             builtBy(createChangelog)
             setClassifier("changelog")

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -3,7 +3,14 @@ plugins {
     id 'maven-publish'
 }
 
-rootProject.gradleutils.setupSigning(project: project, signAllPublications: true)
+apply plugin: 'net.neoforged.gradleutils'
+
+gradleutils.setupSigning(project: project, signAllPublications: true)
+
+changelog {
+    from '20.6'
+    disableAutomaticPublicationRegistration()
+}
 
 dynamicProject {
     runtime("${project.minecraft_version}-${project.neoform_version}",
@@ -405,8 +412,8 @@ afterEvaluate {
             setClassifier("installer")
         }
         // Only publish a changelog for releases
-        changelog(rootProject.createChangelog.outputFile) {
-            builtBy(rootProject.createChangelog)
+        changelog(createChangelog.outputFile) {
+            builtBy(createChangelog)
             setClassifier("changelog")
             setExtension("txt")
         }
@@ -456,6 +463,6 @@ publishing {
         }
     }
     repositories {
-        maven rootProject.gradleutils.getPublishingMaven()
+        maven gradleutils.getPublishingMaven()
     }
 }

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -207,8 +207,6 @@ tasks.withType(Javadoc.class).configureEach {
     options.addStringOption('Xdoclint:all,-missing', '-public')
 }
 
-tasks.withType(GenerateModuleMetadata).configureEach { enabled = false }
-
 configurations {
     forValidation {
         canBeConsumed = true
@@ -230,6 +228,169 @@ artifacts {
     }
 }
 
+AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+// Ensure the two default variants are not published, since they
+// contain Minecraft classes
+javaComponent.withVariantsFromConfiguration(configurations.apiElements) {
+    it.skip()
+}
+javaComponent.withVariantsFromConfiguration(configurations.runtimeElements) {
+    it.skip()
+}
+
+configurations {
+    modDevBundle {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "data"))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-bundle:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {} // Publish it
+    }
+    modDevConfig {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "data"))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-config:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {} // Publish it
+    }
+    installerJar {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "installer"))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.SHADOWED))
+            // The installer targets JDK 8
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        // Publish it
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    universalJar {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInteger())
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+        }
+        // Publish it
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    changelog {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "changelog"))
+        }
+        // Publish it, but only for release versions
+        if (!rootProject.isPreReleaseVersion) {
+            javaComponent.addVariantsFromConfiguration(it) {}
+        }
+    }
+    modDevApiElements {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom userdevCompileOnly, installerLibraries, moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-dependencies:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevRuntimeElements {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom installerLibraries, moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-dependencies:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevModulePath {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-module-path:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+}
+
+dependencies {
+    modDevApiElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-dependencies'
+        }
+        endorseStrictVersions()
+    }
+    modDevRuntimeElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-dependencies'
+        }
+        endorseStrictVersions()
+    }
+}
+
+afterEvaluate {
+    artifacts {
+        modDevBundle(userdevJar) {
+            setClassifier("userdev") // Legacy
+        }
+        modDevConfig(createUserdevJson.output) {
+            builtBy(createUserdevJson)
+            setClassifier("moddev-config")
+        }
+        universalJar(signUniversalJar.output) {
+            builtBy(signUniversalJar)
+            setClassifier("universal")
+        }
+        installerJar(signInstallerJar.output) {
+            builtBy(signInstallerJar)
+            setClassifier("installer")
+        }
+        // Only publish a changelog for releases
+        changelog(rootProject.createChangelog.outputFile) {
+            builtBy(rootProject.createChangelog)
+            setClassifier("changelog")
+            setExtension("txt")
+        }
+    }
+}
+
 publishing {
     publications.create('NeoForge', MavenPublication) {
         groupId = project.group
@@ -237,28 +398,6 @@ publishing {
         version = project.version
 
         from components.java
-
-        artifacts = []
-
-        afterEvaluate {
-            artifact (signUniversalJar.output) {
-                classifier 'universal'
-            }
-            artifact (signInstallerJar.output) {
-                classifier 'installer'
-            }
-            artifact (userdevJar) {
-                classifier 'userdev'
-            }
-            artifact (sourcesJar) {
-                classifier 'sources'
-            }
-        }
-
-        if (!rootProject.isPreReleaseVersion) {
-            // Only publish a changelog for releases
-            changelog.publish(it)
-        }
 
         versionMapping {
             usage('java-api') {

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -364,6 +364,12 @@ configurations {
 }
 
 dependencies {
+    modDevBundle("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform'
+        }
+        endorseStrictVersions()
+    }
     modDevApiElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
         capabilities {
             requireCapability 'net.neoforged:neoform-dependencies'

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -348,6 +348,19 @@ configurations {
         }
         javaComponent.addVariantsFromConfiguration(it) {}
     }
+    modDevTestFixtures {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-test-fixtures:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
 }
 
 dependencies {
@@ -361,6 +374,9 @@ dependencies {
         capabilities {
             requireCapability 'net.neoforged:neoform-dependencies'
         }
+        endorseStrictVersions()
+    }
+    modDevTestFixtures("net.neoforged.fancymodloader:junit-fml:${project.fancy_mod_loader_version}") {
         endorseStrictVersions()
     }
 }

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -274,11 +274,14 @@ configurations {
         canBeResolved = false
         canBeConsumed = true
         attributes {
-            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "installer"))
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.SHADOWED))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EMBEDDED))
             // The installer targets JDK 8
             attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-installer:${project.version}")
         }
         // Publish it
         javaComponent.addVariantsFromConfiguration(it) {}


### PR DESCRIPTION
## Summary of Changes

- Move the task to generate the changelog from `rootProject` to the `neoforge` project. We were accessing it across project
  boundaries to publish its results, which is discouraged by Gradle.
- Enable generation of Gradle module metadata.

## Configuration / Variant Overview

| Configuration/Variant   | Description                                                                              | Capability                                    |
|-------------------------|------------------------------------------------------------------------------------------|:----------------------------------------------|
| `apiElements`           | Publication disabled, since this includes Minecraft code.                                | Implicit                                      |
| `runtimeElements`       | Publication disabled, since this includes Minecraft code.                                | Implicit                                      |
| `modDevBundle`          | The userdev jar. Depends on NeoForm data and tools.                                      | `net.neoforged:neoforge-moddev-bundle`        |
| `modDevConfig`          | The userdev JSON config file.                                                            | `net.neoforged:neoforge-moddev-config`        |
| `installerJar`          | The installer.                                                                           | `net.neoforged:neoforge-installer`            |
| `universalJar`          | Compiled NeoForge code (without Minecraft).                                              | Implicit                                      |     
| `changelog`             | The changelog in TXT format.                                                             | Implicit                                      |
| `modDevApiElements`     | All *additional* dependencies for compiling a mod against NeoForge.                      | `net.neoforged:neoforge-dependencies`         |
| `modDevRuntimeElements` | All *additional* runtime dependencies for running a mod with NeoForge.                   | `net.neoforged:neoforge-dependencies`         |
| `modDevModulePath`      | Contains the subset of `modDevRuntimeElements` that needs to be on the Java module-path. | `net.neoforged:neoforge-moddev-module-path`   |
| `modDevTestFixtures`    | Contains the JUnit plugin for easier testing of mods against Minecraft code.             | `net.neoforged:neoforge-moddev-test-fixtures` |

## Consuming Variants

Example Buildscript to pull all variants and store them locally: [build.zip](https://github.com/user-attachments/files/15780301/build.zip)

## modDevBundle

**File:** `neoforge-21.0.0-alpha.1.21-rc1.20240610.223412-userdev.jar`

**Capability:** `net.neoforged:neoforge-moddev-bundle`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | data |
| org.gradle.dependency.bundling | external |

**Dependencies**
- `net.neoforged:neoform`


## modDevConfig

**File:** `neoforge-21.0.0-alpha.1.21-rc1.20240610.223412-moddev-config.json`

**Capability:** `net.neoforged:neoforge-moddev-config`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | data |
| org.gradle.dependency.bundling | external |


## installerJar

**File:** `neoforge-21.0.0-alpha.1.21-rc1.20240610.223412-installer.jar`

**Capability:** `net.neoforged:neoforge-installer`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | library |
| org.gradle.dependency.bundling | embedded |
| org.gradle.jvm.version | 8 |
| org.gradle.usage | java-runtime |


## universalJar

**File:** `neoforge-21.0.0-alpha.1.21-rc1.20240610.223412-universal.jar`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | library |
| org.gradle.dependency.bundling | external |
| org.gradle.jvm.version | 17 |
| org.gradle.libraryelements | jar |
| org.gradle.usage | java-runtime |


## modDevApiElements

**Capability:** `net.neoforged:neoforge-dependencies`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | library |
| org.gradle.dependency.bundling | external |
| org.gradle.usage | java-api |

**Dependencies**
- `net.neoforged:neoform` (Capabilities: `net.neoforged:neoform-dependencies`)
- `io.github.llamalad7:mixinextras-neoforge`
- `net.neoforged:neoform`
- `net.neoforged.fancymodloader:loader`
- `net.neoforged.fancymodloader:earlydisplay`
- `cpw.mods:securejarhandler`
- `org.ow2.asm:asm`
- `org.ow2.asm:asm-commons`
- `org.ow2.asm:asm-tree`
- `org.ow2.asm:asm-util`
- `org.ow2.asm:asm-analysis`
- `net.neoforged:accesstransformers`
- `net.neoforged:bus`
- `net.neoforged:coremods`
- `cpw.mods:modlauncher`
- `net.minecraftforge:unsafe`
- `net.neoforged:mergetool`
- `com.electronwill.night-config:core`
- `com.electronwill.night-config:toml`
- `org.apache.maven:maven-artifact`
- `net.jodah:typetools`
- `net.minecrell:terminalconsoleappender`
- `net.fabricmc:sponge-mixin`
- `org.openjdk.nashorn:nashorn-core`
- `net.neoforged:JarJarSelector`
- `org.apache.commons:commons-lang3`
- `net.neoforged:JarJarMetadata`
- `org.apache.logging.log4j:log4j-api`
- `org.apache.logging.log4j:log4j-core`
- `cpw.mods:bootstraplauncher`
- `net.neoforged:JarJarFileSystems`


## modDevRuntimeElements

**Capability:** `net.neoforged:neoforge-dependencies`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | library |
| org.gradle.dependency.bundling | external |
| org.gradle.usage | java-runtime |

**Dependencies**
- `net.neoforged:neoform` (Capabilities: `net.neoforged:neoform-dependencies`)
- `net.neoforged:neoform`
- `net.neoforged.fancymodloader:loader`
- `net.neoforged.fancymodloader:earlydisplay`
- `cpw.mods:securejarhandler`
- `org.ow2.asm:asm`
- `org.ow2.asm:asm-commons`
- `org.ow2.asm:asm-tree`
- `org.ow2.asm:asm-util`
- `org.ow2.asm:asm-analysis`
- `net.neoforged:accesstransformers`
- `net.neoforged:bus`
- `net.neoforged:coremods`
- `cpw.mods:modlauncher`
- `net.minecraftforge:unsafe`
- `net.neoforged:mergetool`
- `com.electronwill.night-config:core`
- `com.electronwill.night-config:toml`
- `org.apache.maven:maven-artifact`
- `net.jodah:typetools`
- `net.minecrell:terminalconsoleappender`
- `net.fabricmc:sponge-mixin`
- `org.openjdk.nashorn:nashorn-core`
- `net.neoforged:JarJarSelector`
- `org.apache.commons:commons-lang3`
- `net.neoforged:JarJarMetadata`
- `org.apache.logging.log4j:log4j-api`
- `org.apache.logging.log4j:log4j-core`
- `cpw.mods:bootstraplauncher`
- `net.neoforged:JarJarFileSystems`


## modDevModulePath

**Capability:** `net.neoforged:neoforge-moddev-module-path`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | library |
| org.gradle.dependency.bundling | external |

**Dependencies**
- `cpw.mods:securejarhandler`
- `org.ow2.asm:asm`
- `org.ow2.asm:asm-commons`
- `org.ow2.asm:asm-tree`
- `org.ow2.asm:asm-util`
- `org.ow2.asm:asm-analysis`
- `cpw.mods:bootstraplauncher`
- `net.neoforged:JarJarFileSystems`


## modDevTestFixtures

**Capability:** `net.neoforged:neoforge-moddev-test-fixtures`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | library |
| org.gradle.dependency.bundling | external |
| org.gradle.usage | java-runtime |

**Dependencies**
- `net.neoforged.fancymodloader:junit-fml`


## sourcesElements

**File:** `neoforge-21.0.0-alpha.1.21-rc1.20240610.223412-sources.jar`

**Attributes**
| Attribute  | Value |
| ------------- | ------------- |
| org.gradle.category | documentation |
| org.gradle.dependency.bundling | external |
| org.gradle.docstype | sources |
| org.gradle.usage | java-runtime |


