### PR TITLE
Backport #559 ShieldBlockEvent patch to fix freeze damaging in 1.20.1

### DIFF
--- a/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/minecraft/net/minecraft/world/entity/LivingEntity.java.patch
@@ -162,21 +162,16 @@
              if (!p_21016_.m_269533_(DamageTypeTags.f_268524_)) {
                 Entity entity = p_21016_.m_7640_();
                 if (entity instanceof LivingEntity) {
-@@ -1065,12 +_,13 @@
+@@ -1065,7 +_,8 @@
                 }
              }
  
 -            flag = true;
 +            flag = p_21017_ <= 0;
++         }
           }
  
           if (p_21016_.m_269533_(DamageTypeTags.f_268419_) && this.m_6095_().m_204039_(EntityTypeTags.f_144295_)) {
-             p_21017_ *= 5.0F;
-          }
-+         }
- 
-          this.f_267362_.m_267771_(1.5F);
-          boolean flag1 = true;
 @@ -1108,11 +_,10 @@
                 Player player1 = (Player)entity1;
                 this.f_20889_ = 100;


### PR DESCRIPTION
Tested it in game and Blaze dies in 4 freeze damaging and Cows in 10 so it is increased damage against blazes again.

Closes https://github.com/neoforged/NeoForge/issues/701