### PR TITLE
[1.21] "override" field for solving overlaps in recipe ingredients and patterns.

### DIFF
--- a/patches/net/minecraft/data/DataProvider.java.patch
+++ b/patches/net/minecraft/data/DataProvider.java.patch
@@ -9,3 +9,19 @@
          p_236070_.put("type", 0);
          p_236070_.put("parent", 1);
          p_236070_.defaultReturnValue(2);
+@@ -34,6 +_,15 @@
+     CompletableFuture<?> run(CachedOutput p_236071_);
+ 
+     String getName();
++
++    static <T> CompletableFuture<?> saveStable(CachedOutput p_298323_, HolderLookup.Provider p_323556_, Codec<T> p_299231_, T p_298793_, Path p_298236_, net.minecraft.data.recipes.RecipeOutput recipeOutput) {
++        RegistryOps<JsonElement> registryops = p_323556_.createSerializationContext(JsonOps.INSTANCE);
++        JsonElement jsonelement = p_299231_.encodeStart(registryops, p_298793_).getOrThrow();
++        if (recipeOutput instanceof net.neoforged.neoforge.common.crafting.OverlappingRecipeOutput overlappingRecipeOutput && jsonelement instanceof com.google.gson.JsonObject jsonObject && overlappingRecipeOutput.getOutputOverride() != null) {
++            jsonObject.addProperty("neoforge:override", overlappingRecipeOutput.getOutputOverride().toString());
++        }
++        return saveStable(p_298323_, jsonelement, p_298236_);
++    }
+ 
+     static <T> CompletableFuture<?> saveStable(CachedOutput p_298323_, HolderLookup.Provider p_323556_, Codec<T> p_299231_, T p_298793_, Path p_298236_) {
+         RegistryOps<JsonElement> registryops = p_323556_.createSerializationContext(JsonOps.INSTANCE);

--- a/patches/net/minecraft/data/recipes/RecipeOutput.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeOutput.java.patch
@@ -8,7 +8,7 @@
 -    void accept(ResourceLocation p_312249_, Recipe<?> p_312328_, @Nullable AdvancementHolder p_312176_);
 +public interface RecipeOutput extends net.neoforged.neoforge.common.extensions.IRecipeOutputExtension {
 +    default void accept(ResourceLocation p_312249_, Recipe<?> p_312328_, @Nullable AdvancementHolder p_312176_) {
-+        accept(p_312249_, p_312328_, p_312176_, new net.neoforged.neoforge.common.conditions.ICondition[0]);
++        accept(p_312249_, p_312328_, p_312176_, this);
 +    }
  
      Advancement.Builder advancement();

--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -5,12 +5,12 @@
              new RecipeOutput() {
                  @Override
 -                public void accept(ResourceLocation p_312039_, Recipe<?> p_312254_, @Nullable AdvancementHolder p_311794_) {
-+                public void accept(ResourceLocation p_312039_, Recipe<?> p_312254_, @Nullable AdvancementHolder p_311794_, net.neoforged.neoforge.common.conditions.ICondition... conditions) {
++                public void accept(ResourceLocation p_312039_, Recipe<?> p_312254_, @Nullable AdvancementHolder p_311794_, RecipeOutput other) {
                      if (!set.add(p_312039_)) {
                          throw new IllegalStateException("Duplicate recipe " + p_312039_);
                      } else {
 -                        list.add(DataProvider.saveStable(p_324494_, p_324248_, Recipe.CODEC, p_312254_, RecipeProvider.this.recipePathProvider.json(p_312039_)));
-+                        list.add(DataProvider.saveStable(p_324494_, p_324248_, Recipe.CONDITIONAL_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, conditions)), RecipeProvider.this.recipePathProvider.json(p_312039_)));
++                        list.add(DataProvider.saveStable(p_324494_, p_324248_, Recipe.CONDITIONAL_CODEC, Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_312254_, other.getConditions())), RecipeProvider.this.recipePathProvider.json(p_312039_), other));
                          if (p_311794_ != null) {
                              list.add(
                                  DataProvider.saveStable(
@@ -19,7 +19,7 @@
 -                                    Advancement.CODEC,
 -                                    p_311794_.value(),
 +                                    Advancement.CONDITIONAL_CODEC,
-+                                    Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), conditions)),
++                                    Optional.of(new net.neoforged.neoforge.common.conditions.WithConditions<>(p_311794_.value(), other.getConditions())),
                                      RecipeProvider.this.advancementPathProvider.json(p_311794_.id())
                                  )
                              );

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -21,8 +21,8 @@
 +                Recipe<?> recipe = r.carrier();
                  RecipeHolder<?> recipeholder = new RecipeHolder<>(resourcelocation, recipe);
 -                builder.put(recipe.getType(), recipeholder);
-+                if (entry.getValue() instanceof JsonObject jsonObject && jsonObject.keySet().contains("override")) { // Neo: Adds override recipes to the "overrides" map only.
-+                    overrides.put(ResourceLocation.parse(jsonObject.get("override").getAsString()), recipeholder);
++                if (entry.getValue() instanceof JsonObject jsonObject && jsonObject.keySet().contains("neoforge:override")) { // Neo: Adds override recipes to the "overrides" map only.
++                    overrides.put(ResourceLocation.parse(jsonObject.get("neoforge:override").getAsString()), recipeholder);
 +                } else {
 +                    builder.put(recipe.getType(), recipeholder);
 +                }

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -1,8 +1,11 @@
 --- a/net/minecraft/world/item/crafting/RecipeManager.java
 +++ b/net/minecraft/world/item/crafting/RecipeManager.java
-@@ -50,16 +_,22 @@
+@@ -49,23 +_,40 @@
+     protected void apply(Map<ResourceLocation, JsonElement> p_44037_, ResourceManager p_44038_, ProfilerFiller p_44039_) {
          this.hasErrors = false;
          Builder<RecipeType<?>, RecipeHolder<?>> builder = ImmutableMultimap.builder();
++        com.google.common.collect.LinkedListMultimap<RecipeType<?>, RecipeHolder<?>> finalBuilder = com.google.common.collect.LinkedListMultimap.create(); // Neo: Final version of "builder" that becomes "byType".
++        java.util.HashMap<ResourceLocation, RecipeHolder<?>> overrides = com.google.common.collect.Maps.newHashMap(); // Neo: Stores recipes mapped to the IDs of the recipe they override.
          com.google.common.collect.ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> builder1 = ImmutableMap.builder();
 -        RegistryOps<JsonElement> registryops = this.registries.createSerializationContext(JsonOps.INSTANCE);
 +        RegistryOps<JsonElement> registryops = this.makeConditionalOps(); // Neo: add condition context
@@ -17,7 +20,12 @@
 +                decoded.ifPresentOrElse(r -> {
 +                Recipe<?> recipe = r.carrier();
                  RecipeHolder<?> recipeholder = new RecipeHolder<>(resourcelocation, recipe);
-                 builder.put(recipe.getType(), recipeholder);
+-                builder.put(recipe.getType(), recipeholder);
++                if (entry.getValue() instanceof JsonObject jsonObject && jsonObject.keySet().contains("override")) { // Neo: Adds override recipes to the "overrides" map only.
++                    overrides.put(ResourceLocation.parse(jsonObject.get("override").getAsString()), recipeholder);
++                } else {
++                    builder.put(recipe.getType(), recipeholder);
++                }
                  builder1.put(resourcelocation, recipeholder);
 +                }, () -> {
 +                    LOGGER.debug("Skipping loading recipe {} as its conditions were not met", resourcelocation);
@@ -25,3 +33,15 @@
              } catch (IllegalArgumentException | JsonParseException jsonparseexception) {
                  LOGGER.error("Parsing error loading recipe {}", resourcelocation, jsonparseexception);
              }
+         }
+ 
+-        this.byType = builder.build();
++        builder.build().entries().forEach(entry -> { // Neo: Build "finalBuilder" from "builder", with any matching override recipes from "overrides" inserted first.
++            if (overrides.containsKey(entry.getValue().id())) finalBuilder.put(entry.getKey(), overrides.get(entry.getValue().id()));
++            finalBuilder.put(entry.getKey(), entry.getValue());
++        });
++
++        this.byType = ImmutableMultimap.copyOf(finalBuilder);
+         this.byName = builder1.build();
+         LOGGER.info("Loaded {} recipes", this.byType.size());
+     }

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ConditionalRecipeOutput.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ConditionalRecipeOutput.java
@@ -35,15 +35,20 @@ public class ConditionalRecipeOutput implements RecipeOutput {
     }
 
     @Override
-    public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
+    public ICondition[] getConditions(ICondition... other) {
         ICondition[] innerConditions;
-        if (conditions.length == 0) {
+        if (other.length == 0) {
             innerConditions = this.conditions;
         } else if (this.conditions.length == 0) {
-            innerConditions = conditions;
+            innerConditions = other;
         } else {
-            innerConditions = ArrayUtils.addAll(this.conditions, conditions);
+            innerConditions = ArrayUtils.addAll(this.conditions, other);
         }
-        inner.accept(id, recipe, advancement, innerConditions);
+        return innerConditions;
+    }
+
+    @Override
+    public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, RecipeOutput other) {
+        inner.accept(id, recipe, advancement, this);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/crafting/OverlappingRecipeOutput.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/OverlappingRecipeOutput.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.crafting;
+
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Recipe;
+import org.jetbrains.annotations.Nullable;
+
+public class OverlappingRecipeOutput implements RecipeOutput {
+    private final RecipeOutput inner;
+    @Nullable
+    private final ResourceLocation override;
+
+    public OverlappingRecipeOutput(RecipeOutput inner, ResourceLocation override) {
+        this.inner = inner;
+        this.override = override;
+    }
+
+    @Override
+    public Advancement.Builder advancement() {
+        return inner.advancement();
+    }
+
+    @Nullable
+    public ResourceLocation getOutputOverride() {
+        return override;
+    }
+
+    @Override
+    public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, RecipeOutput other) {
+        inner.accept(id, recipe, advancement, this);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
@@ -38,7 +38,6 @@ import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.fml.util.ObfuscationReflectionHelper;
 import net.neoforged.neoforge.common.Tags;
-import net.neoforged.neoforge.common.conditions.ICondition;
 import org.jetbrains.annotations.Nullable;
 
 public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
@@ -99,10 +98,10 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
 
         super.buildRecipes(new RecipeOutput() {
             @Override
-            public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
+            public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, RecipeOutput other) {
                 Recipe<?> modified = enhance(id, recipe);
                 if (modified != null)
-                    recipeOutput.accept(id, modified, null, conditions);
+                    recipeOutput.accept(id, modified, null, other);
             }
 
             @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IRecipeOutputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IRecipeOutputExtension.java
@@ -11,6 +11,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.crafting.ConditionalRecipeOutput;
+import net.neoforged.neoforge.common.crafting.OverlappingRecipeOutput;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,14 +23,30 @@ public interface IRecipeOutputExtension {
     }
 
     /**
-     * Generates a recipe with the given conditions.
+     * Generates a recipe with the given other recipe output.
      */
-    void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions);
+    void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, RecipeOutput other);
 
     /**
      * Builds a wrapper around this recipe output that adds conditions to all received recipes.
      */
     default RecipeOutput withConditions(ICondition... conditions) {
         return new ConditionalRecipeOutput(self(), conditions);
+    }
+
+    default ICondition[] getConditions(ICondition... other) {
+        return new ICondition[0];
+    }
+
+    /**
+     * Builds a wrapper around this recipe output that adds an output override to all received recipes.
+     */
+    default RecipeOutput withOverrides(ResourceLocation outputOverride) {
+        return new OverlappingRecipeOutput(self(), outputOverride);
+    }
+
+    @Nullable
+    default ResourceLocation getOutputOverride() {
+        return null;
     }
 }

--- a/tests/src/generated/resources/data/minecraft/advancement/recipes/misc/redstone_block.json
+++ b/tests/src/generated/resources/data/minecraft/advancement/recipes/misc/redstone_block.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_cherry_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:cherry_planks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:redstone_block"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_cherry_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:redstone_block"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/minecraft/recipe/redstone_block.json
+++ b/tests/src/generated/resources/data/minecraft/recipe/redstone_block.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "group": "bed",
+  "key": {
+    "#": {
+      "item": "minecraft:yellow_wool"
+    },
+    "X": {
+      "item": "minecraft:cherry_planks"
+    }
+  },
+  "neoforge:override": "minecraft:yellow_bed",
+  "pattern": [
+    "###",
+    "XXX"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:redstone_block"
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/IngredientTests.java
@@ -47,7 +47,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CrafterBlock;
 import net.minecraft.world.level.block.entity.CrafterBlockEntity;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.crafting.BlockTagIngredient;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.DataComponentIngredient;
@@ -325,8 +324,8 @@ public class IngredientTests {
                 }
 
                 @Override
-                public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, ICondition... conditions) {
-                    recipeOutput.accept(id, new CompressedShapelessRecipe((ShapelessRecipe) recipe), advancement, conditions);
+                public void accept(ResourceLocation id, Recipe<?> recipe, @Nullable AdvancementHolder advancement, RecipeOutput other) {
+                    recipeOutput.accept(id, new CompressedShapelessRecipe((ShapelessRecipe) recipe), advancement, other);
                 }
             }, location);
         }
@@ -374,6 +373,57 @@ public class IngredientTests {
                 .thenExecute(crafter -> crafter.setItem(3, Items.CHARCOAL.getDefaultInstance()))
                 .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
                 .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.CHERRY_FENCE))
+
+                .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Serialization tests for overlap override recipes")
+    static void overlappingRecipeOutputSerialization(final DynamicTest test, final RegistrationHelper reg) {
+        reg.addProvider(event -> new RecipeProvider(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                ShapedRecipeBuilder.shaped(RecipeCategory.MISC, Blocks.REDSTONE_BLOCK)
+                        .define('#', Blocks.YELLOW_WOOL)
+                        .define('X', Blocks.CHERRY_PLANKS)
+                        .pattern("###")
+                        .pattern("XXX")
+                        .group("bed")
+                        .unlockedBy(getHasName(Blocks.CHERRY_PLANKS), has(Blocks.CHERRY_PLANKS))
+                        .save(output.withOverrides(ResourceLocation.withDefaultNamespace("yellow_bed")));
+            }
+        });
+
+        test.onGameTest(helper -> helper
+                .startSequence()
+                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.CRAFTER.defaultBlockState().setValue(BlockStateProperties.ORIENTATION, FrontAndTop.UP_NORTH).setValue(CrafterBlock.CRAFTING, true)))
+                .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.CHEST))
+
+                // Try to craft default bed recipe
+                .thenMap(() -> helper.requireBlockEntity(1, 1, 1, CrafterBlockEntity.class))
+                .thenExecute(crafter -> crafter.setItem(3, Items.YELLOW_WOOL.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(4, Items.YELLOW_WOOL.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(5, Items.YELLOW_WOOL.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(6, Items.OAK_PLANKS.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(7, Items.OAK_PLANKS.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(8, Items.OAK_PLANKS.getDefaultInstance()))
+                .thenIdle(3)
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.YELLOW_BED)) // Should craft yellow bed from recipe of yellow wool and oak planks (part of the #planks tag)
+
+                .thenIdle(5) // Crafter cooldown
+
+                // Try to craft recipe that overrides the default bed recipe
+                .thenExecute(crafter -> crafter.setItem(3, Items.YELLOW_WOOL.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(4, Items.YELLOW_WOOL.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(5, Items.YELLOW_WOOL.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(6, Items.CHERRY_PLANKS.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(7, Items.CHERRY_PLANKS.getDefaultInstance()))
+                .thenExecute(crafter -> crafter.setItem(8, Items.CHERRY_PLANKS.getDefaultInstance()))
+                .thenIdle(3)
+                .thenExecute(() -> helper.pulseRedstone(1, 1, 2, 2))
+                .thenExecuteAfter(7, () -> helper.assertContainerContains(1, 2, 1, Items.REDSTONE_BLOCK)) // Should craft the redstone block
 
                 .thenSucceed());
     }


### PR DESCRIPTION
_Updated version of #936_

This PR changes `RecipeManager` to check for a new field in recipes called `'override"`, which allows for specifying a `String` that correlates to another recipe's ID. The recipe with the `override` field will then be prioritized over the recipe with the given ID. This is different from overriding by file in datapacks because it is intended as a way of solving problems caused by a recipe using a broad tag and a modder needing to make a recipe with the same pattern and only one ingredient of that tag.

For example, a modder may be trying to make a Chest for a specific wood type, but in Vanilla, crafting Chests uses the `#planks` tag, so all wood types are normally going to give the default Chest block. Using this, a modder could specify `"override": "minecraft:chest"` in their recipe and it would make their recipe take priority only if using the specific wood block that the chest uses.

Attached is a datapack that demonstrates this system in action.
![2024-06-18_20 56 21](https://github.com/neoforged/NeoForge/assets/67203206/544b8cb1-a527-427c-b667-e66b64b47d19)
![2024-06-18_20 56 32](https://github.com/neoforged/NeoForge/assets/67203206/67670e28-d93a-41bf-befe-d6469710eea2)
[Recipe Override Test.zip](https://github.com/user-attachments/files/15895766/Recipe.Override.Test.zip)

