### PR TITLE
[1.21] Update `ItemAttributeModifierEvent` to be based on `ItemAttributeModifiers` and update new vanilla attribute uses against the event

### DIFF
--- a/patches/net/minecraft/advancements/critereon/ItemAttributeModifiersPredicate.java.patch
+++ b/patches/net/minecraft/advancements/critereon/ItemAttributeModifiersPredicate.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/advancements/critereon/ItemAttributeModifiersPredicate.java
++++ b/net/minecraft/advancements/critereon/ItemAttributeModifiersPredicate.java
+@@ -40,6 +_,14 @@
+         return !this.modifiers.isPresent() || this.modifiers.get().test(p_341374_.modifiers());
+     }
+ 
++    /**
++     * Neo: Override this method to reflect gameplay attribute modifiers instead of only NBT modifiers.
++     */
++    @Override
++    public boolean matches(ItemStack p_333958_) {
++        return matches(p_333958_, p_333958_.getAttributeModifiers());
++    }
++
+     public static record EntryPredicate(
+         Optional<HolderSet<Attribute>> attribute,
+         Optional<ResourceLocation> id,

--- a/patches/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/net/minecraft/world/entity/Mob.java.patch
@@ -69,6 +69,17 @@
              Vec3i vec3i = this.getPickupReach();
  
              for (ItemEntity itementity : this.level()
+@@ -666,6 +_,10 @@
+ 
+     private double getApproximateAttackDamageWithItem(ItemStack p_330413_) {
+         ItemAttributeModifiers itemattributemodifiers = p_330413_.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
++
++        // Neo: Respect gameplay modifiers
++        itemattributemodifiers = p_330413_.getAttributeModifiers();
++
+         return itemattributemodifiers.compute(this.getAttributeBaseValue(Attributes.ATTACK_DAMAGE), EquipmentSlot.MAINHAND);
+     }
+ 
 @@ -701,6 +_,7 @@
  
      @Override

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -118,12 +118,14 @@
      public int getEnchantmentValue() {
          return 0;
      }
-@@ -307,13 +_,20 @@
+@@ -307,13 +_,23 @@
          return false;
      }
  
--    @Deprecated
-+    @Deprecated // Use ItemStack sensitive version or data components. (deprecated by vanilla too)
++    /**
++     * @deprecated Neo: Use {@link Item#getDefaultAttributeModifiers(ItemStack)}
++     */
+     @Deprecated
      public ItemAttributeModifiers getDefaultAttributeModifiers() {
          return ItemAttributeModifiers.EMPTY;
      }

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -132,7 +132,7 @@
              if (this.has(DataComponents.CUSTOM_NAME)) {
                  mutablecomponent.withStyle(ChatFormatting.ITALIC);
              }
-@@ -784,6 +_,7 @@
+@@ -784,12 +_,14 @@
                  list.add(DISABLED_ITEM_TOOLTIP);
              }
  
@@ -140,6 +140,13 @@
              return list;
          }
      }
+ 
+     private void addAttributeTooltips(Consumer<Component> p_330796_, @Nullable Player p_330530_) {
+         ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
++        // Neo: We don't need to call IItemStackExtension#getAttributeModifiers here, since it will be done in forEachModifier.
+         if (itemattributemodifiers.showInTooltip()) {
+             for (EquipmentSlotGroup equipmentslotgroup : EquipmentSlotGroup.values()) {
+                 MutableBoolean mutableboolean = new MutableBoolean(true);
 @@ -897,6 +_,17 @@
          return !this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty();
      }
@@ -158,27 +165,49 @@
      public ItemEnchantments getEnchantments() {
          return this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
      }
-@@ -933,11 +_,15 @@
+@@ -922,6 +_,12 @@
+     }
+ 
+     public void forEachModifier(EquipmentSlotGroup p_348610_, BiConsumer<Holder<Attribute>, AttributeModifier> p_348516_) {
++        // Neo: Reflect real attribute modifiers when doing iteration
++        this.getAttributeModifiers().forEach(p_348610_, p_348516_);
++
++        if (false) {
++        // Start disabled vanilla code
++
+         ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
+         if (!itemattributemodifiers.modifiers().isEmpty()) {
+             itemattributemodifiers.forEach(p_348610_, p_348516_);
+@@ -929,10 +_,19 @@
+             this.getItem().getDefaultAttributeModifiers().forEach(p_348610_, p_348516_);
+         }
+ 
++        // end disabled vanilla code
++        }
++
+         EnchantmentHelper.forEachModifier(this, p_348610_, p_348516_);
      }
  
      public void forEachModifier(EquipmentSlot p_332001_, BiConsumer<Holder<Attribute>, AttributeModifier> p_330882_) {
--        ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
--        if (!itemattributemodifiers.modifiers().isEmpty()) {
--            itemattributemodifiers.forEach(p_332001_, p_330882_);
--        } else {
--            this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
-+        // Neo: Use ItemStack extension method, which fires an event for mod-added attributes modifiers
-+        this.getAttributeModifiers(p_332001_).forEach(p_330882_);
++        // Neo: Reflect real attribute modifiers when doing iteration
++        this.getAttributeModifiers().forEach(p_332001_, p_330882_);
++
 +        if (false) {
-+            ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
-+            if (!itemattributemodifiers.modifiers().isEmpty()) {
-+                itemattributemodifiers.forEach(p_332001_, p_330882_);
-+            } else {
-+                this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
-+            }
++        // Start disabled vanilla code
++
+         ItemAttributeModifiers itemattributemodifiers = this.getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
+         if (!itemattributemodifiers.modifiers().isEmpty()) {
+             itemattributemodifiers.forEach(p_332001_, p_330882_);
+@@ -940,6 +_,9 @@
+             this.getItem().getDefaultAttributeModifiers().forEach(p_332001_, p_330882_);
          }
  
++        // end disabled vanilla code
++        }
++
          EnchantmentHelper.forEachModifier(this, p_332001_, p_330882_);
+     }
+ 
 @@ -951,7 +_,7 @@
  
          MutableComponent mutablecomponent1 = ComponentUtils.wrapInSquareBrackets(mutablecomponent);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.common;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Lifecycle;
@@ -88,8 +87,6 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.SlotAccess;
-import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
@@ -112,6 +109,7 @@ import net.minecraft.world.item.Tiers;
 import net.minecraft.world.item.TippedArrowItem;
 import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
@@ -823,10 +821,10 @@ public class CommonHooks {
     /**
      * Hook to fire {@link ItemAttributeModifierEvent}. Modders should use {@link ItemStack#forEachModifier(EquipmentSlot, BiConsumer)} instead.
      */
-    public static Multimap<Holder<Attribute>, AttributeModifier> getAttributeModifiers(ItemStack stack, EquipmentSlot equipmentSlot, Multimap<Holder<Attribute>, AttributeModifier> attributes) {
-        ItemAttributeModifierEvent event = new ItemAttributeModifierEvent(stack, equipmentSlot, attributes);
+    public static ItemAttributeModifiers computeModifiedAttributes(ItemStack stack, ItemAttributeModifiers defaultModifiers) {
+        ItemAttributeModifierEvent event = new ItemAttributeModifierEvent(stack, defaultModifiers);
         NeoForge.EVENT_BUS.post(event);
-        return event.getModifiers();
+        return event.getBuilder().build();
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -824,7 +824,7 @@ public class CommonHooks {
     public static ItemAttributeModifiers computeModifiedAttributes(ItemStack stack, ItemAttributeModifiers defaultModifiers) {
         ItemAttributeModifierEvent event = new ItemAttributeModifierEvent(stack, defaultModifiers);
         NeoForge.EVENT_BUS.post(event);
-        return event.getBuilder().build();
+        return event.build();
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -64,6 +64,8 @@ public interface IItemExtension {
 
     /**
      * ItemStack sensitive version of getDefaultAttributeModifiers. Used when a stack has no {@link DataComponents#ATTRIBUTE_MODIFIERS} component.
+     * 
+     * @see {@link IItemStackExtension#getAttributeModifiers()} for querying effective attribute modifiers.
      */
     @SuppressWarnings("deprecation")
     default ItemAttributeModifiers getDefaultAttributeModifiers(ItemStack stack) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.common.extensions;
 
-import com.google.common.collect.Multimap;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -25,8 +24,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.animal.Wolf;
 import net.minecraft.world.entity.animal.horse.Horse;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -76,10 +73,11 @@ public interface IItemExtension {
     /**
      * Called to allow items to modify the attributes on them.
      *
-     * @param slot      The slot to adjust the attributes for.
-     * @param modifiers Modifiers currently on the stack either because of a {@link DataComponents#ATTRIBUTE_MODIFIERS} component, or the default attribute modifiers
+     * @param modifiers The default attribute modifiers, either from {@link DataComponent#ATTRIBUTE_MODIFIERS} or {@link #getDefaultAttributeModifiers(ItemStack)}.
      */
-    default void adjustAttributeModifiers(ItemStack stack, EquipmentSlot slot, Multimap<Holder<Attribute>, AttributeModifier> modifiers) {}
+    default ItemAttributeModifiers adjustAttributeModifiers(ItemStack stack, ItemAttributeModifiers modifiers) {
+        return modifiers;
+    }
 
     /**
      * Called when a player drops the item into the world, returning false from this

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -73,15 +73,6 @@ public interface IItemExtension {
     }
 
     /**
-     * Called to allow items to modify the attributes on them.
-     *
-     * @param modifiers The default attribute modifiers, either from {@link DataComponent#ATTRIBUTE_MODIFIERS} or {@link #getDefaultAttributeModifiers(ItemStack)}.
-     */
-    default ItemAttributeModifiers adjustAttributeModifiers(ItemStack stack, ItemAttributeModifiers modifiers) {
-        return modifiers;
-    }
-
-    /**
      * Called when a player drops the item into the world, returning false from this
      * will prevent the item from being removed from the players inventory and
      * spawning in the world

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -479,8 +479,7 @@ public interface IItemStackExtension {
      * This method first computes the default modifiers, using {@link DataComponents.ATTRIBUTE_MODIFIERS} if present, otherwise
      * falling back to {@link Item#getDefaultAttributeModifiers(ItemStack)}.
      * <p>
-     * The underlying item is given a chance to first adjust the defaults via {@link Item#adjustAttributeModifiers},
-     * and finally the {@link ItemAttributeModifiersEvent} is fired to allow external adjustments.
+     * The {@link ItemAttributeModifiersEvent} is then fired to allow external adjustments.
      */
     default ItemAttributeModifiers getAttributeModifiers() {
         ItemAttributeModifiers defaultModifiers = self().getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY);
@@ -489,7 +488,6 @@ public interface IItemStackExtension {
             defaultModifiers = self().getItem().getDefaultAttributeModifiers(self());
         }
 
-        defaultModifiers = self().getItem().adjustAttributeModifiers(self(), defaultModifiers);
         return CommonHooks.computeModifiedAttributes(self(), defaultModifiers);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
@@ -133,7 +133,7 @@ public class ItemAttributeModifierEvent extends Event {
      * {@linkplain #getDefaultModifiers() default modifiers} if no changes were made.
      */
     public ItemAttributeModifiers build() {
-        return this.builder == null ? this.defaultModifiers : this.builder.build();
+        return this.builder == null ? this.defaultModifiers : this.builder.build(this.defaultModifiers.showInTooltip());
     }
 
     /**
@@ -221,8 +221,8 @@ public class ItemAttributeModifierEvent extends Event {
             this.entriesByKey.clear();
         }
 
-        public ItemAttributeModifiers build() {
-            return new ItemAttributeModifiers(ImmutableList.copyOf(this.entries), true);
+        public ItemAttributeModifiers build(boolean showInTooltip) {
+            return new ItemAttributeModifiers(ImmutableList.copyOf(this.entries), showInTooltip);
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
@@ -5,118 +5,227 @@
 
 package net.neoforged.neoforge.event;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import java.util.Collection;
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 import net.minecraft.core.Holder;
-import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.neoforged.bus.api.Event;
-import net.neoforged.neoforge.common.NeoForge;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
- * This event is fired when the attributes for an ItemStack are being calculated.
- * Attributes are calculated on the server when equipping and unequipping an item to add and remove attributes respectively, both must be consistent.
- * Attributes are calculated on the client when rendering an item's tooltip to show relevant attributes.
+ * This event is fired when the attributes for an item stack are queried (for any reason) through {@link ItemStack#getAttributeModifiers()}.
  * <br>
- * Note that this event is fired regardless of if the stack has NBT overriding attributes or not. If your attribute should be
- * ignored when attributes are overridden, you can check for the presence of the {@code AttributeModifiers} tag.
- * <br>
- * This event is fired on the {@link NeoForge#EVENT_BUS}.
+ * This event is fired regardless of if the stack has {@link DataComponents#ATTRIBUTE_MODIFIERS} or not. If your attribute should be
+ * ignored when attributes are overridden, you can check for the presence of the component.
+ * <p>
+ * This event may be fired on both the logical server and logical client.
  */
 public class ItemAttributeModifierEvent extends Event {
     private final ItemStack stack;
-    private final EquipmentSlot slotType;
-    private final Multimap<Holder<Attribute>, AttributeModifier> originalModifiers;
-    private Multimap<Holder<Attribute>, AttributeModifier> unmodifiableModifiers;
-    @Nullable
-    private Multimap<Holder<Attribute>, AttributeModifier> modifiableModifiers;
+    private final ItemAttributeModifiers defaultModifiers;
+    private ItemAttributeModifiersBuilder builder;
 
-    public ItemAttributeModifierEvent(ItemStack stack, EquipmentSlot slotType, Multimap<Holder<Attribute>, AttributeModifier> modifiers) {
+    @ApiStatus.Internal
+    public ItemAttributeModifierEvent(ItemStack stack, ItemAttributeModifiers defaultModifiers) {
         this.stack = stack;
-        this.slotType = slotType;
-        this.unmodifiableModifiers = this.originalModifiers = modifiers;
+        this.defaultModifiers = defaultModifiers;
     }
 
     /**
-     * Returns an unmodifiable view of the attribute multimap. Use other methods from this event to modify the attributes map.
-     * Note that adding attributes based on existing attributes may lead to inconsistent results between the tooltip (client)
-     * and the actual attributes (server) if the listener order is different. Using {@link #getOriginalModifiers()} instead will give more consistent results.
+     * {@return the item stack whose attribute modifiers are being computed}
      */
-    public Multimap<Holder<Attribute>, AttributeModifier> getModifiers() {
-        return this.unmodifiableModifiers;
-    }
-
-    /**
-     * Returns the attribute map before any changes from other event listeners was made.
-     */
-    public Multimap<Holder<Attribute>, AttributeModifier> getOriginalModifiers() {
-        return this.originalModifiers;
-    }
-
-    /**
-     * Gets a modifiable map instance, creating it if the current map is currently unmodifiable
-     */
-    private Multimap<Holder<Attribute>, AttributeModifier> getModifiableMap() {
-        if (this.modifiableModifiers == null) {
-            this.modifiableModifiers = HashMultimap.create(this.originalModifiers);
-            this.unmodifiableModifiers = Multimaps.unmodifiableMultimap(this.modifiableModifiers);
-        }
-        return this.modifiableModifiers;
-    }
-
-    /**
-     * Adds a new attribute modifier to the given stack.
-     * Modifier must have a consistent UUID for consistency between equipping and unequipping items.
-     * Modifier name should clearly identify the mod that added the modifier.
-     * 
-     * @param attribute Attribute
-     * @param modifier  Modifier instance.
-     * @return True if the attribute was added, false if it was already present
-     */
-    public boolean addModifier(Holder<Attribute> attribute, AttributeModifier modifier) {
-        return getModifiableMap().put(attribute, modifier);
-    }
-
-    /**
-     * Removes a single modifier for the given attribute
-     * 
-     * @param attribute Attribute
-     * @param modifier  Modifier instance
-     * @return True if an attribute was removed, false if no change
-     */
-    public boolean removeModifier(Holder<Attribute> attribute, AttributeModifier modifier) {
-        return getModifiableMap().remove(attribute, modifier);
-    }
-
-    /**
-     * Removes all modifiers for the given attribute
-     * 
-     * @param attribute Attribute
-     * @return Collection of removed modifiers
-     */
-    public Collection<AttributeModifier> removeAttribute(Holder<Attribute> attribute) {
-        return getModifiableMap().removeAll(attribute);
-    }
-
-    /**
-     * Removes all modifiers for all attributes
-     */
-    public void clearModifiers() {
-        getModifiableMap().clear();
-    }
-
-    /** Gets the slot containing this stack */
-    public EquipmentSlot getSlotType() {
-        return this.slotType;
-    }
-
-    /** Gets the item stack instance */
     public ItemStack getItemStack() {
         return this.stack;
+    }
+
+    /**
+     * {@return the default attribute modifiers before changes made by the event}
+     */
+    public ItemAttributeModifiers getDefaultModifiers() {
+        return this.defaultModifiers;
+    }
+
+    /**
+     * Returns an unmodifiable view of the attribute modifier entries. Do not use the returned value to create an {@link ItemAttributeModifiers}
+     * since the underlying list is not immutable.
+     * <p>
+     * If you need an {@link ItemAttributeModifiers}, you may need to call {@link #build()}
+     * 
+     * @apiNote Use other methods from this event to adjust the modifiers.
+     */
+    public List<ItemAttributeModifiers.Entry> getModifiers() {
+        return this.builder == null ? this.defaultModifiers.modifiers() : this.builder.getEntryView();
+    }
+
+    /**
+     * Adds a new attribute modifier to the given stack. Two modifiers with the same id may not exist for the same attribute, and this method will fail if one exists.
+     * 
+     * @param attribute The attribute the modifier is for
+     * @param modifier  The new attribute modifier
+     * @param slot      The equipment slots for which the modifier should apply
+     * @return True if the modifier was added, false if it was already present
+     * @apiNote Modifiers must have a unique and consistent {@link ResourceLocation} id, or the modifier will not be removed when the item is unequipped.
+     */
+    public boolean addModifier(Holder<Attribute> attribute, AttributeModifier modifier, EquipmentSlotGroup slot) {
+        return getBuilder().addModifier(attribute, modifier, slot);
+    }
+
+    /**
+     * Removes an attribute modifier for the target attribute by id
+     * 
+     * @return True if an attribute modifier was removed, false otherwise
+     */
+    public boolean removeModifier(Holder<Attribute> attribute, ResourceLocation id) {
+        return getBuilder().removeModifier(attribute, id);
+    }
+
+    /**
+     * Adds a new attribute modifier to the given stack, optionally replacing any existing modifiers with the same id.
+     * 
+     * @param attribute The attribute the modifier is for
+     * @param modifier  The new attribute modifier
+     * @param slot      The equipment slots for which the modifier should apply
+     * @apiNote Modifiers must have a unique and consistent {@link ResourceLocation} id, or the modifier will not be removed when the item is unequipped.
+     */
+    public void replaceModifier(Holder<Attribute> attribute, AttributeModifier modifier, EquipmentSlotGroup slot) {
+        removeModifier(attribute, modifier.id());
+        addModifier(attribute, modifier, slot);
+    }
+
+    /**
+     * Removes modifiers based on a condition.
+     * 
+     * @return true if any modifiers were removed
+     */
+    public boolean removeIf(Predicate<ItemAttributeModifiers.Entry> condition) {
+        return getBuilder().removeIf(condition);
+    }
+
+    /**
+     * Removes all modifiers for the given attribute.
+     * 
+     * @return true if any modifiers were removed
+     */
+    public boolean removeAllModifiersFor(Holder<Attribute> attribute) {
+        return getBuilder().removeIf(entry -> entry.attribute().equals(attribute));
+    }
+
+    /**
+     * Removes all modifiers for all attributes.
+     */
+    public void clearModifiers() {
+        getBuilder().clear();
+    }
+
+    /**
+     * Builds a new {@link ItemAttributeModifiers} with the results of this event, returning the
+     * {@linkplain #getDefaultModifiers() default modifiers} if no changes were made.
+     */
+    public ItemAttributeModifiers build() {
+        return this.builder == null ? this.defaultModifiers : this.builder.build();
+    }
+
+    /**
+     * Returns the builder used for adjusting the attribute modifiers, creating it if it does not already exist.
+     */
+    private ItemAttributeModifiersBuilder getBuilder() {
+        if (this.builder == null) {
+            this.builder = new ItemAttributeModifiersBuilder(this.defaultModifiers);
+        }
+
+        return this.builder;
+    }
+
+    /**
+     * Advanced version of {@link ItemAttributeModifiers.Builder} which supports removal and better sanity-checking.
+     * <p>
+     * The original builder only supports additions and does not guarantee that no duplicate modifiers exist for a given id.
+     */
+    private static class ItemAttributeModifiersBuilder {
+        private List<ItemAttributeModifiers.Entry> entries;
+        private Map<Key, ItemAttributeModifiers.Entry> entriesByKey = new HashMap<>();
+
+        ItemAttributeModifiersBuilder(ItemAttributeModifiers defaultModifiers) {
+            defaultModifiers.modifiers().forEach(entry -> {
+                entries.add(entry);
+                entriesByKey.put(new Key(entry.attribute(), entry.modifier().id()), entry);
+            });
+        }
+
+        /**
+         * {@return an unmodifiable view of the underlying entry list}
+         */
+        List<ItemAttributeModifiers.Entry> getEntryView() {
+            return Collections.unmodifiableList(this.entries);
+        }
+
+        /**
+         * Attempts to add a new modifier, refusing if one is already present with the same id.
+         * 
+         * @return true if the modifier was added
+         */
+        boolean addModifier(Holder<Attribute> attribute, AttributeModifier modifier, EquipmentSlotGroup slot) {
+            Key key = new Key(attribute, modifier.id());
+            if (entriesByKey.containsKey(key)) {
+                return false;
+            }
+
+            ItemAttributeModifiers.Entry entry = new ItemAttributeModifiers.Entry(attribute, modifier, slot);
+            entries.add(entry);
+            entriesByKey.put(key, entry);
+            return true;
+        }
+
+        /**
+         * Removes a modifier for the target attribute with the given id.
+         * 
+         * @return true if a modifier was removed
+         */
+        boolean removeModifier(Holder<Attribute> attribute, ResourceLocation id) {
+            ItemAttributeModifiers.Entry entry = entriesByKey.remove(new Key(attribute, id));
+
+            if (entry != null) {
+                entries.remove(entry);
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * Removes modifiers based on a condition.
+         * 
+         * @return true if any modifiers were removed
+         */
+        boolean removeIf(Predicate<ItemAttributeModifiers.Entry> condition) {
+            this.entries.removeIf(condition);
+            return this.entriesByKey.values().removeIf(condition);
+        }
+
+        void clear() {
+            this.entries.clear();
+            this.entriesByKey.clear();
+        }
+
+        public ItemAttributeModifiers build() {
+            return new ItemAttributeModifiers(ImmutableList.copyOf(this.entries), true);
+        }
+
+        /**
+         * Internal key class. Attribute modifiers are unique by id for each Attribute.
+         */
+        private static record Key(Holder<Attribute> attr, ResourceLocation id) {
+
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.event;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -19,8 +20,10 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
-import net.neoforged.bus.api.Event;
 import org.jetbrains.annotations.ApiStatus;
+import
+
+net.neoforged.bus.api.Event;
 
 /**
  * This event is fired when the attributes for an item stack are queried (for any reason) through {@link ItemStack#getAttributeModifiers()}.
@@ -153,9 +156,12 @@ public class ItemAttributeModifierEvent extends Event {
      */
     private static class ItemAttributeModifiersBuilder {
         private List<ItemAttributeModifiers.Entry> entries;
-        private Map<Key, ItemAttributeModifiers.Entry> entriesByKey = new HashMap<>();
+        private Map<Key, ItemAttributeModifiers.Entry> entriesByKey;
 
         ItemAttributeModifiersBuilder(ItemAttributeModifiers defaultModifiers) {
+            this.entries = new LinkedList<>();
+            this.entriesByKey = new HashMap<>(defaultModifiers.modifiers().size());
+
             defaultModifiers.modifiers().forEach(entry -> {
                 entries.add(entry);
                 entriesByKey.put(new Key(entry.attribute(), entry.modifier().id()), entry);

--- a/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
@@ -20,10 +20,8 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
+import net.neoforged.bus.api.Event;
 import org.jetbrains.annotations.ApiStatus;
-import
-
-net.neoforged.bus.api.Event;
 
 /**
  * This event is fired when the attributes for an item stack are queried (for any reason) through {@link ItemStack#getAttributeModifiers()}.

--- a/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemAttributeModifierEvent.java
@@ -160,10 +160,10 @@ public class ItemAttributeModifierEvent extends Event {
             this.entries = new LinkedList<>();
             this.entriesByKey = new HashMap<>(defaultModifiers.modifiers().size());
 
-            defaultModifiers.modifiers().forEach(entry -> {
+            for (ItemAttributeModifiers.Entry entry : defaultModifiers.modifiers()) {
                 entries.add(entry);
                 entriesByKey.put(new Key(entry.attribute(), entry.modifier().id()), entry);
-            });
+            }
         }
 
         /**

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemEventTests.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.debug.item;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -26,11 +27,11 @@ public class ItemEventTests {
     @TestHolder(description = "Tests if the ItemAttributeModifierEvent allows modifying attributes")
     static void itemAttributeModifier(final DynamicTest test) {
         test.eventListeners().forge().addListener((final ItemAttributeModifierEvent event) -> {
-            if (event.getSlotType() == EquipmentSlot.MAINHAND && event.getItemStack().getItem() == Items.APPLE) {
+            if (event.getItemStack().getItem() == Items.APPLE) {
                 ResourceLocation modifierId = ResourceLocation.fromNamespaceAndPath(test.createModId(), "apple_armor");
-                event.addModifier(Attributes.ARMOR, new AttributeModifier(modifierId, 10f, AttributeModifier.Operation.ADD_VALUE));
-            } else if (event.getSlotType() == EquipmentSlot.CHEST && event.getItemStack().is(Items.GOLDEN_CHESTPLATE)) {
-                event.clearModifiers();
+                event.addModifier(Attributes.ARMOR, new AttributeModifier(modifierId, 10f, AttributeModifier.Operation.ADD_VALUE), EquipmentSlotGroup.MAINHAND);
+            } else if (event.getItemStack().is(Items.GOLDEN_CHESTPLATE)) {
+                event.removeIf(entry -> entry.slot().test(EquipmentSlot.CHEST));
             }
         });
 


### PR DESCRIPTION
This PR refactors `ItemAttributeModifierEvent` to operate on `ItemAttributeModifiers` instead of the legacy (pre-component) `Multimap<Attribute, AttributeModifier>`.   The event retains the same functionality, but with a semantic difference in that it does not fire per-slot, instead firing one time to collect the attributes for all slots.  This change is required to allow the event to produce an `ItemAttributeModifiers`, since that object retains all modifiers for all slots simultaneously. 

As a result, the event can now be used in new vanilla call sites to item attributes, including `ItemAttributeModifiersPredicate`, `Mob#getApproximateAttackDamageWithItem`, and `ItemStack#forEachModifier`.

Closes #906 