### PR TITLE
Update IShearable to support Bogged and perform some fixes and cleanup

### DIFF
--- a/patches/net/minecraft/world/entity/Shearable.java.patch
+++ b/patches/net/minecraft/world/entity/Shearable.java.patch
@@ -11,13 +11,13 @@
 +@Deprecated
 +public interface Shearable extends net.neoforged.neoforge.common.IShearable {
 +    /**
-+     * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable#onSheared(net.minecraft.world.entity.player.Player, net.minecraft.world.item.ItemStack, net.minecraft.world.level.Level, net.minecraft.core.BlockPos, int)} instead.
++     * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable#onSheared(net.minecraft.world.entity.player.Player, net.minecraft.world.item.ItemStack, net.minecraft.world.level.Level, net.minecraft.core.BlockPos)} instead.
 +     */
 +    @Deprecated
      void shear(SoundSource p_21749_);
  
 +    /**
-+     * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable#isShearable(net.minecraft.world.item.ItemStack, net.minecraft.world.level.Level, net.minecraft.core.BlockPos)} instead.
++     * @deprecated Neo: Use {@link net.neoforged.neoforge.common.IShearable#isShearable(net.minecraft.world.entity.player.Player, net.minecraft.world.item.ItemStack, net.minecraft.world.level.Level, net.minecraft.core.BlockPos)} instead.
 +     */
 +    @Deprecated
      boolean readyForShearing();

--- a/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
+++ b/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
@@ -5,7 +5,7 @@
              this.playSound(soundevent, 1.0F, 1.0F);
              return InteractionResult.sidedSuccess(this.level().isClientSide);
 -        } else if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
-+        } else if (false && itemstack.getItem() == Items.SHEARS && this.readyForShearing()) { //Forge: Moved to onSheared
++        } else if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { //Neo: Moved to onSheared
              this.shear(SoundSource.PLAYERS);
              this.gameEvent(GameEvent.SHEAR, p_28941_);
              if (!this.level().isClientSide) {

--- a/patches/net/minecraft/world/entity/animal/Sheep.java.patch
+++ b/patches/net/minecraft/world/entity/animal/Sheep.java.patch
@@ -5,7 +5,7 @@
      public InteractionResult mobInteract(Player p_29853_, InteractionHand p_29854_) {
          ItemStack itemstack = p_29853_.getItemInHand(p_29854_);
 -        if (itemstack.is(Items.SHEARS)) {
-+        if (false && itemstack.getItem() == Items.SHEARS) { //Forge: Moved to onSheared
++        if (false && itemstack.is(Items.SHEARS)) { //Neo: Moved to onSheared
              if (!this.level().isClientSide && this.readyForShearing()) {
                  this.shear(SoundSource.PLAYERS);
                  this.gameEvent(GameEvent.SHEAR, p_29853_);

--- a/patches/net/minecraft/world/entity/animal/SnowGolem.java.patch
+++ b/patches/net/minecraft/world/entity/animal/SnowGolem.java.patch
@@ -14,7 +14,7 @@
      protected InteractionResult mobInteract(Player p_29920_, InteractionHand p_29921_) {
          ItemStack itemstack = p_29920_.getItemInHand(p_29921_);
 -        if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
-+        if (false && itemstack.getItem() == Items.SHEARS && this.readyForShearing()) { //Forge: Moved to onSheared
++        if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { //Neo: Moved to onSheared
              this.shear(SoundSource.PLAYERS);
              this.gameEvent(GameEvent.SHEAR, p_29920_);
              if (!this.level().isClientSide) {

--- a/patches/net/minecraft/world/entity/monster/Bogged.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Bogged.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/Bogged.java
++++ b/net/minecraft/world/entity/monster/Bogged.java
+@@ -74,7 +_,7 @@
+     @Override
+     protected InteractionResult mobInteract(Player p_330736_, InteractionHand p_331786_) {
+         ItemStack itemstack = p_330736_.getItemInHand(p_331786_);
+-        if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
++        if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { //Neo: Moved to onSheared
+             this.shear(SoundSource.PLAYERS);
+             this.gameEvent(GameEvent.SHEAR, p_330736_);
+             if (!this.level().isClientSide) {

--- a/patches/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/net/minecraft/world/item/ShearsItem.java.patch
@@ -1,20 +1,22 @@
 --- a/net/minecraft/world/item/ShearsItem.java
 +++ b/net/minecraft/world/item/ShearsItem.java
-@@ -55,6 +_,27 @@
+@@ -55,6 +_,29 @@
      }
  
      @Override
 +    public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity entity, net.minecraft.world.InteractionHand hand) {
 +        if (entity instanceof net.neoforged.neoforge.common.IShearable target) {
-+            if (entity.level().isClientSide) return InteractionResult.CONSUME;
 +            BlockPos pos = entity.blockPosition();
-+            if (target.isShearable(stack, entity.level(), pos)) {
-+                target.onSheared(player, stack, entity.level(), pos, stack.getEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.FORTUNE))
-+                      .forEach(drop -> target.spawnShearedDrop(entity.level(), pos, drop));
++            Level level = entity.level();
++            if (target.isShearable(player, stack, level, pos)) {
++                if (level.isClientSide) return InteractionResult.SUCCESS;
++                for (ItemStack drop : target.onSheared(player, stack, level, pos)) {
++                    target.spawnShearedDrop(level, pos, drop);
++                }
 +                entity.gameEvent(GameEvent.SHEAR, player);
-+                stack.hurtAndBreak(1, player, hand == net.minecraft.world.InteractionHand.MAIN_HAND ? net.minecraft.world.entity.EquipmentSlot.MAINHAND : net.minecraft.world.entity.EquipmentSlot.OFFHAND);
++                stack.hurtAndBreak(1, player, LivingEntity.getSlotForHand(hand));
++                return InteractionResult.CONSUME;
 +            }
-+            return InteractionResult.SUCCESS;
 +        }
 +        return InteractionResult.PASS;
 +    }

--- a/src/main/java/net/neoforged/neoforge/common/IShearable.java
+++ b/src/main/java/net/neoforged/neoforge/common/IShearable.java
@@ -15,6 +15,7 @@ import net.minecraft.world.entity.Shearable;
 import net.minecraft.world.entity.animal.MushroomCow;
 import net.minecraft.world.entity.animal.SnowGolem;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.monster.Bogged;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -39,7 +40,8 @@ public interface IShearable {
      * @param pos   Block's position in level.
      * @return If this is shearable, and onSheared should be called.
      */
-    default boolean isShearable(ItemStack item, Level level, BlockPos pos) {
+    default boolean isShearable(@Nullable Player player, ItemStack item, Level level, BlockPos pos) {
+        //Default to checking readyForShearing if we are the vanilla shearable interface, and if we aren't assume a default of true
         return !(this instanceof Shearable shearable) || shearable.readyForShearing();
     }
 
@@ -55,10 +57,9 @@ public interface IShearable {
      * @param item    The ItemStack that is being used, may be empty.
      * @param level   The current level.
      * @param pos     If this is a block, the block's position in level.
-     * @param fortune The fortune level of the shears being used.
      * @return A List containing all items that resulted from the shearing process. May be empty.
      */
-    default List<ItemStack> onSheared(@Nullable Player player, ItemStack item, Level level, BlockPos pos, int fortune) {
+    default List<ItemStack> onSheared(@Nullable Player player, ItemStack item, Level level, BlockPos pos) {
         if (this instanceof LivingEntity entity && this instanceof Shearable shearable) {
             if (!level.isClientSide) {
                 List<ItemEntity> drops = new ArrayList<>();
@@ -82,6 +83,8 @@ public interface IShearable {
     default void spawnShearedDrop(Level level, BlockPos pos, ItemStack drop) {
         if (this instanceof SnowGolem golem) {
             golem.spawnAtLocation(drop, 1.7F);
+        } else if (this instanceof Bogged bogged) {
+            bogged.spawnAtLocation(drop);
         } else if (this instanceof MushroomCow cow) {
             // Note: Vanilla uses addFreshEntity instead of spawnAtLocation for spawning mooshrooms drops
             // In case a mod is capturing drops for the entity we instead do it the same way we patch in MushroomCow#shear

--- a/src/main/java/net/neoforged/neoforge/common/IShearable.java
+++ b/src/main/java/net/neoforged/neoforge/common/IShearable.java
@@ -54,9 +54,9 @@ public interface IShearable {
      * <p>
      * For entities, they should trust their internal location information over the values passed into this function.
      *
-     * @param item    The ItemStack that is being used, may be empty.
-     * @param level   The current level.
-     * @param pos     If this is a block, the block's position in level.
+     * @param item  The ItemStack that is being used, may be empty.
+     * @param level The current level.
+     * @param pos   If this is a block, the block's position in level.
      * @return A List containing all items that resulted from the shearing process. May be empty.
      */
     default List<ItemStack> onSheared(@Nullable Player player, ItemStack item, Level level, BlockPos pos) {


### PR DESCRIPTION
This is partially a follow-up to #581, now that breaking changes can be made:
- Adds a `@Nullable Player` param to `isShearable` in case implementers have a use case and want to only let certain players (such as the entity's owner) shear it
- Removed the `int fortune` parameter from `onSheared` as it is more reasonable to have people who need it to just query it from the passed in item stack

Additionally the following changes have been made:
- Fixes the client swinging arm when interacting with already sheared entities (#606)
- Support shearing minecraft's Bogged mob without potentially duplicating drops (I haven't tested, but my suspicion is they were duped before this change, due to running in the mob and from the shears)
- Updated our patches "disabling" certain if statements to only be adding the `false` and the comment, rather than also reverting an `stack.is(Items.SHEARS)` check to an `stack.getItem() == Items.SHEARS` check.