### PR TITLE
Fix rendering of non-translucent particles behind translucent geometry

### DIFF
--- a/patches/net/minecraft/client/particle/ParticleEngine.java.patch
+++ b/patches/net/minecraft/client/particle/ParticleEngine.java.patch
@@ -57,13 +57,13 @@
          }
      }
  
-+    /** @deprecated Neo: use {@link #render(LightTexture, Camera, float, net.minecraft.client.renderer.culling.Frustum)}  with Frustum as additional parameter */
++    /** @deprecated Neo: use {@link #render(LightTexture, Camera, float, net.minecraft.client.renderer.culling.Frustum, java.util.function.Predicate)} with additional parameters */
 +    @Deprecated
      public void render(LightTexture p_107339_, Camera p_107340_, float p_107341_) {
-+        render(p_107339_, p_107340_, p_107341_, null);
++        render(p_107339_, p_107340_, p_107341_, null, type -> true);
 +    }
 +
-+    public void render(LightTexture p_107339_, Camera p_107340_, float p_107341_, @Nullable net.minecraft.client.renderer.culling.Frustum frustum) {
++    public void render(LightTexture p_107339_, Camera p_107340_, float p_107341_, @Nullable net.minecraft.client.renderer.culling.Frustum frustum, java.util.function.Predicate<ParticleRenderType> renderTypePredicate) {
          p_107339_.turnOnLightLayer();
          RenderSystem.enableDepthTest();
 +        //TODO porting: is this even needed with the particle render order fix???
@@ -72,7 +72,7 @@
  
 -        for (ParticleRenderType particlerendertype : RENDER_ORDER) {
 +        for(ParticleRenderType particlerendertype : this.particles.keySet()) { // Forge: allow custom IParticleRenderType's
-+            if (particlerendertype == ParticleRenderType.NO_RENDER) continue;
++            if (particlerendertype == ParticleRenderType.NO_RENDER || !renderTypePredicate.test(particlerendertype)) continue;
              Iterable<Particle> iterable = this.particles.get(particlerendertype);
              if (iterable != null) {
                  RenderSystem.setShader(GameRenderer::getParticleShader);

--- a/patches/net/minecraft/client/particle/ParticleRenderType.java.patch
+++ b/patches/net/minecraft/client/particle/ParticleRenderType.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/particle/ParticleRenderType.java
++++ b/net/minecraft/client/particle/ParticleRenderType.java
+@@ -126,4 +_,8 @@
+     void begin(BufferBuilder p_107436_, TextureManager p_107437_);
+ 
+     void end(Tesselator p_107438_);
++
++    default boolean isTranslucent() {
++        return this == PARTICLE_SHEET_TRANSLUCENT;
++    }
+ }

--- a/patches/net/minecraft/client/particle/ParticleRenderType.java.patch
+++ b/patches/net/minecraft/client/particle/ParticleRenderType.java.patch
@@ -1,11 +1,48 @@
 --- a/net/minecraft/client/particle/ParticleRenderType.java
 +++ b/net/minecraft/client/particle/ParticleRenderType.java
-@@ -126,4 +_,8 @@
+@@ -52,6 +_,11 @@
+         public String toString() {
+             return "PARTICLE_SHEET_OPAQUE";
+         }
++
++        @Override
++        public boolean isTranslucent() {
++            return false;
++        }
+     };
+     ParticleRenderType PARTICLE_SHEET_TRANSLUCENT = new ParticleRenderType() {
+         @Override
+@@ -91,6 +_,11 @@
+         public String toString() {
+             return "PARTICLE_SHEET_LIT";
+         }
++
++        @Override
++        public boolean isTranslucent() {
++            return false;
++        }
+     };
+     ParticleRenderType CUSTOM = new ParticleRenderType() {
+         @Override
+@@ -107,6 +_,11 @@
+         public String toString() {
+             return "CUSTOM";
+         }
++
++        @Override
++        public boolean isTranslucent() {
++            return false;
++        }
+     };
+     ParticleRenderType NO_RENDER = new ParticleRenderType() {
+         @Override
+@@ -126,4 +_,9 @@
      void begin(BufferBuilder p_107436_, TextureManager p_107437_);
  
      void end(Tesselator p_107438_);
 +
++    /** {@return whether this type renders before or after the translucent chunk layer} */
 +    default boolean isTranslucent() {
-+        return this == PARTICLE_SHEET_TRANSLUCENT;
++        return true;
 +    }
  }

--- a/patches/net/minecraft/client/particle/ParticleRenderType.java.patch
+++ b/patches/net/minecraft/client/particle/ParticleRenderType.java.patch
@@ -24,18 +24,6 @@
      };
      ParticleRenderType CUSTOM = new ParticleRenderType() {
          @Override
-@@ -107,6 +_,11 @@
-         public String toString() {
-             return "CUSTOM";
-         }
-+
-+        @Override
-+        public boolean isTranslucent() {
-+            return false;
-+        }
-     };
-     ParticleRenderType NO_RENDER = new ParticleRenderType() {
-         @Override
 @@ -126,4 +_,9 @@
      void begin(BufferBuilder p_107436_, TextureManager p_107437_);
  

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -132,22 +132,27 @@
          }
  
          this.minecraft.debugRenderer.render(posestack, multibuffersource$buffersource, d0, d1, d2);
-@@ -1173,7 +_,8 @@
+@@ -1173,9 +_,13 @@
              this.particlesTarget.copyDepthFrom(this.minecraft.getMainRenderTarget());
              RenderStateShard.PARTICLES_TARGET.setupRenderState();
              profilerfiller.popPush("particles");
 -            this.minecraft.particleEngine.render(p_109606_, p_109604_, f);
-+            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum);
++            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum, type -> true);
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
              RenderStateShard.PARTICLES_TARGET.clearRenderState();
          } else {
++            // Neo: render solid particles before translucent geometry to match order of chunk render types, fixes solid particles disappearing underwater
++            profilerfiller.popPush("solid_particles");
++            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum, type -> !type.isTranslucent());
              profilerfiller.popPush("translucent");
+             if (this.translucentTarget != null) {
+                 this.translucentTarget.clear(Minecraft.ON_OSX);
 @@ -1187,7 +_,8 @@
              profilerfiller.popPush("string");
              this.renderSectionLayer(RenderType.tripwire(), d0, d1, d2, p_254120_, p_323920_);
              profilerfiller.popPush("particles");
 -            this.minecraft.particleEngine.render(p_109606_, p_109604_, f);
-+            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum);
++            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum, type -> type.isTranslucent()); // Neo: only render translucent particles at this stage
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
          }
  

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -141,7 +141,7 @@
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, posestack, p_254120_, p_323920_, this.ticks, p_109604_, frustum);
              RenderStateShard.PARTICLES_TARGET.clearRenderState();
          } else {
-+            // Neo: render solid particles before translucent geometry to match order of chunk render types, fixes solid particles disappearing underwater
++            // Neo: render solid particles before translucent geometry to match order of chunk render types, fixes solid particles disappearing underwater in Fast/Fancy (MC-161917)
 +            profilerfiller.popPush("solid_particles");
 +            this.minecraft.particleEngine.render(p_109606_, p_109604_, f, frustum, type -> !type.isTranslucent());
              profilerfiller.popPush("translucent");


### PR DESCRIPTION
This PR fixes a vanilla bug where solid particles generally tend to be invisible behind translucent geometry (i.e. water). This was introduced in 19w39a, when all particle rendering was moved to run after the translucent chunk layer is drawn. In previous versions, particle rendering was run before that layer was drawn.

My guess (although I have not verified it) is that the translucent geometry populates a depth buffer which then causes particles below it to be ignored, regardless of opacity. Mojang introduced a "solution" to this bug in the 1.16 era in the form of Fabulous mode, but that degrades performance significantly especially on weaker hardware, and changes many fundamental aspects of the rendering pipeline, which some mods are not compatible with.

It turns out that the issue can be fixed rather easily by conditionally restoring the pre-19w39a behavior. This is done by splitting particle rendering into two phases, like how terrain rendering works. Any particles on a non-translucent render pass are rendered before we render the translucent chunk layer, just like non-translucent chunk layers. Translucent particles continue to render at the usual time after translucent geometry is rendered. As such, the way translucent particles interact with translucent geometry visually will not change, but non-translucent particles will once again be visible.

Non-translucent particles in front of translucent geometry still render in front as expected.

This is done in my implementation by:

* Patching a `Predicate<ParticleRenderType>` parameter into `ParticleEngine`,
* Adding an `isTranslucent` method into `ParticleRenderType` (modders can override this for custom render types if desired), and
* Adding a second `ParticleEngine.render` call into `LevelRenderer` within the non-Fabulous portion of particle rendering, that runs before the translucent chunk layer is drawn, and renders non-translucent particle render types. The change is not applied to the Fabulous branch, as Fabulous' sorting already handles this without issues, and so there is no real reason to adjust behavior. We just render all the particle types at the same time there.

Although Mojang have made it relatively clear on the bug tracker that Fabulous mode is the intended solution to most of these "glitches" with translucency, I still think this change is worthwhile for inclusion in NeoForge as it opens up more possibilities for mods to use particle effects without needing to require their users to enable Fabulous, and deal with the associated drawbacks. It seems incredibly unlikely that there would be any use case in which particles being hidden based on their position relative to translucent geometry is desired.

To close, here is a screenshot demonstrating the issue and fix. Notice that the bubble column vortex is now shown, as are the underwater ambience particles.

Before PR:

![2024-05-19_17 12 12](https://github.com/neoforged/NeoForge/assets/42941056/10a4803d-4f44-46f9-b6c8-b9542af4a6fa)

After PR:

![2024-05-19_17 08 10](https://github.com/neoforged/NeoForge/assets/42941056/56caabb6-8b87-47e4-a927-c0d914ae3e91)
