### PR TITLE
Fix enchantment attribute modifiers not being applied

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -158,23 +158,27 @@
      public ItemEnchantments getEnchantments() {
          return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
      }
-@@ -933,12 +_,16 @@
+@@ -933,11 +_,15 @@
      }
  
      public void forEachModifier(EquipmentSlot p_332001_, BiConsumer<Holder<Attribute>, AttributeModifier> p_330882_) {
+-        ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
+-        if (!itemattributemodifiers.modifiers().isEmpty()) {
+-            itemattributemodifiers.forEach(p_332001_, p_330882_);
+-        } else {
+-            this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
 +        // Neo: Use ItemStack extension method, which fires an event for mod-added attributes modifiers
 +        this.getAttributeModifiers(p_332001_).forEach(p_330882_);
 +        if (false) {
-         ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
-         if (!itemattributemodifiers.modifiers().isEmpty()) {
-             itemattributemodifiers.forEach(p_332001_, p_330882_);
-         } else {
-             this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
++            ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
++            if (!itemattributemodifiers.modifiers().isEmpty()) {
++                itemattributemodifiers.forEach(p_332001_, p_330882_);
++            } else {
++                this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
++            }
          }
-+        }
  
          EnchantmentHelper.forEachModifier(this, p_332001_, p_330882_);
-     }
 @@ -951,7 +_,7 @@
  
          MutableComponent mutablecomponent1 = ComponentUtils.wrapInSquareBrackets(mutablecomponent);

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -158,15 +158,23 @@
      public ItemEnchantments getEnchantments() {
          return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
      }
-@@ -933,6 +_,8 @@
+@@ -933,12 +_,16 @@
      }
  
      public void forEachModifier(EquipmentSlot p_332001_, BiConsumer<Holder<Attribute>, AttributeModifier> p_330882_) {
++        // Neo: Use ItemStack extension method, which fires an event for mod-added attributes modifiers
 +        this.getAttributeModifiers(p_332001_).forEach(p_330882_);
-+        if (true) return;
++        if (false) {
          ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
          if (!itemattributemodifiers.modifiers().isEmpty()) {
              itemattributemodifiers.forEach(p_332001_, p_330882_);
+         } else {
+             this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
+         }
++        }
+ 
+         EnchantmentHelper.forEachModifier(this, p_332001_, p_330882_);
+     }
 @@ -951,7 +_,7 @@
  
          MutableComponent mutablecomponent1 = ComponentUtils.wrapInSquareBrackets(mutablecomponent);


### PR DESCRIPTION
This PR fixes #1120 by replacing the short-circuting `if (true) return;` statement in `ItemStack#forEachModifier(EquipmentSlot, ...)` with an `if (false) { ... }` that encompasses the code replaced by the item stack extension method call, thus allowing the call to `EnchantmentHelper` to happen.

An explanatory comment was added (where none existed before) to assist future debugging of that patch, and for simple patch hygiene reasons.

Tested by obtaining a golden shovel with a max-level Efficiency enchantment through `/enchant`, and digging through dirt: mining dirt should be instant, with a block at even the quickest click. (It should also be possible to verify the attribute modifier's application manually through the `/attribute` command.)

---

Note that, as noted in my comment on the linked issue, this does not address the fact that the other `forEachModifier` method that takes in an `EquipmentSlotGroup` is left unmodified, and thus outside the reach of the `ItemAttributeModifiersEvent` (which is fired by that item stack extension method). I leave that work to another contributor, since it requires refactoring the event for both `EquipmentSlot` and `EquipmentSlotGroup`.