### PR TITLE
[1.21] Fix attachment codec wrappers not using registry ops

### DIFF
--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -202,13 +202,13 @@ public final class AttachmentType<T> {
             return serialize(new IAttachmentSerializer<>() {
                 @Override
                 public T read(IAttachmentHolder holder, Tag tag, HolderLookup.Provider provider) {
-                    return codec.parse(NbtOps.INSTANCE, tag).result().get();
+                    return codec.parse(provider.createSerializationContext(NbtOps.INSTANCE), tag).result().get();
                 }
 
                 @Nullable
                 @Override
                 public Tag write(T attachment, HolderLookup.Provider provider) {
-                    return shouldSerialize.test(attachment) ? codec.encodeStart(NbtOps.INSTANCE, attachment).result().get() : null;
+                    return shouldSerialize.test(attachment) ? codec.encodeStart(provider.createSerializationContext(NbtOps.INSTANCE), attachment).result().get() : null;
                 }
             });
         }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -12,10 +12,16 @@ import com.mojang.serialization.Codec;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.nbt.IntTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantments;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.neoforged.neoforge.attachment.AttachmentType;
@@ -124,6 +130,26 @@ public class AttachmentTests {
             helper.assertFalse(respawnedPlayer.getData(lostOnDeathBoolean), "Lost-on-death attachment should not have remained after respawning.");
             helper.assertTrue(respawnedPlayer.getData(keptOnDeathBoolean), "Kept-on-death attachment should have remained after respawning.");
 
+            helper.succeed();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that attachments with dynamic data are de/serialized well")
+    static void dynamicDataContentSerialization(DynamicTest test, RegistrationHelper reg) {
+        var stackType = reg.attachments()
+                .register("stack", () -> AttachmentType.builder(() -> new ItemStack(Items.IRON_AXE)).serialize(ItemStack.CODEC).build());
+        test.onGameTest(helper -> {
+            var player = helper.makeMockPlayer();
+            var stack = new ItemStack(Items.IRON_SWORD);
+            var enchantments = new ItemEnchantments.Mutable(ItemEnchantments.EMPTY);
+            enchantments.set(helper.getLevel().registryAccess().registryOrThrow(Registries.ENCHANTMENT).getHolderOrThrow(Enchantments.SHARPNESS), 3);
+            stack.set(DataComponents.ENCHANTMENTS, enchantments.toImmutable());
+            player.setData(stackType, stack);
+            helper.catchException(() -> {
+                player.serializeAttachments(helper.getLevel().registryAccess()); // This will throw if it fails
+            });
             helper.succeed();
         });
     }


### PR DESCRIPTION
Users may use `ItemStack`s or other registry-based objects in their attachment types, some of which may be from dynamic registries, so we use a registry ops wrapper by default.