### PR TITLE
Patch in missing LivingJumpEvent for Slime and Camel

### DIFF
--- a/patches/net/minecraft/world/entity/animal/camel/Camel.java.patch
+++ b/patches/net/minecraft/world/entity/animal/camel/Camel.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/entity/animal/camel/Camel.java
++++ b/net/minecraft/world/entity/animal/camel/Camel.java
+@@ -286,6 +_,7 @@
+         this.dashCooldown = 55;
+         this.setDashing(true);
+         this.hasImpulse = true;
++        net.neoforged.neoforge.common.CommonHooks.onLivingJump(this);
+     }
+ 
+     public boolean isDashing() {

--- a/patches/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -16,7 +16,7 @@
          this.setDeltaMovement(vec3.x, d0, vec3.z);
          this.setIsJumping(true);
          this.hasImpulse = true;
-+                    net.neoforged.neoforge.common.CommonHooks.onLivingJump(this);
++        net.neoforged.neoforge.common.CommonHooks.onLivingJump(this);
          if (p_275435_.z > 0.0) {
              float f = Mth.sin(this.getYRot() * (float) (Math.PI / 180.0));
              float f1 = Mth.cos(this.getYRot() * (float) (Math.PI / 180.0));

--- a/patches/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Slime.java.patch
@@ -33,6 +33,14 @@
              }
          }
  
+@@ -332,6 +_,7 @@
+         Vec3 vec3 = this.getDeltaMovement();
+         this.setDeltaMovement(vec3.x, (double)this.getJumpPower(), vec3.z);
+         this.hasImpulse = true;
++        net.neoforged.neoforge.common.CommonHooks.onLivingJump(this);
+     }
+ 
+     @Nullable
 @@ -361,6 +_,12 @@
      public EntityDimensions getDefaultDimensions(Pose p_316359_) {
          return super.getDefaultDimensions(p_316359_).scale((float)this.getSize());

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
@@ -38,7 +38,8 @@ public abstract class LivingEvent extends EntityEvent {
      * LivingJumpEvent is fired when an Entity jumps.<br>
      * This event is fired whenever an Entity jumps in
      * {@code LivingEntity#jumpFromGround()}, {@code MagmaCube#jumpFromGround()},
-     * and {@code Horse#jumpFromGround()}.<br>
+     * {@code Slime#jumpFromGround()}, {@code Camel#executeRidersJump()},
+     * and {@code AbstractHorse#executeRidersJump()}.<br>
      * <br>
      * This event is fired via the {@link CommonHooks#onLivingJump(LivingEntity)}.<br>
      * <br>


### PR DESCRIPTION
The event was not being fired for Slime and Camel as they overrode the original methods we patched into. These entities needed special handling. I did double check hierarchy and this should cover all vanilla mobs that call executeRidersJump or jumpFromGround. Javadoc on the event is updated and fixed now.

Closes https://github.com/neoforged/NeoForge/issues/843

