### PR TITLE
[no ci] Fixed Bubble Column gametest template size

### DIFF
--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -147,7 +147,7 @@ public class BlockTests {
                 .withDefaultWhiteModel()
                 .withBlockItem();
 
-        test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 2, 3)
+        test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 3, 3)
                 .fill(0, 0, 0, 2, 2, 2, Blocks.WATER));
 
         test.onGameTest(helper -> helper.startSequence()


### PR DESCRIPTION
Was causing gametest server to exit due to trying to fill outside the bounds of the template. This PR fixes that by increasing bounds of template to handle the fill water size.

![image](https://github.com/neoforged/NeoForge/assets/40846040/2d524efe-9be9-422c-bae4-e09cf18646ee)

Caused by this:
![image](https://github.com/neoforged/NeoForge/assets/40846040/c64a05b5-59c1-4b9f-b20a-c47b0a75c39b)

@Matyrobbrt Would it be possible for PRs to not pass if the gametest server crashes? Seems the original report is that https://github.com/neoforged/NeoForge/pull/792 was passing despite gametest crashing.
![image](https://github.com/neoforged/NeoForge/assets/40846040/5a777df5-11ca-474f-86b1-e5396f4edc9f)

https://github.com/neoforged/NeoForge/actions/runs/9103823259/job/25026483132?pr=792
![image](https://github.com/neoforged/NeoForge/assets/40846040/22c8a82a-f0bf-41bf-8e98-9d9705d0d53e)
