### PR TITLE
[1.21] Fix data generator merge issue

### DIFF
--- a/patches/net/minecraft/data/DataGenerator.java.patch
+++ b/patches/net/minecraft/data/DataGenerator.java.patch
@@ -16,7 +16,7 @@
                  stopwatch1.start();
                  hashcache.applyUpdate(hashcache.generateUpdate(p_254418_, p_253750_::run).join());
                  stopwatch1.stop();
-@@ -56,6 +_,34 @@
+@@ -56,6 +_,46 @@
      public DataGenerator.PackGenerator getBuiltinDatapack(boolean p_253826_, String p_254134_) {
          Path path = this.vanillaPackOutput.getOutputFolder(PackOutput.Target.DATA_PACK).resolve("minecraft").resolve("datapacks").resolve(p_254134_);
          return new DataGenerator.PackGenerator(p_253826_, p_254134_, new PackOutput(path));
@@ -48,6 +48,18 @@
 +            DataGenerator.this.providersToRun.put(id, provider);
 +
 +        return provider;
++    }
++
++    public void merge(DataGenerator other) {
++        other.providersToRun.forEach((id, provider) -> {
++            if(!allProviderIds.add(id))
++                throw new IllegalStateException("Duplicate provider: " + id);
++
++            providersToRun.put(id, provider);
++        });
++
++        other.providersToRun.clear();
++        other.allProviderIds.clear();
      }
  
      static {

--- a/patches/net/minecraft/data/DataGenerator.java.patch
+++ b/patches/net/minecraft/data/DataGenerator.java.patch
@@ -16,10 +16,15 @@
                  stopwatch1.start();
                  hashcache.applyUpdate(hashcache.generateUpdate(p_254418_, p_253750_::run).join());
                  stopwatch1.stop();
-@@ -56,6 +_,46 @@
+@@ -56,6 +_,51 @@
      public DataGenerator.PackGenerator getBuiltinDatapack(boolean p_253826_, String p_254134_) {
          Path path = this.vanillaPackOutput.getOutputFolder(PackOutput.Target.DATA_PACK).resolve("minecraft").resolve("datapacks").resolve(p_254134_);
          return new DataGenerator.PackGenerator(p_253826_, p_254134_, new PackOutput(path));
++    }
++
++    public PackGenerator getBuiltinDatapack(boolean run, String namespace, String path) {
++        var packPath = vanillaPackOutput.getOutputFolder(PackOutput.Target.DATA_PACK).resolve(namespace).resolve("datapacks").resolve(path);
++        return new PackGenerator(run, namespace + '_' + path, new PackOutput(packPath));
 +    }
 +
 +    public Map<String, DataProvider> getProvidersView() {

--- a/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
@@ -130,7 +130,7 @@ public class GatherDataEvent extends Event implements IModBusEvent {
             paths.values().forEach(lst -> {
                 DataGenerator parent = lst.get(0);
                 for (int x = 1; x < lst.size(); x++)
-                    lst.get(x).getProvidersView().forEach((name, provider) -> parent.addProvider(true, provider));
+                    parent.merge(lst.get(x));
                 try {
                     parent.run();
                 } catch (IOException ex) {


### PR DESCRIPTION
When using the current DataGenerator system to generate built-in packs, you can easily run into `Duplicate Provider` errors.

This is due to how the system merges all providers down to a single larger provider in `GatherDataEvent`.
The current implementation ignores the `id` providers are registered with, which for most providers is no issue, but providers registered for built-in packs have the `id` prefixed with the packs `id`.

this PR aims to fix that issue by introducing a simple `DataGenerator.merge` method, which simply pulls the providers and their registered ids directly from the sub generators backing maps and moving them into the parents.

---

This pr also introduces a simple overload helper `DataGenerator.getBuiltinDatapack`, this is to allow generating modded builtin packs.

[_Original Discord message_](https://discord.com/channels/313125603924639766/852298000042164244/1255109284522623070)