### PR TITLE
Adds an extension method to items (adjustAttributeModifiers) to allow modifying the exposed attributes

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -69,7 +69,7 @@ public interface IItemExtension {
      * ItemStack sensitive version of getDefaultAttributeModifiers. Used when a stack has no {@link DataComponents#ATTRIBUTE_MODIFIERS} component.
      */
     @SuppressWarnings("deprecation")
-    default ItemAttributeModifiers getAttributeModifiers(ItemStack stack) {
+    default ItemAttributeModifiers getDefaultAttributeModifiers(ItemStack stack) {
         return self().getDefaultAttributeModifiers();
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import com.google.common.collect.Multimap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -24,6 +25,8 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.animal.Wolf;
 import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -63,12 +66,20 @@ public interface IItemExtension {
     }
 
     /**
-     * ItemStack sensitive version of getItemAttributeModifiers
+     * ItemStack sensitive version of getDefaultAttributeModifiers. Used when a stack has no {@link DataComponents#ATTRIBUTE_MODIFIERS} component.
      */
     @SuppressWarnings("deprecation")
     default ItemAttributeModifiers getAttributeModifiers(ItemStack stack) {
         return self().getDefaultAttributeModifiers();
     }
+
+    /**
+     * Called to allow items to modify the attributes on them.
+     *
+     * @param slot      The slot to adjust the attributes for.
+     * @param modifiers Modifiers currently on the stack either because of a {@link DataComponents#ATTRIBUTE_MODIFIERS} component, or the default attribute modifiers
+     */
+    default void adjustAttributeModifiers(ItemStack stack, EquipmentSlot slot, Multimap<Holder<Attribute>, AttributeModifier> modifiers) {}
 
     /**
      * Called when a player drops the item into the world, returning false from this

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -491,6 +491,7 @@ public interface IItemStackExtension {
         } else {
             self().getItem().getAttributeModifiers(self()).forEach(equipmentSlot, multimap::put);
         }
+        self().getItem().adjustAttributeModifiers(self(), equipmentSlot, multimap);
         return CommonHooks.getAttributeModifiers(self(), equipmentSlot, multimap);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -489,7 +489,7 @@ public interface IItemStackExtension {
         if (!itemattributemodifiers.modifiers().isEmpty()) {
             itemattributemodifiers.forEach(equipmentSlot, multimap::put);
         } else {
-            self().getItem().getAttributeModifiers(self()).forEach(equipmentSlot, multimap::put);
+            self().getItem().getDefaultAttributeModifiers(self()).forEach(equipmentSlot, multimap::put);
         }
         self().getItem().adjustAttributeModifiers(self(), equipmentSlot, multimap);
         return CommonHooks.getAttributeModifiers(self(), equipmentSlot, multimap);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/MayFlyAttributeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/MayFlyAttributeTest.java
@@ -58,7 +58,7 @@ public class MayFlyAttributeTest {
         }
 
         @Override
-        public ItemAttributeModifiers getAttributeModifiers(ItemStack stack) {
+        public ItemAttributeModifiers getDefaultAttributeModifiers(ItemStack stack) {
             return ItemAttributeModifiers.builder()
                     .add(NeoForgeMod.CREATIVE_FLIGHT, MODIFIER, EquipmentSlotGroup.ANY)
                     .build();


### PR DESCRIPTION
Use case of this extension method:
- Streamlining of modifying and adding attributes for an item without having to use the `ItemAttributeModifierEvent` and then instance check and add.
- Allowing an item to override the attributes set by the data component. This is mostly useful for when you want to expose an attribute on your item regardless of if it is set in the component. For example I have an item that conditionally is capable of providing flight, and I don't want that feature to get broken if a mod or pack wants to add extra attributes to an instance of my item.

Both of these used to be possible via overriding `getAttributeModifiers` as we then could return more things. The issue with the current version of `getAttributeModifiers` is that it is only called if there is no data component set on the item with the attributes. I decided to leave the `getAttributeModifiers` alone rather than moving it into the default implementation of this method so that people can continue to prebake stack sensitive defaults if that is of use to them.