### PR TITLE
Fix ComputeCameraAngles event applying roll in global space

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -61,15 +61,16 @@
                  } catch (Throwable throwable1) {
                      CrashReport crashreport1 = CrashReport.forThrowable(throwable1, "Rendering screen");
                      CrashReportCategory crashreportcategory1 = crashreport1.addCategory("Screen render details");
-@@ -1273,12 +_,16 @@
+@@ -1273,12 +_,18 @@
          }
  
          this.resetProjectionMatrix(matrix4f);
 +        net.neoforged.neoforge.client.event.ViewportEvent.ComputeCameraAngles cameraSetup = net.neoforged.neoforge.client.ClientHooks.onCameraSetup(this, camera, p_109090_);
 +        camera.setAnglesInternal(cameraSetup.getYaw(), cameraSetup.getPitch());
          Matrix4f matrix4f1 = new Matrix4f()
--            .rotationXYZ(camera.getXRot() * (float) (Math.PI / 180.0), camera.getYRot() * (float) (Math.PI / 180.0) + (float) Math.PI, 0.0F);
-+            .rotationXYZ(camera.getXRot() * (float) (Math.PI / 180.0), camera.getYRot() * (float) (Math.PI / 180.0) + (float) Math.PI, cameraSetup.getRoll() * (float) (Math.PI / 180.0));
+             .rotationXYZ(camera.getXRot() * (float) (Math.PI / 180.0), camera.getYRot() * (float) (Math.PI / 180.0) + (float) Math.PI, 0.0F);
++        // Neo: Use matrix multiplication so roll is stacked on top of vanilla XY rotations
++        matrix4f1 = new Matrix4f().rotationZ(cameraSetup.getRoll() * (float) (Math.PI / 180.0)).mul(matrix4f1);
          this.minecraft
              .levelRenderer
              .prepareCullFrustum(camera.getPosition(), matrix4f1, this.getProjectionMatrix(Math.max(d0, (double)this.minecraft.options.fov().get().intValue())));


### PR DESCRIPTION
The current `GameRenderer` patch (which was modified during the 1.20.5 port) inlines the roll rotation directly into `rotateXYZ`, but that causes it to be applied in the global coordinate space, causing #962. To solve this problem we use matrix multiplication which restores the previous behavior of the roll being applied relative to the vanilla XY rotation. As a side effect it cleans up the patch to only require adding two new lines rather than replacing an existing line. The extra matrix allocation is inconsequential for performance as it's done once per frame.

Fixes #962