### PR TITLE
[1.21] Fix angles set in ViewportEvent.ComputeCameraAngles not taking effect

### DIFF
--- a/patches/net/minecraft/client/Camera.java.patch
+++ b/patches/net/minecraft/client/Camera.java.patch
@@ -8,12 +8,14 @@
  
      public void setup(BlockGetter p_90576_, Entity p_90577_, boolean p_90578_, boolean p_90579_, float p_90580_) {
          this.initialized = true;
-@@ -49,7 +_,8 @@
+@@ -49,7 +_,10 @@
          this.entity = p_90577_;
          this.detached = p_90578_;
          this.partialTickTime = p_90580_;
 -        this.setRotation(p_90577_.getViewYRot(p_90580_), p_90577_.getViewXRot(p_90580_));
-+        var cameraSetup = net.neoforged.neoforge.client.ClientHooks.onCameraSetup(this, p_90577_.getViewYRot(p_90580_), p_90577_.getViewXRot(p_90580_), p_90580_);
++        var cameraSetup = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ViewportEvent.ComputeCameraAngles(
++                this, p_90580_, p_90577_.getViewYRot(p_90580_), p_90577_.getViewXRot(p_90580_), 0)
++        );
 +        this.setRotation(cameraSetup.getYaw(), cameraSetup.getPitch(), cameraSetup.getRoll());
          this.setPosition(
              Mth.lerp((double)p_90580_, p_90577_.xo, p_90577_.getX()),

--- a/patches/net/minecraft/client/Camera.java.patch
+++ b/patches/net/minecraft/client/Camera.java.patch
@@ -1,6 +1,29 @@
 --- a/net/minecraft/client/Camera.java
 +++ b/net/minecraft/client/Camera.java
-@@ -61,7 +_,7 @@
+@@ -42,6 +_,7 @@
+     private float eyeHeightOld;
+     private float partialTickTime;
+     public static final float FOG_DISTANCE_SCALE = 0.083333336F;
++    private float roll;
+ 
+     public void setup(BlockGetter p_90576_, Entity p_90577_, boolean p_90578_, boolean p_90579_, float p_90580_) {
+         this.initialized = true;
+@@ -49,7 +_,8 @@
+         this.entity = p_90577_;
+         this.detached = p_90578_;
+         this.partialTickTime = p_90580_;
+-        this.setRotation(p_90577_.getViewYRot(p_90580_), p_90577_.getViewXRot(p_90580_));
++        var cameraSetup = net.neoforged.neoforge.client.ClientHooks.onCameraSetup(this, p_90577_.getViewYRot(p_90580_), p_90577_.getViewXRot(p_90580_), p_90580_);
++        this.setRotation(cameraSetup.getYaw(), cameraSetup.getPitch(), cameraSetup.getRoll());
+         this.setPosition(
+             Mth.lerp((double)p_90580_, p_90577_.xo, p_90577_.getX()),
+             Mth.lerp((double)p_90580_, p_90577_.yo, p_90577_.getY()) + (double)Mth.lerp(p_90580_, this.eyeHeightOld, this.eyeHeight),
+@@ -57,11 +_,11 @@
+         );
+         if (p_90578_) {
+             if (p_90579_) {
+-                this.setRotation(this.yRot + 180.0F, -this.xRot);
++                this.setRotation(this.yRot + 180.0F, -this.xRot, -this.roll);
              }
  
              float f = p_90577_ instanceof LivingEntity livingentity ? livingentity.getScale() : 1.0F;
@@ -9,15 +32,33 @@
          } else if (p_90577_ instanceof LivingEntity && ((LivingEntity)p_90577_).isSleeping()) {
              Direction direction = ((LivingEntity)p_90577_).getBedOrientation();
              this.setRotation(direction != null ? direction.toYRot() - 180.0F : 0.0F, 0.0F);
-@@ -221,6 +_,18 @@
+@@ -102,10 +_,17 @@
+         this.setPosition(new Vec3(this.position.x + (double)vector3f.x, this.position.y + (double)vector3f.y, this.position.z + (double)vector3f.z));
+     }
+ 
++    /** @deprecated Neo: call {@link #setRotation(float, float, float)} instead */
++    @Deprecated
+     protected void setRotation(float p_90573_, float p_90574_) {
++        setRotation(p_90573_, p_90574_, 0F);
++    }
++
++    protected void setRotation(float p_90573_, float p_90574_, float roll) {
+         this.xRot = p_90574_;
+         this.yRot = p_90573_;
+-        this.rotation.rotationYXZ((float) Math.PI - p_90573_ * (float) (Math.PI / 180.0), -p_90574_ * (float) (Math.PI / 180.0), 0.0F);
++        this.roll = roll;
++        this.rotation.rotationYXZ((float) Math.PI - p_90573_ * (float) (Math.PI / 180.0), -p_90574_ * (float) (Math.PI / 180.0), -roll * (float) (Math.PI / 180.0));
+         FORWARDS.rotate(this.rotation, this.forwards);
+         UP.rotate(this.rotation, this.up);
+         LEFT.rotate(this.rotation, this.left);
+@@ -221,6 +_,17 @@
  
      public float getPartialTickTime() {
          return this.partialTickTime;
 +    }
 +
-+    public void setAnglesInternal(float yaw, float pitch) {
-+        this.yRot = yaw;
-+        this.xRot = pitch;
++    public float getRoll() {
++        return this.roll;
 +    }
 +
 +    public net.minecraft.world.level.block.state.BlockState getBlockAtCamera() {

--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -61,17 +61,7 @@
                  } catch (Throwable throwable1) {
                      CrashReport crashreport1 = CrashReport.forThrowable(throwable1, "Rendering screen");
                      CrashReportCategory crashreportcategory1 = crashreport1.addCategory("Screen render details");
-@@ -1253,12 +_,18 @@
-         }
- 
-         this.resetProjectionMatrix(matrix4f);
-+        net.neoforged.neoforge.client.event.ViewportEvent.ComputeCameraAngles cameraSetup = net.neoforged.neoforge.client.ClientHooks.onCameraSetup(this, camera, f);
-+        camera.setAnglesInternal(cameraSetup.getYaw(), cameraSetup.getPitch());
-         Quaternionf quaternionf = camera.rotation().conjugate(new Quaternionf());
-         Matrix4f matrix4f1 = new Matrix4f().rotation(quaternionf);
-+        // Neo: Use matrix multiplication so roll is stacked on top of vanilla XY rotations
-+        matrix4f1 = new Matrix4f().rotationZ(cameraSetup.getRoll() * (float) (Math.PI / 180.0)).mul(matrix4f1);
-         this.minecraft
+@@ -1259,6 +_,8 @@
              .levelRenderer
              .prepareCullFrustum(camera.getPosition(), matrix4f1, this.getProjectionMatrix(Math.max(d0, (double)this.minecraft.options.fov().get().intValue())));
          this.minecraft.levelRenderer.renderLevel(p_348589_, flag, camera, this, this.lightTexture, matrix4f1, matrix4f);

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -435,8 +435,8 @@ public class ClientHooks {
         }
     }
 
-    public static ViewportEvent.ComputeCameraAngles onCameraSetup(GameRenderer renderer, Camera camera, float partial) {
-        ViewportEvent.ComputeCameraAngles event = new ViewportEvent.ComputeCameraAngles(renderer, camera, partial, camera.getYRot(), camera.getXRot(), 0);
+    public static ViewportEvent.ComputeCameraAngles onCameraSetup(Camera camera, float yaw, float pitch, float partial) {
+        ViewportEvent.ComputeCameraAngles event = new ViewportEvent.ComputeCameraAngles(Minecraft.getInstance().gameRenderer, camera, partial, yaw, pitch, 0);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -435,12 +435,6 @@ public class ClientHooks {
         }
     }
 
-    public static ViewportEvent.ComputeCameraAngles onCameraSetup(Camera camera, float yaw, float pitch, float partial) {
-        ViewportEvent.ComputeCameraAngles event = new ViewportEvent.ComputeCameraAngles(Minecraft.getInstance().gameRenderer, camera, partial, yaw, pitch, 0);
-        NeoForge.EVENT_BUS.post(event);
-        return event;
-    }
-
     public static void onModifyBakingResult(Map<ModelResourceLocation, BakedModel> models, Map<ResourceLocation, AtlasSet.StitchResult> stitchResults, ModelBakery modelBakery) {
         Function<Material, TextureAtlasSprite> textureGetter = material -> {
             AtlasSet.StitchResult stitchResult = stitchResults.get(material.atlasLocation());

--- a/src/main/java/net/neoforged/neoforge/client/event/ViewportEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ViewportEvent.java
@@ -257,8 +257,8 @@ public abstract class ViewportEvent extends Event {
         private float roll;
 
         @ApiStatus.Internal
-        public ComputeCameraAngles(GameRenderer renderer, Camera camera, double renderPartialTicks, float yaw, float pitch, float roll) {
-            super(renderer, camera, renderPartialTicks);
+        public ComputeCameraAngles(Camera camera, double renderPartialTicks, float yaw, float pitch, float roll) {
+            super(Minecraft.getInstance().gameRenderer, camera, renderPartialTicks);
             this.setYaw(yaw);
             this.setPitch(pitch);
             this.setRoll(roll);


### PR DESCRIPTION
This PR moves the dispatch of `ViewportEvent.ComputeCameraAngles` to `Camera#setup()` to fix the modified angles not affecting the three camera vectors (forward, up, left) and modifications to pitch and yaw in the event not taking effect at all.

Fixes #1123