### PR TITLE
Update FML to improve error reporting

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
@@ -5,14 +5,11 @@
 
 package net.neoforged.neoforge.client.gui;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Streams;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
@@ -24,7 +21,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
 import net.neoforged.fml.ModLoadingIssue;
 import net.neoforged.fml.i18n.FMLTranslations;
-import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.client.gui.widget.ExtendedButton;
 import org.apache.logging.log4j.LogManager;
@@ -109,8 +105,6 @@ public class LoadingErrorScreen extends ErrorScreen {
                 addEntry(new LoadingMessageEntry(parent.errorHeader, true));
             errors.forEach(e -> addEntry(new LoadingMessageEntry(e.text)));
             if (both) {
-                int maxChars = (this.width - 10) / parent.minecraft.font.width("-");
-                addEntry(new LoadingMessageEntry(Component.literal("\n" + Strings.repeat("-", maxChars) + "\n")));
                 addEntry(new LoadingMessageEntry(parent.warningHeader, true));
             }
             warnings.forEach(w -> addEntry(new LoadingMessageEntry(w.text)));
@@ -123,7 +117,7 @@ public class LoadingErrorScreen extends ErrorScreen {
 
         @Override
         public int getRowWidth() {
-            return this.width;
+            return this.width - 15;
         }
 
         public class LoadingMessageEntry extends ObjectSelectionList.Entry<LoadingMessageEntry> {
@@ -151,7 +145,7 @@ public class LoadingErrorScreen extends ErrorScreen {
                 int y = top + 2;
                 for (FormattedCharSequence string : strings) {
                     if (center)
-                        guiGraphics.drawString(font, string, left + (width) - font.width(string) / 2F, (float) y, 0xFFFFFF, false);
+                        guiGraphics.drawString(font, string, left + (width - font.width(string)) / 2F, (float) y, 0xFFFFFF, false);
                     else
                         guiGraphics.drawString(font, string, left + 5, y, 0xFFFFFF, false);
                     y += font.lineHeight;
@@ -163,34 +157,8 @@ public class LoadingErrorScreen extends ErrorScreen {
     private record FormattedIssue(Component text, ModLoadingIssue issue) {
         public static FormattedIssue of(ModLoadingIssue issue) {
             return new FormattedIssue(
-                    Component.literal(FMLTranslations.parseMessage(issue.translationKey(), formatArgs(issue))),
+                    Component.literal(FMLTranslations.translateIssue(issue)),
                     issue);
-        }
-
-        private static Object[] formatArgs(ModLoadingIssue issue) {
-            var modInfo = issue.affectedMod();
-            if (modInfo == null && issue.affectedModFile() != null) {
-                if (!issue.affectedModFile().getModInfos().isEmpty()) {
-                    modInfo = issue.affectedModFile().getModInfos().getFirst();
-                }
-            }
-
-            return Streams.concat(Stream.of(modInfo, null), issue.translationArgs().stream())
-                    .map(FormattedIssue::formatArg)
-                    .toArray();
-        }
-
-        private static Object formatArg(Object arg) {
-            if (arg instanceof Path path) {
-                var gameDir = FMLLoader.getGamePath();
-                if (path.startsWith(gameDir)) {
-                    return gameDir.relativize(path).toString();
-                } else {
-                    return path.toString();
-                }
-            } else {
-                return arg;
-            }
         }
     }
 }


### PR DESCRIPTION
This fixes various issues:

- The warning/error headers not being centered when both warnings and errors were present
- Removing the "- - - - - - -" separator between warnings and errors since it was not resized correctly when the screen size changed
- By bumping FML:
  - Fix issues when exceptions were thrown in init tasks rather than event dispatch since those were not correctly converted to mod loading issues
  - Fix various problems with translations using the wrong argument indices and sometimes causing crashes due to that.

![image](https://github.com/neoforged/NeoForge/assets/1261399/f7049f44-a096-4828-b71c-c5c6396ba1eb)
