### PR TITLE
Verify some IExtensibleEnum during the connection phase

### DIFF
--- a/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
@@ -13,6 +13,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.configuration.RegistryDataMapNegotiation;
 import net.neoforged.neoforge.network.configuration.SyncConfig;
+import net.neoforged.neoforge.network.configuration.SyncExtensibleEnums;
 import net.neoforged.neoforge.network.configuration.SyncRegistries;
 import net.neoforged.neoforge.network.event.RegisterConfigurationTasksEvent;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
@@ -44,5 +45,6 @@ public class ConfigurationInitialization {
 
         //These two can always be registered they detect the listener connection type internally and will skip themselves.
         event.register(new RegistryDataMapNegotiation(event.getListener()));
+        event.register(new SyncExtensibleEnums(event.getListener()));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -17,6 +17,7 @@ import net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
 import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
+import net.neoforged.neoforge.network.payload.ExtensibleEnumDataPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncStartPayload;
@@ -56,6 +57,10 @@ public class NetworkInitialization {
                         KnownRegistryDataMapsPayload.TYPE,
                         KnownRegistryDataMapsPayload.STREAM_CODEC,
                         ClientRegistryManager::handleKnownDataMaps)
+                .configurationToClient(
+                        ExtensibleEnumDataPayload.TYPE,
+                        ExtensibleEnumDataPayload.STREAM_CODEC,
+                        ClientPayloadHandler::handle)
                 .configurationToServer(
                         KnownRegistryDataMapsReplyPayload.TYPE,
                         KnownRegistryDataMapsReplyPayload.STREAM_CODEC,

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
@@ -5,21 +5,17 @@
 
 package net.neoforged.neoforge.network.configuration;
 
-import java.util.List;
-import java.util.function.Consumer;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.MobCategory;
-import net.minecraft.world.item.Rarity;
-import net.minecraft.world.item.component.FireworkExplosion;
-import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.network.payload.ExtensibleEnumDataPayload;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.function.Consumer;
+
 /**
- * Syncs registries to the client
+ * Syncs extensible Enums and verifies that they match
  */
 @ApiStatus.Internal
 public record SyncExtensibleEnums(ServerConfigurationPacketListener listener) implements ICustomConfigurationTask {
@@ -29,7 +25,7 @@ public record SyncExtensibleEnums(ServerConfigurationPacketListener listener) im
     @Override
     public void run(Consumer<CustomPacketPayload> sender) {
         if (listener.hasChannel(ExtensibleEnumDataPayload.TYPE)) {
-            sender.accept(ExtensibleEnumDataPayload.factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(MobCategory.class, BiomeSpecialEffects.GrassColorModifier.class)));
+            sender.accept(ExtensibleEnumDataPayload.INSTANCE);
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.configuration;
+
+import java.util.List;
+import java.util.function.Consumer;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.item.Rarity;
+import net.minecraft.world.item.component.FireworkExplosion;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.network.payload.ExtensibleEnumDataPayload;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Syncs registries to the client
+ */
+@ApiStatus.Internal
+public record SyncExtensibleEnums(ServerConfigurationPacketListener listener) implements ICustomConfigurationTask {
+    private static final ResourceLocation ID = new ResourceLocation(NeoForgeVersion.MOD_ID, "sync_extensible_enums");
+    public static final Type TYPE = new Type(ID);
+
+    @Override
+    public void run(Consumer<CustomPacketPayload> sender) {
+        if (listener.hasChannel(ExtensibleEnumDataPayload.TYPE)) {
+            sender.accept(ExtensibleEnumDataPayload.factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(MobCategory.class, BiomeSpecialEffects.GrassColorModifier.class)));
+        }
+    }
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
@@ -5,14 +5,13 @@
 
 package net.neoforged.neoforge.network.configuration;
 
+import java.util.function.Consumer;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.network.payload.ExtensibleEnumDataPayload;
 import org.jetbrains.annotations.ApiStatus;
-
-import java.util.function.Consumer;
 
 /**
  * Syncs extensible Enums and verifies that they match

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
@@ -26,6 +26,7 @@ public record SyncExtensibleEnums(ServerConfigurationPacketListener listener) im
         if (listener.hasChannel(ExtensibleEnumDataPayload.TYPE)) {
             sender.accept(ExtensibleEnumDataPayload.getOrCreateInstance());
         }
+        listener.finishCurrentTask(TYPE);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
@@ -24,7 +24,7 @@ public record SyncExtensibleEnums(ServerConfigurationPacketListener listener) im
     @Override
     public void run(Consumer<CustomPacketPayload> sender) {
         if (listener.hasChannel(ExtensibleEnumDataPayload.TYPE)) {
-            sender.accept(ExtensibleEnumDataPayload.INSTANCE);
+            sender.accept(ExtensibleEnumDataPayload.getInstance());
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncExtensibleEnums.java
@@ -24,7 +24,7 @@ public record SyncExtensibleEnums(ServerConfigurationPacketListener listener) im
     @Override
     public void run(Consumer<CustomPacketPayload> sender) {
         if (listener.hasChannel(ExtensibleEnumDataPayload.TYPE)) {
-            sender.accept(ExtensibleEnumDataPayload.getInstance());
+            sender.accept(ExtensibleEnumDataPayload.getOrCreateInstance());
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
@@ -5,6 +5,10 @@
 
 package net.neoforged.neoforge.network.payload;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
@@ -17,11 +21,6 @@ import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.neoforged.neoforge.common.IExtensibleEnum;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import org.jetbrains.annotations.ApiStatus;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * A payload used to verify that specific Enums that implement {@linkplain IExtensibleEnum} have the same Enum Constants in the same order.

--- a/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
@@ -36,9 +36,9 @@ public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map
 
     private static ExtensibleEnumDataPayload<?> INSTANCE = null;
 
-    public static synchronized ExtensibleEnumDataPayload<?> getInstance() {
+    public static synchronized ExtensibleEnumDataPayload<?> getOrCreateInstance() {
         if (INSTANCE == null) {
-            INSTANCE = factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(BiomeSpecialEffects.GrassColorModifier.class));
+            INSTANCE = create(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(BiomeSpecialEffects.GrassColorModifier.class));
         }
         return INSTANCE;
     }
@@ -68,7 +68,7 @@ public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map
         return new ExtensibleEnumDataPayload<>(map);
     }
 
-    private static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> factory(List<Class<? extends T>> orderedEnums, List<Class<? extends T>> unorderedEnums) {
+    private static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> create(List<Class<? extends T>> orderedEnums, List<Class<? extends T>> unorderedEnums) {
         Map<Class<? extends T>, EnumData> map = new HashMap<>();
         for (Class<? extends T> enumToVerify : orderedEnums) {
             map.put(enumToVerify, new EnumData(Arrays.stream(enumToVerify.getEnumConstants()).map(Enum::name).toList(), true));

--- a/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
@@ -14,7 +14,6 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.component.FireworkExplosion;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
@@ -39,7 +38,7 @@ public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map
 
     public static synchronized ExtensibleEnumDataPayload<?> getInstance() {
         if (INSTANCE == null) {
-            INSTANCE = factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(MobCategory.class, BiomeSpecialEffects.GrassColorModifier.class));
+            INSTANCE = factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(BiomeSpecialEffects.GrassColorModifier.class));
         }
         return INSTANCE;
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.payload;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.common.IExtensibleEnum;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A payload used to verify that specific Enums that implement {@linkplain IExtensibleEnum} have the same Enum Constants in the same order.
+ */
+@ApiStatus.Internal
+public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map<Class<? extends T>, EnumData> enums) implements CustomPacketPayload {
+    public static final Type<ExtensibleEnumDataPayload<?>> TYPE = new Type<>(new ResourceLocation(NeoForgeVersion.MOD_ID, "extensible_enum_data"));
+    public static final StreamCodec<FriendlyByteBuf, ExtensibleEnumDataPayload<?>> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs.list()),
+            ExtensibleEnumDataPayload::enumClassNames,
+            EnumData.STREAM_CODEC.apply(ByteBufCodecs.list()),
+            ExtensibleEnumDataPayload::enumValueNames,
+            ExtensibleEnumDataPayload::of);
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> of(List<String> enumClassNames, List<EnumData> enumData) {
+        Map<Class<? extends T>, EnumData> map = new HashMap<>();
+        if (enumClassNames.size() != enumData.size()) {
+            throw new IllegalArgumentException("different amount of enum classes and enum value lists during extensible enum sync");
+        }
+        for (int i = 0; i < enumClassNames.size(); i++) {
+            String enumClassName = enumClassNames.get(i);
+            EnumData data = enumData.get(i);
+            try {
+                Class<? extends T> enumClazz = (Class<? extends T>) Class.forName(enumClassName);
+                if (!Enum.class.isAssignableFrom(enumClazz)) {
+                    throw new IllegalStateException("Class " + enumClassName + " is not an Enum");
+                }
+                if (!IExtensibleEnum.class.isAssignableFrom(enumClazz)) {
+                    throw new IllegalStateException("Class " + enumClassName + " is not IExtensible");
+                }
+                map.put(enumClazz, data);
+            } catch (ClassNotFoundException cnfe) {
+                throw new IllegalStateException("EnumClass " + enumClassName + " couldn't be found", cnfe);
+            }
+        }
+        return new ExtensibleEnumDataPayload<>(map);
+    }
+
+    public static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> factory(List<Class<? extends T>> orderedEnums, List<Class<? extends T>> unorderedEnums) {
+        Map<Class<? extends T>, EnumData> map = new HashMap<>();
+        for (Class<? extends T> enumToVerify : orderedEnums) {
+            map.put(enumToVerify, new EnumData(Arrays.stream(enumToVerify.getEnumConstants()).map(Enum::name).toList(), true));
+        }
+        for (Class<? extends T> enumToVerify : unorderedEnums) {
+            map.put(enumToVerify, new EnumData(Arrays.stream(enumToVerify.getEnumConstants()).map(Enum::name).toList(), false));
+        }
+        return new ExtensibleEnumDataPayload<>(map);
+    }
+
+    @Override
+    public Type<ExtensibleEnumDataPayload<?>> type() {
+        return TYPE;
+    }
+
+    private List<String> enumClassNames() {
+        return enums().keySet().stream().map(Class::getName).toList();
+    }
+
+    private List<EnumData> enumValueNames() {
+        return enums().values().stream().toList();
+    }
+
+    public record EnumData(List<String> enumValues, boolean verifyOrder) {
+        private static final StreamCodec<FriendlyByteBuf, EnumData> STREAM_CODEC = StreamCodec.composite(
+                ByteBufCodecs.STRING_UTF8.apply(ByteBufCodecs.list()),
+                EnumData::enumValues,
+                ByteBufCodecs.BOOL,
+                EnumData::verifyOrder,
+                EnumData::new);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
@@ -5,18 +5,23 @@
 
 package net.neoforged.neoforge.network.payload;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.item.Rarity;
+import net.minecraft.world.item.component.FireworkExplosion;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.neoforged.neoforge.common.IExtensibleEnum;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A payload used to verify that specific Enums that implement {@linkplain IExtensibleEnum} have the same Enum Constants in the same order.
@@ -30,6 +35,8 @@ public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map
             EnumData.STREAM_CODEC.apply(ByteBufCodecs.list()),
             ExtensibleEnumDataPayload::enumValueNames,
             ExtensibleEnumDataPayload::of);
+
+    public static final ExtensibleEnumDataPayload<?> INSTANCE = factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(MobCategory.class, BiomeSpecialEffects.GrassColorModifier.class));
 
     @SuppressWarnings("unchecked")
     private static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> of(List<String> enumClassNames, List<EnumData> enumData) {
@@ -56,7 +63,7 @@ public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map
         return new ExtensibleEnumDataPayload<>(map);
     }
 
-    public static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> factory(List<Class<? extends T>> orderedEnums, List<Class<? extends T>> unorderedEnums) {
+    private static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> factory(List<Class<? extends T>> orderedEnums, List<Class<? extends T>> unorderedEnums) {
         Map<Class<? extends T>, EnumData> map = new HashMap<>();
         for (Class<? extends T> enumToVerify : orderedEnums) {
             map.put(enumToVerify, new EnumData(Arrays.stream(enumToVerify.getEnumConstants()).map(Enum::name).toList(), true));

--- a/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ExtensibleEnumDataPayload.java
@@ -35,7 +35,14 @@ public record ExtensibleEnumDataPayload<T extends Enum<?> & IExtensibleEnum>(Map
             ExtensibleEnumDataPayload::enumValueNames,
             ExtensibleEnumDataPayload::of);
 
-    public static final ExtensibleEnumDataPayload<?> INSTANCE = factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(MobCategory.class, BiomeSpecialEffects.GrassColorModifier.class));
+    private static ExtensibleEnumDataPayload<?> INSTANCE = null;
+
+    public static synchronized ExtensibleEnumDataPayload<?> getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = factory(List.of(Rarity.class, FireworkExplosion.Shape.class), List.of(MobCategory.class, BiomeSpecialEffects.GrassColorModifier.class));
+        }
+        return INSTANCE;
+    }
 
     @SuppressWarnings("unchecked")
     private static <T extends Enum<?> & IExtensibleEnum> ExtensibleEnumDataPayload<T> of(List<String> enumClassNames, List<EnumData> enumData) {

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -216,6 +216,7 @@
   "neoforge.network.aux_light_data.failed": "Failed to handle auxiliary light data for chunk %s: %s",
 
   "neoforge.network.data_maps.failed": "Failed to handle registry data map sync for registry %s: %s",
+  "neoforge.network.extensible_enum_data.failed": "Enum mismatches found: %s",
   "neoforge.network.data_maps.missing_our": "Cannot connect to server as it is missing mandatory registry data maps present on the client: %s",
   "neoforge.network.data_maps.missing_their": "Cannot connect to server as it has mandatory registry data maps not present on the client: %s"
 }

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -216,7 +216,7 @@
   "neoforge.network.aux_light_data.failed": "Failed to handle auxiliary light data for chunk %s: %s",
 
   "neoforge.network.data_maps.failed": "Failed to handle registry data map sync for registry %s: %s",
-  "neoforge.network.extensible_enum_data.failed": "Enum mismatches found: %s",
+  "neoforge.network.extensible_enum_data.failed": "Extensible Enum mismatches found. Make sure that your server and client have the same mods.",
   "neoforge.network.data_maps.missing_our": "Cannot connect to server as it is missing mandatory registry data maps present on the client: %s",
   "neoforge.network.data_maps.missing_their": "Cannot connect to server as it has mandatory registry data maps not present on the client: %s"
 }


### PR DESCRIPTION
Adds a Payload that is sent during configuration phase of a connection to verify certain extensible enums from being the same. This prevents hard to track down issues by making sure that those issues fail early with decent info for devs. The checked enums are Rarity, FireworkExplosion.Shape and GrassColorModifier. The first 2 are verified for presence/absence of values and the correct order while the last one only is verified for presence/absence of values. That's because the first 2 are serialized with the ordinal and the last by name (correct order is not needed for that one).

I currently only check those 3 as they are the only extensible enums that are sent over the network.

This is an example on how the connection error looks to the user:
![image](https://github.com/neoforged/NeoForge/assets/36055315/396569b3-0193-4634-bcc8-466e408fc282)
