### PR TITLE
[1.20.6] Add `BlockDropsEvent`

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -35,8 +35,8 @@
      public boolean destroyBlock(BlockPos p_9281_) {
          BlockState blockstate1 = this.level.getBlockState(p_9281_);
 -        if (!this.player.getMainHandItem().getItem().canAttackBlock(blockstate1, this.level, p_9281_, this.player)) {
-+        int exp = net.neoforged.neoforge.common.CommonHooks.fireBlockBreak(level, gameModeForPlayer, player, p_9281_, blockstate1);
-+        if (exp == -1) {
++        var event = net.neoforged.neoforge.common.CommonHooks.fireBlockBreak(level, gameModeForPlayer, player, p_9281_, blockstate1);
++        if (event.isCanceled()) {
              return false;
          } else {
              BlockEntity blockentity = this.level.getBlockEntity(p_9281_);
@@ -58,16 +58,16 @@
 -                    boolean flag = this.player.hasCorrectToolForDrops(blockstate);
 +                    boolean flag1 = blockstate.canHarvestBlock(this.level, p_9281_, this.player); // previously player.hasCorrectToolForDrops(blockstate)
                      itemstack.mineBlock(this.level, blockstate, p_9281_, this.player);
-+                    if (itemstack.isEmpty() && !itemstack1.isEmpty())
-+                        net.neoforged.neoforge.event.EventHooks.onPlayerDestroyItem(this.player, itemstack1, InteractionHand.MAIN_HAND);
 +                    boolean flag = removeBlock(p_9281_, blockstate, flag1);
 +
                      if (flag1 && flag) {
                          block.playerDestroy(this.level, this.player, p_9281_, blockstate, blockentity, itemstack1);
                      }
  
-+                    if (flag && exp > 0)
-+                        blockstate.getBlock().popExperience(level, p_9281_, exp);
++                    // Neo: Fire the PlayerDestroyItemEvent if the tool was broken at any point during the break process
++                    if (itemstack.isEmpty() && !itemstack1.isEmpty()) {
++                        net.neoforged.neoforge.event.EventHooks.onPlayerDestroyItem(this.player, itemstack1, InteractionHand.MAIN_HAND);
++                    }
 +
                      return true;
                  }

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -47,7 +47,7 @@
              getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null).forEach(p_152406_ -> popResource(p_49952_, p_49953_, p_152406_));
 -            p_49951_.spawnAfterBreak((ServerLevel)p_49952_, p_49953_, ItemStack.EMPTY, true);
 +            List<ItemEntity> captured = stopCapturingDrops();
-+            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49952_, p_49953_, p_49951_, null, captured, null, ItemStack.EMPTY, true);
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49952_, p_49953_, p_49951_, null, captured, null, ItemStack.EMPTY);
          }
      }
  
@@ -57,7 +57,7 @@
              getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_).forEach(p_49859_ -> popResource((ServerLevel)p_49894_, p_49895_, p_49859_));
 -            p_49893_.spawnAfterBreak((ServerLevel)p_49894_, p_49895_, ItemStack.EMPTY, true);
 +            List<ItemEntity> captured = stopCapturingDrops();
-+            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49894_, p_49895_, p_49893_, p_49896_, captured, null, ItemStack.EMPTY, true);
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49894_, p_49895_, p_49893_, p_49896_, captured, null, ItemStack.EMPTY);
          }
      }
  
@@ -69,7 +69,7 @@
              getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
 -            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, true);
 +            List<ItemEntity> captured = stopCapturingDrops();
-+            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49883_, p_49884_, p_49882_, p_49885_, captured, p_49886_, p_49887_, true);
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49883_, p_49884_, p_49882_, p_49885_, captured, p_49886_, p_49887_);
          }
      }
  

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -39,21 +39,41 @@
          } else if (blockstate.canOcclude()) {
              Block.BlockStatePairKey block$blockstatepairkey = new Block.BlockStatePairKey(p_152445_, blockstate, p_152448_);
              Object2ByteLinkedOpenHashMap<Block.BlockStatePairKey> object2bytelinkedopenhashmap = OCCLUSION_CACHE.get();
-@@ -297,9 +_,12 @@
-     public static void dropResources(
-         BlockState p_49882_, Level p_49883_, BlockPos p_49884_, @Nullable BlockEntity p_49885_, @Nullable Entity p_49886_, ItemStack p_49887_
-     ) {
-+        dropResources(p_49882_, p_49883_, p_49884_, p_49885_, p_49886_, p_49887_, true);
-+    }
-+    public static void dropResources(BlockState p_49882_, Level p_49883_, BlockPos p_49884_, @Nullable BlockEntity p_49885_, @Nullable Entity p_49886_, ItemStack p_49887_, boolean dropXp) {
-         if (p_49883_ instanceof ServerLevel) {
-             getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
--            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, true);
-+            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, dropXp);
+@@ -282,15 +_,19 @@
+ 
+     public static void dropResources(BlockState p_49951_, Level p_49952_, BlockPos p_49953_) {
+         if (p_49952_ instanceof ServerLevel) {
++            beginCapturingDrops();
+             getDrops(p_49951_, (ServerLevel)p_49952_, p_49953_, null).forEach(p_152406_ -> popResource(p_49952_, p_49953_, p_152406_));
+-            p_49951_.spawnAfterBreak((ServerLevel)p_49952_, p_49953_, ItemStack.EMPTY, true);
++            List<ItemEntity> captured = stopCapturingDrops();
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49952_, p_49953_, p_49951_, null, captured, null, ItemStack.EMPTY, true);
          }
      }
  
-@@ -327,7 +_,7 @@
+     public static void dropResources(BlockState p_49893_, LevelAccessor p_49894_, BlockPos p_49895_, @Nullable BlockEntity p_49896_) {
+         if (p_49894_ instanceof ServerLevel) {
++            beginCapturingDrops();
+             getDrops(p_49893_, (ServerLevel)p_49894_, p_49895_, p_49896_).forEach(p_49859_ -> popResource((ServerLevel)p_49894_, p_49895_, p_49859_));
+-            p_49893_.spawnAfterBreak((ServerLevel)p_49894_, p_49895_, ItemStack.EMPTY, true);
++            List<ItemEntity> captured = stopCapturingDrops();
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49894_, p_49895_, p_49893_, p_49896_, captured, null, ItemStack.EMPTY, true);
+         }
+     }
+ 
+@@ -298,8 +_,10 @@
+         BlockState p_49882_, Level p_49883_, BlockPos p_49884_, @Nullable BlockEntity p_49885_, @Nullable Entity p_49886_, ItemStack p_49887_
+     ) {
+         if (p_49883_ instanceof ServerLevel) {
++            beginCapturingDrops();
+             getDrops(p_49882_, (ServerLevel)p_49883_, p_49884_, p_49885_, p_49886_, p_49887_).forEach(p_49944_ -> popResource(p_49883_, p_49884_, p_49944_));
+-            p_49882_.spawnAfterBreak((ServerLevel)p_49883_, p_49884_, p_49887_, true);
++            List<ItemEntity> captured = stopCapturingDrops();
++            net.neoforged.neoforge.common.CommonHooks.handleBlockDrops((ServerLevel) p_49883_, p_49884_, p_49882_, p_49885_, captured, p_49886_, p_49887_, true);
+         }
+     }
+ 
+@@ -327,19 +_,26 @@
      }
  
      private static void popResource(Level p_152441_, Supplier<ItemEntity> p_152442_, ItemStack p_152443_) {
@@ -61,8 +81,15 @@
 +        if (!p_152441_.isClientSide && !p_152443_.isEmpty() && p_152441_.getGameRules().getBoolean(GameRules.RULE_DOBLOCKDROPS) && !p_152441_.restoringBlockSnapshots) {
              ItemEntity itementity = p_152442_.get();
              itementity.setDefaultPickUpDelay();
-             p_152441_.addFreshEntity(itementity);
-@@ -335,11 +_,12 @@
+-            p_152441_.addFreshEntity(itementity);
++            // Neo: Add drops to the captured list if capturing is enabled.
++            if (capturedDrops != null) {
++                capturedDrops.add(itementity);
++            }
++            else {
++                p_152441_.addFreshEntity(itementity);
++            }
+         }
      }
  
      public void popExperience(ServerLevel p_49806_, BlockPos p_49807_, int p_49808_) {
@@ -76,16 +103,6 @@
      public float getExplosionResistance() {
          return this.explosionResistance;
      }
-@@ -358,7 +_,8 @@
-     public void playerDestroy(Level p_49827_, Player p_49828_, BlockPos p_49829_, BlockState p_49830_, @Nullable BlockEntity p_49831_, ItemStack p_49832_) {
-         p_49828_.awardStat(Stats.BLOCK_MINED.get(this));
-         p_49828_.causeFoodExhaustion(0.005F);
--        dropResources(p_49830_, p_49827_, p_49829_, p_49831_, p_49828_, p_49832_);
-+        //Forge: Don't drop xp as part of the resources as it is handled by the patches in ServerPlayerGameMode#destroyBlock
-+        dropResources(p_49830_, p_49827_, p_49829_, p_49831_, p_49828_, p_49832_, false);
-     }
- 
-     public void setPlacedBy(Level p_49847_, BlockPos p_49848_, BlockState p_49849_, @Nullable LivingEntity p_49850_, ItemStack p_49851_) {
 @@ -386,8 +_,10 @@
  
      public void updateEntityAfterFallOn(BlockGetter p_49821_, Entity p_49822_) {
@@ -105,11 +122,40 @@
      public boolean dropFromExplosion(Explosion p_49826_) {
          return true;
      }
-@@ -486,6 +_,75 @@
+@@ -486,6 +_,104 @@
          return this.stateDefinition.getPossibleStates().stream().collect(ImmutableMap.toImmutableMap(Function.identity(), p_152459_));
      }
  
 +    /* ======================================== FORGE START =====================================*/
++
++    /**
++     * Short-lived holder of dropped item entities.
++     *
++     * When not null, records all item entities from {@link #popResource(Level, Supplier, ItemStack)} instead of adding them to the world.
++     */
++    @Nullable
++    private static List<ItemEntity> capturedDrops = null;
++
++    /**
++     * Initializes {@link #capturedDrops}, starting the drop capture process.
++     *
++     * Must only be called on the server thread.
++     */
++    private static void beginCapturingDrops() {
++        capturedDrops = new java.util.ArrayList<>();
++    }
++
++    /**
++     * Ends the drop capture process by setting {@link #capturedDrops} to null and returning the old list.
++     *
++     * Must only be called on the server thread.
++     */
++    private static List<ItemEntity> stopCapturingDrops() {
++        List<ItemEntity> drops = capturedDrops;
++        capturedDrops = null;
++        return drops;
++    }
++
 +    private Object renderProperties;
 +
 +    /*

--- a/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -46,7 +46,7 @@
          }
      }
  
-@@ -336,12 +_,13 @@
+@@ -336,8 +_,8 @@
          if (f == -1.0F) {
              return 0.0F;
          } else {
@@ -57,11 +57,6 @@
          }
      }
  
-     protected void spawnAfterBreak(BlockState p_222949_, ServerLevel p_222950_, BlockPos p_222951_, ItemStack p_222952_, boolean p_222953_) {
-+        if (p_222953_) net.neoforged.neoforge.common.CommonHooks.dropXpForBlock(p_222949_, p_222950_, p_222951_, p_222952_);
-     }
- 
-     protected void attack(BlockState p_60499_, Level p_60500_, BlockPos p_60501_, Player p_60502_) {
 @@ -360,8 +_,7 @@
  
      public final ResourceKey<LootTable> getLootTable() {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -449,7 +449,7 @@ public class CommonHooks {
      * @param pos         The broken block's position
      * @param state       The broken block's state
      * @param blockEntity The block entity from the given position
-     * @param drops       The list of all items dropped by the block
+     * @param drops       The list of all items dropped by the block, captured from {@link Block#getDrops}
      * @param breaker     The entity who broke the block, or null if unknown
      * @param tool        The tool used when breaking the block; may be empty
      */

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -478,7 +478,7 @@ public class CommonHooks {
      * @param player   The breaking player
      * @param pos      The position of the block being broken
      * @param state    The state of the block being broken
-     * @return The experience dropped by the broken block, or -1 if the break event was canceled.
+     * @return The event
      */
     public static BlockEvent.BreakEvent fireBlockBreak(Level level, GameType gameType, ServerPlayer player, BlockPos pos, BlockState state) {
         boolean preCancelEvent = false;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -442,8 +442,8 @@ public class CommonHooks {
     }
 
     /**
-     * Fires the {@link BlockDropsEvent} when block drops are determined.
-     * If the event is not cancelled, all drops must be added to the world, and then {@link Block#spawnAfterBreak} must be called.
+     * Fires the {@link BlockDropsEvent} when block drops (items and experience) are determined.
+     * If the event is not cancelled, all drops will be added to the world, and then {@link BlockBehaviour#spawnAfterBreak} will be called.
      * 
      * @param level       The level
      * @param pos         The broken block's position
@@ -452,16 +452,15 @@ public class CommonHooks {
      * @param drops       The list of all items dropped by the block
      * @param breaker     The entity who broke the block, or null if unknown
      * @param tool        The tool used when breaking the block; may be empty
-     * @param dropXp      The value of the patched-in dropXp parameter from dropResources.
      */
-    public static void handleBlockDrops(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool, boolean dropXp) {
-        BlockDropsEvent event = new BlockDropsEvent(level, pos, state, blockEntity, drops, breaker, tool, dropXp);
+    public static void handleBlockDrops(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool) {
+        BlockDropsEvent event = new BlockDropsEvent(level, pos, state, blockEntity, drops, breaker, tool);
         NeoForge.EVENT_BUS.post(event);
         if (!event.isCanceled()) {
             for (ItemEntity entity : event.getDrops()) {
                 level.addFreshEntity(entity);
             }
-            // Always pass false to spawnAfterBreak since we handle XP externally.
+            // Always pass false for the dropXP (last) param to spawnAfterBreak since we handle XP.
             state.spawnAfterBreak((ServerLevel) level, pos, tool, false);
             if (event.getDroppedExperience() > 0) {
                 state.getBlock().popExperience(level, pos, event.getDroppedExperience());

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -205,20 +205,24 @@ public interface IBlockExtension {
      *
      * Return true if the block is actually destroyed.
      *
-     * Note: When used in multiplayer, this is called on both client and
-     * server sides!
+     * This function is called on both the logical client and logical server.
      *
      * @param state       The current state.
      * @param level       The current level
      * @param player      The player damaging the block, may be null
      * @param pos         Block position in level
-     * @param willHarvest True if Block.harvestBlock will be called after this, if the return in true.
-     *                    Can be useful to delay the destruction of tile entities till after harvestBlock
+     * @param willHarvest The result of {@link #canHarvestBlock}, if called on the server by a non-creative player, otherwise always false.
      * @param fluid       The current fluid state at current position
      * @return True if the block is actually destroyed.
      */
     default boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) {
-        return level.setBlock(pos, fluid.createLegacyBlock(), level.isClientSide ? 11 : 3);
+        if (level.isClientSide()) {
+            // On the client, vanilla calls Level#setBlock, per MultiPlayerGameMode#destroyBlock
+            return level.setBlock(pos, fluid.createLegacyBlock(), 11);
+        } else {
+            // On the server, vanilla calls Level#removeBlock, per ServerPlayerGameMode#destroyBlock
+            return level.removeBlock(pos, false);
+        }
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -120,14 +120,12 @@ public interface IBlockStateExtension {
      *
      * Return true if the block is actually destroyed.
      *
-     * Note: When used in multiplayer, this is called on both client and
-     * server sides!
+     * This function is called on both the logical client and logical server.
      *
      * @param level       The current level
      * @param player      The player damaging the block, may be null
      * @param pos         Block position in level
-     * @param willHarvest True if Block.harvestBlock will be called after this, if the return in true.
-     *                    Can be useful to delay the destruction of tile entities till after harvestBlock
+     * @param willHarvest The result of {@link #canHarvestBlock}, if called on the server by a non-creative player, otherwise always false.
      * @param fluid       The current fluid and block state for the position in the level.
      * @return True if the block is actually destroyed.
      */
@@ -349,6 +347,7 @@ public interface IBlockStateExtension {
      * @return Amount of XP from breaking this block.
      */
     default int getExpDrop(LevelReader level, RandomSource randomSource, BlockPos pos, int fortuneLevel, int silkTouchLevel) {
+        // TODO: Change this method to have context of the full tool ItemStack instead of just the enchantment levels.
         return self().getBlock().getExpDrop(self(), level, randomSource, pos, fortuneLevel, silkTouchLevel);
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.level;
+
+import java.util.List;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.loot.LootModifier;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Fired when a block is broken and the drops have been determined, but before they have been added to the world. This event can be used to manipulate the dropped item entities.
+ * <p>
+ * No guarantees can be made about the block. It will either have already been removed from the world, or will be removed after the event terminates.
+ * <p>
+ * If you wish to edit the state of the block in-world, use {@link BreakEvent}.
+ */
+public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
+    @Nullable
+    private final BlockEntity blockEntity;
+    private final List<ItemEntity> drops;
+    @Nullable
+    private final Entity breaker;
+    private final ItemStack tool;
+
+    public BlockDropsEvent(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool) {
+        super(level, pos, state);
+        this.blockEntity = blockEntity;
+        this.drops = drops;
+        this.breaker = breaker;
+        this.tool = tool;
+    }
+
+    /**
+     * Returns a mutable list of item entities that will be dropped by this block.
+     * <p>
+     * When this event completes successfully, all entities in this list will be added to the world.
+     * 
+     * @return A mutable list of item entities.
+     * @apiNote Prefer using {@link LootModifier}s to add additional loot drops.
+     */
+    public List<ItemEntity> getDrops() {
+        return this.drops;
+    }
+
+    /**
+     * {@return the block entity from the current position, if available}
+     */
+    @Nullable
+    public BlockEntity getBlockEntity() {
+        return blockEntity;
+    }
+
+    /**
+     * {@return the entity that broke the block, or null if unknown}
+     */
+    @Nullable
+    public Entity getBreaker() {
+        return this.breaker;
+    }
+
+    /**
+     * {@return the tool used when breaking this block; may be empty}
+     */
+    public ItemStack getTool() {
+        return this.tool;
+    }
+
+    /**
+     * Cancels this event, preventing any drops from being spawned and preventing {@link Block#spawnAfterBreak} from being called.
+     */
+    @Override
+    public void setCanceled(boolean canceled) {
+        ICancellableEvent.super.setCanceled(canceled);
+    }
+
+    @Override
+    public ServerLevel getLevel() {
+        return (ServerLevel) super.getLevel();
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -36,6 +36,17 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
     private final ItemStack tool;
     private int experience;
 
+    /**
+     * Constructs a new BlockDropsEvent
+     *
+     * @param level       The level of the broken block
+     * @param pos         The position of the broken block
+     * @param state       The state of the broken block
+     * @param blockEntity The block entity of the broken block, if available
+     * @param drops       The list of drops from {@link Block#getDrops}
+     * @param breaker     The entity who broke the block, if any
+     * @param tool        The tool used to break the block. May be empty
+     */
     public BlockDropsEvent(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool) {
         super(level, pos, state);
         this.blockEntity = blockEntity;

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -36,20 +36,16 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
     private final ItemStack tool;
     private int experience;
 
-    public BlockDropsEvent(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool, boolean dropXp) {
+    public BlockDropsEvent(ServerLevel level, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, List<ItemEntity> drops, @Nullable Entity breaker, ItemStack tool) {
         super(level, pos, state);
         this.blockEntity = blockEntity;
         this.drops = drops;
         this.breaker = breaker;
         this.tool = tool;
 
-        if (dropXp) {
-            int fortuneLevel = tool.getEnchantmentLevel(Enchantments.FORTUNE);
-            int silkTouchLevel = tool.getEnchantmentLevel(Enchantments.SILK_TOUCH);
-            this.experience = state.getExpDrop(level, level.random, pos, fortuneLevel, silkTouchLevel);
-        } else {
-            this.experience = 0;
-        }
+        int fortuneLevel = tool.getEnchantmentLevel(Enchantments.FORTUNE);
+        int silkTouchLevel = tool.getEnchantmentLevel(Enchantments.SILK_TOUCH);
+        this.experience = state.getExpDrop(level, level.random, pos, fortuneLevel, silkTouchLevel);
     }
 
     /**
@@ -113,6 +109,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
      * Set the amount of experience points that will be dropped by the block
      *
      * @param experience The new amount. Must be a positive value.
+     * @apiNote When cancelled, no experience is dropped, regardless of this value.
      */
     public void setDroppedExperience(int experience) {
         Preconditions.checkArgument(experience > 0, "May not set a negative experience drop.");

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -14,7 +14,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
-import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.BaseFireBlock;
@@ -25,7 +24,6 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.ToolAction;
 import net.neoforged.neoforge.common.ToolActions;
 import net.neoforged.neoforge.common.util.BlockSnapshot;
-import net.neoforged.neoforge.event.EventHooks;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class BlockEvent extends Event {
@@ -58,44 +56,18 @@ public abstract class BlockEvent extends Event {
      * Canceling this event will prevent the Block from being broken.
      */
     public static class BreakEvent extends BlockEvent implements ICancellableEvent {
-        /** Reference to the Player who broke the block. If no player is available, use a EntityFakePlayer */
+        /**
+         * Reference to the Player who broke the block. If no player is available, use a EntityFakePlayer
+         */
         private final Player player;
-        private int exp;
 
         public BreakEvent(Level level, BlockPos pos, BlockState state, Player player) {
             super(level, pos, state);
             this.player = player;
-
-            if (state == null || !EventHooks.doPlayerHarvestCheck(player, state, level, pos)) // Handle empty block or player unable to break block scenario
-            {
-                this.exp = 0;
-            } else {
-                int fortuneLevel = player.getMainHandItem().getEnchantmentLevel(Enchantments.FORTUNE);
-                int silkTouchLevel = player.getMainHandItem().getEnchantmentLevel(Enchantments.SILK_TOUCH);
-                this.exp = state.getExpDrop(level, level.random, pos, fortuneLevel, silkTouchLevel);
-            }
         }
 
         public Player getPlayer() {
             return player;
-        }
-
-        /**
-         * Get the experience dropped by the block after the event has processed
-         *
-         * @return The experience to drop or 0 if the event was canceled
-         */
-        public int getExpToDrop() {
-            return this.isCanceled() ? 0 : exp;
-        }
-
-        /**
-         * Set the amount of experience dropped by the block after the event has processed
-         *
-         * @param exp 1 or higher to drop experience, else nothing will drop
-         */
-        public void setExpToDrop(int exp) {
-            this.exp = exp;
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -54,7 +54,7 @@ public abstract class BlockEvent extends Event {
     }
 
     /**
-     * Event that is fired when an Block is about to be broken by a player
+     * Event that is fired when a Block is about to be broken by a player
      * Canceling this event will prevent the Block from being broken.
      */
     public static class BreakEvent extends BlockEvent implements ICancellableEvent {

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -43,6 +43,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -237,6 +238,14 @@ public class ExtendedGameTestHelper extends GameTestHelper {
                     pos,
                     this.getTick());
         }
+    }
+
+    public void breakBlock(BlockPos relativePos, ItemStack tool, @Nullable Entity breakingEntity) {
+        BlockState state = getBlockState(relativePos);
+        BlockPos absolutePos = absolutePos(relativePos);
+        BlockEntity blockEntity = state.hasBlockEntity() ? getLevel().getBlockEntity(absolutePos) : null;
+        Block.dropResources(state, getLevel(), absolutePos, blockEntity, breakingEntity, tool);
+        getLevel().destroyBlock(absolutePos, false);
     }
 
     public void boneMeal(BlockPos pos, Player player) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -32,7 +32,8 @@ import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 
 @ForEachTest(groups = { BlockTests.GROUP + ".event", "event" })
 public class BlockEventTests {
-    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @GameTest
+    @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if the BlockDropsEvent prevents dropping items and experience when cancelled.")
     public static void blockDropsEventCancel(final DynamicTest test) {
         test.whenEnabled(listeners -> listeners.forge().addListener((final BlockDropsEvent event) -> {
@@ -66,7 +67,8 @@ public class BlockEventTests {
                 .thenSucceed());
     }
 
-    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @GameTest
+    @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if the BlockDropsEvent can modify dropped experience.")
     public static void blockDropsEventExperience(final DynamicTest test) {
         test.whenEnabled(listeners -> listeners.forge().addListener((final BlockDropsEvent event) -> {
@@ -89,7 +91,8 @@ public class BlockEventTests {
                 .thenSucceed());
     }
 
-    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @GameTest
+    @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if the BlockDropsEvent can move dropped items.")
     public static void blockDropsEventMovement(final DynamicTest test) {
         test.whenEnabled(listeners -> listeners.forge().addListener((final BlockDropsEvent event) -> {
@@ -112,7 +115,8 @@ public class BlockEventTests {
                 .thenSucceed());
     }
 
-    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @GameTest
+    @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if the entity place event is fired")
     public static void entityPlacedEvent(final DynamicTest test) {
         test.whenEnabled(listeners -> listeners.forge()
@@ -142,7 +146,8 @@ public class BlockEventTests {
                 .thenSucceed());
     }
 
-    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @GameTest
+    @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if the block modification event is fired")
     public static void blockModificationEvent(final DynamicTest test) {
         test.eventListeners().forge().addListener((final BlockEvent.BlockToolModificationEvent event) -> {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.debug.block;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.animal.Sheep;
@@ -15,11 +16,13 @@ import net.minecraft.world.entity.animal.goat.Goat;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RedstoneLampBlock;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ToolActions;
+import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.eventtest.internal.TestsMod;
 import net.neoforged.testframework.DynamicTest;
@@ -30,6 +33,35 @@ import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 
 @ForEachTest(groups = { BlockTests.GROUP + ".event", "event" })
 public class BlockEventTests {
+    @GameTest(template = TestsMod.TEMPLATE_3x3)
+    @TestHolder(description = "Tests if the BlockDestroyed event is fired and works properly.")
+    public static void blockDestroyedEvent(final DynamicTest test) {
+        test.whenEnabled(listeners -> listeners.forge().addListener((final BlockDropsEvent event) -> {
+            if (event.getState().getBlock() == Blocks.DIRT && !event.getTool().is(ItemTags.SHOVELS)) {
+                event.setCanceled(true); // Make dirt not drop unless it was broken by a shovel to test cancellation as a whole.
+            }
+            if (event.getState().getBlock() == Blocks.NETHER_QUARTZ_ORE && event.getTool().is(Items.IRON_PICKAXE)) {
+                event.setCanceled(true); // Make Nether Quartz drop no items when broken with an Iron Pickaxe.
+            }
+            test.pass();
+        }));
+
+        BlockPos pos = new BlockPos(1, 1, 1);
+
+        test.onGameTest(helper -> helper
+                .startSequence() // Dirt Test
+                .thenExecute(() -> helper.setBlock(pos, Blocks.DIRT))
+                .thenExecute(() -> helper.breakBlock(pos, new ItemStack(Items.DIAMOND_HOE), helper.makeMockPlayer(GameType.SURVIVAL)))
+                .thenExecute(() -> helper.assertBlockNotPresent(Blocks.DIRT, pos))
+                .thenExecute(() -> helper.assertItemEntityNotPresent(Items.DIRT))
+                .thenIdle(5) // Quartz Test
+                .thenExecute(() -> helper.setBlock(pos, Blocks.NETHER_QUARTZ_ORE))
+                .thenExecute(() -> helper.breakBlock(pos, new ItemStack(Items.IRON_PICKAXE), helper.makeMockPlayer(GameType.SURVIVAL)))
+                .thenExecute(() -> helper.assertBlockNotPresent(Blocks.NETHER_QUARTZ_ORE, pos))
+                .thenExecute(() -> helper.assertItemEntityNotPresent(Items.QUARTZ))
+                .thenSucceed());
+    }
+
     @GameTest(template = TestsMod.TEMPLATE_3x3)
     @TestHolder(description = "Tests if the entity place event is fired")
     public static void entityPlacedEvent(final DynamicTest test) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEventTests.java
@@ -23,7 +23,6 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.ToolActions;
 import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
-import net.neoforged.neoforge.eventtest.internal.TestsMod;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;


### PR DESCRIPTION
This PR adds the `BlockDropsEvent`, which allows for control over the dropped item entities and experience when breaking a block. This allows usecases such as teleporting the drops of a block that are not possible through GLM's. In addition, it allows us to remove the hack that is allowing XP modifications through the `BlockEvent.BreakEvent` and move it to the new event.

The event can be cancelled, which will result in nothing (items or experience) being dropped.  The block will remain broken.

Continuation of #788 