### PR TITLE
Add a spotless rule that automatically converts `@Nullable` annotations

### DIFF
--- a/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
+++ b/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
@@ -50,7 +50,19 @@ spotless {
                 throw new GradleException('@NotNull and @Nonnull are disallowed.')
             }
         }
-        bumpThisNumberIfACustomStepChanges(2)
+
+//        custom 'noJavaNullableAnnotation', { String fileContents ->
+//            String disallowedLine = "import javax.annotation.Nullable;"
+//            if (fileContents.contains(disallowedLine)) {
+//                throw new GradleException("@Nullable from javax is disallowed, use the jetbrains annotation instead.")
+//            }
+//        }
+        custom 'replaceJavaNullableAnnotation', { String fileContents ->
+            String disallowedLine = "import javax.annotation.Nullable;"
+
+            fileContents.replace(disallowedLine, "import org.jetbrains.annotations.Nullable;")
+        }
+        bumpThisNumberIfACustomStepChanges(3)
     }
 }
 

--- a/src/main/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
@@ -12,9 +12,9 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.function.Function;
-import javax.annotation.Nullable;
 import net.minecraft.client.renderer.block.model.BlockElement;
 import net.minecraft.client.renderer.block.model.BlockElementFace;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Holds extra data that may be injected into a face.<p>

--- a/src/main/java/net/neoforged/neoforge/common/advancements/critereon/PiglinNeutralArmorEntityPredicate.java
+++ b/src/main/java/net/neoforged/neoforge/common/advancements/critereon/PiglinNeutralArmorEntityPredicate.java
@@ -6,13 +6,13 @@
 package net.neoforged.neoforge.common.advancements.critereon;
 
 import com.mojang.serialization.MapCodec;
-import javax.annotation.Nullable;
 import net.minecraft.advancements.critereon.EntitySubPredicate;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 
 public class PiglinNeutralArmorEntityPredicate implements EntitySubPredicate {
     public static final PiglinNeutralArmorEntityPredicate INSTANCE = new PiglinNeutralArmorEntityPredicate();

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IServerCommonPacketListenerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IServerCommonPacketListenerExtension.java
@@ -5,12 +5,12 @@
 
 package net.neoforged.neoforge.common.extensions;
 
-import javax.annotation.Nullable;
 import net.minecraft.network.PacketSendListener;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.ServerCommonPacketListener;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Extension interface for {@link ServerCommonPacketListener}

--- a/src/main/java/net/neoforged/neoforge/common/world/chunk/TicketController.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/chunk/TicketController.java
@@ -7,13 +7,13 @@ package net.neoforged.neoforge.common.world.chunk;
 
 import java.util.Objects;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ForcedChunksSavedData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A class used to manage chunk loading tickets associated with a specific ID.

--- a/src/main/java/net/neoforged/neoforge/event/entity/SpawnPlacementRegisterEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/SpawnPlacementRegisterEvent.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.event.entity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -20,6 +19,7 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This event allows each {@link EntityType} to have a {@link SpawnPlacements.SpawnPredicate} registered or modified.

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerRespawnPositionEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerRespawnPositionEvent.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.event.entity.player;
 
 import java.util.Objects;
-import javax.annotation.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
@@ -19,6 +18,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Fired by {@link PlayerList#respawn(ServerPlayer, boolean)} before the server respawns a player.

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredient.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import net.minecraft.core.Holder;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -26,6 +25,7 @@ import net.neoforged.neoforge.common.crafting.ICustomIngredient;
 import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class serves as the fluid analogue of an item {@link Ingredient},

--- a/src/main/java/net/neoforged/neoforge/network/DualStackUtils.java
+++ b/src/main/java/net/neoforged/neoforge/network/DualStackUtils.java
@@ -14,13 +14,13 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
-import javax.annotation.Nullable;
 import net.minecraft.client.multiplayer.resolver.ResolvedServerAddress;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.client.multiplayer.resolver.ServerNameResolver;
 import net.minecraft.util.HttpUtil;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 public class DualStackUtils {

--- a/src/main/java/net/neoforged/neoforge/registries/RegistrySnapshot.java
+++ b/src/main/java/net/neoforged/neoforge/registries/RegistrySnapshot.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.annotation.Nullable;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.RegistrationInfo;
 import net.minecraft.core.Registry;
@@ -21,6 +20,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
 
 public class RegistrySnapshot {
     private static final Comparator<ResourceLocation> SORTER = ResourceLocation::compareNamespaced;

--- a/testframework/src/main/java/net/neoforged/testframework/TestListener.java
+++ b/testframework/src/main/java/net/neoforged/testframework/TestListener.java
@@ -7,11 +7,11 @@ package net.neoforged.testframework;
 
 import java.lang.invoke.MethodType;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.world.entity.Entity;
 import net.neoforged.testframework.impl.ReflectionUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A listener which listens for changes in tests.

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/GameTestData.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/GameTestData.java
@@ -6,11 +6,11 @@
 package net.neoforged.testframework.gametest;
 
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.level.block.Rotation;
+import org.jetbrains.annotations.Nullable;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/StructureTemplateBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/StructureTemplateBuilder.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
@@ -29,6 +28,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 import net.neoforged.fml.util.ObfuscationReflectionHelper;
 import net.neoforged.testframework.impl.ReflectionUtils;
+import org.jetbrains.annotations.Nullable;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault

--- a/testframework/src/main/java/net/neoforged/testframework/impl/FrameworkCollectors.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/FrameworkCollectors.java
@@ -25,7 +25,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -47,6 +46,7 @@ import net.neoforged.testframework.impl.test.MethodBasedEventTest;
 import net.neoforged.testframework.impl.test.MethodBasedGameTestTest;
 import net.neoforged.testframework.impl.test.MethodBasedTest;
 import net.neoforged.testframework.registration.RegistrationHelper;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Type;
 
 public final class FrameworkCollectors {


### PR DESCRIPTION
This PR adds a spotless rule that checks for the `@Nullable` annotation from `javax`, and replaces them with the `@Nullable` annotation from jetbrains.

Alternatively, I have commented out another idea that just throws a gradle exception. If the consensus is towards that implementation, we will be using that instead.