### PR TITLE
[1.20.6] Fix FP precision issues of the particle bound debug renderer close to horizontal coordinate limits

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/main/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -34,14 +34,18 @@ public final class ParticleBoundsDebugRenderer {
 
         PoseStack poseStack = event.getPoseStack();
         poseStack.pushPose();
-        poseStack.translate(-camPos.x, -camPos.y, -camPos.z);
 
         VertexConsumer consumer = Minecraft.getInstance().renderBuffers().bufferSource().getBuffer(RenderType.lines());
 
         Minecraft.getInstance().particleEngine.iterateParticles(particle -> {
             var bb = particle.getRenderBoundingBox(event.getPartialTick());
             if (!bb.isInfinite() && event.getFrustum().isVisible(bb)) {
+                poseStack.pushPose();
+                var offset = particle.getPos().subtract(camPos);
+                poseStack.translate(offset.x, offset.y, offset.z);
+                bb = bb.move(-particle.getPos().x, -particle.getPos().y, -particle.getPos().z);
                 LevelRenderer.renderLineBox(poseStack, consumer, bb, 1F, 0F, 0F, 1F);
+                poseStack.popPose();
             }
         });
 


### PR DESCRIPTION
This PR fixes the particle bound debug renderer not rendering the bounding boxes correctly when close to the horizontal coordinate limits (+-30,000,000).

Fixes #1028