### PR TITLE
Fix Registry Object Constructor Access Transformers

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -535,12 +535,12 @@ public net.minecraft.world.level.levelgen.NoiseGeneratorSettings floatingIslands
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings nether(Lnet/minecraft/data/worldgen/BootstrapContext;)Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # nether
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings lambda$static$0(Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App; # lambda$static$0
 #endgroup
-public net.minecraft.world.level.levelgen.feature.featuresize.FeatureSizeType <init>(Lcom/mojang/serialization/Codec;)V # constructor
-public net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
-public net.minecraft.world.level.levelgen.feature.rootplacers.RootPlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
-public net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProviderType <init>(Lcom/mojang/serialization/Codec;)V # constructor
-public net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecoratorType <init>(Lcom/mojang/serialization/Codec;)V # constructor
-public net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.featuresize.FeatureSizeType <init>(Lcom/mojang/serialization/MapCodec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacerType <init>(Lcom/mojang/serialization/MapCodec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.rootplacers.RootPlacerType <init>(Lcom/mojang/serialization/MapCodec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProviderType <init>(Lcom/mojang/serialization/MapCodec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecoratorType <init>(Lcom/mojang/serialization/MapCodec;)V # constructor
+public net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacerType <init>(Lcom/mojang/serialization/MapCodec;)V # constructor
 protected net.minecraft.world.level.portal.PortalForcer level # level
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool rolls # rolls


### PR DESCRIPTION
Some of the registry objects have private constructors that originally used to use `Codec`s. However, in 1.20.6, this changed to use `MapCodec`s and was not updated for all ATs. This updates the incorrect definitions such that the ATs are applied.

Closes #1144 