### PR TITLE
[1.21] Add missing tool, block entity, and breaker context to getExpDrop

### DIFF
--- a/patches/net/minecraft/world/level/block/DropExperienceBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DropExperienceBlock.java.patch
@@ -1,17 +1,19 @@
 --- a/net/minecraft/world/level/block/DropExperienceBlock.java
 +++ b/net/minecraft/world/level/block/DropExperienceBlock.java
-@@ -30,8 +_,11 @@
+@@ -30,8 +_,13 @@
      @Override
      protected void spawnAfterBreak(BlockState p_221086_, ServerLevel p_221087_, BlockPos p_221088_, ItemStack p_221089_, boolean p_221090_) {
          super.spawnAfterBreak(p_221086_, p_221087_, p_221088_, p_221089_, p_221090_);
 -        if (p_221090_) {
 -            this.tryDropExperience(p_221087_, p_221088_, p_221089_, this.xpRange);
 -        }
-+
 +    }
 +
++    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes this.xpRange to tryDropExperience.
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelReader level, net.minecraft.util.RandomSource randomSource, BlockPos pos) {
-+        return this.xpRange.sample(randomSource);
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
++        return this.xpRange.sample(level.getRandom());
      }
  }

--- a/patches/net/minecraft/world/level/block/RedStoneOreBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/RedStoneOreBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/RedStoneOreBlock.java
 +++ b/net/minecraft/world/level/block/RedStoneOreBlock.java
-@@ -87,9 +_,10 @@
+@@ -87,9 +_,14 @@
      @Override
      protected void spawnAfterBreak(BlockState p_221907_, ServerLevel p_221908_, BlockPos p_221909_, ItemStack p_221910_, boolean p_221911_) {
          super.spawnAfterBreak(p_221907_, p_221908_, p_221909_, p_221910_, p_221911_);
@@ -8,9 +8,13 @@
 -            this.tryDropExperience(p_221908_, p_221909_, p_221910_, UniformInt.of(1, 5));
 -        }
 +    }
++
++    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes UniformInt.of(1, 5) to tryDropExperience.
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelReader world, RandomSource randomSource, BlockPos pos) {
-+        return 1 + randomSource.nextInt(5);
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
++        return UniformInt.of(1, 5).sample(level.getRandom());
      }
  
      @Override

--- a/patches/net/minecraft/world/level/block/RedStoneOreBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/RedStoneOreBlock.java.patch
@@ -11,8 +11,8 @@
 +
 +    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes UniformInt.of(1, 5) to tryDropExperience.
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos, 
-+            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity,
 +            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
 +        return UniformInt.of(1, 5).sample(level.getRandom());
      }

--- a/patches/net/minecraft/world/level/block/SculkCatalystBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SculkCatalystBlock.java.patch
@@ -12,8 +12,8 @@
 +
 +    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes this.xpRange to tryDropExperience.
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos, 
-+            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity,
 +            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
 +        return this.xpRange.sample(level.getRandom());
      }

--- a/patches/net/minecraft/world/level/block/SculkCatalystBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SculkCatalystBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/SculkCatalystBlock.java
 +++ b/net/minecraft/world/level/block/SculkCatalystBlock.java
-@@ -66,8 +_,11 @@
+@@ -66,8 +_,14 @@
      @Override
      protected void spawnAfterBreak(BlockState p_222109_, ServerLevel p_222110_, BlockPos p_222111_, ItemStack p_222112_, boolean p_222113_) {
          super.spawnAfterBreak(p_222109_, p_222110_, p_222111_, p_222112_, p_222113_);
@@ -10,8 +10,11 @@
 +
 +    }
 +
++    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes this.xpRange to tryDropExperience.
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelReader level, RandomSource randomSource, BlockPos pos) {
-+        return this.xpRange.sample(randomSource);
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
++        return this.xpRange.sample(level.getRandom());
      }
  }

--- a/patches/net/minecraft/world/level/block/SculkSensorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SculkSensorBlock.java.patch
@@ -1,17 +1,19 @@
 --- a/net/minecraft/world/level/block/SculkSensorBlock.java
 +++ b/net/minecraft/world/level/block/SculkSensorBlock.java
-@@ -292,8 +_,11 @@
+@@ -292,8 +_,13 @@
      @Override
      protected void spawnAfterBreak(BlockState p_222142_, ServerLevel p_222143_, BlockPos p_222144_, ItemStack p_222145_, boolean p_222146_) {
          super.spawnAfterBreak(p_222142_, p_222143_, p_222144_, p_222145_, p_222146_);
 -        if (p_222146_) {
 -            this.tryDropExperience(p_222143_, p_222144_, p_222145_, ConstantInt.of(5));
 -        }
-+
 +    }
 +
++    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes ConstantInt.of(5) to tryDropExperience.
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelReader level, RandomSource randomSource, BlockPos pos) {
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
 +        return 5;
      }
  }

--- a/patches/net/minecraft/world/level/block/SculkSensorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SculkSensorBlock.java.patch
@@ -12,7 +12,7 @@
 +    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes ConstantInt.of(5) to tryDropExperience.
 +    @Override
 +    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
-+            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity,
 +            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
 +        return 5;
      }

--- a/patches/net/minecraft/world/level/block/SculkShriekerBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SculkShriekerBlock.java.patch
@@ -1,18 +1,23 @@
 --- a/net/minecraft/world/level/block/SculkShriekerBlock.java
 +++ b/net/minecraft/world/level/block/SculkShriekerBlock.java
-@@ -141,9 +_,12 @@
+@@ -141,12 +_,17 @@
      @Override
      protected void spawnAfterBreak(BlockState p_222192_, ServerLevel p_222193_, BlockPos p_222194_, ItemStack p_222195_, boolean p_222196_) {
          super.spawnAfterBreak(p_222192_, p_222193_, p_222194_, p_222195_, p_222196_);
 -        if (p_222196_) {
 -            this.tryDropExperience(p_222193_, p_222194_, p_222195_, ConstantInt.of(5));
 -        }
-+
-+    }
-+
-+    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelReader level, RandomSource randomSource, BlockPos pos) {
-+        return 5;
      }
  
++    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes ConstantInt.of(5) to tryDropExperience.
++    @Override
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
++        return 5;
++    }
      @Nullable
++    
+     @Override
+     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level p_222173_, BlockState p_222174_, BlockEntityType<T> p_222175_) {
+         return !p_222173_.isClientSide

--- a/patches/net/minecraft/world/level/block/SculkShriekerBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SculkShriekerBlock.java.patch
@@ -1,23 +1,20 @@
 --- a/net/minecraft/world/level/block/SculkShriekerBlock.java
 +++ b/net/minecraft/world/level/block/SculkShriekerBlock.java
-@@ -141,12 +_,17 @@
+@@ -141,9 +_,14 @@
      @Override
      protected void spawnAfterBreak(BlockState p_222192_, ServerLevel p_222193_, BlockPos p_222194_, ItemStack p_222195_, boolean p_222196_) {
          super.spawnAfterBreak(p_222192_, p_222193_, p_222194_, p_222195_, p_222196_);
 -        if (p_222196_) {
 -            this.tryDropExperience(p_222193_, p_222194_, p_222195_, ConstantInt.of(5));
 -        }
-     }
- 
++    }
++
 +    // Neo: Patch-in override for getExpDrop. Original vanilla logic passes ConstantInt.of(5) to tryDropExperience.
 +    @Override
 +    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
-+            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity,
 +            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
 +        return 5;
-+    }
+     }
+ 
      @Nullable
-+    
-     @Override
-     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level p_222173_, BlockState p_222174_, BlockEntityType<T> p_222175_) {
-         return !p_222173_.isClientSide

--- a/patches/net/minecraft/world/level/block/SpawnerBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SpawnerBlock.java.patch
@@ -14,7 +14,7 @@
 +    // Original vanilla logic passes 15 + p_222478_.random.nextInt(15) + p_222478_.random.nextInt(15) to popExperience, bypassing enchantments
 +    @Override
 +    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
-+            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity,
 +            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
 +        return 15 + level.getRandom().nextInt(15) + level.getRandom().nextInt(15);
      }

--- a/patches/net/minecraft/world/level/block/SpawnerBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/SpawnerBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/SpawnerBlock.java
 +++ b/net/minecraft/world/level/block/SpawnerBlock.java
-@@ -46,10 +_,12 @@
+@@ -46,10 +_,15 @@
      @Override
      protected void spawnAfterBreak(BlockState p_222477_, ServerLevel p_222478_, BlockPos p_222479_, ItemStack p_222480_, boolean p_222481_) {
          super.spawnAfterBreak(p_222477_, p_222478_, p_222479_, p_222480_, p_222481_);
@@ -8,12 +8,15 @@
 -            int i = 15 + p_222478_.random.nextInt(15) + p_222478_.random.nextInt(15);
 -            this.popExperience(p_222478_, p_222479_, i);
 -        }
-+
 +    }
 +
++    // Neo: Patch-in override for getExpDrop. Also fixes MC-273642 (Spawner XP drops bypass enchantments)
++    // Original vanilla logic passes 15 + p_222478_.random.nextInt(15) + p_222478_.random.nextInt(15) to popExperience, bypassing enchantments
 +    @Override
-+    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelReader world, net.minecraft.util.RandomSource randomSource, BlockPos pos) {
-+        return 15 + randomSource.nextInt(15) + randomSource.nextInt(15);
++    public int getExpDrop(BlockState state, net.minecraft.world.level.LevelAccessor level, BlockPos pos,
++            @org.jetbrains.annotations.Nullable net.minecraft.world.level.block.entity.BlockEntity blockEntity, 
++            @org.jetbrains.annotations.Nullable net.minecraft.world.entity.Entity breaker, ItemStack tool) {
++        return 15 + level.getRandom().nextInt(15) + level.getRandom().nextInt(15);
      }
  
      @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -30,6 +30,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ShovelItem;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.EmptyBlockGetter;
@@ -445,15 +446,17 @@ public interface IBlockExtension {
     }
 
     /**
-     * Gathers how much experience this block drops when broken.
+     * Returns how many experience points this block drops when broken, before application of {@linkplain EnchantmentEffectComponents#BLOCK_EXPERIENCE enchantments}.
      *
-     * @param state        The current state
-     * @param level        The level
-     * @param randomSource Random source to use for experience randomness
-     * @param pos          Block position
-     * @return Amount of XP from breaking this block.
+     * @param state       The state of the block being broken
+     * @param level       The level
+     * @param pos         The position of the block being broken
+     * @param blockEntity The block entity, if any
+     * @param breaker     The entity who broke the block, if known
+     * @param tool        The item stack used to break the block. May be empty
+     * @return The amount of experience points dropped by this block
      */
-    default int getExpDrop(BlockState state, LevelReader level, RandomSource randomSource, BlockPos pos) {
+    default int getExpDrop(BlockState state, LevelAccessor level, BlockPos pos, @Nullable BlockEntity blockEntity, @Nullable Entity breaker, ItemStack tool) {
         return 0;
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -22,6 +22,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
@@ -31,6 +32,7 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.SignalGetter;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
@@ -338,18 +340,17 @@ public interface IBlockStateExtension {
     }
 
     /**
-     * Gathers how much experience this block drops when broken.
+     * Returns how many experience points this block drops when broken, before application of {@linkplain EnchantmentEffectComponents#BLOCK_EXPERIENCE enchantments}.
      *
-     * @param level          The level
-     * @param randomSource   Random source to use for experience randomness
-     * @param pos            Block position
-     * @param fortuneLevel   fortune enchantment level of tool being used
-     * @param silkTouchLevel silk touch enchantment level of tool being used
-     * @return Amount of XP from breaking this block.
+     * @param level       The level
+     * @param pos         The position of the block being broken
+     * @param blockEntity The block entity, if any
+     * @param breaker     The entity who broke the block, if known
+     * @param tool        The item stack used to break the block. May be empty
+     * @return The amount of experience points dropped by this block
      */
-    default int getExpDrop(LevelReader level, RandomSource randomSource, BlockPos pos) {
-        // TODO: Change this method to have context of the full tool ItemStack instead of just the enchantment levels.
-        return self().getBlock().getExpDrop(self(), level, randomSource, pos);
+    default int getExpDrop(LevelAccessor level, BlockPos pos, @Nullable BlockEntity blockEntity, @Nullable Entity breaker, ItemStack tool) {
+        return self().getBlock().getExpDrop(self(), level, pos, blockEntity, breaker, tool);
     }
 
     default BlockState rotate(LevelAccessor level, BlockPos pos, Rotation direction) {

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockDropsEvent.java
@@ -54,7 +54,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
         this.breaker = breaker;
         this.tool = tool;
 
-        this.experience = EnchantmentHelper.processBlockExperience(level, tool, state.getExpDrop(level, level.random, pos));
+        this.experience = EnchantmentHelper.processBlockExperience(level, tool, state.getExpDrop(level, pos, blockEntity, breaker, tool));
     }
 
     /**
@@ -115,7 +115,7 @@ public class BlockDropsEvent extends BlockEvent implements ICancellableEvent {
     }
 
     /**
-     * Set the amount of experience points that will be dropped by the block
+     * Set the amount of experience points that will be dropped by the block. This is the true value, after enchantments have been applied.
      *
      * @param experience The new amount. Must not be negative.
      * @apiNote When cancelled, no experience is dropped, regardless of this value.


### PR DESCRIPTION
This PR adds the available `BlockEntity`, `Entity` (breaker), and `ItemStack` (tool) context to `IBlockExtension#getExpDrop`, which allows mods to adjust their dropped experience with this context without needing to use the `BlockDropsEvent`.

This is a breaking change to the signature of `IBlockExtension#getExpDrop` and all callers/overrides.

Closes #1101 