### PR TITLE
[1.21] Fixed ProjectileWeaponItem#customArrow patch

### DIFF
--- a/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -20,7 +20,7 @@
 +        ItemStack itemstack1 = this.getProjectile(weapon);
 +        AbstractArrow abstractarrow = this.getArrow(itemstack1, p_32142_, weapon);
 +        if (weapon.getItem() instanceof net.minecraft.world.item.ProjectileWeaponItem weaponItem)
-+            abstractarrow = weaponItem.customArrow(abstractarrow, weapon);
++            abstractarrow = weaponItem.customArrow(abstractarrow, itemstack1, weapon);
          double d0 = p_32141_.getX() - this.getX();
          double d1 = p_32141_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32141_.getZ() - this.getZ();

--- a/patches/net/minecraft/world/entity/monster/Illusioner.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Illusioner.java.patch
@@ -9,7 +9,7 @@
          ItemStack itemstack1 = this.getProjectile(itemstack);
          AbstractArrow abstractarrow = ProjectileUtil.getMobArrow(this, itemstack1, p_32919_, itemstack);
 +        if (itemstack.getItem() instanceof net.minecraft.world.item.BowItem bowItem)
-+            abstractarrow = bowItem.customArrow(abstractarrow, itemstack1);
++            abstractarrow = bowItem.customArrow(abstractarrow, itemstack1, itemstack);
          double d0 = p_32918_.getX() - this.getX();
          double d1 = p_32918_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32918_.getZ() - this.getZ();

--- a/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -5,7 +5,7 @@
          }
  
 -        return abstractarrow;
-+        return customArrow(abstractarrow, p_330846_);
++        return customArrow(abstractarrow, p_331497_, p_330846_);
      }
  
      protected static List<ItemStack> draw(ItemStack p_331565_, ItemStack p_330406_, LivingEntity p_330823_) {
@@ -25,7 +25,7 @@
          }
 +    }
 +
-+    public AbstractArrow customArrow(AbstractArrow arrow, net.minecraft.world.item.ItemStack stack) {
++    public AbstractArrow customArrow(AbstractArrow arrow, ItemStack projectileStack, ItemStack weaponStack) {
 +        return arrow;
      }
  }


### PR DESCRIPTION
This PR simply passes both the projectileStack and weaponStack into ProjectileWeaponItem#customArrow, to allow to easier arrow entity creation.

The customArrow method (previously in BowItem) had previously had the projectile/arrow stack passed into it, but the 1.20.5 port had on accident (I assume) changed it to be the weapon stack. Except for in Illusioner, where the projectile stack was still used.