### PR TITLE
[port/1.21] Fix issues relating to gameplay-enchantment support

### DIFF
--- a/patches/net/minecraft/advancements/critereon/ItemEnchantmentsPredicate.java.patch
+++ b/patches/net/minecraft/advancements/critereon/ItemEnchantmentsPredicate.java.patch
@@ -10,7 +10,7 @@
 +        public boolean matches(ItemStack p_333958_) {
 +            var lookup = net.neoforged.neoforge.common.CommonHooks.resolveLookup(net.minecraft.core.registries.Registries.ENCHANTMENT);
 +            if (lookup != null) {
-+                matches(p_333958_, p_333958_.getAllEnchantments(lookup));
++                return matches(p_333958_, p_333958_.getAllEnchantments(lookup));
 +            }
 +            return super.matches(p_333958_);
 +        }

--- a/patches/net/minecraft/advancements/critereon/ItemEnchantmentsPredicate.java.patch
+++ b/patches/net/minecraft/advancements/critereon/ItemEnchantmentsPredicate.java.patch
@@ -1,14 +1,19 @@
 --- a/net/minecraft/advancements/critereon/ItemEnchantmentsPredicate.java
 +++ b/net/minecraft/advancements/critereon/ItemEnchantmentsPredicate.java
-@@ -48,6 +_,11 @@
-             super(p_333967_);
-         }
- 
-+        @Override // Neo: use getAllEnchantments for enchantments
-+        public boolean matches(ItemStack p_333958_) {
-+            return matches(p_333958_, p_333958_.getAllEnchantments());
-+        }
-+
-         @Override
+@@ -52,6 +_,16 @@
          public DataComponentType<ItemEnchantments> componentType() {
              return DataComponents.ENCHANTMENTS;
+         }
++
++        // Neo: use IItemExtension#getAllEnchantments for enchantments when testing this predicate.
++        @Override
++        public boolean matches(ItemStack p_333958_) {
++            var lookup = net.neoforged.neoforge.common.CommonHooks.resolveLookup(net.minecraft.core.registries.Registries.ENCHANTMENT);
++            if (lookup != null) {
++                matches(p_333958_, p_333958_.getAllEnchantments(lookup));
++            }
++            return super.matches(p_333958_);
++        }
+     }
+ 
+     public static class StoredEnchantments extends ItemEnchantmentsPredicate {

--- a/patches/net/minecraft/core/Holder.java.patch
+++ b/patches/net/minecraft/core/Holder.java.patch
@@ -5,40 +5,10 @@
  import net.minecraft.tags.TagKey;
  
 -public interface Holder<T> {
-+public interface Holder<T> extends net.neoforged.neoforge.registries.datamaps.IWithData<T> {
++public interface Holder<T> extends net.neoforged.neoforge.common.extensions.IHolderExtension<T> {
      T value();
  
      boolean isBound();
-@@ -41,6 +_,29 @@
-         return this.unwrapKey().map(p_316542_ -> p_316542_.location().toString()).orElse("[unregistered]");
-     }
- 
-+    // Neo Start
-+
-+    /**
-+     * {@return the holder that this holder wraps}
-+     *
-+     * Useful for holders that delegate to another holder.
-+     */
-+    default Holder<T> getDelegate() {
-+        return this;
-+    }
-+
-+    /**
-+     * Attempts to resolve the underlying {@link HolderLookup.RegistryLookup} from a {@link Holder}.
-+     * <p>
-+     * This will only succeed if the underlying holder is a {@link Holder.Reference}.
-+     */
-+    @org.jetbrains.annotations.Nullable
-+    default HolderLookup.RegistryLookup<T> unwrapLookup() {
-+        return null;
-+    }
-+
-+    // Neo End
-+
-     static <T> Holder<T> direct(T p_205710_) {
-         return new Holder.Direct<>(p_205710_);
-     }
 @@ -220,6 +_,14 @@
              }
          }

--- a/patches/net/minecraft/core/Holder.java.patch
+++ b/patches/net/minecraft/core/Holder.java.patch
@@ -9,10 +9,12 @@
      T value();
  
      boolean isBound();
-@@ -41,6 +_,15 @@
+@@ -41,6 +_,29 @@
          return this.unwrapKey().map(p_316542_ -> p_316542_.location().toString()).orElse("[unregistered]");
      }
  
++    // Neo Start
++    
 +    /**
 +     * {@return the holder that this holder wraps}
 +     *
@@ -21,6 +23,18 @@
 +    default Holder<T> getDelegate() {
 +        return this;
 +    }
++
++    /**
++     * Attempts to resolve the underlying {@link HolderLookup.RegistryLookup} from a {@link Holder}.
++     * <p>
++     * This will only succeed if the underlying holder is a {@link Holder.Reference}.
++     */
++    @org.jetbrains.annotations.Nullable
++    default HolderLookup.RegistryLookup<T> unwrapLookup() {
++        return null;
++    }
++
++    // Neo End
 +
      static <T> Holder<T> direct(T p_205710_) {
          return new Holder.Direct<>(p_205710_);
@@ -40,11 +54,12 @@
          public void bindTags(Collection<TagKey<T>> p_205770_) {
              this.tags = Set.copyOf(p_205770_);
          }
-@@ -232,6 +_,18 @@
-         @Override
+@@ -233,6 +_,28 @@
          public String toString() {
              return "Reference{" + this.key + "=" + this.value + "}";
-+        }
+         }
++
++        // Neo Start
 +
 +        // Neo: Add DeferredHolder-compatible hashCode() and equals() overrides
 +        @Override
@@ -56,6 +71,15 @@
 +        public boolean equals(Object obj) {
 +            if (this == obj) return true;
 +            return obj instanceof Holder<?> h && h.kind() == Kind.REFERENCE && h.unwrapKey().orElseThrow() == this.key();
-         }
++        }
++
++        @Override
++        @org.jetbrains.annotations.Nullable
++        public HolderLookup.RegistryLookup<T> unwrapLookup() {
++            return this.owner instanceof HolderLookup.RegistryLookup<T> rl ? rl : null;
++        }
++
++        // Neo End
  
          public static enum Type {
+             STAND_ALONE,

--- a/patches/net/minecraft/core/Holder.java.patch
+++ b/patches/net/minecraft/core/Holder.java.patch
@@ -14,7 +14,7 @@
      }
  
 +    // Neo Start
-+    
++
 +    /**
 +     * {@return the holder that this holder wraps}
 +     *

--- a/patches/net/minecraft/world/item/ArrowItem.java.patch
+++ b/patches/net/minecraft/world/item/ArrowItem.java.patch
@@ -9,7 +9,7 @@
 +     * Called to determine if this arrow will be infinite when fired. If an arrow is infinite, then the arrow will never be consumed (regardless of enchantments).
 +     * <p>
 +     * Only called on the logical server.
-+     * 
++     *
 +     * @param ammo The ammo stack (containing this item)
 +     * @param bow  The bow stack
 +     * @param livingEntity The entity who is firing the bow

--- a/patches/net/minecraft/world/item/ArrowItem.java.patch
+++ b/patches/net/minecraft/world/item/ArrowItem.java.patch
@@ -1,13 +1,21 @@
 --- a/net/minecraft/world/item/ArrowItem.java
 +++ b/net/minecraft/world/item/ArrowItem.java
-@@ -24,4 +_,10 @@
+@@ -24,4 +_,18 @@
          arrow.pickup = AbstractArrow.Pickup.ALLOWED;
          return arrow;
      }
 +
-+    public boolean isInfinite(ItemStack stack, ItemStack bow, net.minecraft.world.entity.LivingEntity livingEntity) {
-+        // TODO 1.21 - probably needs to decide based on tags/other datapack logic
-+        int enchant = net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(livingEntity.registryAccess().registryOrThrow(net.minecraft.core.registries.Registries.ENCHANTMENT).getHolderOrThrow(net.minecraft.world.item.enchantment.Enchantments.INFINITY), bow);
-+        return enchant > 0 && this.getClass() == net.minecraft.world.item.ArrowItem.class;
++    /**
++     * Called to determine if this arrow will be infinite when fired. If an arrow is infinite, then the arrow will never be consumed (regardless of enchantments).
++     * <p>
++     * Only called on the logical server.
++     * 
++     * @param ammo The ammo stack (containing this item)
++     * @param bow  The bow stack
++     * @param livingEntity The entity who is firing the bow
++     * @return True if the arrow is infinite
++     */
++    public boolean isInfinite(ItemStack ammo, ItemStack bow, net.minecraft.world.entity.LivingEntity livingEntity) {
++        return false;
 +    }
  }

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -140,6 +140,28 @@
              return list;
          }
      }
+@@ -897,10 +_,21 @@
+         return !this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty();
+     }
+ 
++    /**
++     * @deprecated Neo: Use {@link #getTagEnchantments()} for NBT enchantments, or {@link #getAllEnchantments} for gameplay.
++     */
++    @Deprecated
+     public ItemEnchantments getEnchantments() {
+         return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
+     }
+ 
++    /**
++     * Gets all enchantments from NBT. Use {@link ItemStack#getAllEnchantments} for gameplay logic.
++     */
++    public ItemEnchantments getTagEnchantments() {
++        return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
++    }
++
+     public boolean isFramed() {
+         return this.entityRepresentation instanceof ItemFrame;
+     }
 @@ -933,6 +_,8 @@
      }
  

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -140,27 +140,23 @@
              return list;
          }
      }
-@@ -897,10 +_,21 @@
+@@ -897,6 +_,17 @@
          return !this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty();
-     }
- 
-+    /**
-+     * @deprecated Neo: Use {@link #getTagEnchantments()} for NBT enchantments, or {@link #getAllEnchantments} for gameplay.
-+     */
-+    @Deprecated
-     public ItemEnchantments getEnchantments() {
-         return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
      }
  
 +    /**
 +     * Gets all enchantments from NBT. Use {@link ItemStack#getAllEnchantments} for gameplay logic.
 +     */
 +    public ItemEnchantments getTagEnchantments() {
-+        return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
++        return getEnchantments();
 +    }
 +
-     public boolean isFramed() {
-         return this.entityRepresentation instanceof ItemFrame;
++    /**
++     * @deprecated Neo: Use {@link #getTagEnchantments()} for NBT enchantments, or {@link #getAllEnchantments} for gameplay.
++     */
++    @Deprecated
+     public ItemEnchantments getEnchantments() {
+         return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
      }
 @@ -933,6 +_,8 @@
      }

--- a/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -9,12 +9,13 @@
      }
  
      protected static List<ItemStack> draw(ItemStack p_331565_, ItemStack p_330406_, LivingEntity p_330823_) {
-@@ -115,7 +_,7 @@
+@@ -115,7 +_,8 @@
      }
  
      protected static ItemStack useAmmo(ItemStack p_331207_, ItemStack p_331434_, LivingEntity p_330302_, boolean p_330934_) {
 -        int i = !p_330934_ && !p_330302_.hasInfiniteMaterials() && p_330302_.level() instanceof ServerLevel serverlevel
-+        int i = !p_330934_ && !(p_330302_.hasInfiniteMaterials() || (p_331434_.getItem() instanceof ArrowItem && ((ArrowItem) p_331434_.getItem()).isInfinite(p_331434_, p_331207_, p_330302_))) && p_330302_.level() instanceof ServerLevel serverlevel
++        // Neo: Adjust this check to respect ArrowItem#isInfinite, bypassing processAmmoUse if true.
++        int i = !p_330934_ && p_330302_.level() instanceof ServerLevel serverlevel && !(p_330302_.hasInfiniteMaterials() || (p_331434_.getItem() instanceof ArrowItem && ((ArrowItem) p_331434_.getItem()).isInfinite(p_331434_, p_331207_, p_330302_)))
              ? EnchantmentHelper.processAmmoUse(serverlevel, p_331207_, p_331434_, 1)
              : 0;
          if (i > p_331434_.getCount()) {

--- a/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -15,7 +15,7 @@
      protected static ItemStack useAmmo(ItemStack p_331207_, ItemStack p_331434_, LivingEntity p_330302_, boolean p_330934_) {
 -        int i = !p_330934_ && !p_330302_.hasInfiniteMaterials() && p_330302_.level() instanceof ServerLevel serverlevel
 +        // Neo: Adjust this check to respect ArrowItem#isInfinite, bypassing processAmmoUse if true.
-+        int i = !p_330934_ && p_330302_.level() instanceof ServerLevel serverlevel && !(p_330302_.hasInfiniteMaterials() || (p_331434_.getItem() instanceof ArrowItem && ((ArrowItem) p_331434_.getItem()).isInfinite(p_331434_, p_331207_, p_330302_)))
++        int i = !p_330934_ && p_330302_.level() instanceof ServerLevel serverlevel && !(p_330302_.hasInfiniteMaterials() || (p_331434_.getItem() instanceof ArrowItem ai && ai.isInfinite(p_331434_, p_331207_, p_330302_)))
              ? EnchantmentHelper.processAmmoUse(serverlevel, p_331207_, p_331434_, 1)
              : 0;
          if (i > p_331434_.getCount()) {

--- a/patches/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -1,21 +1,22 @@
 --- a/net/minecraft/world/item/enchantment/Enchantment.java
 +++ b/net/minecraft/world/item/enchantment/Enchantment.java
-@@ -504,6 +_,26 @@
-         return new Enchantment.Builder(p_345873_);
+@@ -132,6 +_,10 @@
+         return this.definition.slots().stream().anyMatch(p_345027_ -> p_345027_.test(p_345146_));
      }
  
-+    // TODO 1.21: Make IEnchantmentExtension additions data-driven along with these methods:
++    /**
++     * @deprecated Neo: Use {@link ItemStack#isPrimaryItemFor(Holder)}
++     */
++    @Deprecated
+     public boolean isPrimaryItem(ItemStack p_336088_) {
+         return this.isSupportedItem(p_336088_) && (this.definition.primaryItems.isEmpty() || p_336088_.is(this.definition.primaryItems.get()));
+     }
+@@ -503,6 +_,15 @@
+     public static Enchantment.Builder enchantment(Enchantment.EnchantmentDefinition p_345873_) {
+         return new Enchantment.Builder(p_345873_);
+     }
 +
-+//    /**
-+//     * This applies specifically to applying at the enchanting table. The other method {@link #canEnchant(ItemStack)}
-+//     * applies for <i>all possible</i> enchantments.
-+//     * @param stack
-+//     * @return
-+//     */
-+//    public boolean canApplyAtEnchantingTable(ItemStack stack) {
-+//        return stack.canApplyAtEnchantingTable(this);
-+//    }
-+//
++//    TODO: Reimplement. Not sure if we want to patch EnchantmentDefinition or hack this in as an EnchantmentEffectComponent.
 +//    /**
 +//     * Is this enchantment allowed to be enchanted on books via Enchantment Table
 +//     * @return false to disable the vanilla feature
@@ -23,7 +24,6 @@
 +//    public boolean isAllowedOnBooks() {
 +//        return true;
 +//    }
-+
+ 
      public static class Builder {
          private final Enchantment.EnchantmentDefinition definition;
-         private HolderSet<Enchantment> exclusiveSet = HolderSet.direct();

--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -44,6 +44,19 @@
              if (itemenchantments != null && !itemenchantments.isEmpty()) {
                  EnchantedItemInUse enchantediteminuse = new EnchantedItemInUse(p_44852_, p_345566_, p_345792_);
  
+@@ -417,6 +_,12 @@
+     public static boolean hasTag(ItemStack p_345665_, TagKey<Enchantment> p_345928_) {
+         ItemEnchantments itemenchantments = p_345665_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
+ 
++        // Neo: Respect gameplay-only enchantments when enchantment effect tag checks
++        var lookup = net.neoforged.neoforge.common.CommonHooks.resolveLookup(net.minecraft.core.registries.Registries.ENCHANTMENT);
++        if (lookup != null) {
++            itemenchantments = p_345665_.getAllEnchantments(lookup);
++        }
++
+         for (Entry<Holder<Enchantment>> entry : itemenchantments.entrySet()) {
+             Holder<Enchantment> holder = entry.getKey();
+             if (holder.is(p_345928_)) {
 @@ -484,7 +_,7 @@
  
      public static int getEnchantmentCost(RandomSource p_220288_, int p_220289_, int p_220290_, ItemStack p_220291_) {

--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -10,21 +10,27 @@
      }
  
      public static ItemEnchantments updateEnchantments(ItemStack p_331034_, Consumer<ItemEnchantments.Mutable> p_332031_) {
-@@ -120,7 +_,7 @@
-     }
- 
+@@ -122,6 +_,12 @@
      private static void runIterationOnItem(ItemStack p_345425_, EnchantmentHelper.EnchantmentVisitor p_345023_) {
--        ItemEnchantments itemenchantments = p_345425_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
-+        ItemEnchantments itemenchantments = p_345425_.getAllEnchantments(); // Neo: Allow gameplay enchantments to run too.
+         ItemEnchantments itemenchantments = p_345425_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
  
++        // Neo: Respect gameplay-only enchantments when doing iterations
++        var lookup = net.neoforged.neoforge.common.CommonHooks.resolveLookup(net.minecraft.core.registries.Registries.ENCHANTMENT);
++        if (lookup != null) {
++            itemenchantments = p_345425_.getAllEnchantments(lookup);
++        }
++
          for (Entry<Holder<Enchantment>> entry : itemenchantments.entrySet()) {
              p_345023_.accept(entry.getKey(), entry.getIntValue());
-@@ -131,7 +_,7 @@
-         ItemStack p_44852_, EquipmentSlot p_345566_, LivingEntity p_345792_, EnchantmentHelper.EnchantmentInSlotVisitor p_345683_
+         }
+@@ -132,6 +_,10 @@
      ) {
          if (!p_44852_.isEmpty()) {
--            ItemEnchantments itemenchantments = p_44852_.get(DataComponents.ENCHANTMENTS);
-+            ItemEnchantments itemenchantments = p_44852_.getAllEnchantments(); // Neo: Allow gameplay enchantments to run too.
+             ItemEnchantments itemenchantments = p_44852_.get(DataComponents.ENCHANTMENTS);
++
++            // Neo: Respect gameplay-only enchantments when doing iterations
++            itemenchantments = p_44852_.getAllEnchantments(p_345792_.registryAccess().lookupOrThrow(net.minecraft.core.registries.Registries.ENCHANTMENT));
++
              if (itemenchantments != null && !itemenchantments.isEmpty()) {
                  EnchantedItemInUse enchantediteminuse = new EnchantedItemInUse(p_44852_, p_345566_, p_345792_);
  

--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -62,3 +62,14 @@
          if (i <= 0) {
              return list;
          } else {
+@@ -575,7 +_,9 @@
+     public static List<EnchantmentInstance> getAvailableEnchantmentResults(int p_44818_, ItemStack p_44819_, Stream<Holder<Enchantment>> p_345348_) {
+         List<EnchantmentInstance> list = Lists.newArrayList();
+         boolean flag = p_44819_.is(Items.BOOK);
+-        p_345348_.filter(p_344529_ -> p_344529_.value().isPrimaryItem(p_44819_) || flag).forEach(p_344478_ -> {
++        // Neo: Rewrite filter logic to call isPrimaryItemFor instead of hardcoded vanilla logic.
++        // The original logic is recorded in the default implementation of IItemExtension#isPrimaryItemFor.
++        p_345348_.filter(p_44819_::isPrimaryItemFor).forEach(p_344478_ -> {
+             Enchantment enchantment = p_344478_.value();
+ 
+             for (int i = enchantment.getMaxLevel(); i >= enchantment.getMinLevel(); i--) {

--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -9,7 +9,7 @@
 +     */
 +    @Deprecated
      public static int getItemEnchantmentLevel(Holder<Enchantment> p_346179_, ItemStack p_44845_) {
-+        // To reduce patch size, update this method to always check gameplay enchantments, and add getTagEnchantmentLevel as a helper for mods.
++        // Neo: To reduce patch size, update this method to always check gameplay enchantments, and add getTagEnchantmentLevel as a helper for mods.
 +        return p_44845_.getEnchantmentLevel(p_346179_);
 +    }
 +

--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -1,15 +1,25 @@
 --- a/net/minecraft/world/item/enchantment/EnchantmentHelper.java
 +++ b/net/minecraft/world/item/enchantment/EnchantmentHelper.java
-@@ -48,8 +_,7 @@
+@@ -47,7 +_,19 @@
+ import org.apache.commons.lang3.mutable.MutableObject;
  
  public class EnchantmentHelper {
++    /**
++     * @deprecated Neo: Use {@link #getTagEnchantmentLevel(Holder, ItemStack)} for NBT enchantments, or {@link ItemStack#getEnchantmentLevel(Holder)} for gameplay.
++     */
++    @Deprecated
      public static int getItemEnchantmentLevel(Holder<Enchantment> p_346179_, ItemStack p_44845_) {
--        ItemEnchantments itemenchantments = p_44845_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
--        return itemenchantments.getLevel(p_346179_);
++        // To reduce patch size, update this method to always check gameplay enchantments, and add getTagEnchantmentLevel as a helper for mods.
 +        return p_44845_.getEnchantmentLevel(p_346179_);
++    }
++
++    /**
++     * Gets the level of an enchantment from NBT. Use {@link ItemStack#getEnchantmentLevel(Holder)} for gameplay logic.
++     */
++    public static int getTagEnchantmentLevel(Holder<Enchantment> p_346179_, ItemStack p_44845_) {
+         ItemEnchantments itemenchantments = p_44845_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
+         return itemenchantments.getLevel(p_346179_);
      }
- 
-     public static ItemEnchantments updateEnchantments(ItemStack p_331034_, Consumer<ItemEnchantments.Mutable> p_332031_) {
 @@ -122,6 +_,12 @@
      private static void runIterationOnItem(ItemStack p_345425_, EnchantmentHelper.EnchantmentVisitor p_345023_) {
          ItemEnchantments itemenchantments = p_345425_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -90,12 +90,15 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup.RegistryLookup;
+import net.minecraft.core.Registry;
 import net.minecraft.locale.Language;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.PlayerChatMessage;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraft.util.Mth;
@@ -1047,5 +1050,15 @@ public class ClientHooks {
      */
     public static void fireClientTickPost() {
         NeoForge.EVENT_BUS.post(new ClientTickEvent.Post());
+    }
+
+    @Nullable
+    @SuppressWarnings("resource")
+    public static <T> RegistryLookup<T> resolveLookup(ResourceKey<? extends Registry<T>> key) {
+        ClientLevel level = Minecraft.getInstance().level;
+        if (level != null) {
+            return level.registryAccess().lookup(key).orElse(null);
+        }
+        return null;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
@@ -1,0 +1,34 @@
+package net.neoforged.neoforge.common.extensions;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry;
+import net.neoforged.neoforge.registries.datamaps.IWithData;
+
+/**
+ * Extension for {@link Holder}
+ */
+public interface IHolderExtension<T> extends IWithData<T> {
+
+    /**
+     * {@return the holder that this holder wraps}
+     *
+     * Used by {@link Registry#safeCastToReference} to resolve the underlying {@link Holder.Reference} for delegating holders.
+     */
+    default Holder<T> getDelegate() {
+        return (Holder<T>) this;
+    }
+
+    /**
+     * Attempts to resolve the underlying {@link HolderLookup.RegistryLookup} from a {@link Holder}.
+     * <p>
+     * This will only succeed if the underlying holder is a {@link Holder.Reference}.
+     */
+    @Nullable
+    default HolderLookup.RegistryLookup<T> unwrapLookup() {
+        return null;
+    }
+
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
@@ -1,17 +1,20 @@
-package net.neoforged.neoforge.common.extensions;
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 
-import org.jetbrains.annotations.Nullable;
+package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
 import net.neoforged.neoforge.registries.datamaps.IWithData;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Extension for {@link Holder}
  */
 public interface IHolderExtension<T> extends IWithData<T> {
-
     /**
      * {@return the holder that this holder wraps}
      *
@@ -30,5 +33,4 @@ public interface IHolderExtension<T> extends IWithData<T> {
     default HolderLookup.RegistryLookup<T> unwrapLookup() {
         return null;
     }
-
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -420,20 +420,21 @@ public interface IItemExtension {
     }
 
     /**
-     * Checks whether an item can be enchanted with a certain enchantment. This
-     * applies specifically to enchanting an item in the enchanting table and is
-     * called when retrieving the list of possible enchantments for an item.
-     * Enchantments may additionally (or exclusively) be doing their own checks in
-     * {@link Enchantment#canApplyAtEnchantingTable(ItemStack)};
-     * check the individual implementation for reference. By default this will check
-     * if the enchantment type is valid for this item type.
+     * Checks if an item should be treated as a primary item for a given enchantment.
+     * <p>
+     * Primary items are those that are able to receive the enchantment during enchanting,
+     * either from the enchantment table or other random enchantment mechanisms.
+     * As a special case, books are primary items for every enchantment.
+     * <p>
+     * Other application mechanisms, such as the anvil, check {@link Enchantment#isSupportedItem(ItemStack)} instead.
+     * If you want those mechanisms to be able to apply an enchantment, you will need to add your item to the relevant tag.
      *
      * @param stack       the item stack to be enchanted
      * @param enchantment the enchantment to be applied
-     * @return true if the enchantment can be applied to this item
+     * @return true if this item should be treated as a primary item for the enchantment
      */
-    default boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment) {
-        return enchantment.getSupportedItems().contains(stack.getItem().builtInRegistryHolder());
+    default boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
+        return stack.getItem() == Items.BOOK || enchantment.value().isPrimaryItem(stack);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup.RegistryLookup;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
@@ -457,13 +458,14 @@ public interface IItemExtension {
      * Used in several places in code including armor enchantment hooks.
      * The returned value(s) must have the same level as {@link #getEnchantmentLevel(ItemStack, Enchantment)}.
      *
-     * @param stack The item stack being checked
+     * @param stack  The item stack being checked
+     * @param lookup A registry lookup, used to resolve enchantment {@link Holder}s.
      * @return Map of all enchantments on the stack, empty if no enchantments are present
      * @see #getEnchantmentLevel(ItemStack, Enchantment)
      * @apiNote Call via {@link IItemStackExtension#getAllEnchantments()}.
      */
     @ApiStatus.OverrideOnly
-    default ItemEnchantments getAllEnchantments(ItemStack stack) {
+    default ItemEnchantments getAllEnchantments(ItemStack stack, RegistryLookup<Enchantment> lookup) {
         return stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -432,7 +432,9 @@ public interface IItemExtension {
      * @param stack       the item stack to be enchanted
      * @param enchantment the enchantment to be applied
      * @return true if this item should be treated as a primary item for the enchantment
+     * @apiNote Call via {@link IItemStackExtension#isPrimaryItemFor(Holder)}
      */
+    @ApiStatus.OverrideOnly
     default boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
         return stack.getItem() == Items.BOOK || enchantment.value().isPrimaryItem(stack);
     }
@@ -440,34 +442,34 @@ public interface IItemExtension {
     /**
      * Gets the level of the enchantment currently present on the stack. By default, returns the enchantment level present in NBT.
      * Most enchantment implementations rely upon this method.
-     * The returned value must be the same as getting the enchantment from {@link #getAllEnchantments(ItemStack)}
+     * The returned value must be the same as getting the enchantment from {@link #getAllEnchantments}
      *
      * @param stack       The item stack being checked
      * @param enchantment The enchantment being checked for
      * @return Level of the enchantment, or 0 if not present
-     * @see #getAllEnchantments(ItemStack)
-     * @apiNote Call via {@link IItemStackExtension#getEnchantmentLevel(Enchantment)}.
+     * @see #getAllEnchantments
+     * @apiNote Call via {@link IItemStackExtension#getEnchantmentLevel}.
      */
     @ApiStatus.OverrideOnly
     default int getEnchantmentLevel(ItemStack stack, Holder<Enchantment> enchantment) {
-        ItemEnchantments itemenchantments = stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
+        ItemEnchantments itemenchantments = stack.getTagEnchantments();
         return itemenchantments.getLevel(enchantment);
     }
 
     /**
      * Gets a map of all enchantments present on the stack. By default, returns the enchantments present in NBT.
      * Used in several places in code including armor enchantment hooks.
-     * The returned value(s) must have the same level as {@link #getEnchantmentLevel(ItemStack, Enchantment)}.
+     * The returned value(s) must have the same level as {@link #getEnchantmentLevel}.
      *
      * @param stack  The item stack being checked
      * @param lookup A registry lookup, used to resolve enchantment {@link Holder}s.
      * @return Map of all enchantments on the stack, empty if no enchantments are present
-     * @see #getEnchantmentLevel(ItemStack, Enchantment)
-     * @apiNote Call via {@link IItemStackExtension#getAllEnchantments()}.
+     * @see #getEnchantmentLevel
+     * @apiNote Call via {@link IItemStackExtension#getAllEnchantments}.
      */
     @ApiStatus.OverrideOnly
     default ItemEnchantments getAllEnchantments(ItemStack stack, RegistryLookup<Enchantment> lookup) {
-        return stack.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
+        return stack.getTagEnchantments();
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -9,6 +9,7 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup.RegistryLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
@@ -182,9 +183,9 @@ public interface IItemStackExtension {
      * @see #getEnchantmentLevel(Enchantment)
      * @see DataComponents#ENCHANTMENTS
      */
-    default ItemEnchantments getAllEnchantments() {
-        var enchantments = self().getItem().getAllEnchantments(self());
-        return EventHooks.getEnchantmentLevel(enchantments, self());
+    default ItemEnchantments getAllEnchantments(RegistryLookup<Enchantment> lookup) {
+        var enchantments = self().getItem().getAllEnchantments(self(), lookup);
+        return EventHooks.getAllEnchantmentLevels(enchantments, self(), lookup);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -147,7 +147,7 @@ public interface IItemStackExtension {
     /**
      * Gets the gameplay level of the target enchantment on this stack.
      * <p>
-     * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} for gameplay logic.
+     * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel} for gameplay logic.
      * <p>
      * Use {@link EnchantmentHelper#getEnchantmentsForCrafting} and {@link EnchantmentHelper#setEnchantments} when modifying the item's enchantments.
      *

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -156,16 +156,13 @@ public interface IItemStackExtension {
     /**
      * Gets the gameplay level of the target enchantment on this stack.
      * <p>
-     * Equivalent to calling {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)}.
+     * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel(Enchantment, ItemStack)} for gameplay logic.
      * <p>
-     * Use in place of {@link EnchantmentHelper#getItemEnchantmentLevel(Enchantment, ItemStack)} for gameplay logic.
-     * <p>
-     * Use {@link DataComponents#ENCHANTMENTS} instead when modifying the item's enchantments.
+     * Use {@link EnchantmentHelper#getEnchantmentsForCrafting} and {@link EnchantmentHelper#setEnchantments} when modifying the item's enchantments.
      *
      * @param enchantment The enchantment being checked for.
      * @return The level of the enchantment, or 0 if not present.
-     * @see #getAllEnchantments()
-     * @see DataComponents#ENCHANTMENTS
+     * @see {@link #getAllEnchantments} to get all gameplay enchantments
      */
     default int getEnchantmentLevel(Holder<Enchantment> enchantment) {
         int level = self().getItem().getEnchantmentLevel(self(), enchantment);
@@ -175,13 +172,12 @@ public interface IItemStackExtension {
     /**
      * Gets the gameplay level of all enchantments on this stack.
      * <p>
-     * Use in place of {@link DataComponents#ENCHANTMENTS} for gameplay logic.
+     * Use in place of {@link ItemStack#getTagEnchantments()} for gameplay logic.
      * <p>
-     * Use {@link DataComponents#ENCHANTMENTS} instead when modifying the item's enchantments.
+     * Use {@link EnchantmentHelper#getEnchantmentsForCrafting} and {@link EnchantmentHelper#setEnchantments} when modifying the item's enchantments.
      *
      * @return Map of all enchantments on the stack, or an empty map if no enchantments are present.
-     * @see #getEnchantmentLevel(Enchantment)
-     * @see DataComponents#ENCHANTMENTS
+     * @see {@link #getEnchantmentLevel} to get the level of a single enchantment for gameplay purposes
      */
     default ItemEnchantments getAllEnchantments(RegistryLookup<Enchantment> lookup) {
         var enchantments = self().getItem().getAllEnchantments(self(), lookup);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -138,19 +138,10 @@ public interface IItemStackExtension {
     }
 
     /**
-     * Checks whether an item can be enchanted with a certain enchantment. This
-     * applies specifically to enchanting an item in the enchanting table and is
-     * called when retrieving the list of possible enchantments for an item.
-     * Enchantments may additionally (or exclusively) be doing their own checks in
-     * {@link Enchantment#canApplyAtEnchantingTable(ItemStack)};
-     * check the individual implementation for reference. By default this will check
-     * if the enchantment type is valid for this item type.
-     *
-     * @param enchantment the enchantment to be applied
-     * @return true if the enchantment can be applied to this item
+     * @see {@link IItemExtension#isPrimaryItemFor(ItemStack, Holder)}
      */
-    default boolean canApplyAtEnchantingTable(Enchantment enchantment) {
-        return self().getItem().canApplyAtEnchantingTable(self(), enchantment);
+    default boolean isPrimaryItemFor(Holder<Enchantment> enchantment) {
+        return self().getItem().isPrimaryItemFor(self(), enchantment);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1037,13 +1037,15 @@ public class EventHooks {
      * @return The new level of the enchantment.
      */
     public static int getEnchantmentLevelSpecific(int level, ItemStack stack, Holder<Enchantment> ench) {
+        RegistryLookup<Enchantment> lookup = ench.unwrapLookup();
+        if (lookup == null) { // Pretty sure this is never null, but I can't *prove* that it isn't.
+            return level;
+        }
+
         var enchantments = new ItemEnchantments.Mutable(ItemEnchantments.EMPTY);
         enchantments.set(ench, level);
-        RegistryLookup<Enchantment> lookup = ench.unwrapLookup();
-        if (lookup != null) { // Pretty sure this is never null, but I can't *prove* that it isn't.
-            var event = new GetEnchantmentLevelEvent(stack, enchantments, ench, ench.unwrapLookup());
-            NeoForge.EVENT_BUS.post(event);
-        }
+        var event = new GetEnchantmentLevelEvent(stack, enchantments, ench, ench.unwrapLookup());
+        NeoForge.EVENT_BUS.post(event);
         return enchantments.getLevel(ench);
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -25,6 +25,7 @@ import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup.RegistryLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.Component;
@@ -1038,8 +1039,11 @@ public class EventHooks {
     public static int getEnchantmentLevelSpecific(int level, ItemStack stack, Holder<Enchantment> ench) {
         var enchantments = new ItemEnchantments.Mutable(ItemEnchantments.EMPTY);
         enchantments.set(ench, level);
-        var event = new GetEnchantmentLevelEvent(stack, enchantments, ench);
-        NeoForge.EVENT_BUS.post(event);
+        RegistryLookup<Enchantment> lookup = ench.unwrapLookup();
+        if (lookup != null) { // Pretty sure this is never null, but I can't *prove* that it isn't.
+            var event = new GetEnchantmentLevelEvent(stack, enchantments, ench, ench.unwrapLookup());
+            NeoForge.EVENT_BUS.post(event);
+        }
         return enchantments.getLevel(ench);
     }
 
@@ -1050,9 +1054,9 @@ public class EventHooks {
      * @param stack        The stack being queried against.
      * @return The new enchantment map.
      */
-    public static ItemEnchantments getEnchantmentLevel(ItemEnchantments enchantments, ItemStack stack) {
+    public static ItemEnchantments getAllEnchantmentLevels(ItemEnchantments enchantments, ItemStack stack, RegistryLookup<Enchantment> lookup) {
         var mutableEnchantments = new ItemEnchantments.Mutable(enchantments);
-        var event = new GetEnchantmentLevelEvent(stack, mutableEnchantments, null);
+        var event = new GetEnchantmentLevelEvent(stack, mutableEnchantments, null, lookup);
         NeoForge.EVENT_BUS.post(event);
         return mutableEnchantments.toImmutable();
     }

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/GetEnchantmentLevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/GetEnchantmentLevelEvent.java
@@ -5,7 +5,9 @@
 
 package net.neoforged.neoforge.event.enchanting;
 
+import java.util.Optional;
 import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup.RegistryLookup;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -25,11 +27,13 @@ public class GetEnchantmentLevelEvent extends Event {
     protected final ItemEnchantments.Mutable enchantments;
     @Nullable
     protected final Holder<Enchantment> targetEnchant;
+    protected final RegistryLookup<Enchantment> lookup;
 
-    public GetEnchantmentLevelEvent(ItemStack stack, ItemEnchantments.Mutable enchantments, @Nullable Holder<Enchantment> targetEnchant) {
+    public GetEnchantmentLevelEvent(ItemStack stack, ItemEnchantments.Mutable enchantments, @Nullable Holder<Enchantment> targetEnchant, RegistryLookup<Enchantment> lookup) {
         this.stack = stack;
         this.enchantments = enchantments;
         this.targetEnchant = targetEnchant;
+        this.lookup = lookup;
     }
 
     /**
@@ -80,5 +84,23 @@ public class GetEnchantmentLevelEvent extends Event {
      */
     public boolean isTargetting(ResourceKey<Enchantment> ench) {
         return this.targetEnchant == null || this.targetEnchant.is(ench);
+    }
+
+    /**
+     * Attempts to resolve a {@link Holder.Reference} for a target enchantment.
+     * Since enchantments are data, they are not guaranteed to exist.
+     * 
+     * @param key The target resource key
+     * @return If the holder was available, an Optional containing it; otherwise an empty Optional.
+     */
+    public Optional<Holder.Reference<Enchantment>> getHolder(ResourceKey<Enchantment> key) {
+        return this.lookup.get(key);
+    }
+
+    /**
+     * {@return the underlying registry lookup, which can be used to access enchantment Holders}
+     */
+    public RegistryLookup<Enchantment> getLookup() {
+        return lookup;
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/enchantment/EnchantmentLevelTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/enchantment/EnchantmentLevelTests.java
@@ -33,16 +33,20 @@ public class EnchantmentLevelTests {
             ItemEnchantments.Mutable enchants = e.getEnchantments();
 
             // Increase the level of sharpness by 1 in all cases.
-            if (e.isTargetting(Enchantments.SHARPNESS)) {
-                enchants.set(e.getTargetEnchant(), enchants.getLevel(e.getTargetEnchant()) + 1);
-            }
+            e.getHolder(Enchantments.SHARPNESS).ifPresent(holder -> {
+                if (e.isTargetting(holder)) {
+                    enchants.set(holder, enchants.getLevel(holder) + 1);
+                }
+            });
 
             // Increase the level of fire aspect by 1 if the stack contains specific NBT.
-            if (e.isTargetting(Enchantments.FIRE_ASPECT)) {
-                if (e.getStack().getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).contains("boost_fire_aspect")) {
-                    enchants.set(e.getTargetEnchant(), enchants.getLevel(e.getTargetEnchant()) + 1);
+            e.getHolder(Enchantments.FIRE_ASPECT).ifPresent(holder -> {
+                if (e.isTargetting(holder)) {
+                    if (e.getStack().getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).contains("boost_fire_aspect")) {
+                        enchants.set(holder, enchants.getLevel(holder) + 1);
+                    }
                 }
-            }
+            });
         });
 
         test.onGameTest(helper -> {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
@@ -41,7 +41,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.SingleRecipeInput;
 import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Blocks;
@@ -138,8 +137,8 @@ public class GlobalLootModifiersTest {
         public ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
             ItemStack ctxTool = context.getParamOrNull(LootContextParams.TOOL);
             var reg = context.getLevel().registryAccess().registryOrThrow(Registries.ENCHANTMENT);
-            //return early if silk-touch is already applied (otherwise we'll get stuck in an infinite loop).
-            if (ctxTool == null || EnchantmentHelper.getItemEnchantmentLevel(reg.getHolderOrThrow(Enchantments.SILK_TOUCH), ctxTool) > 0)
+            // return early if silk-touch is already applied (otherwise we'll get stuck in an infinite loop).
+            if (ctxTool == null || ctxTool.getEnchantmentLevel(reg.getHolderOrThrow(Enchantments.SILK_TOUCH)) > 0)
                 return generatedLoot;
             ItemStack fakeTool = ctxTool.copy();
             fakeTool.enchant(reg.getHolderOrThrow(Enchantments.SILK_TOUCH), 1);


### PR DESCRIPTION
The switch to data enchantments has left `GetEnchantmentLevelEvent` and `IItemExtension#getAllEnchantments` inoperable due to the inability to resolve `Holder`s, which are required to populate an `ItemEnchantments` instance.  This PR provides the necessary `RegistryLookup<Enchantment>` to these contexts, retrieving it "as safely as possible".

The term "as safely as possible" means compromising between accessing magic global state and patching a ton of locations.  The primary technique used to access the `RegistryLookup` is by retrieving it from the existing `Holder.Reference` objects, or whatever other context is available (such as an entity).

In two cases, there was no relevant context available, which means that the global state has to be accessed through the new `CommonHooks.resolveLookup` function. The cases were:
1. `ItemEnchantmentsPredicate.Enchantments#matches`, which only has `ItemStack` context, and
2. `EnchantmentHelper#runIterationOnItem(ItemStack, EnchantmentHelper.EnchantmentVisitor)`, which does not have any access to a server or level.

All other cases use available local state to resolve the `RegistryLookup`.

In addition, this PR resolves a todo in `ArrowItem#isInfinite`, updating it to reflect current systems.