### PR TITLE
[1.21] Add back missed patch for RegistryFriendlyByteBuf connection type awareness

### DIFF
--- a/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java.patch
@@ -59,10 +59,12 @@
      }
  
      @Override
-@@ -126,6 +_,12 @@
+@@ -125,7 +_,13 @@
+     public void handleConfigurationFinished(ServerboundFinishConfigurationPacket p_294283_) {
          PacketUtils.ensureRunningOnSameThread(p_294283_, this, this.server);
          this.finishCurrentTask(JoinWorldTask.TYPE);
-         this.connection.setupOutboundProtocol(GameProtocols.CLIENTBOUND_TEMPLATE.bind(RegistryFriendlyByteBuf.decorator(this.server.registryAccess())));
+-        this.connection.setupOutboundProtocol(GameProtocols.CLIENTBOUND_TEMPLATE.bind(RegistryFriendlyByteBuf.decorator(this.server.registryAccess())));
++        this.connection.setupOutboundProtocol(GameProtocols.CLIENTBOUND_TEMPLATE.bind(RegistryFriendlyByteBuf.decorator(this.server.registryAccess(), this.connectionType)));
 +        // Packets can only be sent after the outbound protocol is set up again
 +        if (this.connectionType == net.neoforged.neoforge.network.connection.ConnectionType.OTHER) {
 +            //We need to also initialize this here, as the client may have sent the packet before we have finished our configuration.


### PR DESCRIPTION
This PR adds back a missed patch passing the `ConnectionType` to `RegistryFriendlyByteBuf` to allow for connection-aware serilization. This caused connection-aware serialization to assume a non-NeoForge connection on the server and NeoForge on the client, breaking sync of `PotionContents` with custom effects set.