### PR TITLE
Allow querying and baking top-level models from ModelBaker

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -13,10 +13,16 @@
          this.topLevelModels.values().forEach(p_247954_ -> p_247954_.resolveParents(this::getModel));
          p_252014_.pop();
      }
-@@ -246,14 +_,24 @@
+@@ -246,14 +_,30 @@
          }
  
          @Override
++        @Nullable
++        public UnbakedModel getTopLevelModel(ModelResourceLocation location) {
++            return topLevelModels.get(location);
++        }
++
++        @Override
 +        public Function<Material, TextureAtlasSprite> getModelTextureGetter() {
 +            return this.modelTextureGetter;
 +        }
@@ -39,15 +45,16 @@
                  ModelBakery.this.bakedCache.put(modelbakery$bakedcachekey, bakedmodel1);
                  return bakedmodel1;
              }
-@@ -261,13 +_,18 @@
+@@ -261,13 +_,19 @@
  
          @Nullable
          BakedModel bakeUncached(UnbakedModel p_352386_, ModelState p_352194_) {
 +            return bakeUncached(p_352386_, p_352194_, this.modelTextureGetter);
 +        }
 +
++        @Override
 +        @Nullable
-+        BakedModel bakeUncached(UnbakedModel p_352386_, ModelState p_352194_, Function<Material, TextureAtlasSprite> sprites) {
++        public BakedModel bakeUncached(UnbakedModel p_352386_, ModelState p_352194_, Function<Material, TextureAtlasSprite> sprites) {
              if (p_352386_ instanceof BlockModel blockmodel && blockmodel.getRootModel() == ModelBakery.GENERATION_MARKER) {
                  return ModelBakery.ITEM_MODEL_GENERATOR
 -                    .generateBlockModel(this.modelTextureGetter, blockmodel)

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IModelBakerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IModelBakerExtension.java
@@ -9,13 +9,21 @@ import java.util.function.Function;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.client.resources.model.ModelState;
+import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.Nullable;
 
 public interface IModelBakerExtension {
     @Nullable
+    UnbakedModel getTopLevelModel(ModelResourceLocation location);
+
+    @Nullable
     BakedModel bake(ResourceLocation location, ModelState state, Function<Material, TextureAtlasSprite> sprites);
+
+    @Nullable
+    BakedModel bakeUncached(UnbakedModel model, ModelState state, Function<Material, TextureAtlasSprite> sprites);
 
     Function<Material, TextureAtlasSprite> getModelTextureGetter();
 }


### PR DESCRIPTION
Some mods need to access top-level models from other models (for example to access the model for a specific block state). The unbaked top-level models are safe to access from baking and already available, this PR just adds the necessary methods to `IModelBakerExtension`.