### PR TITLE
Make heart types an extensible enum and add an event to modify them

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -385,12 +385,12 @@
          CONTAINER(
              new ResourceLocation("hud/heart/container"),
              new ResourceLocation("hud/heart/container_blinking"),
-@@ -1406,8 +_,22 @@
+@@ -1406,8 +_,23 @@
              } else {
                  gui$hearttype = NORMAL;
              }
--
 +            gui$hearttype = net.neoforged.neoforge.event.EventHooks.firePlayerHeartTypeEvent(p_168733_, gui$hearttype);
+ 
              return gui$hearttype;
 +        }
 +

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -370,15 +370,42 @@
                  this.toolHighlightTimer = (int)(40.0 * this.minecraft.options.notificationDisplayTime().get());
              } else if (this.toolHighlightTimer > 0) {
                  this.toolHighlightTimer--;
-@@ -1287,6 +_,11 @@
-                 p_282761_.drawString(font, SAVING_TEXT, p_282761_.guiWidth() - j - 10, p_282761_.guiHeight() - 15, k);
-             }
+@@ -1289,8 +_,13 @@
          }
-+    }
-+
+     }
+ 
 +    @org.jetbrains.annotations.ApiStatus.Internal
 +    public void initModdedOverlays() {
 +        this.layerManager.initModdedLayers();
-     }
- 
++    }
++
      @OnlyIn(Dist.CLIENT)
+-    public static enum HeartType {
++    public static enum HeartType implements net.neoforged.neoforge.common.IExtensibleEnum {
+         CONTAINER(
+             new ResourceLocation("hud/heart/container"),
+             new ResourceLocation("hud/heart/container_blinking"),
+@@ -1406,8 +_,22 @@
+             } else {
+                 gui$hearttype = NORMAL;
+             }
+-
++            gui$hearttype = net.neoforged.neoforge.event.EventHooks.firePlayerHeartTypeEvent(p_168733_, gui$hearttype);
+             return gui$hearttype;
++        }
++
++        public static HeartType create(
++                String name,
++                ResourceLocation full,
++                ResourceLocation fullBlinking,
++                ResourceLocation half,
++                ResourceLocation halfBlinking,
++                ResourceLocation hardcoreFull,
++                ResourceLocation hardcoreFullBlinking,
++                ResourceLocation hardcoreHalf,
++                ResourceLocation hardcoreHalfBlinking
++        ) {
++            throw new IllegalStateException("Enum not extended");
+         }
+     }
+ }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -16,6 +16,7 @@ import java.util.function.Consumer;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -139,6 +140,7 @@ import net.neoforged.neoforge.event.entity.player.PermissionsChangedEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerDestroyItemEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerFlyableFallEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerHeartTypeEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerRespawnPositionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerSetSpawnEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerSleepInBedEvent;
@@ -860,6 +862,18 @@ public class EventHooks {
 
     public static void firePlayerSmeltedEvent(Player player, ItemStack smelted) {
         NeoForge.EVENT_BUS.post(new PlayerEvent.ItemSmeltedEvent(player, smelted));
+    }
+
+    /**
+     * Called by {@link Gui.HeartType#forPlayer} to allow for modification of the displayed heart type in the
+     * health bar.
+     *
+     * @param player    The local {@link Player}
+     * @param heartType The {@link Gui.HeartType} which would be displayed by vanilla
+     * @return The heart type which should be displayed
+     */
+    public static Gui.HeartType firePlayerHeartTypeEvent(Player player, Gui.HeartType heartType) {
+        return NeoForge.EVENT_BUS.post(new PlayerHeartTypeEvent(player, heartType)).getType();
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerHeartTypeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerHeartTypeEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.player;
+
+import net.minecraft.client.gui.Gui;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Fired by {@link Gui.HeartType#forPlayer} to allow mods to change the heart sprite which is displayed in the player's
+ * health bar.
+ *
+ * <p>
+ * This event is fired only on the client.
+ */
+public class PlayerHeartTypeEvent extends PlayerEvent {
+    private final Gui.HeartType originalType;
+    private Gui.HeartType type;
+
+    public PlayerHeartTypeEvent(Player player, Gui.HeartType type) {
+        super(player);
+        this.type = type;
+        this.originalType = type;
+    }
+
+    /**
+     * @return The original heart type which would be displayed by vanilla.
+     */
+    public Gui.HeartType getOriginalType() {
+        return originalType;
+    }
+
+    /**
+     * @return The heart type which will be displayed on the health bar.
+     */
+    public Gui.HeartType getType() {
+        return type;
+    }
+
+    /**
+     * Set the heart sprite which will be displayed on the {@link Player}'s health bar.
+     *
+     * @param type The {@link Gui.HeartType} to display
+     */
+    public void setType(Gui.HeartType type) {
+        this.type = type;
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -93,6 +93,7 @@ protected net.minecraft.client.gui.Gui renderPortalOverlay(Lnet/minecraft/client
 public net.minecraft.client.gui.Gui renderHotbar(FLnet/minecraft/client/gui/GuiGraphics;)V # renderHotbar
 public net.minecraft.client.gui.Gui renderEffects(Lnet/minecraft/client/gui/GuiGraphics;)V # renderEffects
 protected net.minecraft.client.gui.Gui drawBackdrop(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;III)V # drawBackdrop
+public net.minecraft.client.gui.Gui$HeartType
 protected net.minecraft.client.gui.components.AbstractButton SPRITES
 protected net.minecraft.client.gui.components.AbstractSelectionList$Entry list # list
 protected net.minecraft.client.gui.components.AbstractSliderButton getSprite()Lnet/minecraft/resources/ResourceLocation; # getSprite


### PR DESCRIPTION
Closes #961 by making `HeartType` an extensible enum and adding `PlayerHeartTypeEvent` to modify the heart type.