### PR TITLE
[1.21] Fix `RenderNameTagEvent` not applying its results to `renderNameTag`

### DIFF
--- a/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -1,17 +1,19 @@
 --- a/net/minecraft/client/renderer/entity/EntityRenderer.java
 +++ b/net/minecraft/client/renderer/entity/EntityRenderer.java
-@@ -94,7 +_,10 @@
+@@ -94,8 +_,11 @@
              }
          }
  
 -        if (this.shouldShowName(p_114485_)) {
+-            this.renderNameTag(p_114485_, p_114485_.getDisplayName(), p_114488_, p_114489_, p_114490_, p_114487_);
 +        // Neo: Post the RenderNameTagEvent and conditionally wrap #renderNameTag based on the result.
 +        var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent(p_114485_, p_114485_.getDisplayName(), this, p_114488_, p_114489_, p_114490_, p_114487_);
 +        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
 +        if (event.canRender().isTrue() || event.canRender().isDefault() && this.shouldShowName(p_114485_)) {
-             this.renderNameTag(p_114485_, p_114485_.getDisplayName(), p_114488_, p_114489_, p_114490_, p_114487_);
++            this.renderNameTag(p_114485_, event.getContent(), p_114488_, p_114489_, p_114490_, p_114487_);
          }
      }
+ 
 @@ -181,7 +_,7 @@
  
      protected void renderNameTag(T p_114498_, Component p_114499_, PoseStack p_114500_, MultiBufferSource p_114501_, int p_114502_, float p_316698_) {


### PR DESCRIPTION
The contents, acquired via `.getContent()` are not fetched or applied after the `RenderNameTagEvent` is called. It is simply ignored and `pEntity.getDisplayName()` is included when renderNameTag is called, instead. Now, `pEntity.getDisplayName()` is replaced with `event.getContent()`.
Fixes #1122