### PR TITLE
Fix crash when setting zero experience in BlockDropsEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -123,7 +123,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
      * @apiNote When cancelled, no experience is dropped, regardless of this value.
      */
     public void setDroppedExperience(int experience) {
-        Preconditions.checkArgument(experience > 0, "May not set a negative experience drop.");
+        Preconditions.checkArgument(experience >= 0, "May not set a negative experience drop.");
         this.experience = experience;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -119,7 +119,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
     /**
      * Set the amount of experience points that will be dropped by the block
      *
-     * @param experience The new amount. Must be a positive value.
+     * @param experience The new amount. Must not be negative.
      * @apiNote When cancelled, no experience is dropped, regardless of this value.
      */
     public void setDroppedExperience(int experience) {


### PR DESCRIPTION
Seems I (and reviewers) missed the lack of a `=` in that check.

Closes #1088