### PR TITLE
Fix entities' item_handler_automation capability getting ignored in certain cases

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.items;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.core.BlockPos;
@@ -209,15 +210,12 @@ public class VanillaInventoryCodeHooks {
         // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
         List<Entity> list = worldIn.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
         if (!list.isEmpty()) {
-            Entity entity;
-            IItemHandler entityCap;
-            do {
-                entity = list.remove(worldIn.random.nextInt(list.size()));
-                entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
+            Collections.shuffle(list);
+            for(Entity entity : list) {
+            	IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
+                if (entityCap != null)
+                    return Optional.of(ImmutablePair.of(entityCap, entity));
             }
-            while (entityCap != null && !list.isEmpty());
-            if (entityCap != null)
-                return Optional.of(ImmutablePair.of(entityCap, entity));
         }
 
         return Optional.empty();

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -211,7 +211,7 @@ public class VanillaInventoryCodeHooks {
         List<Entity> list = worldIn.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
         if (!list.isEmpty()) {
             Collections.shuffle(list);
-            for(Entity entity : list) {
+            for (Entity entity : list) {
             	IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
                 if (entityCap != null)
                     return Optional.of(ImmutablePair.of(entityCap, entity));

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -209,8 +209,13 @@ public class VanillaInventoryCodeHooks {
         // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
         List<Entity> list = worldIn.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
         if (!list.isEmpty()) {
-            var entity = list.get(worldIn.random.nextInt(list.size()));
-            var entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
+            Entity entity;
+            IItemHandler entityCap;
+            do {
+                entity = list.remove(worldIn.random.nextInt(list.size()));
+                entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
+            }
+            while (entityCap != null && !list.isEmpty());
             if (entityCap != null)
                 return Optional.of(ImmutablePair.of(entityCap, entity));
         }

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -212,7 +212,7 @@ public class VanillaInventoryCodeHooks {
         if (!list.isEmpty()) {
             Collections.shuffle(list);
             for (Entity entity : list) {
-            	IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
+                IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
                 if (entityCap != null)
                     return Optional.of(ImmutablePair.of(entityCap, entity));
             }


### PR DESCRIPTION
### Issue
The `item_handler_automation` entity capability can sometimes be ignored when multiple entities are above a vanilla hopper. This is especially evident when an entity having an inventory that the hopper cannot extract from stands on the same hopper as an entity without the capability (like a player).

As a concrete example, take this custom boat with a passcode-protected chest. The boat's capability is set up so that the vanilla hopper cannot extract from it. With the boat being the only entity above the hopper, this works fine. However as soon as the player walks into the detection area of the hopper, the hopper starts extracting from the boat.
<details><summary>Showcase</summary>

https://github.com/neoforged/NeoForge/assets/5149876/59533363-53c0-4778-995e-875f08eae0bb

</details>

### Cause
When checking whether entities above a hopper have the `item_handler_automation` capability, NeoForge takes any random such entity and returns its capability (see [VanillaInventoryCodeHooks](https://github.com/neoforged/NeoForge/blob/7c6475b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java#L212-L215)), or empty if the entity does not have the capability. The problem is that if this selected entity does not have it, the hopper [falls back to vanilla code](https://github.com/neoforged/NeoForge/blob/7c6475b/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch#L15-L17), which then, keeping in line with the example, finds the boat, and extracts from it.

### Fix
Instead of returning the first random entity, the code now checks as many random entities as necessary until it finds an entity with the `item_handler_automation` capability. This makes sure the capability is respected, and the vanilla hopper code is not run when such an entity exists above the hopper. If no entity with this capability is found, the vanilla code will run as normal.