### PR TITLE
Add more Codecs to NeoForgeExtraCodecs

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -122,13 +122,16 @@ public class NeoForgeExtraCodecs {
      * @param names the aliases
      */
     public static <T> MapCodec<T> aliasedFieldOf(final Codec<T> codec, final String... names) {
-        if (names.length == 0)
-            throw new IllegalArgumentException("Must have at least one name!");
-        return new AliasedFieldMapCodec<>(List.of(names), names[0], codec) {
-            @Override
-            Decoder<T> decoder(String name) {
-                return codec;
-            }
+        return switch (names.length) {
+            case 0 -> throw new IllegalArgumentException("Must have at least one name!");
+            case 1 -> codec.fieldOf(names[0]);
+            case 2 -> mapWithAlternative(codec.fieldOf(names[0]), codec.fieldOf(names[1]));
+            default -> new AliasedFieldMapCodec<>(List.of(names), names[0], codec) {
+                @Override
+                Decoder<T> decoder(String name) {
+                    return codec;
+                }
+            };
         };
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -228,7 +228,7 @@ public class NeoForgeExtraCodecs {
             final Codec<C> collectionCodec, final String pluralName,
             final Function<? super T, ? extends C> fromSingleton,
             final C emptyCollection) {
-        return mapWithAlternative(codec.fieldOf(singularName).flatXmap(
+        return withAlternative(codec.fieldOf(singularName).flatXmap(
                 t -> DataResult.success(fromSingleton.apply(t)),
                 collection -> collection.size() == 1
                         ? DataResult.success(Iterables.getOnlyElement(collection))

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -240,7 +240,7 @@ public class NeoForgeExtraCodecs {
                 if (singular != null) {
                     final DataResult<C> result = codec.parse(ops, singular).map(fromSingleton);
                     // Prevent silent decode error when plural is not present in input
-                    if (result.isSuccess() || input.get(pluralName) != null)
+                    if (result.isSuccess() || input.get(pluralName) == null)
                         return result;
                 }
                 return this.alternative.decode(ops, input);


### PR DESCRIPTION
**New Codecs**:

- Codecs for arrays including primitive arrays. Supports size limits.
- New `aliasFieldOf` Codec supporting alias-specific decoders.
- List version of `singularOrPlural` and `singularOrPluralNotEmpty` Codecs.
- Compressible `setOf` Codec (using implementation similar to EnumSet).
- Codec for enum that doesn't implements `StringRepresentable`.
- Codec for `EnumSet`, compressible by default.

**Changes**:

- Optimized `aliasFieldOf` Codec by flattening the structure (the old implementation wraps `mapWithAlternative` multiple times when aliases are more than 2).
- Made `singularOrPlural` Codec able to decode inputs with neither the singular or the plural key (decode to empty collection in this case) and vice versa, so it's more user friendly.