### PR TITLE
Allow superclasses of RFBB for (Fluid)IngredientType stream codec

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/crafting/IngredientType.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IngredientType.java
@@ -15,7 +15,7 @@ import net.minecraft.network.codec.StreamCodec;
  *
  * <p>Note that the {@link #streamCodec()} is only used if {@link ICustomIngredient#isSimple()} returns {@code false}.
  */
-public record IngredientType<T extends ICustomIngredient>(MapCodec<T> codec, StreamCodec<RegistryFriendlyByteBuf, T> streamCodec) {
+public record IngredientType<T extends ICustomIngredient>(MapCodec<T> codec, StreamCodec<? super RegistryFriendlyByteBuf, T> streamCodec) {
     /**
      * Constructor for ingredient types that use a regular codec for network syncing.
      */

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredientType.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredientType.java
@@ -22,7 +22,7 @@ import net.neoforged.neoforge.common.crafting.IngredientType;
  * @param <T> The type of fluid ingredient
  * @see IngredientType IngredientType, a similar class for custom item ingredients
  */
-public record FluidIngredientType<T extends FluidIngredient>(MapCodec<T> codec, StreamCodec<RegistryFriendlyByteBuf, T> streamCodec) {
+public record FluidIngredientType<T extends FluidIngredient>(MapCodec<T> codec, StreamCodec<? super RegistryFriendlyByteBuf, T> streamCodec) {
     public FluidIngredientType(MapCodec<T> mapCodec) {
         this(mapCodec, ByteBufCodecs.fromCodecWithRegistries(mapCodec.codec()));
     }


### PR DESCRIPTION
Fixes #1191.