### PR TITLE
[1.20.6] Fix event results not defaulting to default

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/MobEffectEvent.java
@@ -92,7 +92,7 @@ public abstract class MobEffectEvent extends LivingEvent {
      * 
      */
     public static class Applicable extends MobEffectEvent {
-        protected Result result;
+        protected Result result = Result.DEFAULT;
 
         @ApiStatus.Internal
         public Applicable(LivingEntity living, MobEffectInstance effectInstance) {
@@ -123,6 +123,7 @@ public abstract class MobEffectEvent extends LivingEvent {
         /**
          * {@return If the mob effect should be applied or not, based on the current event result}
          */
+        @SuppressWarnings("deprecation") // Expected as the single call site for canBeAffected
         public boolean getApplicationResult() {
             if (this.result == Result.APPLY) {
                 return true;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/MobSpawnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/MobSpawnEvent.java
@@ -103,7 +103,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
         private final BlockPos pos;
         private final RandomSource random;
         private final boolean defaultResult;
-        private Result result;
+        private Result result = Result.DEFAULT;
 
         /**
          * Internal.
@@ -237,7 +237,7 @@ public abstract class MobSpawnEvent extends EntityEvent {
         @Nullable
         private final BaseSpawner spawner;
         private final MobSpawnType spawnType;
-        private Result result;
+        private Result result = Result.DEFAULT;
 
         public PositionCheck(Mob mob, ServerLevelAccessor level, MobSpawnType spawnType, @Nullable BaseSpawner spawner) {
             super(mob, level, mob.getX(), mob.getY(), mob.getZ());


### PR DESCRIPTION
#588 introduced a subtle bug into a couple events, where the default value of the results was not set to `DEFAULT`, causing unintended behaviors.  This PR fixes the three cases.

Closes #1006 