### PR TITLE
Add an Item Ability to determine if an item can remove wolf armor (#1062)

### DIFF
--- a/patches/net/minecraft/world/entity/animal/Wolf.java.patch
+++ b/patches/net/minecraft/world/entity/animal/Wolf.java.patch
@@ -14,6 +14,15 @@
                      return InteractionResult.sidedSuccess(this.level().isClientSide());
                  } else {
                      if (item instanceof DyeItem dyeitem && this.isOwnedBy(p_30412_)) {
+@@ -440,7 +_,7 @@
+                         this.setBodyArmorItem(itemstack.copyWithCount(1));
+                         itemstack.consume(1, p_30412_);
+                         return InteractionResult.SUCCESS;
+-                    } else if (itemstack.is(Items.SHEARS)
++                    } else if (itemstack.canPerformAction(net.neoforged.neoforge.common.ItemAbilities.SHEARS_REMOVE_ARMOR)
+                         && this.isOwnedBy(p_30412_)
+                         && this.hasArmor()
+                         && (!EnchantmentHelper.has(this.getBodyArmorItem(), EnchantmentEffectComponents.PREVENT_ARMOR_CHANGE) || p_30412_.isCreative())) {
 @@ -488,7 +_,7 @@
      }
  

--- a/src/generated/resources/data/minecraft/advancement/husbandry/remove_wolf_armor.json
+++ b/src/generated/resources/data/minecraft/advancement/husbandry/remove_wolf_armor.json
@@ -1,0 +1,42 @@
+{
+  "parent": "minecraft:husbandry/tame_an_animal",
+  "criteria": {
+    "remove_wolf_armor": {
+      "conditions": {
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:wolf"
+            }
+          }
+        ],
+        "item": {
+          "predicates": {
+            "neoforge:item_ability": "shears_remove_armor"
+          }
+        }
+      },
+      "trigger": "minecraft:player_interacted_with_entity"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "advancements.husbandry.remove_wolf_armor.description"
+    },
+    "icon": {
+      "count": 1,
+      "id": "minecraft:shears"
+    },
+    "title": {
+      "translate": "advancements.husbandry.remove_wolf_armor.title"
+    }
+  },
+  "requirements": [
+    [
+      "remove_wolf_armor"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/src/main/java/net/neoforged/neoforge/common/ItemAbilities.java
+++ b/src/main/java/net/neoforged/neoforge/common/ItemAbilities.java
@@ -77,6 +77,11 @@ public class ItemAbilities {
     public static final ItemAbility SHEARS_HARVEST = ItemAbility.get("shears_harvest");
 
     /**
+     * This action is exposed by shears and corresponds to a harvest action that is triggered with a right click on armored wolves.
+     */
+    public static final ItemAbility SHEARS_REMOVE_ARMOR = ItemAbility.get("shears_remove_armor");
+
+    /**
      * This action is exposed by shears and corresponds to a carve action that is triggered with a right click on a block that supports such behaviour.
      * Example: Right click with shears o a pumpkin to carve it
      */
@@ -121,7 +126,7 @@ public class ItemAbilities {
     public static final Set<ItemAbility> DEFAULT_SHOVEL_ACTIONS = of(SHOVEL_DIG, SHOVEL_FLATTEN);
     public static final Set<ItemAbility> DEFAULT_PICKAXE_ACTIONS = of(PICKAXE_DIG);
     public static final Set<ItemAbility> DEFAULT_SWORD_ACTIONS = of(SWORD_DIG, SWORD_SWEEP);
-    public static final Set<ItemAbility> DEFAULT_SHEARS_ACTIONS = of(SHEARS_DIG, SHEARS_HARVEST, SHEARS_CARVE, SHEARS_DISARM);
+    public static final Set<ItemAbility> DEFAULT_SHEARS_ACTIONS = of(SHEARS_DIG, SHEARS_HARVEST, SHEARS_REMOVE_ARMOR, SHEARS_CARVE, SHEARS_DISARM);
     public static final Set<ItemAbility> DEFAULT_SHIELD_ACTIONS = of(SHIELD_BLOCK);
     public static final Set<ItemAbility> DEFAULT_FISHING_ROD_ACTIONS = of(FISHING_ROD_CAST);
     public static final Set<ItemAbility> DEFAULT_TRIDENT_ACTIONS = of(TRIDENT_THROW);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeAdvancementProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeAdvancementProvider.java
@@ -61,6 +61,7 @@ public class NeoForgeAdvancementProvider extends AdvancementProvider {
     private static List<AdvancementGenerator> getVanillaAdvancementProviders(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
         List<BiFunction<Criterion<?>, HolderLookup.Provider, Criterion<?>>> criteriaReplacers = new ArrayList<>();
         criteriaReplacers.add(replaceMatchToolCriteria(ItemAbilities.AXE_WAX_OFF, getPrivateValue(VanillaHusbandryAdvancements.class, null, "WAX_SCRAPING_TOOLS")));
+        criteriaReplacers.add(replaceInteractCriteria(ItemPredicate.Builder.item().withSubPredicate(ItemAbilityPredicate.TYPE, new ItemAbilityPredicate(ItemAbilities.SHEARS_REMOVE_ARMOR)).build(), Items.SHEARS));
         criteriaReplacers.add(replaceInteractCriteria(ItemPredicate.Builder.item().withSubPredicate(PiglinCurrencyItemPredicate.TYPE, PiglinCurrencyItemPredicate.INSTANCE).build(), PiglinAi.BARTERING_ITEM));
         criteriaReplacers.add(replaceWearingPredicate(EntityPredicate.Builder.entity().subPredicate(PiglinNeutralArmorEntityPredicate.INSTANCE).build(), predicate -> {
             if (predicate.head().filter(item -> predicateMatches(item, Items.GOLDEN_HELMET)).isPresent()) {


### PR DESCRIPTION
Fixes #1062 by adding a new Item Ability that is used to determine whether a stack is able to remove wolf armor. I decided to go this route rather than making `Wolf` implement `IShearable` because of the following reasons:
- Unlike other mobs when falling through in their interact predicate, wolves fall back to having the player toggle the wolves sitting state. This takes precedent over falling through to see if the item has an interaction on the entity
- There isn't a great way to replace the advancement without just having it get replaced to an item ability anyway
- Only the owner can shear the wolf (Minor, given we have player context in `IShearable#isShearable`)
- Wolves don't trigger the shear game event (minor)