### PR TITLE
[1.21] Fix contents of  `ComputeCameraAngles` not being applied after event fires

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -65,7 +65,7 @@
          }
  
          this.resetProjectionMatrix(matrix4f);
-+        net.neoforged.neoforge.client.event.ViewportEvent.ComputeCameraAngles cameraSetup = net.neoforged.neoforge.client.ClientHooks.onCameraSetup(this, camera, f);
++        net.neoforged.neoforge.client.event.ViewportEvent.ComputeCameraAngles cameraSetup = net.neoforged.neoforge.client.ClientHooks.onCameraSetup(this, camera, f, camera.getYRot(), camera.getXRot());
 +        camera.setAnglesInternal(cameraSetup.getYaw(), cameraSetup.getPitch());
          Quaternionf quaternionf = camera.rotation().conjugate(new Quaternionf());
          Matrix4f matrix4f1 = new Matrix4f().rotation(quaternionf);

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -435,8 +435,8 @@ public class ClientHooks {
         }
     }
 
-    public static ViewportEvent.ComputeCameraAngles onCameraSetup(GameRenderer renderer, Camera camera, float partial) {
-        ViewportEvent.ComputeCameraAngles event = new ViewportEvent.ComputeCameraAngles(renderer, camera, partial, camera.getYRot(), camera.getXRot(), 0);
+    public static ViewportEvent.ComputeCameraAngles onCameraSetup(GameRenderer renderer, Camera camera, float partial, float yaw, float pitch) {
+        ViewportEvent.ComputeCameraAngles event = new ViewportEvent.ComputeCameraAngles(renderer, camera, partial, yaw, pitch, 0);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }


### PR DESCRIPTION
Changes to rotation made in the `ComputeCameraAngles` event aren't applied to the overall camera rotation. There doesn't appear to be any visual change.

`setAnglesInternal` updates the `yRot` and `xRot` fields of the Camera. However, when actually applying the rotations, the rotation field is referenced instead.

This PR aims to fix that.

Fixes #1123