### PR TITLE
Fix spotless weirdly adding or removing blank lines in some records

### DIFF
--- a/codeformat/formatter-config.xml
+++ b/codeformat/formatter-config.xml
@@ -99,7 +99,7 @@
         <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_if_empty"/>
-        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="-1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
@@ -342,7 +342,7 @@
         <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="0"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>

--- a/src/main/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
  * @param ambientOcclusion If this face has AO
  */
 public record ExtraFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion) {
-
     public static final ExtraFaceData DEFAULT = new ExtraFaceData(0xFFFFFFFF, 0, 0, true);
 
     public static final Codec<Integer> COLOR = Codec.either(Codec.INT, Codec.STRING).xmap(
@@ -41,6 +40,7 @@ public record ExtraFaceData(int color, int blockLight, int skyLight, boolean amb
                             Codec.intRange(0, 15).optionalFieldOf("sky_light", 0).forGetter(ExtraFaceData::skyLight),
                             Codec.BOOL.optionalFieldOf("ambient_occlusion", true).forGetter(ExtraFaceData::ambientOcclusion))
                     .apply(builder, ExtraFaceData::new));
+
     /**
      * Parses an ExtraFaceData from JSON
      * 

--- a/src/main/java/net/neoforged/neoforge/client/model/renderable/BakedModelRenderable.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/renderable/BakedModelRenderable.java
@@ -76,9 +76,9 @@ public class BakedModelRenderable implements IRenderable<BakedModelRenderable.Co
     }
 
     public record Context(@Nullable BlockState state, Direction[] faces, RandomSource randomSource, long seed, ModelData data, Vector4f tint) {
-
         private static final Direction[] ALL_FACES_AND_NULL = Arrays.copyOf(Direction.values(), Direction.values().length + 1);
         private static final Vector4f WHITE = new Vector4f(1, 1, 1, 1);
+
         public Context(ModelData data) {
             this(null, ALL_FACES_AND_NULL, RandomSource.create(), 42, data, WHITE);
         }

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedAddEntityPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedAddEntityPayload.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record AdvancedAddEntityPayload(int entityId, byte[] customPayload) implements CustomPacketPayload {
-
     public static final Type<AdvancedAddEntityPayload> TYPE = new Type<>(new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_add_entity"));
     public static final StreamCodec<FriendlyByteBuf, AdvancedAddEntityPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.VAR_INT,
@@ -33,6 +32,7 @@ public record AdvancedAddEntityPayload(int entityId, byte[] customPayload) imple
             NeoForgeStreamCodecs.UNBOUNDED_BYTE_ARRAY,
             AdvancedAddEntityPayload::customPayload,
             AdvancedAddEntityPayload::new);
+
     public AdvancedAddEntityPayload(Entity e) {
         this(e.getId(), writeCustomData(e));
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record AdvancedContainerSetDataPayload(byte containerId, short dataId, int value) implements CustomPacketPayload {
-
     public static final Type<AdvancedContainerSetDataPayload> TYPE = new Type<>(new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_container_set_data"));
     public static final StreamCodec<RegistryFriendlyByteBuf, AdvancedContainerSetDataPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.BYTE,
@@ -33,6 +32,7 @@ public record AdvancedContainerSetDataPayload(byte containerId, short dataId, in
             ByteBufCodecs.VAR_INT,
             AdvancedContainerSetDataPayload::value,
             AdvancedContainerSetDataPayload::new);
+
     @Override
     public Type<AdvancedContainerSetDataPayload> type() {
         return TYPE;

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Component name, byte[] additionalData) implements CustomPacketPayload {
-
     public static final Type<AdvancedOpenScreenPayload> TYPE = new Type<>(new ResourceLocation(NeoForgeVersion.MOD_ID, "advanced_open_screen"));
     public static final StreamCodec<RegistryFriendlyByteBuf, AdvancedOpenScreenPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.VAR_INT,
@@ -40,6 +39,7 @@ public record AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Comp
             NeoForgeStreamCodecs.UNBOUNDED_BYTE_ARRAY,
             AdvancedOpenScreenPayload::additionalData,
             AdvancedOpenScreenPayload::new);
+
     @Override
     public Type<AdvancedOpenScreenPayload> type() {
         return TYPE;

--- a/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryComponent.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryComponent.java
@@ -25,13 +25,13 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record ModdedNetworkQueryComponent(ResourceLocation id, String version, Optional<PacketFlow> flow, boolean optional) {
-
     public static final StreamCodec<FriendlyByteBuf, ModdedNetworkQueryComponent> STREAM_CODEC = StreamCodec.composite(
             ResourceLocation.STREAM_CODEC, ModdedNetworkQueryComponent::id,
             ByteBufCodecs.STRING_UTF8, ModdedNetworkQueryComponent::version,
             ByteBufCodecs.optional(NeoForgeStreamCodecs.enumCodec(PacketFlow.class)), ModdedNetworkQueryComponent::flow,
             ByteBufCodecs.BOOL, ModdedNetworkQueryComponent::optional,
             ModdedNetworkQueryComponent::new);
+
     public ModdedNetworkQueryComponent(PayloadRegistration<?> reg) {
         this(reg.id(), reg.version(), reg.flow(), reg.optional());
     }


### PR DESCRIPTION
The current eclipse formatter config forces an empty lines before static fields in some records and no empty line afterwards.

This PR makes the formatter longer force these weird additions/removals.

But it's sadly not possible to force these lines to (not) exist, so existing code will not be automatically reformatted. Therefore I also manually reformatted the affected records.