### PR TITLE
Fix withSearchBar not setting the background texture for the creative menu

### DIFF
--- a/patches/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -151,11 +151,11 @@
  
 +        /**
 +         * Gives this tab a search bar.
-+         * <p>Note that, if using a custom {@link #withBackgroundLocation(net.minecraft.resources.ResourceLocation) background image}, you will need to make sure that your image contains the input box and the scroll bar.</p>
++         * <p>Note that, if using a custom {@link #backgroundTexture(net.minecraft.resources.ResourceLocation) background image}, you will need to make sure that your image contains the input box and the scroll bar.</p>
 +         */
 +        public CreativeModeTab.Builder withSearchBar() {
 +            this.hasSearchBar = true;
-+            if (this.backgroundTexture == null)
++            if (this.backgroundTexture == CreativeModeTab.DEFAULT_BACKGROUND)
 +                return this.backgroundTexture(CREATIVE_ITEM_SEARCH_BACKGROUND);
 +            return this;
 +        }


### PR DESCRIPTION
`CreativeModeTab.Builder.backgroundTexture` now initializes to `CreativeModeTab.DEFAULT_BACKGROUND` by default instead of `null`. This just updates the check so that if it is still the default value then it can override.