### PR TITLE
[1.21] Fix duplicate registration error for empty loot table

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -680,12 +680,13 @@ public class EventHooks {
         return NeoForge.EVENT_BUS.post(new ProjectileImpactEvent(projectile, ray)).isCanceled();
     }
 
+    @Nullable
     public static LootTable loadLootTable(ResourceLocation name, LootTable table) {
         if (table == LootTable.EMPTY) // Empty table has a null name, and shouldn't be modified anyway.
-            return table;
+            return null;
         LootTableLoadEvent event = new LootTableLoadEvent(name, table);
-        if (NeoForge.EVENT_BUS.post(event).isCanceled())
-            return LootTable.EMPTY;
+        if (NeoForge.EVENT_BUS.post(event).isCanceled() || event.getTable() == LootTable.EMPTY)
+            return null;
         return event.getTable();
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.event;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.DynamicOps;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
 import java.io.File;
 import java.util.EnumSet;
@@ -100,6 +101,7 @@ import net.minecraft.world.level.portal.DimensionTransition;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.level.storage.PlayerDataStorage;
 import net.minecraft.world.level.storage.ServerLevelData;
+import net.minecraft.world.level.storage.loot.LootDataType;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
@@ -680,6 +682,11 @@ public class EventHooks {
         return NeoForge.EVENT_BUS.post(new ProjectileImpactEvent(projectile, ray)).isCanceled();
     }
 
+    /**
+     * Fires the {@link LootTableLoadEvent} for non-empty loot tables and returns the table if the event was not
+     * canceled and the table was not set to {@link LootTable#EMPTY} in the event. Otherwise returns {@code null}
+     * which maps to an empty {@link Optional} in {@link LootDataType#deserialize(ResourceLocation, DynamicOps, Object)}
+     */
     @Nullable
     public static LootTable loadLootTable(ResourceLocation name, LootTable table) {
         if (table == LootTable.EMPTY) // Empty table has a null name, and shouldn't be modified anyway.


### PR DESCRIPTION
This PR fixes the duplicate registration error for the empty loot table when a loot table is loaded as empty due to resource conditions, the `LootTableLoadEvent` is canceled or the table is set to `LootTable.EMPTY` in the event.