### PR TITLE
[1.21] Fix PlayerRespawnPositionEvent position copying logic

### DIFF
--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -57,25 +57,28 @@
          ServerLevel serverlevel = p_11287_.serverLevel();
          p_11287_.awardStat(Stats.LEAVE_GAME);
          this.save(p_11287_);
-@@ -440,6 +_,8 @@
+@@ -440,13 +_,20 @@
          this.players.remove(p_11237_);
          p_11237_.serverLevel().removePlayerImmediately(p_11237_, p_348558_);
          DimensionTransition dimensiontransition = p_11237_.findRespawnPositionAndUseSpawnBlock(p_11238_, DimensionTransition.DO_NOTHING);
++
++        // Neo: Allow changing the respawn position of players. The local dimension transition is updated with the new target.
 +        var event = net.neoforged.neoforge.event.EventHooks.firePlayerRespawnPositionEvent(p_11237_, dimensiontransition, p_11238_);
 +        dimensiontransition = event.getDimensionTransition();
++
          ServerLevel serverlevel = dimensiontransition.newLevel();
          ServerPlayer serverplayer = new ServerPlayer(this.server, serverlevel, p_11237_.getGameProfile(), p_11237_.clientInformation());
          serverplayer.connection = p_11237_.connection;
-@@ -456,6 +_,9 @@
- 
-         Vec3 vec3 = dimensiontransition.pos();
-         serverplayer.moveTo(vec3.x, vec3.y, vec3.z, dimensiontransition.yRot(), dimensiontransition.xRot());
-+        if (event.changePlayerSpawnPosition()) {
-+            serverplayer.setRespawnPosition(dimensiontransition.newLevel().dimension(), BlockPos.containing(vec3), dimensiontransition.yRot(), p_11237_.isRespawnForced(), false);
-+        }
-         if (dimensiontransition.missingRespawnBlock()) {
-             serverplayer.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.NO_RESPAWN_BLOCK_AVAILABLE, 0.0F));
+         serverplayer.restoreFrom(p_11237_, p_11238_);
+         serverplayer.setId(p_11237_.getId());
+         serverplayer.setMainArm(p_11237_.getMainArm());
+-        if (!dimensiontransition.missingRespawnBlock()) {
++
++        // Neo: Allow the event to control if the original spawn position is copied
++        if (event.copyOriginalSpawnPosition()) {
+             serverplayer.copyRespawnPosition(p_11237_);
          }
+ 
 @@ -477,6 +_,7 @@
          this.playersByUUID.put(serverplayer.getUUID(), serverplayer);
          serverplayer.initInventoryMenu();

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerRespawnPositionEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerRespawnPositionEvent.java
@@ -30,13 +30,14 @@ public class PlayerRespawnPositionEvent extends PlayerEvent {
     private DimensionTransition dimensionTransition;
     private final DimensionTransition originalDimensionTransition;
     private final boolean fromEndFight;
-    private boolean changePlayerSpawnPosition = true;
+    private boolean copyOriginalSpawnPosition;
 
     public PlayerRespawnPositionEvent(ServerPlayer player, DimensionTransition dimensionTransition, boolean fromEndFight) {
         super(player);
         this.dimensionTransition = dimensionTransition;
         this.originalDimensionTransition = dimensionTransition;
         this.fromEndFight = fromEndFight;
+        this.copyOriginalSpawnPosition = !this.originalDimensionTransition.missingRespawnBlock();
     }
 
     /**
@@ -77,21 +78,27 @@ public class PlayerRespawnPositionEvent extends PlayerEvent {
     }
 
     /**
-     * @return Whether the respawn position will be used as the player's spawn position from then on. Defaults to {@code true}.
-     *         {@link PlayerSetSpawnEvent} will be fired if this is {@code true}.
+     * If the respawn position of the original player will be copied to the fresh player via {@link ServerPlayer#copyRespawnPosition(ServerPlayer)}.
+     * <p>
+     * This defaults to true if the {@linkplain #getOriginalDimensionTransition() original dimension transition}
+     * was not {@linkplain DimensionTransition#missingRespawnBlock() missing a respawn block}.
+     * <p>
+     * This has no impact on the selected position for the current respawn, but controls if the player will (for example) retain their bed as their set respawn position.
      */
-    public boolean changePlayerSpawnPosition() {
-        return changePlayerSpawnPosition;
+    public boolean copyOriginalSpawnPosition() {
+        return copyOriginalSpawnPosition;
     }
 
     /**
-     * Set whether the respawn position will be used as the player's spawn position from then on.
-     * Defaults to {@code true}. {@link PlayerSetSpawnEvent} will be fired if this is {@code true}.
+     * Changes if the original player's respawn position will be copied to the fresh player via {@link ServerPlayer#copyRespawnPosition(ServerPlayer)}.
+     * <p>
+     * If you wish to modify the set respawn position of the fresh player (for future respawns, not the current respawn), you can
+     * change the respawn position of the {@linkplain #getEntity() current player} and set this value to true.
      * 
-     * @param changePlayerSpawnPosition Whether to set the player's spawn position.
+     * @see #copyOriginalSpawnPosition()
      */
-    public void setChangePlayerSpawnPosition(boolean changePlayerSpawnPosition) {
-        this.changePlayerSpawnPosition = changePlayerSpawnPosition;
+    public void setCopyOriginalSpawnPosition(boolean copyOriginalSpawnPosition) {
+        this.copyOriginalSpawnPosition = copyOriginalSpawnPosition;
     }
 
     /**


### PR DESCRIPTION
Fixes a regression introduced in porting that caused the `PlayerRespawnPositionEvent` to always update the player's saved respawn point to the new "real" target spawnpoint.

This change removes the erroneous additional `setRespawnPosition` call that was performing the aforementioned update, and renames `changePlayerSpawnPosition` to `copyOriginalSpawnPosition` to better reflect what is actually going on.

The default value of `copyOriginalSpawnPosition` was updated from `true` to `!this.originalDimensionTransition.missingRespawnBlock()` so that it only happens (by default) when vanilla would originally copy it, while giving the event control over if it actually occurs.

Closes https://github.com/neoforged/NeoForge/issues/1107