### PR TITLE
Update NeoGradle to fix installer processor issues

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'net.neoforged.gradle.platform' version '7.0.135'
+    id 'net.neoforged.gradle.platform' version '7.0.136'
 }
 
 rootProject.name = rootDir.name


### PR DESCRIPTION
This PR updates NeoGradle to fix an issue where the installer profile's `libraries` section does not contain the tools used by the installer processors, causing installations to fail with messages starting with "Missing jar for processor".

See neoforged/NeoGradle#190 for details on the fix.