### PR TITLE
[1.21] Add holder helpers to LevelReader and HolderLookupProvider

### DIFF
--- a/patches/net/minecraft/core/HolderLookup.java.patch
+++ b/patches/net/minecraft/core/HolderLookup.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/core/HolderLookup.java
 +++ b/net/minecraft/core/HolderLookup.java
+@@ -26,7 +_,7 @@
+         return this.listTags().map(HolderSet.Named::key);
+     }
+ 
+-    public interface Provider {
++    public interface Provider extends net.neoforged.neoforge.common.extensions.IHolderLookupProviderExtension{
+         Stream<ResourceKey<? extends Registry<?>>> listRegistries();
+ 
+         <T> Optional<HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> p_256285_);
 @@ -96,6 +_,11 @@
              };
          }

--- a/patches/net/minecraft/core/HolderLookup.java.patch
+++ b/patches/net/minecraft/core/HolderLookup.java.patch
@@ -5,7 +5,7 @@
      }
  
 -    public interface Provider {
-+    public interface Provider extends net.neoforged.neoforge.common.extensions.IHolderLookupProviderExtension{
++    public interface Provider extends net.neoforged.neoforge.common.extensions.IHolderLookupProviderExtension {
          Stream<ResourceKey<? extends Registry<?>>> listRegistries();
  
          <T> Optional<HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> p_256285_);

--- a/patches/net/minecraft/world/level/LevelReader.java.patch
+++ b/patches/net/minecraft/world/level/LevelReader.java.patch
@@ -9,14 +9,3 @@
      @Nullable
      ChunkAccess getChunk(int p_46823_, int p_46824_, ChunkStatus p_330944_, boolean p_46826_);
  
-@@ -181,6 +_,10 @@
-     @Deprecated
-     default boolean hasChunkAt(BlockPos p_46806_) {
-         return this.hasChunkAt(p_46806_.getX(), p_46806_.getZ());
-+    }
-+
-+    default boolean isAreaLoaded(BlockPos center, int range) {
-+        return this.hasChunksAt(center.offset(-range, -range, -range), center.offset(range, range, range));
-     }
- 
-     @Deprecated

--- a/patches/net/minecraft/world/level/LevelReader.java.patch
+++ b/patches/net/minecraft/world/level/LevelReader.java.patch
@@ -1,13 +1,22 @@
 --- a/net/minecraft/world/level/LevelReader.java
 +++ b/net/minecraft/world/level/LevelReader.java
-@@ -183,6 +_,10 @@
-         return this.hasChunkAt(p_46806_.getX(), p_46806_.getZ());
-     }
+@@ -22,7 +_,7 @@
+ import net.minecraft.world.level.levelgen.Heightmap;
+ import net.minecraft.world.phys.AABB;
  
-+    default boolean isAreaLoaded(BlockPos center, int range) {
-+        return this.hasChunksAt(center.offset(-range, -range, -range), center.offset(range, range, range));
+-public interface LevelReader extends BlockAndTintGetter, CollisionGetter, SignalGetter, BiomeManager.NoiseBiomeSource {
++public interface LevelReader extends BlockAndTintGetter, CollisionGetter, SignalGetter, BiomeManager.NoiseBiomeSource, net.neoforged.neoforge.common.extensions.ILevelReaderExtension {
+     @Nullable
+     ChunkAccess getChunk(int p_46823_, int p_46824_, ChunkStatus p_330944_, boolean p_46826_);
+ 
+@@ -181,6 +_,10 @@
+     @Deprecated
+     default boolean hasChunkAt(BlockPos p_46806_) {
+         return this.hasChunkAt(p_46806_.getX(), p_46806_.getZ());
 +    }
 +
++    default boolean isAreaLoaded(BlockPos center, int range) {
++        return this.hasChunksAt(center.offset(-range, -range, -range), center.offset(range, range, range));
+     }
+ 
      @Deprecated
-     default boolean hasChunksAt(BlockPos p_46833_, BlockPos p_46834_) {
-         return this.hasChunksAt(p_46833_.getX(), p_46833_.getY(), p_46833_.getZ(), p_46834_.getX(), p_46834_.getY(), p_46834_.getZ());

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderLookupProviderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderLookupProviderExtension.java
@@ -17,7 +17,6 @@ public interface IHolderLookupProviderExtension {
 
     /**
      * Shortcut method to get a holder from a ResourceKey.
-     * Can be accessed through LevelReader, see {@link ILevelReaderExtension}
      * 
      * @throws IllegalStateException if the registry or key is not found.
      */
@@ -27,7 +26,6 @@ public interface IHolderLookupProviderExtension {
 
     /**
      * Shortcut method to get an optional holder from a ResourceKey.
-     * Can be accessed through LevelReader, see {@link ILevelReaderExtension}
      */
     default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
         Optional<HolderLookup.RegistryLookup<T>> registry = this.self().lookup(key.registryKey());

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderLookupProviderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderLookupProviderExtension.java
@@ -11,14 +11,24 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.ResourceKey;
 
 public interface IHolderLookupProviderExtension {
-    default HolderLookup.Provider self() {
+    private HolderLookup.Provider self() {
         return (HolderLookup.Provider) this;
     }
 
+    /**
+     * Shortcut method to get a holder from a ResourceKey.
+     * Can be accessed through LevelReader, see {@link ILevelReaderExtension}
+     * 
+     * @throws IllegalStateException if the registry or key is not found.
+     */
     default <T> Holder<T> holderOrThrow(ResourceKey<T> key) {
         return this.self().lookupOrThrow(key.registryKey()).getOrThrow(key);
     }
 
+    /**
+     * Shortcut method to get an optional holder from a ResourceKey.
+     * Can be accessed through LevelReader, see {@link ILevelReaderExtension}
+     */
     default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
         Optional<HolderLookup.RegistryLookup<T>> registry = this.self().lookup(key.registryKey());
         return registry.flatMap(tRegistryLookup -> tRegistryLookup.get(key));

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderLookupProviderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderLookupProviderExtension.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import java.util.Optional;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.resources.ResourceKey;
+
+public interface IHolderLookupProviderExtension {
+    default HolderLookup.Provider self() {
+        return (HolderLookup.Provider) this;
+    }
+
+    default <T> Holder<T> holderOrThrow(ResourceKey<T> key) {
+        return this.self().lookupOrThrow(key.registryKey()).getOrThrow(key);
+    }
+
+    default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
+        Optional<HolderLookup.RegistryLookup<T>> registry = this.self().lookup(key.registryKey());
+        return registry.flatMap(tRegistryLookup -> tRegistryLookup.get(key));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -7,11 +7,7 @@ package net.neoforged.neoforge.common.extensions;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -109,21 +105,4 @@ public interface ILevelExtension {
      * but it is safe to call on any {@link Level}, without the need for an {@code instanceof} check.
      */
     default void invalidateCapabilities(ChunkPos pos) {}
-
-    /**
-     * Returns a holder for the key using this levels registry access.
-     * 
-     * @throws IllegalStateException if the registry is missing or the key is not present in the registry
-     */
-    default <T> Holder.Reference<T> holderOrThrow(ResourceKey<T> key) {
-        return self().registryAccess().registryOrThrow(key.registryKey()).getHolderOrThrow(key);
-    }
-
-    /**
-     * Returns an optional holder for the key using this levels registry access.
-     */
-    default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
-        Optional<Registry<T>> registry = self().registryAccess().registry(key.registryKey());
-        return registry.flatMap(ts -> ts.getHolder(key));
-    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -7,7 +7,11 @@ package net.neoforged.neoforge.common.extensions;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -105,4 +109,21 @@ public interface ILevelExtension {
      * but it is safe to call on any {@link Level}, without the need for an {@code instanceof} check.
      */
     default void invalidateCapabilities(ChunkPos pos) {}
+
+    /**
+     * Returns a holder for the key using this levels registry access.
+     * 
+     * @throws IllegalStateException if the registry is missing or the key is not present in the registry
+     */
+    default <T> Holder.Reference<T> holderOrThrow(ResourceKey<T> key) {
+        return self().registryAccess().registryOrThrow(key.registryKey()).getHolderOrThrow(key);
+    }
+
+    /**
+     * Returns an optional holder for the key using this levels registry access.
+     */
+    default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
+        Optional<Registry<T>> registry = self().registryAccess().registry(key.registryKey());
+        return registry.flatMap(ts -> ts.getHolder(key));
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
@@ -14,7 +14,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.LevelReader;
 
 public interface ILevelReaderExtension extends RegistryAccess {
-    default LevelReader self() {
+    private LevelReader self() {
         return (LevelReader) this;
     }
 
@@ -25,6 +25,7 @@ public interface ILevelReaderExtension extends RegistryAccess {
     /**
      * Delegates the implementation of RegistryAccess to enable modders to access HolderLookup.Provider methods
      * directly without traversing through level.registryAccess().
+     * For additional utilities, see {@link IHolderLookupProviderExtension}
      */
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
@@ -6,13 +6,14 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.LevelReader;
 
-public interface ILevelReaderExtension {
+public interface ILevelReaderExtension extends RegistryAccess {
     default LevelReader self() {
         return (LevelReader) this;
     }
@@ -22,19 +23,17 @@ public interface ILevelReaderExtension {
     }
 
     /**
-     * Returns a holder for the key using this levels registry access.
-     *
-     * @throws IllegalStateException if the registry is missing or the key is not present in the registry
+     * Delegates the implementation of RegistryAccess to enable modders to access HolderLookup.Provider methods
+     * directly without traversing through level.registryAccess().
      */
-    default <T> Holder.Reference<T> holderOrThrow(ResourceKey<T> key) {
-        return self().registryAccess().registryOrThrow(key.registryKey()).getHolderOrThrow(key);
+
+    @Override
+    default <E> Optional<Registry<E>> registry(ResourceKey<? extends Registry<? extends E>> p_123085_) {
+        return self().registryAccess().registry(p_123085_);
     }
 
-    /**
-     * Returns a optional holder for the key using this levels registry access.
-     */
-    default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
-        Optional<Registry<T>> registry = self().registryAccess().registry(key.registryKey());
-        return registry.flatMap(ts -> ts.getHolder(key));
+    @Override
+    default Stream<RegistryEntry<?>> registries() {
+        return self().registryAccess().registries();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import java.util.Optional;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.LevelReader;
+
+public interface ILevelReaderExtension {
+    default LevelReader self() {
+        return (LevelReader) this;
+    }
+
+    /**
+     * Returns a holder for the key using this levels registry access.
+     *
+     * @throws IllegalStateException if the registry is missing or the key is not present in the registry
+     */
+    default <T> Holder.Reference<T> holderOrThrow(ResourceKey<T> key) {
+        return self().registryAccess().registryOrThrow(key.registryKey()).getHolderOrThrow(key);
+    }
+
+    /**
+     * Returns a optional holder for the key using this levels registry access.
+     */
+    default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
+        Optional<Registry<T>> registry = self().registryAccess().registry(key.registryKey());
+        return registry.flatMap(ts -> ts.getHolder(key));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -14,6 +15,10 @@ import net.minecraft.world.level.LevelReader;
 public interface ILevelReaderExtension {
     default LevelReader self() {
         return (LevelReader) this;
+    }
+
+    default boolean isAreaLoaded(BlockPos center, int range) {
+        return self().hasChunksAt(center.offset(-range, -range, -range), center.offset(range, range, range));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelReaderExtension.java
@@ -6,14 +6,12 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
-import java.util.stream.Stream;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Registry;
-import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.LevelReader;
 
-public interface ILevelReaderExtension extends RegistryAccess {
+public interface ILevelReaderExtension {
     private LevelReader self() {
         return (LevelReader) this;
     }
@@ -23,18 +21,20 @@ public interface ILevelReaderExtension extends RegistryAccess {
     }
 
     /**
-     * Delegates the implementation of RegistryAccess to enable modders to access HolderLookup.Provider methods
-     * directly without traversing through level.registryAccess().
-     * For additional utilities, see {@link IHolderLookupProviderExtension}
+     * Shortcut method to get a holder from a ResourceKey.
+     * see {@link IHolderLookupProviderExtension}
+     *
+     * @throws IllegalStateException if the registry or key is not found.
      */
-
-    @Override
-    default <E> Optional<Registry<E>> registry(ResourceKey<? extends Registry<? extends E>> p_123085_) {
-        return self().registryAccess().registry(p_123085_);
+    default <T> Holder<T> holderOrThrow(ResourceKey<T> key) {
+        return this.self().registryAccess().holderOrThrow(key);
     }
 
-    @Override
-    default Stream<RegistryEntry<?>> registries() {
-        return self().registryAccess().registries();
+    /**
+     * Shortcut method to get an optional holder from a ResourceKey.
+     * see {@link IHolderLookupProviderExtension}
+     */
+    default <T> Optional<Holder.Reference<T>> holder(ResourceKey<T> key) {
+        return this.self().registryAccess().holder(key);
     }
 }


### PR DESCRIPTION
Numerous mods have found themselves in wrapper hell, and it seems like everyone is making utility methods such as 
```java
public class HolderHelper {

    public static <T> Holder<T> unwrap(Level level, ResourceKey<T> key){
        return level.registryAccess().registryOrThrow(key.registryKey()).getHolderOrThrow(key);
    }
}
```
to cut down on the verbosity. Bringing it closer to level instead lets us easily unwrap objects we expect to be present, such as enchantments or our own keys.
```java
level.holder(Enchantments.SILK_TOUCH)
```