### PR TITLE
[WIP] [RFC] Early WIP of extension slot API proof of concept.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/customslots/ExtensionSlotItemCapability.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/ExtensionSlotItemCapability.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.capabilities.ItemCapability;
+import org.jetbrains.annotations.Nullable;
+
+// TODO: Move to capabilities class?
+public class ExtensionSlotItemCapability {
+    public static final ResourceLocation EXTENSION_CAP_NAME = ResourceLocation.fromNamespaceAndPath("neoforge", "extension_slots");
+    public static final ItemCapability<IExtensionSlotItem, @Nullable Void> INSTANCE = ItemCapability.createVoid(EXTENSION_CAP_NAME, IExtensionSlotItem.class);
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/ExtensionSlotItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/ExtensionSlotItemHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.items.IItemHandlerModifiable;
+import org.jetbrains.annotations.Nullable;
+
+public class ExtensionSlotItemHandler implements IExtensionSlot {
+    protected final IExtensionSlotSource owner;
+    protected final ResourceLocation slotType;
+    protected final int slot;
+    protected final IItemHandlerModifiable inventory;
+
+    public ExtensionSlotItemHandler(IExtensionSlotSource owner, ResourceLocation slotType, IItemHandlerModifiable inventory, int slot) {
+        this.owner = owner;
+        this.slotType = slotType;
+        this.slot = slot;
+        this.inventory = inventory;
+    }
+
+    @Override
+    public IExtensionSlotSource getContainer() {
+        return owner;
+    }
+
+    @Override
+    public ResourceLocation getType() {
+        return slotType;
+    }
+
+    /**
+     * @return The contents of the slot. The stack is *NOT* required to be of an IExtensionSlotItem!
+     */
+    @Override
+    public ItemStack getContents() {
+        return inventory.getStackInSlot(slot);
+    }
+
+    @Override
+    public void setContents(ItemStack stack) {
+        ItemStack oldStack = getContents();
+        if (oldStack == stack) return;
+        if (!oldStack.isEmpty())
+            notifyUnequip(oldStack);
+        inventory.setStackInSlot(slot, stack);
+        if (!stack.isEmpty())
+            notifyEquip(stack);
+    }
+
+    @Override
+    public void onContentsChanged() {
+        owner.onContentsChanged(this);
+    }
+
+    @Override
+    public @Nullable TagKey<Item> getEquipTag() {
+        return null;
+    }
+
+    private void notifyEquip(ItemStack stack) {
+        var extItem = stack.getCapability(ExtensionSlotItemCapability.INSTANCE, null);
+        if (extItem != null) {
+            extItem.onEquipped(stack, this);
+        }
+    }
+
+    private void notifyUnequip(ItemStack stack) {
+        var extItem = stack.getCapability(ExtensionSlotItemCapability.INSTANCE, null);
+        if (extItem != null) {
+            extItem.onUnequipped(stack, this);
+        }
+    }
+
+    public void onWornTick() {
+        ItemStack stack = getContents();
+        if (stack.isEmpty())
+            return;
+        var extItem = stack.getCapability(ExtensionSlotItemCapability.INSTANCE, null);
+        if (extItem != null) {
+            extItem.onWornTick(stack, this);
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/IExtensionSlot.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/IExtensionSlot.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import org.jetbrains.annotations.Nullable;
+
+public interface IExtensionSlot {
+    // Context
+    IExtensionSlotSource getContainer();
+
+    ResourceLocation getType();
+
+    // Access
+    ItemStack getContents();
+
+    void setContents(ItemStack stack);
+
+    void onContentsChanged();
+
+    /**
+     * @return A tag key for the items allowed in this slot. `null` allows all items.
+     */
+    @Nullable
+    TagKey<Item> getEquipTag();
+
+    private boolean checkTag(ItemStack stack) {
+        var tag = getEquipTag();
+        return tag == null || stack.is(tag);
+    }
+
+    // Permissions
+
+    /**
+     * Queries wether or not the stack can be placed in this slot.
+     *
+     * @param stack The ItemStack in the slot.
+     */
+    default boolean canEquip(ItemStack stack) {
+        var cap = stack.getCapability(ExtensionSlotItemCapability.INSTANCE);
+        return (cap == null || cap.canEquip(stack, this)) && checkTag(stack);
+    }
+
+    /**
+     * Queries wether or not the stack can be removed from this slot.
+     *
+     * @param stack The ItemStack in the slot.
+     */
+    default boolean canUnequip(ItemStack stack) {
+        var cap = stack.getCapability(ExtensionSlotItemCapability.INSTANCE);
+        return cap != null
+                ? cap.canUnequip(stack, this)
+                : !EnchantmentHelper.has(stack, EnchantmentEffectComponents.PREVENT_ARMOR_CHANGE);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/IExtensionSlotItem.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/IExtensionSlotItem.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+
+/**
+ * Exposed as a CAPABILITY by items that need additional granularity on the slots they can be inserted in,
+ * and optionally to provide custom processing for insertion, ticking, etc.
+ */
+public interface IExtensionSlotItem {
+    /**
+     * Runs once per tick for as long as the item remains equipped in the given slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default void onWornTick(ItemStack stack, IExtensionSlot slot) {
+    }
+
+    /**
+     * Called when the item is equipped to an extension slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default void onEquipped(ItemStack stack, IExtensionSlot slot) {
+    }
+
+    /**
+     * Called when the item is removed from an extension slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default void onUnequipped(ItemStack stack, IExtensionSlot slot) {
+    }
+
+    /**
+     * Queries wether or not the stack can be placed in the slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default boolean canEquip(ItemStack stack, IExtensionSlot slot) {
+        return true;
+    }
+
+    /**
+     * Queries wether or not the stack can be removed from the slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default boolean canUnequip(ItemStack stack, IExtensionSlot slot) {
+        return !EnchantmentHelper.has(stack, EnchantmentEffectComponents.PREVENT_ARMOR_CHANGE);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/IExtensionSlotSource.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/IExtensionSlotSource.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.world.entity.LivingEntity;
+
+public interface IExtensionSlotSource {
+    /**
+     * @return
+     */
+    LivingEntity getOwner();
+
+    ImmutableList<IExtensionSlot> getSlots();
+
+    void onContentsChanged(IExtensionSlot slot);
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/LivingExtensionSlots.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/LivingExtensionSlots.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Class that exposes extension slots on living entities
+ */
+public class LivingExtensionSlots {
+    private final Multimap<ResourceLocation, IExtensionSlot> registeredSlots = ArrayListMultimap.create();
+
+    public void addSlots(IExtensionSlotSource slots) {
+        for (var slot : slots.getSlots()) {
+            registeredSlots.put(slot.getType(), slot);
+        }
+    }
+
+    public Collection<IExtensionSlot> getSlots(ResourceLocation slotType) {
+        return Collections.unmodifiableCollection(registeredSlots.get(slotType));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/SlotExtension.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/SlotExtension.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots;
+
+import net.minecraft.world.Container;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * To be used in Menus.
+ */
+public class SlotExtension extends Slot {
+    private static final Container emptyInventory = new SimpleContainer(0);
+    private final IExtensionSlot slot;
+
+    public SlotExtension(IExtensionSlot slot, int x, int y) {
+        super(emptyInventory, 0, x, y);
+        this.slot = slot;
+    }
+
+    /**
+     * Check if the stack is allowed to be placed in this slot, used for armor slots as well as furnace fuel.
+     */
+    @Override
+    public boolean mayPlace(ItemStack stack) {
+        if (stack.isEmpty())
+            return false;
+
+        return slot.canEquip(stack);
+    }
+
+    /**
+     * Helper fnct to get the stack in the slot.
+     */
+    @Override
+    public ItemStack getItem() {
+        return slot.getContents();
+    }
+
+    // Override if your IItemHandler does not implement IItemHandlerModifiable
+
+    /**
+     * Helper method to put a stack in the slot.
+     */
+    @Override
+    public void set(ItemStack stack) {
+        slot.setContents(stack);
+        this.setChanged();
+    }
+
+    /**
+     * if par2 has more items than par1, onCrafting(item,countIncrease) is called
+     */
+    @Override
+    public void onQuickCraft(ItemStack oldStackIn, ItemStack newStackIn) {
+
+    }
+
+    /**
+     * Returns the maximum stack size for a given slot (usually the same as getInventoryStackLimit(), but 1 in the case
+     * of armor slots)
+     */
+    @Override
+    public int getMaxStackSize() {
+        return 1;
+    }
+
+    @Override
+    public int getMaxStackSize(ItemStack stack) {
+        return 1;
+    }
+
+    /**
+     * Return whether this slot's stack can be taken from this slot.
+     */
+    @Override
+    public boolean mayPickup(Player playerIn) {
+        return slot.canUnequip(slot.getContents());
+    }
+
+    /**
+     * Decrease the size of the stack in slot (first int arg) by the amount of the second int arg. Returns the new
+     * stack.
+     */
+    @Override
+    public ItemStack remove(int amount) {
+        ItemStack itemstack = slot.getContents();
+
+        int available = Math.min(itemstack.getCount(), amount);
+        int remaining = itemstack.getCount() - available;
+
+        ItemStack split = itemstack.copy();
+        split.setCount(available);
+        itemstack.setCount(remaining);
+
+        if (remaining <= 0)
+            slot.setContents(ItemStack.EMPTY);
+
+        this.setChanged();
+
+        return split;
+    }
+
+    public IExtensionSlot getExtensionSlot() {
+        return slot;
+    }
+
+    @Override
+    public boolean isSameInventory(Slot other) {
+        return other instanceof SlotExtension && ((SlotExtension) other).getExtensionSlot() == this.slot;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.customslots;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/net/neoforged/neoforge/customslots/vanilla/VanillaEquipmentSlot.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/vanilla/VanillaEquipmentSlot.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots.vanilla;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.customslots.IExtensionSlot;
+import net.neoforged.neoforge.customslots.IExtensionSlotSource;
+import org.jetbrains.annotations.Nullable;
+
+public class VanillaEquipmentSlot implements IExtensionSlot {
+    private final VanillaLivingEquipment container;
+    private final ResourceLocation id;
+    private final EquipmentSlot slot;
+    @Nullable
+    private final TagKey<Item> slotTag;
+
+    VanillaEquipmentSlot(VanillaLivingEquipment container, ResourceLocation id, EquipmentSlot slot, @Nullable TagKey<Item> slotTag) {
+        this.container = container;
+        this.id = id;
+        this.slot = slot;
+        this.slotTag = slotTag;
+    }
+
+    @Override
+    public IExtensionSlotSource getContainer() {
+        return container;
+    }
+
+    @Override
+    public ResourceLocation getType() {
+        return id;
+    }
+
+    /**
+     * @return The contents of the slot. The stack is *NOT* required to be of an IExtensionSlotItem!
+     */
+    @Override
+    public ItemStack getContents() {
+        return container.getOwner().getItemBySlot(slot);
+    }
+
+    @Override
+    public void setContents(ItemStack stack) {
+        container.getOwner().setItemSlot(slot, stack);
+    }
+
+    @Override
+    public void onContentsChanged() {
+        container.onContentsChanged(this);
+    }
+
+    @Nullable
+    @Override
+    public TagKey<Item> getEquipTag() {
+        return slotTag;
+    }
+
+    @Override
+    public boolean canEquip(ItemStack stack) {
+        if (stack.getItem().canEquip(stack, slot, container.getOwner()))
+            return true;
+        return IExtensionSlot.super.canEquip(stack);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/vanilla/VanillaLivingEquipment.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/vanilla/VanillaLivingEquipment.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.customslots.vanilla;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.neoforge.customslots.IExtensionSlot;
+import net.neoforged.neoforge.customslots.IExtensionSlotSource;
+
+public class VanillaLivingEquipment implements IExtensionSlotSource {
+    public static final ResourceLocation HEAD = ResourceLocation.withDefaultNamespace(EquipmentSlot.HEAD.getName());
+    public static final ResourceLocation CHEST = ResourceLocation.withDefaultNamespace(EquipmentSlot.CHEST.getName());
+    public static final ResourceLocation LEGS = ResourceLocation.withDefaultNamespace(EquipmentSlot.LEGS.getName());
+    public static final ResourceLocation FEET = ResourceLocation.withDefaultNamespace(EquipmentSlot.FEET.getName());
+    public static final ResourceLocation OFFHAND = ResourceLocation.withDefaultNamespace(EquipmentSlot.OFFHAND.getName());
+    public static final ResourceLocation MAINHAND = ResourceLocation.withDefaultNamespace(EquipmentSlot.MAINHAND.getName());
+
+    private final LivingEntity owner;
+    private final ImmutableList<IExtensionSlot> slots = ImmutableList.of(
+            new VanillaEquipmentSlot(this, HEAD, EquipmentSlot.HEAD, ItemTags.HEAD_ARMOR),
+            new VanillaEquipmentSlot(this, CHEST, EquipmentSlot.CHEST, ItemTags.CHEST_ARMOR),
+            new VanillaEquipmentSlot(this, LEGS, EquipmentSlot.LEGS, ItemTags.LEG_ARMOR),
+            new VanillaEquipmentSlot(this, FEET, EquipmentSlot.FEET, ItemTags.FOOT_ARMOR),
+            new VanillaEquipmentSlot(this, OFFHAND, EquipmentSlot.OFFHAND, null),
+            new VanillaEquipmentSlot(this, MAINHAND, EquipmentSlot.MAINHAND, null)
+    );
+
+    public VanillaLivingEquipment(LivingEntity owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public ImmutableList<IExtensionSlot> getSlots() {
+        return slots;
+    }
+
+    @Override
+    public void onContentsChanged(IExtensionSlot slot) {
+
+    }
+
+    @Override
+    public LivingEntity getOwner() {
+        return owner;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/customslots/vanilla/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/customslots/vanilla/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.customslots.vanilla;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Nothing here is final. Even this description is just a braindump.

There have always been mods that extend the player inventory (and sometimes other entities). Usually, though, there was only one popular option for any major version. The situation may be changing.

Here is a very early proposal for what I would like an API that unifies access to these mod's extension slots. It is loosely based on my own code I wrote years ago with the idea of eventually making a PR to forge. <https://github.com/gigaherz/ToolBelt/tree/1.20.1/src/main/java/dev/gigaherz/toolbelt/customslots>

My use case is that my Tool Belt "finds" the belt slot when opening the GUI, while the gui is open, I require consistent access to the slot (meaning I can check every tick if the belt is still in that slot), and if I actually implemented a feature that has been in my TODO list, I would need to mutate the stack or replace it in the slot. So it would greatly benefit me if we had a shared API for accessing these slots.

I am sure there are many uses cases which I have not yet considered. I am prepared to make any changes necessary for them, or even to make way for someone else's design.

This API has been designed to fulfill these requirements:
1. the ability to identify all "belt" slots from all mods, in one place
2. the ability to uniquely identify one specific "belt" slot among the multiple
3. the ability to re-query and set the contents of that slot

The design includes:
- A capability to gather all the extension slots, and provide access to them by "type".
- An interface slots implement to allow access to the slot.
- An interface for items to provide special handling for equip, unequip, and ticking.
- Querying a slot type returns a collection of slots matching that type.
- The returned objects are to be consistent and valid across ticks (eg. while a GUI remains open).
- The objects that fit in a slot are decided based on a tag, but can provide additional filtering in their handler.

Questions I have for the community:
- Should slot types be a registry? this would allow having slot type tags, and it would allow having common tags for slot types so people can query all "c:belt" slots
- Should be API to submit slots to the query handler be part of the query interface? or something external
- Is it ok to expect and require that all inventory extensions use tags to decide if items go in the slot?

Additional considerations:
- Should the API provide methods for storage of the slot contents? (IMO, no, or at least not mandatory, since slots could work differently, eg. someone could make a set of inventory extension slots that is shared among people of one team or some such)
- Should the API provide methods for handling death in a proper way? (IMO, yes, but we mostly do that already <https://github.com/gigaherz/ToolBelt/blob/master/src/main/java/dev/gigaherz/toolbelt/slot/BeltAttachment.java#L130-L170>)
- Should be API provide facilities for synchronizing slots to the client?
- Should the API provide facilities for displaying the slots in a GUI?