### PR TITLE
Instead of relying on a global placeholder, bake the version into the neoforge.mods.toml

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -429,6 +429,17 @@ dependencies {
     }
 }
 
+processResources {
+    inputs.property("version", project.version)
+    filesMatching("META-INF/neoforge.mods.toml") {
+        expand([
+                "global": [
+                        "neoForgeVersion": project.version
+                ]
+        ])
+    }
+}
+
 afterEvaluate {
     artifacts {
         modDevBundle(userdevJar) {


### PR DESCRIPTION
Currently, it's not possible to get the version of NeoForge simply based on the jar file itself, since it sets its own version to whatever was passed on the CLI commandline.

This PR changes that by replacing the placeholder with the actual project version number, when NF is built.