### PR TITLE
[1.21] Fix per-face ExtraFaceData not getting saved in datagen

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ModelBuilder.java
@@ -341,9 +341,8 @@ public class ModelBuilder<T extends ModelBuilder<T>> extends ModelFile {
                     if (face.tintIndex() != -1) {
                         faceObj.addProperty("tintindex", face.tintIndex());
                     }
-                    // TODO 1.21 - port properly
-                    if (false) { //if (!face.getFaceData().equals(ExtraFaceData.DEFAULT)) {
-                        faceObj.add("neoforge_data", ExtraFaceData.CODEC.encodeStart(JsonOps.INSTANCE, face.faceData()).result().get());
+                    if (!face.faceData().equals(ExtraFaceData.DEFAULT)) {
+                        faceObj.add("neoforge_data", ExtraFaceData.CODEC.encodeStart(JsonOps.INSTANCE, face.faceData()).result().orElseThrow());
                     }
                     faces.add(dir.getSerializedName(), faceObj);
                 }


### PR DESCRIPTION
This PR fixes the serialization of per-face `ExtraFaceData` in model datagen which was missed during the port