### PR TITLE
[1.20.x] Fix patch conflicts introduced by #999

### DIFF
--- a/patches/com/mojang/blaze3d/vertex/VertexFormatElement.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/VertexFormatElement.java.patch
@@ -22,7 +22,7 @@
              GlStateManager._vertexAttribPointer(p_167048_, p_167043_, p_167044_, false, p_167045_, p_167046_);
 @@ -186,6 +_,10 @@
          @OnlyIn(Dist.CLIENT)
-         public interface SetupState {
+         interface SetupState {
              void setupBufferState(int p_167053_, int p_167054_, int p_167055_, long p_167056_, int p_167057_, int p_167058_);
 +        }
 +

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -379,18 +379,19 @@
 +        this.layerManager.initModdedLayers();
 +    }
 +
-     @OnlyIn(Dist.CLIENT)
--    public static enum HeartType {
-+    public static enum HeartType implements net.neoforged.neoforge.common.IExtensibleEnum {
+     public @OnlyIn(Dist.CLIENT)
+-    static enum HeartType {
++    static enum HeartType implements net.neoforged.neoforge.common.IExtensibleEnum {
          CONTAINER(
              new ResourceLocation("hud/heart/container"),
              new ResourceLocation("hud/heart/container_blinking"),
-@@ -1406,8 +_,23 @@
-             } else {
+@@ -1407,7 +_,24 @@
                  gui$hearttype = NORMAL;
              }
-+            gui$hearttype = net.neoforged.neoforge.event.EventHooks.firePlayerHeartTypeEvent(p_168733_, gui$hearttype);
  
++            // Neo: Allow mods to override the heart type with a custom one.
++            gui$hearttype = net.neoforged.neoforge.event.EventHooks.firePlayerHeartTypeEvent(p_168733_, gui$hearttype);
++
              return gui$hearttype;
 +        }
 +

--- a/patches/net/minecraft/client/renderer/block/model/ItemOverrides.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/ItemOverrides.java.patch
@@ -47,4 +47,4 @@
 +        return com.google.common.collect.ImmutableList.copyOf(overrides);
      }
  
-     @OnlyIn(Dist.CLIENT)
+     public @OnlyIn(Dist.CLIENT)

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'net.neoforged.gradle.platform' version '7.0.138'
+    id 'net.neoforged.gradle.platform' version '7.0.136'
 }
 
 rootProject.name = rootDir.name

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'net.neoforged.gradle.platform' version '7.0.136'
+    id 'net.neoforged.gradle.platform' version '7.0.138'
 }
 
 rootProject.name = rootDir.name


### PR DESCRIPTION
~~pls help I cannot import the `neo foreg` thank you~~

(I still can't, pls help)

Merging of #999 introduced a patch conflict due to a change that was made between its last pipeline run and time of merge, this PR fixes that