### PR TITLE
[1.21] Add missing alias resolve in MappedRegistry#getHolder() and properly handle null name in MappedRegistry#get()

### DIFF
--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -69,7 +69,13 @@
      }
  
      @Nullable
-@@ -189,7 +_,7 @@
+@@ -184,12 +_,12 @@
+ 
+     @Override
+     public Optional<Holder.Reference<T>> getHolder(ResourceLocation p_316743_) {
+-        return Optional.ofNullable(this.byLocation.get(p_316743_));
++        return Optional.ofNullable(this.byLocation.get(resolve(p_316743_)));
+     }
  
      @Override
      public Optional<Holder.Reference<T>> getHolder(ResourceKey<T> p_205905_) {
@@ -92,7 +98,7 @@
      @Override
      public T get(@Nullable ResourceLocation p_122739_) {
 -        Holder.Reference<T> reference = this.byLocation.get(p_122739_);
-+        Holder.Reference<T> reference = this.byLocation.get(resolve(p_122739_));
++        Holder.Reference<T> reference = this.byLocation.get(p_122739_ != null ? resolve(p_122739_) : null);
          return getValueFromNullable(reference);
      }
  


### PR DESCRIPTION
This PR adds back a missing registry alias resolve in `MappedRegistry#getHolder(ResourceLocation)` and updates `MappedRegistry#get(ResourceLocation)` to safely handle a null RL with respect to alias resolving.