### PR TITLE
[1.21] Add Experimental FeatureFlag

### DIFF
--- a/patches/net/minecraft/data/DataGenerator.java.patch
+++ b/patches/net/minecraft/data/DataGenerator.java.patch
@@ -16,7 +16,7 @@
                  stopwatch1.start();
                  hashcache.applyUpdate(hashcache.generateUpdate(p_254418_, p_253750_::run).join());
                  stopwatch1.stop();
-@@ -56,6 +_,34 @@
+@@ -56,6 +_,46 @@
      public DataGenerator.PackGenerator getBuiltinDatapack(boolean p_253826_, String p_254134_) {
          Path path = this.vanillaPackOutput.getOutputFolder(PackOutput.Target.DATA_PACK).resolve("minecraft").resolve("datapacks").resolve(p_254134_);
          return new DataGenerator.PackGenerator(p_253826_, p_254134_, new PackOutput(path));
@@ -48,6 +48,18 @@
 +            DataGenerator.this.providersToRun.put(id, provider);
 +
 +        return provider;
++    }
++
++    public void merge(DataGenerator other) {
++        other.providersToRun.forEach((id, provider) -> {
++            if(!allProviderIds.add(id))
++                throw new IllegalStateException("Duplicate provider: " + id);
++
++            providersToRun.put(id, provider);
++        });
++
++        other.providersToRun.clear();
++        other.allProviderIds.clear();
      }
  
      static {

--- a/patches/net/minecraft/data/DataGenerator.java.patch
+++ b/patches/net/minecraft/data/DataGenerator.java.patch
@@ -16,10 +16,15 @@
                  stopwatch1.start();
                  hashcache.applyUpdate(hashcache.generateUpdate(p_254418_, p_253750_::run).join());
                  stopwatch1.stop();
-@@ -56,6 +_,46 @@
+@@ -56,6 +_,51 @@
      public DataGenerator.PackGenerator getBuiltinDatapack(boolean p_253826_, String p_254134_) {
          Path path = this.vanillaPackOutput.getOutputFolder(PackOutput.Target.DATA_PACK).resolve("minecraft").resolve("datapacks").resolve(p_254134_);
          return new DataGenerator.PackGenerator(p_253826_, p_254134_, new PackOutput(path));
++    }
++
++    public PackGenerator getBuiltinDatapack(boolean run, String namespace, String path) {
++        var packPath = vanillaPackOutput.getOutputFolder(PackOutput.Target.DATA_PACK).resolve(namespace).resolve("datapacks").resolve(path);
++        return new PackGenerator(run, namespace + '_' + path, new PackOutput(packPath));
 +    }
 +
 +    public Map<String, DataProvider> getProvidersView() {

--- a/patches/net/minecraft/world/flag/FeatureFlags.java.patch
+++ b/patches/net/minecraft/world/flag/FeatureFlags.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/world/flag/FeatureFlags.java
++++ b/net/minecraft/world/flag/FeatureFlags.java
+@@ -13,6 +_,7 @@
+     public static final Codec<FeatureFlagSet> CODEC;
+     public static final FeatureFlagSet VANILLA_SET;
+     public static final FeatureFlagSet DEFAULT_FLAGS;
++    public static final FeatureFlag MOD_EXPERIMENTAL;
+ 
+     public static String printMissingFlags(FeatureFlagSet p_250581_, FeatureFlagSet p_250326_) {
+         return printMissingFlags(REGISTRY, p_250581_, p_250326_);
+@@ -33,6 +_,7 @@
+         VANILLA = featureflagregistry$builder.createVanilla("vanilla");
+         BUNDLE = featureflagregistry$builder.createVanilla("bundle");
+         TRADE_REBALANCE = featureflagregistry$builder.createVanilla("trade_rebalance");
++        MOD_EXPERIMENTAL = featureflagregistry$builder.create(ResourceLocation.fromNamespaceAndPath("neoforge", "mod_experimental"));
+         REGISTRY = featureflagregistry$builder.build();
+         CODEC = REGISTRY.codec();
+         VANILLA_SET = FeatureFlagSet.of(VANILLA);

--- a/patches/net/minecraft/world/flag/FeatureFlags.java.patch
+++ b/patches/net/minecraft/world/flag/FeatureFlags.java.patch
@@ -1,9 +1,22 @@
 --- a/net/minecraft/world/flag/FeatureFlags.java
 +++ b/net/minecraft/world/flag/FeatureFlags.java
-@@ -13,6 +_,7 @@
+@@ -13,6 +_,20 @@
      public static final Codec<FeatureFlagSet> CODEC;
      public static final FeatureFlagSet VANILLA_SET;
      public static final FeatureFlagSet DEFAULT_FLAGS;
++    /**
++     * A <b>feature flag</b> for use with experimental features that may introduce unexpected or potentially bug-inducing behaviors.<br>
++     * Unlike the standard set of flags, which can change frequently, this flag remains consistent across major version updates.<br>
++     * <br><p>
++     * Modders can reference this flag during built-in feature registration.<br>
++     * However, they must provide their own flagged datapacks to associate datapack features (such as recipes and enchantments) with this flag.<br>
++     * These datapacks can be provided either as optional files or via the {@linkplain net.neoforged.neoforge.event.AddPackFindersEvent} event.
++     * </p>
++     * <br><p>
++     * It is highly recommended that modders document which features are experimental and which ones are not.<br>
++     * Due to the nature of this flag being a <i>‘catch-all’</i>, it enables any and all modded experiments that may exist.
++     * </p>
++     */
 +    public static final FeatureFlag MOD_EXPERIMENTAL;
  
      public static String printMissingFlags(FeatureFlagSet p_250581_, FeatureFlagSet p_250326_) {

--- a/src/generated/resources/data/neoforge/datapacks/mod_experimental/pack.mcmeta
+++ b/src/generated/resources/data/neoforge/datapacks/mod_experimental/pack.mcmeta
@@ -8,6 +8,10 @@
     "description": {
       "translate": "pack.neoforge.experimental.description"
     },
-    "pack_format": 48
+    "pack_format": 48,
+    "supported_formats": [
+      0,
+      2147483647
+    ]
   }
 }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -38,13 +38,8 @@ import net.minecraft.data.metadata.PackMetadataGenerator;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.PackLocationInfo;
-import net.minecraft.server.packs.PackSelectionConfig;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.PathPackResources;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
-import net.minecraft.server.packs.repository.BuiltInPackSource;
-import net.minecraft.server.packs.repository.KnownPack;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraft.sounds.SoundEvent;
@@ -638,27 +633,13 @@ public class NeoForgeMod {
 
         modEventBus.register(NeoForgeDataMaps.class);
 
-        modEventBus.addListener(AddPackFindersEvent.class, event -> {
-            if (event.getPackType() != PackType.SERVER_DATA) {
-                return;
-            }
-
-            var modInfo = container.getModInfo();
-            var resource = modInfo.getOwningFile().getFile().findResource("data/neoforge/datapacks/mod_experimental");
-            var version = modInfo.getVersion();
-
-            var pack = Pack.readMetaAndCreate(
-                    new PackLocationInfo(
-                            "neoforge:mod_experimental",
-                            Component.translatable("pack.neoforge.experiments.description"),
-                            PackSource.FEATURE,
-                            Optional.of(new KnownPack("neoforge", "mod_experimental", version.toString()))),
-                    BuiltInPackSource.fromName(path -> new PathPackResources(path, resource)),
-                    PackType.SERVER_DATA,
-                    new PackSelectionConfig(false, Pack.Position.BOTTOM, true));
-
-            event.addRepositorySource(consumer -> consumer.accept(pack));
-        });
+        modEventBus.addListener(AddPackFindersEvent.class, event -> event.addPackFinders(
+                ResourceLocation.fromNamespaceAndPath("neoforge", "data/neoforge/datapacks/mod_experimental"),
+                PackType.SERVER_DATA,
+                Component.translatable("pack.neoforge.experimental.name"),
+                PackSource.FEATURE,
+                false,
+                Pack.Position.BOTTOM));
 
         if (isPRBuild(container.getModInfo().getVersion().toString())) {
             isPRBuild = true;

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.common;
 
+import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
@@ -32,12 +33,15 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryCodecs;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataGenerator;
+import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.metadata.PackMetadataGenerator;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.FeatureFlagsMetadataSection;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.server.packs.repository.Pack;
@@ -54,6 +58,8 @@ import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
@@ -686,6 +692,33 @@ public class NeoForgeMod {
         gen.addProvider(event.includeClient(), new NeoForgeSpriteSourceProvider(packOutput, lookupProvider, existingFileHelper));
         gen.addProvider(event.includeClient(), new VanillaSoundDefinitionsProvider(packOutput, existingFileHelper));
         gen.addProvider(event.includeClient(), new NeoForgeLanguageProvider(packOutput));
+
+        // mod experimental pack
+        // custom impl since using PackMetadataGenerator throws "duplicate provider" (getName() is final which is used for provider id)
+        gen.addProvider(true, new DataProvider() {
+            @Override
+            public CompletableFuture<?> run(CachedOutput cache) {
+                var json = new JsonObject();
+
+                json.add(PackMetadataSection.TYPE.getMetadataSectionName(), PackMetadataSection.TYPE.toJson(new PackMetadataSection(
+                        Component.translatable("pack.neoforge.experimental.description"),
+                        DetectedVersion.BUILT_IN.getPackVersion(PackType.SERVER_DATA),
+                        Optional.of(new InclusiveRange<>(0, Integer.MAX_VALUE)))));
+
+                json.add(FeatureFlagsMetadataSection.TYPE.getMetadataSectionName(), FeatureFlagsMetadataSection.TYPE.toJson(new FeatureFlagsMetadataSection(FeatureFlagSet.of(FeatureFlags.MOD_EXPERIMENTAL))));
+
+                return DataProvider.saveStable(cache, json, packOutput.getOutputFolder(PackOutput.Target.DATA_PACK)
+                        .resolve("neoforge")
+                        .resolve("datapacks")
+                        .resolve("mod_experimental")
+                        .resolve("pack.mcmeta"));
+            }
+
+            @Override
+            public String getName() {
+                return "mod_experimental_pack";
+            }
+        });
     }
 
     // done in an event instead of deferred to only enable if a mod requests it

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -642,7 +642,7 @@ public class NeoForgeMod {
                 Component.translatable("pack.neoforge.experimental.name"),
                 PackSource.FEATURE,
                 false,
-                Pack.Position.BOTTOM));
+                Pack.Position.TOP));
 
         if (isPRBuild(container.getModInfo().getVersion().toString())) {
             isPRBuild = true;

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -38,8 +38,15 @@ import net.minecraft.data.metadata.PackMetadataGenerator;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackLocationInfo;
+import net.minecraft.server.packs.PackSelectionConfig;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
+import net.minecraft.server.packs.repository.BuiltInPackSource;
+import net.minecraft.server.packs.repository.KnownPack;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackSource;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.InclusiveRange;
@@ -136,6 +143,7 @@ import net.neoforged.neoforge.common.world.NoneStructureModifier;
 import net.neoforged.neoforge.common.world.StructureModifier;
 import net.neoforged.neoforge.common.world.StructureModifiers;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
+import net.neoforged.neoforge.event.AddPackFindersEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.fluids.BaseFlowingFluid;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
@@ -629,6 +637,28 @@ public class NeoForgeMod {
         NeoForge.EVENT_BUS.addListener(CapabilityHooks::cleanCapabilityListenerReferencesOnTick);
 
         modEventBus.register(NeoForgeDataMaps.class);
+
+        modEventBus.addListener(AddPackFindersEvent.class, event -> {
+            if (event.getPackType() != PackType.SERVER_DATA) {
+                return;
+            }
+
+            var modInfo = container.getModInfo();
+            var resource = modInfo.getOwningFile().getFile().findResource("data/neoforge/datapacks/mod_experimental");
+            var version = modInfo.getVersion();
+
+            var pack = Pack.readMetaAndCreate(
+                    new PackLocationInfo(
+                            "neoforge:mod_experimental",
+                            Component.translatable("pack.neoforge.experiments.description"),
+                            PackSource.FEATURE,
+                            Optional.of(new KnownPack("neoforge", "mod_experimental", version.toString()))),
+                    BuiltInPackSource.fromName(path -> new PathPackResources(path, resource)),
+                    PackType.SERVER_DATA,
+                    new PackSelectionConfig(false, Pack.Position.BOTTOM, true));
+
+            event.addRepositorySource(consumer -> consumer.accept(pack));
+        });
 
         if (isPRBuild(container.getModInfo().getVersion().toString())) {
             isPRBuild = true;

--- a/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
@@ -130,7 +130,7 @@ public class GatherDataEvent extends Event implements IModBusEvent {
             paths.values().forEach(lst -> {
                 DataGenerator parent = lst.get(0);
                 for (int x = 1; x < lst.size(); x++)
-                    lst.get(x).getProvidersView().forEach((name, provider) -> parent.addProvider(true, provider));
+                    parent.merge(lst.get(x));
                 try {
                     parent.run();
                 } catch (IOException ex) {

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -194,7 +194,8 @@
   "neoforge.chatType.system": "%1$s",
 
   "pack.neoforge.description": "NeoForge data/resource pack",
-  "pack.neoforge.experimental.description": "NeoForge mod experiments data pack",
+  "pack.neoforge.experimental.name": "NeoForge mod experiments data pack",
+  "pack.neoforge.experimental.description": "Enables experimental mod items",
   "pack.neoforge.source.child": "child",
 
   "neoforge.network.negotiation.failure.mod": "Channel of mod \"%1$s\" failed to connect: %2$s",

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -194,8 +194,8 @@
   "neoforge.chatType.system": "%1$s",
 
   "pack.neoforge.description": "NeoForge data/resource pack",
-  "pack.neoforge.experimental.name": "NeoForge mod experiments data pack",
-  "pack.neoforge.experimental.description": "Enables experimental mod items",
+  "pack.neoforge.experimental.name": "Experimental mod features",
+  "pack.neoforge.experimental.description": "Enables mod provided experimental features",
   "pack.neoforge.source.child": "child",
 
   "neoforge.network.negotiation.failure.mod": "Channel of mod \"%1$s\" failed to connect: %2$s",

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -194,6 +194,7 @@
   "neoforge.chatType.system": "%1$s",
 
   "pack.neoforge.description": "NeoForge data/resource pack",
+  "pack.neoforge.experimental.description": "NeoForge mod experiments data pack",
   "pack.neoforge.source.child": "child",
 
   "neoforge.network.negotiation.failure.mod": "Channel of mod \"%1$s\" failed to connect: %2$s",

--- a/src/main/resources/data/neoforge/datapacks/mod_experimental/pack.mcmeta
+++ b/src/main/resources/data/neoforge/datapacks/mod_experimental/pack.mcmeta
@@ -1,0 +1,13 @@
+{
+  "features": {
+    "enabled": [
+      "neoforge:mod_experimental"
+    ]
+  },
+  "pack": {
+    "description": {
+      "translate": "pack.neoforge.experimental.description"
+    },
+    "pack_format": 48
+  }
+}

--- a/tests/src/generated/resources/data/neotests_experimental_tests_moda/datapacks/experimental_features/data/neotests_experimental_tests_moda/advancement/recipes/misc/diamond_from_dirt.json
+++ b/tests/src/generated/resources/data/neotests_experimental_tests_moda/datapacks/experimental_features/data/neotests_experimental_tests_moda/advancement/recipes/misc/diamond_from_dirt.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_dirt": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:dirt"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_experimental_tests_moda:diamond_from_dirt"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_dirt"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_experimental_tests_moda:diamond_from_dirt"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_experimental_tests_moda/datapacks/experimental_features/data/neotests_experimental_tests_moda/recipe/diamond_from_dirt.json
+++ b/tests/src/generated/resources/data/neotests_experimental_tests_moda/datapacks/experimental_features/data/neotests_experimental_tests_moda/recipe/diamond_from_dirt.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "experimental",
+  "ingredients": [
+    {
+      "item": "minecraft:dirt"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:diamond"
+  }
+}

--- a/tests/src/generated/resources/data/neotests_experimental_tests_moda/datapacks/experimental_features/pack.mcmeta
+++ b/tests/src/generated/resources/data/neotests_experimental_tests_moda/datapacks/experimental_features/pack.mcmeta
@@ -1,0 +1,11 @@
+{
+  "features": {
+    "enabled": [
+      "neoforge:mod_experimental"
+    ]
+  },
+  "pack": {
+    "description": "Enables experimental features (neotests_experimental_tests_moda)",
+    "pack_format": 48
+  }
+}

--- a/tests/src/generated/resources/data/neotests_experimental_tests_modb/datapacks/experimental_features/data/neotests_experimental_tests_modb/advancement/recipes/misc/dirt_from_diamond.json
+++ b/tests/src/generated/resources/data/neotests_experimental_tests_modb/datapacks/experimental_features/data/neotests_experimental_tests_modb/advancement/recipes/misc/dirt_from_diamond.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_diamond": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#c:gems/diamond"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_experimental_tests_modb:dirt_from_diamond"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_diamond"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_experimental_tests_modb:dirt_from_diamond"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_experimental_tests_modb/datapacks/experimental_features/data/neotests_experimental_tests_modb/recipe/dirt_from_diamond.json
+++ b/tests/src/generated/resources/data/neotests_experimental_tests_modb/datapacks/experimental_features/data/neotests_experimental_tests_modb/recipe/dirt_from_diamond.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "group": "experimental",
+  "ingredients": [
+    {
+      "tag": "c:gems/diamond"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:dirt"
+  }
+}

--- a/tests/src/generated/resources/data/neotests_experimental_tests_modb/datapacks/experimental_features/pack.mcmeta
+++ b/tests/src/generated/resources/data/neotests_experimental_tests_modb/datapacks/experimental_features/pack.mcmeta
@@ -1,0 +1,11 @@
+{
+  "features": {
+    "enabled": [
+      "neoforge:mod_experimental"
+    ]
+  },
+  "pack": {
+    "description": "Enables experimental features (neotests_experimental_tests_modb)",
+    "pack_format": 48
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/resources/ExperimentalTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/resources/ExperimentalTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.resources;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.UnaryOperator;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.metadata.PackMetadataGenerator;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import net.minecraft.data.recipes.ShapelessRecipeBuilder;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackSource;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.flag.FeatureFlags;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+import net.neoforged.neoforge.event.AddPackFindersEvent;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import org.apache.commons.lang3.function.TriConsumer;
+
+@ForEachTest
+public final class ExperimentalTests {
+    @TestHolder(value = "experimental_tests_base", description = "Test providing experimental items and blocks")
+    private static void baseMod(DynamicTest test) {
+        var registration = test.registrationHelper();
+        var items = registration.items();
+
+        items.registerSimpleItem("experimental_item", new Item.Properties().requiredFeatures(FeatureFlags.MOD_EXPERIMENTAL));
+
+        var block = registration.blocks().registerSimpleBlock("experimental_block", BlockBehaviour.Properties.ofFullCopy(Blocks.STONE).requiredFeatures(FeatureFlags.MOD_EXPERIMENTAL));
+        items.registerSimpleBlockItem(block);
+    }
+
+    @TestHolder(value = "experimental_tests_moda", description = "Test providing experimental feature pack (dirt -> diamond recipe)")
+    private static void modA(DynamicTest test) {
+        commonMod(test, (event, pack, lookupProvider) -> pack.addProvider(output -> new RecipeProvider(output, lookupProvider) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                // recipe for dirt -> diamond enabled when MOD_EXPERIMENTAL is enabled
+                ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, Items.DIAMOND)
+                        .requires(Items.DIRT)
+                        .unlockedBy("has_dirt", has(Items.DIRT))
+                        .group("experimental")
+                        .save(output, ResourceLocation.fromNamespaceAndPath(test.createModId(), "diamond_from_dirt"));
+            }
+        }));
+    }
+
+    @TestHolder(value = "experimental_tests_modb", description = "Test providing experimental feature pack (diamond -> dirt recipe)")
+    private static void modB(DynamicTest test) {
+        commonMod(test, (event, pack, lookupProvider) -> pack.addProvider(output -> new RecipeProvider(output, lookupProvider) {
+            @Override
+            protected void buildRecipes(RecipeOutput output) {
+                // recipe for diamond -> dirt enabled when MOD_EXPERIMENTAL is enabled
+                ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, Items.DIRT)
+                        .requires(Tags.Items.GEMS_DIAMOND)
+                        .unlockedBy("has_diamond", has(Tags.Items.GEMS_DIAMOND))
+                        .group("experimental")
+                        .save(output, ResourceLocation.fromNamespaceAndPath(test.createModId(), "dirt_from_diamond"));
+            }
+        }));
+    }
+
+    private static void commonMod(DynamicTest test, TriConsumer<DataGenerator, DataGenerator.PackGenerator, CompletableFuture<HolderLookup.Provider>> gatherData) {
+        var packName = "experimental_features";
+        var modBus = test.framework().modEventBus();
+        var modId = test.createModId();
+
+        // register pack finder for experimental features pack
+        modBus.addListener(AddPackFindersEvent.class, event -> event.addPackFinders(
+                ResourceLocation.fromNamespaceAndPath("neotests", "data/" + modId + "/datapacks/" + packName),
+                PackType.SERVER_DATA,
+                Component.literal("Experimental Features (" + modId + ")"),
+                PackSource.create(UnaryOperator.identity(), false),
+                false,
+                Pack.Position.BOTTOM));
+
+        modBus.addListener(GatherDataEvent.class, event -> {
+            var generator = event.getGenerator();
+            var pack = generator.getBuiltinDatapack(event.includeServer(), modId, packName);
+            // generate pack metadata for experimental features pack
+            pack.addProvider(output -> PackMetadataGenerator.forFeaturePack(output, Component.literal("Enables experimental features (" + modId + ")"), FeatureFlagSet.of(FeatureFlags.MOD_EXPERIMENTAL)));
+            // generate any additional data for this pack
+            gatherData.accept(generator, pack, event.getLookupProvider());
+        });
+    }
+}


### PR DESCRIPTION
Implements a simple feature flag that mod developers can use to mark their elements as experimental.
This flag can be enabled via the ‘Experiments’ screen during level creation, similar to Mojang’s built-in flags.

_Resolves issue #1106_