### PR TITLE
Fire `ScreenEvent.BackgroundRendered` not being called for AbstractContainerScreen

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -32,7 +32,11 @@
          ItemStack itemstack = this.draggingItem.isEmpty() ? this.menu.getCarried() : this.draggingItem;
          if (!itemstack.isEmpty()) {
              int l1 = 8;
-@@ -156,13 +_,25 @@
+@@ -153,16 +_,29 @@
+     public void renderBackground(GuiGraphics p_295206_, int p_295457_, int p_294596_, float p_296351_) {
+         this.renderTransparentBackground(p_295206_);
+         this.renderBg(p_295206_, p_296351_, p_295457_, p_294596_);
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ScreenEvent.BackgroundRendered(this, p_295206_));
      }
  
      public static void renderSlotHighlight(GuiGraphics p_283692_, int p_281453_, int p_281915_, int p_283504_) {


### PR DESCRIPTION
Fixes #1077 
Fire `ScreenEvent.BackgroundRendered` not being called for AbstractContainerScreen