### PR TITLE
Add CraftingContext support

### DIFF
--- a/patches/net/minecraft/world/inventory/CrafterMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/CrafterMenu.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/world/inventory/CrafterMenu.java
++++ b/net/minecraft/world/inventory/CrafterMenu.java
+@@ -117,9 +_,12 @@
+         if (this.player instanceof ServerPlayer serverplayer) {
+             Level level = serverplayer.level();
+             CraftingInput craftinginput = this.container.asCraftInput();
++            // using the player-free context here since the player won't be usable by the dispense method
++            net.neoforged.neoforge.common.CommonHooks.setCraftingContext(level, serverplayer, this.container);
+             ItemStack itemstack = CrafterBlock.getPotentialResults(level, craftinginput)
+                 .map(p_344359_ -> p_344359_.value().assemble(craftinginput, level.registryAccess()))
+                 .orElse(ItemStack.EMPTY);
++            net.neoforged.neoforge.common.CommonHooks.setCraftingContext(null);
+             this.resultContainer.setItem(0, itemstack);
+         }
+     }

--- a/patches/net/minecraft/world/inventory/CraftingMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/CraftingMenu.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/world/inventory/CraftingMenu.java
++++ b/net/minecraft/world/inventory/CraftingMenu.java
+@@ -70,6 +_,7 @@
+             CraftingInput craftinginput = p_150550_.asCraftInput();
+             ServerPlayer serverplayer = (ServerPlayer)p_150549_;
+             ItemStack itemstack = ItemStack.EMPTY;
++            net.neoforged.neoforge.common.CommonHooks.setCraftingContext(p_150548_, serverplayer, p_150550_);
+             Optional<RecipeHolder<CraftingRecipe>> optional = p_150548_.getServer()
+                 .getRecipeManager()
+                 .getRecipeFor(RecipeType.CRAFTING, craftinginput, p_150548_, p_345124_);
+@@ -83,6 +_,7 @@
+                     }
+                 }
+             }
++            net.neoforged.neoforge.common.CommonHooks.setCraftingContext(null);
+ 
+             p_150551_.setItem(0, itemstack);
+             p_150547_.setRemoteSlot(0, itemstack);

--- a/patches/net/minecraft/world/inventory/ResultSlot.java.patch
+++ b/patches/net/minecraft/world/inventory/ResultSlot.java.patch
@@ -12,9 +12,9 @@
          CraftingInput craftinginput = craftinginput$positioned.input();
          int i = craftinginput$positioned.left();
          int j = craftinginput$positioned.top();
-+        net.neoforged.neoforge.common.CommonHooks.setCraftingPlayer(p_150638_);
++        net.neoforged.neoforge.common.CommonHooks.setCraftingContext(p_150638_.level(), p_150638_, this.craftSlots, craftinginput$positioned);
          NonNullList<ItemStack> nonnulllist = p_150638_.level().getRecipeManager().getRemainingItemsFor(RecipeType.CRAFTING, craftinginput, p_150638_.level());
-+        net.neoforged.neoforge.common.CommonHooks.setCraftingPlayer(null);
++        net.neoforged.neoforge.common.CommonHooks.setCraftingContext(null);
  
          for (int k = 0; k < craftinginput.height(); k++) {
              for (int l = 0; l < craftinginput.width(); l++) {

--- a/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/world/level/block/CrafterBlock.java
++++ b/net/minecraft/world/level/block/CrafterBlock.java
+@@ -157,6 +_,8 @@
+     protected void dispenseFrom(BlockState p_307495_, ServerLevel p_307310_, BlockPos p_307672_) {
+         if (p_307310_.getBlockEntity(p_307672_) instanceof CrafterBlockEntity crafterblockentity) {
+             CraftingInput craftinginput = crafterblockentity.asCraftInput();
++
++            net.neoforged.neoforge.common.CommonHooks.setCraftingContext(p_307310_, null, crafterblockentity);
+             Optional<RecipeHolder<CraftingRecipe>> optional = getPotentialResults(p_307310_, craftinginput);
+             if (optional.isEmpty()) {
+                 p_307310_.levelEvent(1050, p_307672_, 0);
+@@ -185,6 +_,7 @@
+                     crafterblockentity.setChanged();
+                 }
+             }
++            net.neoforged.neoforge.common.CommonHooks.setCraftingContext(null);
+         }
+     }
+ 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -97,6 +97,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.AdventureModePredicate;
 import net.minecraft.world.item.ArmorItem;
@@ -113,6 +114,7 @@ import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.ChunkPos;
@@ -691,21 +693,67 @@ public class CommonHooks {
         return true;
     }
 
-    private static ThreadLocal<Player> craftingPlayer = new ThreadLocal<Player>();
+    public static final class CraftingContext {
+        public final @Nullable Player player;
+        public final Level level;
+        public final @Nullable CraftingContainer container;
+        private @Nullable CraftingInput.Positioned positionedInput;
 
-    public static void setCraftingPlayer(Player player) {
-        craftingPlayer.set(player);
+        public CraftingContext(@Nullable Player player, Level level, @Nullable CraftingContainer container, @Nullable CraftingInput.Positioned positionedInput) {
+            this.player = player;
+            this.level = level;
+            this.container = container;
+            this.positionedInput = positionedInput;
+        }
+
+        @Nullable
+        CraftingInput.Positioned getPositionedInput() {
+            // calculating this is somewhat expensive, so we avoid precalculating it
+            // and cache / use the one from the vanilla code if possible
+            if (positionedInput == null && container != null)
+                positionedInput = container.asPositionedCraftInput();
+            return positionedInput;
+        }
     }
 
-    public static Player getCraftingPlayer() {
-        return craftingPlayer.get();
+    private static ThreadLocal<CraftingContext> craftingContext = new ThreadLocal<>();
+
+    public static void setCraftingContext(@Nullable CraftingContext context) {
+        craftingContext.set(context);
     }
 
+    public static void setCraftingContext(Level level, @Nullable Player player, @Nullable CraftingContainer container) {
+        craftingContext.set(new CraftingContext(player, level, container, null));
+    }
+
+    public static void setCraftingContext(Level level, @Nullable Player player, @Nullable CraftingContainer container, CraftingInput.Positioned positionedInput) {
+        craftingContext.set(new CraftingContext(player, level, container, positionedInput));
+    }
+
+    public static @Nullable CraftingContext getCraftingContext() {
+        return craftingContext.get();
+    }
+
+    @Deprecated(since = "1.21")
+    public static void setCraftingPlayer(@Nullable Player player) {
+        craftingContext.set(player == null ? null : new CraftingContext(player, player.level(), null, null));
+    }
+
+    @Deprecated(since = "1.21")
+    public static @Nullable Player getCraftingPlayer() {
+        CraftingContext context = craftingContext.get();
+        if (context == null) return null;
+        return context.player;
+    }
+
+    // TODO this is not called and the whole PlayerDestroyItemEvent probably needs to be reworked
     public static ItemStack getCraftingRemainingItem(ItemStack stack) {
         if (stack.getItem().hasCraftingRemainingItem(stack)) {
             stack = stack.getItem().getCraftingRemainingItem(stack);
             if (!stack.isEmpty() && stack.isDamageableItem() && stack.getDamageValue() > stack.getMaxDamage()) {
-                EventHooks.onPlayerDestroyItem(craftingPlayer.get(), stack, null);
+                CraftingContext context = getCraftingContext();
+                if (context != null && context.player != null)
+                    EventHooks.onPlayerDestroyItem(context.player, stack, null);
                 return ItemStack.EMPTY;
             }
             return stack;


### PR DESCRIPTION
Previously we only supported the player in the get remaining items stage, this adds it to all stages of recipe evaluation and adds the Level and CraftingContainer as well. This will help in situations such as: the recipe needs to use durability from items in get remaining items; the recipe needs to distinguish between two identical inputs where one is shifted down or right in the grid; etc.