### PR TITLE
Re-add Vanilla constructor for `ServerStatus`

### DIFF
--- a/patches/net/minecraft/network/protocol/status/ServerStatus.java.patch
+++ b/patches/net/minecraft/network/protocol/status/ServerStatus.java.patch
@@ -10,7 +10,7 @@
  ) {
      public static final Codec<ServerStatus> CODEC = RecordCodecBuilder.create(
          p_337519_ -> p_337519_.group(
-@@ -29,7 +_,8 @@
+@@ -29,10 +_,21 @@
                      ServerStatus.Players.CODEC.lenientOptionalFieldOf("players").forGetter(ServerStatus::players),
                      ServerStatus.Version.CODEC.lenientOptionalFieldOf("version").forGetter(ServerStatus::version),
                      ServerStatus.Favicon.CODEC.lenientOptionalFieldOf("favicon").forGetter(ServerStatus::favicon),

--- a/patches/net/minecraft/network/protocol/status/ServerStatus.java.patch
+++ b/patches/net/minecraft/network/protocol/status/ServerStatus.java.patch
@@ -20,3 +20,16 @@
                  )
                  .apply(p_337519_, ServerStatus::new)
      );
++
++    public ServerStatus(
++        Component description,
++        Optional<ServerStatus.Players> players,
++        Optional<ServerStatus.Version> version,
++        Optional<ServerStatus.Favicon> favicon,
++        boolean enforcesSecureChat
++    ) {
++        this(description, players, version, favicon, enforcesSecureChat, false);
++    }
+ 
+     public static record Favicon(byte[] iconBytes) {
+         private static final String PREFIX = "data:image/png;base64,";

--- a/patches/net/minecraft/network/protocol/status/ServerStatus.java.patch
+++ b/patches/net/minecraft/network/protocol/status/ServerStatus.java.patch
@@ -10,7 +10,7 @@
  ) {
      public static final Codec<ServerStatus> CODEC = RecordCodecBuilder.create(
          p_337519_ -> p_337519_.group(
-@@ -29,10 +_,21 @@
+@@ -29,10 +_,25 @@
                      ServerStatus.Players.CODEC.lenientOptionalFieldOf("players").forGetter(ServerStatus::players),
                      ServerStatus.Version.CODEC.lenientOptionalFieldOf("version").forGetter(ServerStatus::version),
                      ServerStatus.Favicon.CODEC.lenientOptionalFieldOf("favicon").forGetter(ServerStatus::favicon),
@@ -21,6 +21,10 @@
                  .apply(p_337519_, ServerStatus::new)
      );
 +
++    /**
++     * @deprecated Neo: Use {@link #ServerStatus(Component, Optional, Optional, Optional, boolean, boolean)}
++     */
++    @Deprecated
 +    public ServerStatus(
 +        Component description,
 +        Optional<ServerStatus.Players> players,


### PR DESCRIPTION
In NeoForge, `ServerStatus` has an extra field, `isModded`, however a constructor matching Vanilla's was never added that fills this with a default value. That is what this PR adds.