### PR TITLE
[1.21] Fix ModelEvent.RegisterAdditional and BakedModelRenderable

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/resources/model/ModelBakery.java
 +++ b/net/minecraft/client/resources/model/ModelBakery.java
-@@ -117,6 +_,13 @@
+@@ -117,6 +_,12 @@
          p_252014_.popPush("special");
          this.loadSpecialItemModelAndDependencies(ItemRenderer.TRIDENT_IN_HAND_MODEL);
          this.loadSpecialItemModelAndDependencies(ItemRenderer.SPYGLASS_IN_HAND_MODEL);
@@ -8,7 +8,6 @@
 +        net.neoforged.neoforge.client.ClientHooks.onRegisterAdditionalModels(additionalModels);
 +        for (ModelResourceLocation rl : additionalModels) {
 +            UnbakedModel unbakedmodel = this.getModel(rl.id());
-+            this.unbakedCache.put(rl.id(), unbakedmodel);
 +            this.registerModelAndLoadDependencies(rl, unbakedmodel);
 +        }
          this.topLevelModels.values().forEach(p_247954_ -> p_247954_.resolveParents(this::getModel));

--- a/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,16 +1,15 @@
 --- a/net/minecraft/client/resources/model/ModelBakery.java
 +++ b/net/minecraft/client/resources/model/ModelBakery.java
-@@ -117,6 +_,14 @@
+@@ -117,6 +_,13 @@
          p_252014_.popPush("special");
          this.loadSpecialItemModelAndDependencies(ItemRenderer.TRIDENT_IN_HAND_MODEL);
          this.loadSpecialItemModelAndDependencies(ItemRenderer.SPYGLASS_IN_HAND_MODEL);
-+        Set<ResourceLocation> additionalModels = new HashSet<>();
++        Set<ModelResourceLocation> additionalModels = new HashSet<>();
 +        net.neoforged.neoforge.client.ClientHooks.onRegisterAdditionalModels(additionalModels);
-+        for (ResourceLocation rl : additionalModels) {
-+            UnbakedModel unbakedmodel = this.getModel(rl); // loadTopLevel(...), but w/o ModelResourceLocation limitation
-+            this.unbakedCache.put(rl, unbakedmodel);
-+            // TODO 1.21 - Port model loading to handle MRLs
-+            //this.topLevelModels.put(rl, unbakedmodel);
++        for (ModelResourceLocation rl : additionalModels) {
++            UnbakedModel unbakedmodel = this.getModel(rl.id());
++            this.unbakedCache.put(rl.id(), unbakedmodel);
++            this.registerModelAndLoadDependencies(rl, unbakedmodel);
 +        }
          this.topLevelModels.values().forEach(p_247954_ -> p_247954_.resolveParents(this::getModel));
          p_252014_.pop();

--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -16,17 +16,6 @@
  
      public ModelManager(TextureManager p_119406_, BlockColors p_119407_, int p_119408_) {
          this.blockColors = p_119407_;
-@@ -78,6 +_,10 @@
-         this.atlases = new AtlasSet(VANILLA_ATLASES, p_119406_);
-     }
- 
-+    public BakedModel getModel(ResourceLocation modelLocation) {
-+        return this.bakedRegistry.getOrDefault(modelLocation, this.missingModel);
-+    }
-+
-     public BakedModel getModel(ModelResourceLocation p_119423_) {
-         return this.bakedRegistry.getOrDefault(p_119423_, this.missingModel);
-     }
 @@ -100,6 +_,7 @@
          Executor p_249221_
      ) {

--- a/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
@@ -4,7 +4,7 @@
  @OnlyIn(Dist.CLIENT)
  public record ModelResourceLocation(ResourceLocation id, String variant) {
      public static final String INVENTORY_VARIANT = "inventory";
-+    public static final String NEOFORGE_STANDALONE_VARIANT = "neoforge_standalone";
++    public static final String STANDALONE_VARIANT = "standalone";
  
      public ModelResourceLocation(ResourceLocation id, String variant) {
          variant = lowercaseVariant(variant);
@@ -17,8 +17,8 @@
 +    /**
 +     * Construct a {@code ModelResourceLocation} for use in the {@link net.neoforged.neoforge.client.event.ModelEvent.RegisterAdditional}
 +     */
-+    public static ModelResourceLocation neoForgeStandalone(ResourceLocation id) {
-+        return new ModelResourceLocation(id, NEOFORGE_STANDALONE_VARIANT);
++    public static ModelResourceLocation standalone(ResourceLocation id) {
++        return new ModelResourceLocation(id, STANDALONE_VARIANT);
      }
  
      private static String lowercaseVariant(String p_248567_) {

--- a/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
@@ -4,18 +4,21 @@
  @OnlyIn(Dist.CLIENT)
  public record ModelResourceLocation(ResourceLocation id, String variant) {
      public static final String INVENTORY_VARIANT = "inventory";
-+    public static final String NEOFORGE_SPECIAL_VARIANT = "neoforge_special";
++    public static final String NEOFORGE_STANDALONE_VARIANT = "neoforge_standalone";
  
      public ModelResourceLocation(ResourceLocation id, String variant) {
          variant = lowercaseVariant(variant);
-@@ -21,6 +_,10 @@
+@@ -21,6 +_,13 @@
  
      public static ModelResourceLocation inventory(ResourceLocation p_352141_) {
          return new ModelResourceLocation(p_352141_, "inventory");
 +    }
 +
-+    public static ModelResourceLocation neoforgeSpecial(ResourceLocation id) {
-+        return new ModelResourceLocation(id, NEOFORGE_SPECIAL_VARIANT);
++    /**
++     * Construct a {@code ModelResourceLocation} for use in the {@link net.neoforged.neoforge.client.event.ModelEvent.RegisterAdditional}
++     */
++    public static ModelResourceLocation neoForgeStandalone(ResourceLocation id) {
++        return new ModelResourceLocation(id, NEOFORGE_STANDALONE_VARIANT);
      }
  
      private static String lowercaseVariant(String p_248567_) {

--- a/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/client/resources/model/ModelResourceLocation.java
++++ b/net/minecraft/client/resources/model/ModelResourceLocation.java
+@@ -8,6 +_,7 @@
+ @OnlyIn(Dist.CLIENT)
+ public record ModelResourceLocation(ResourceLocation id, String variant) {
+     public static final String INVENTORY_VARIANT = "inventory";
++    public static final String NEOFORGE_SPECIAL_VARIANT = "neoforge_special";
+ 
+     public ModelResourceLocation(ResourceLocation id, String variant) {
+         variant = lowercaseVariant(variant);
+@@ -21,6 +_,10 @@
+ 
+     public static ModelResourceLocation inventory(ResourceLocation p_352141_) {
+         return new ModelResourceLocation(p_352141_, "inventory");
++    }
++
++    public static ModelResourceLocation neoforgeSpecial(ResourceLocation id) {
++        return new ModelResourceLocation(id, NEOFORGE_SPECIAL_VARIANT);
+     }
+ 
+     private static String lowercaseVariant(String p_248567_) {

--- a/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelResourceLocation.java.patch
@@ -8,7 +8,7 @@
  
      public ModelResourceLocation(ResourceLocation id, String variant) {
          variant = lowercaseVariant(variant);
-@@ -21,6 +_,13 @@
+@@ -21,6 +_,14 @@
  
      public static ModelResourceLocation inventory(ResourceLocation p_352141_) {
          return new ModelResourceLocation(p_352141_, "inventory");
@@ -16,6 +16,7 @@
 +
 +    /**
 +     * Construct a {@code ModelResourceLocation} for use in the {@link net.neoforged.neoforge.client.event.ModelEvent.RegisterAdditional}
++     * to load a model at the given path directly instead of going through blockstates or item model auto-prefixing.
 +     */
 +    public static ModelResourceLocation standalone(ResourceLocation id) {
 +        return new ModelResourceLocation(id, STANDALONE_VARIANT);

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -719,7 +719,7 @@ public class ClientHooks {
         ModLoader.postEvent(new RegisterKeyMappingsEvent(options));
     }
 
-    public static void onRegisterAdditionalModels(Set<ResourceLocation> additionalModels) {
+    public static void onRegisterAdditionalModels(Set<ModelResourceLocation> additionalModels) {
         ModLoader.postEvent(new ModelEvent.RegisterAdditional(additionalModels));
     }
 

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -130,7 +130,7 @@ public abstract class ModelEvent extends Event {
     /**
      * Fired when the {@link net.minecraft.client.resources.model.ModelBakery} is notified of the resource manager reloading.
      * Allows developers to register models to be loaded, along with their dependencies. Models registered through this
-     * event must use the {@link ModelResourceLocation#STANDALONE_VARIANT} variant
+     * event must use the {@link ModelResourceLocation#STANDALONE_VARIANT} variant.
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
@@ -146,6 +146,8 @@ public abstract class ModelEvent extends Event {
 
         /**
          * Registers a model to be loaded, along with its dependencies.
+         * <p>
+         * The {@link ModelResourceLocation} passed to this method must later be used to recover the loaded model.
          */
         public void register(ModelResourceLocation model) {
             Preconditions.checkArgument(

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -129,7 +129,8 @@ public abstract class ModelEvent extends Event {
 
     /**
      * Fired when the {@link net.minecraft.client.resources.model.ModelBakery} is notified of the resource manager reloading.
-     * Allows developers to register models to be loaded, along with their dependencies.
+     * Allows developers to register models to be loaded, along with their dependencies. Models registered through this
+     * event must use the {@link ModelResourceLocation#NEOFORGE_STANDALONE_VARIANT} variant
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
@@ -148,8 +149,8 @@ public abstract class ModelEvent extends Event {
          */
         public void register(ModelResourceLocation model) {
             Preconditions.checkArgument(
-                    model.getVariant().equals(ModelResourceLocation.NEOFORGE_SPECIAL_VARIANT),
-                    "Side-loaded models must use the '" + ModelResourceLocation.NEOFORGE_SPECIAL_VARIANT + "' variant");
+                    model.getVariant().equals(ModelResourceLocation.NEOFORGE_STANDALONE_VARIANT),
+                    "Side-loaded models must use the '" + ModelResourceLocation.NEOFORGE_STANDALONE_VARIANT + "' variant");
             models.add(model);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -136,17 +136,20 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterAdditional extends ModelEvent implements IModBusEvent {
-        private final Set<ResourceLocation> models;
+        private final Set<ModelResourceLocation> models;
 
         @ApiStatus.Internal
-        public RegisterAdditional(Set<ResourceLocation> models) {
+        public RegisterAdditional(Set<ModelResourceLocation> models) {
             this.models = models;
         }
 
         /**
          * Registers a model to be loaded, along with its dependencies.
          */
-        public void register(ResourceLocation model) {
+        public void register(ModelResourceLocation model) {
+            Preconditions.checkArgument(
+                    model.getVariant().equals(ModelResourceLocation.NEOFORGE_SPECIAL_VARIANT),
+                    "Side-loaded models must use the '" + ModelResourceLocation.NEOFORGE_SPECIAL_VARIANT + "' variant");
             models.add(model);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -130,7 +130,7 @@ public abstract class ModelEvent extends Event {
     /**
      * Fired when the {@link net.minecraft.client.resources.model.ModelBakery} is notified of the resource manager reloading.
      * Allows developers to register models to be loaded, along with their dependencies. Models registered through this
-     * event must use the {@link ModelResourceLocation#NEOFORGE_STANDALONE_VARIANT} variant
+     * event must use the {@link ModelResourceLocation#STANDALONE_VARIANT} variant
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
@@ -149,8 +149,8 @@ public abstract class ModelEvent extends Event {
          */
         public void register(ModelResourceLocation model) {
             Preconditions.checkArgument(
-                    model.getVariant().equals(ModelResourceLocation.NEOFORGE_STANDALONE_VARIANT),
-                    "Side-loaded models must use the '" + ModelResourceLocation.NEOFORGE_STANDALONE_VARIANT + "' variant");
+                    model.getVariant().equals(ModelResourceLocation.STANDALONE_VARIANT),
+                    "Side-loaded models must use the '" + ModelResourceLocation.STANDALONE_VARIANT + "' variant");
             models.add(model);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/renderable/BakedModelRenderable.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/renderable/BakedModelRenderable.java
@@ -11,8 +11,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.Direction;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.Unit;
 import net.minecraft.world.inventory.InventoryMenu;
@@ -37,7 +37,7 @@ public class BakedModelRenderable implements IRenderable<BakedModelRenderable.Co
      *
      * @see ModelEvent.RegisterAdditional
      */
-    public static BakedModelRenderable of(ResourceLocation model) {
+    public static BakedModelRenderable of(ModelResourceLocation model) {
         return of(Minecraft.getInstance().getModelManager().getModel(model));
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
@@ -67,7 +67,7 @@ public class RenderableTest {
     }
 
     private static class Client {
-        private static ModelResourceLocation MODEL_LOC = ModelResourceLocation.neoForgeStandalone(
+        private static ModelResourceLocation MODEL_LOC = ModelResourceLocation.standalone(
                 ResourceLocation.fromNamespaceAndPath("minecraft", "block/blue_stained_glass"));
 
         private static IRenderable<CompositeRenderable.Transforms> renderable;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
@@ -67,7 +67,7 @@ public class RenderableTest {
     }
 
     private static class Client {
-        private static ModelResourceLocation MODEL_LOC = ModelResourceLocation.neoforgeSpecial(
+        private static ModelResourceLocation MODEL_LOC = ModelResourceLocation.neoForgeStandalone(
                 ResourceLocation.fromNamespaceAndPath("minecraft", "block/blue_stained_glass"));
 
         private static IRenderable<CompositeRenderable.Transforms> renderable;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/RenderableTest.java
@@ -13,6 +13,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -66,7 +67,8 @@ public class RenderableTest {
     }
 
     private static class Client {
-        private static ResourceLocation MODEL_LOC = ResourceLocation.fromNamespaceAndPath("minecraft", "block/blue_stained_glass");
+        private static ModelResourceLocation MODEL_LOC = ModelResourceLocation.neoforgeSpecial(
+                ResourceLocation.fromNamespaceAndPath("minecraft", "block/blue_stained_glass"));
 
         private static IRenderable<CompositeRenderable.Transforms> renderable;
         private static IRenderable<ModelData> bakedRenderable;


### PR DESCRIPTION
This PR updates `ModelEvent.RegisterAdditional` and `BakedModelRenderable` to use `ModelResourceLocation`s instead of `ResourceLocation`s to match vanilla changes and removes a now broken patched-in model getter in `ModelManager`.