### PR TITLE
Fix non-simple ShapelessRecipe matches

### DIFF
--- a/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -20,7 +20,7 @@
          if (p_346123_.ingredientCount() != this.ingredients.size()) {
              return false;
 +        } else if (!isSimple) {
-+            var nonEmptyItems = new java.util.ArrayList<ItemStack>(this.ingredients.size());
++            var nonEmptyItems = new java.util.ArrayList<ItemStack>(p_346123_.ingredientCount());
 +            for (var item : p_346123_.items())
 +                if (!item.isEmpty())
 +                    nonEmptyItems.add(item);

--- a/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapelessRecipe.java.patch
@@ -15,12 +15,16 @@
      }
  
      @Override
-@@ -54,6 +_,8 @@
+@@ -54,6 +_,12 @@
      public boolean matches(CraftingInput p_346123_, Level p_44263_) {
          if (p_346123_.ingredientCount() != this.ingredients.size()) {
              return false;
 +        } else if (!isSimple) {
-+            return net.neoforged.neoforge.common.util.RecipeMatcher.findMatches(p_346123_.items(), this.ingredients) != null;
++            var nonEmptyItems = new java.util.ArrayList<ItemStack>(this.ingredients.size());
++            for (var item : p_346123_.items())
++                if (!item.isEmpty())
++                    nonEmptyItems.add(item);
++            return net.neoforged.neoforge.common.util.RecipeMatcher.findMatches(nonEmptyItems, this.ingredients) != null;
          } else {
              return p_346123_.size() == 1 && this.ingredients.size() == 1
                  ? this.ingredients.getFirst().test(p_346123_.getItem(0))


### PR DESCRIPTION
This fixes the failing `testSizedIngredient` test. We're lucky that this got caught like that!