### PR TITLE
Add logging to catch-all exception handlers in packet handlers and fix null-arguments to translations.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -39,9 +39,12 @@ import net.neoforged.neoforge.network.payload.FrozenRegistrySyncStartPayload;
 import net.neoforged.neoforge.registries.RegistryManager;
 import net.neoforged.neoforge.registries.RegistrySnapshot;
 import org.jetbrains.annotations.ApiStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApiStatus.Internal
 public final class ClientPayloadHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClientPayloadHandler.class);
     private static final Set<ResourceLocation> toSynchronize = Sets.newConcurrentHashSet();
     private static final Map<ResourceLocation, RegistrySnapshot> synchronizedRegistries = Maps.newConcurrentMap();
 
@@ -75,7 +78,8 @@ public final class ClientPayloadHandler {
             synchronizedRegistries.clear();
             context.reply(FrozenRegistrySyncCompletedPayload.INSTANCE);
         } catch (Throwable t) {
-            context.disconnect(Component.translatable("neoforge.network.registries.sync.failed", t.getMessage()));
+            LOGGER.error("Failed to handle registry sync from server.", t);
+            context.disconnect(Component.translatable("neoforge.network.registries.sync.failed", t.toString()));
         }
     }
 
@@ -95,7 +99,8 @@ public final class ClientPayloadHandler {
                 }
             }
         } catch (Throwable t) {
-            context.disconnect(Component.translatable("neoforge.network.advanced_add_entity.failed", t.getMessage()));
+            LOGGER.error("Failed to handle advanced add entity from server.", t);
+            context.disconnect(Component.translatable("neoforge.network.advanced_add_entity.failed", t.toString()));
         }
     }
 
@@ -106,7 +111,8 @@ public final class ClientPayloadHandler {
         try {
             createMenuScreen(msg.name(), msg.menuType(), msg.windowId(), buf);
         } catch (Throwable t) {
-            context.disconnect(Component.translatable("neoforge.network.advanced_open_screen.failed", t.getMessage()));
+            LOGGER.error("Failed to handle advanced open screen from server.", t);
+            context.disconnect(Component.translatable("neoforge.network.advanced_open_screen.failed", t.toString()));
         } finally {
             buf.release();
         }
@@ -131,7 +137,8 @@ public final class ClientPayloadHandler {
                 manager.handleLightDataSync(msg.entries());
             }
         } catch (Throwable t) {
-            context.disconnect(Component.translatable("neoforge.network.aux_light_data.failed", msg.pos().toString(), t.getMessage()));
+            LOGGER.error("Failed to handle auxiliary light data from server.", t);
+            context.disconnect(Component.translatable("neoforge.network.aux_light_data.failed", msg.pos().toString(), t.toString()));
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/registries/ClientRegistryManager.java
+++ b/src/main/java/net/neoforged/neoforge/registries/ClientRegistryManager.java
@@ -45,8 +45,8 @@ public class ClientRegistryManager {
                 payload.dataMaps().forEach((attachKey, maps) -> registry.dataMaps.put(RegistryManager.getDataMap(payload.registryKey(), attachKey), Collections.unmodifiableMap(maps)));
                 NeoForge.EVENT_BUS.post(new DataMapsUpdatedEvent(regAccess, registry, DataMapsUpdatedEvent.UpdateCause.CLIENT_SYNC));
             } catch (Throwable t) {
-                context.disconnect(Component.translatable("neoforge.network.data_maps.failed", payload.registryKey().location().toString(), t.getMessage()));
                 LOGGER.error("Failed to handle registry data map sync: ", t);
+                context.disconnect(Component.translatable("neoforge.network.data_maps.failed", payload.registryKey().location().toString(), t.toString()));
             }
         });
     }


### PR DESCRIPTION
This is the result of a user in Discord getting the following error. As it turns out, this masks a `NullPointerException`, which has a `null` message and crashes the translatable component.
In addition, not logging the actual exception with full stack trace would have made debugging this error impossible too, so I also added logging.
Please note that I did not test this since I do not have the ability to trigger the actual error condition ;-)

```
[01Jul2024 20:37:16.384] [Render thread/ERROR] [net.minecraft.util.thread.BlockableEventLoop/FATAL]: Error executing task on Client
java.util.concurrent.CompletionException: java.lang.IllegalArgumentException: TranslatableContents' arguments must be either a Component, Number, Boolean, or a String. Was given null for neoforge.network.registries.sync.failed
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770) ~[?:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:148) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:122) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:111) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.runTick(Minecraft.java:1158) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.run(Minecraft.java:810) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.main.Main.main(Main.java:230) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at MC-BOOTSTRAP/fml_loader@4.0.6/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:136) ~[loader-4.0.6.jar%23143!/:4.0]
	at MC-BOOTSTRAP/fml_loader@4.0.6/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:124) ~[loader-4.0.6.jar%23143!/:4.0]
	at MC-BOOTSTRAP/fml_loader@4.0.6/net.neoforged.fml.loading.targets.NeoForgeClientUserdevLaunchHandler.runService(NeoForgeClientUserdevLaunchHandler.java:23) ~[loader-4.0.6.jar%23143!/:4.0]
	at MC-BOOTSTRAP/fml_loader@4.0.6/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:118) ~[loader-4.0.6.jar%23143!/:4.0]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30) [modlauncher-11.0.3.jar%23125!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53) [modlauncher-11.0.3.jar%23125!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71) [modlauncher-11.0.3.jar%23125!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.Launcher.run(Launcher.java:103) [modlauncher-11.0.3.jar%23125!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.Launcher.main(Launcher.java:74) [modlauncher-11.0.3.jar%23125!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26) [modlauncher-11.0.3.jar%23125!/:?]
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.3/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23) [modlauncher-11.0.3.jar%23125!/:?]
	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210) [bootstraplauncher-2.0.2.jar:?]
	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69) [bootstraplauncher-2.0.2.jar:?]
Caused by: java.lang.IllegalArgumentException: TranslatableContents' arguments must be either a Component, Number, Boolean, or a String. Was given null for neoforge.network.registries.sync.failed
	at TRANSFORMER/minecraft@1.21/net.minecraft.network.chat.contents.TranslatableContents.<init>(TranslatableContents.java:87) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.network.chat.Component.translatable(Component.java:157) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at TRANSFORMER/neoforge@21.0.46-beta/net.neoforged.neoforge.network.handlers.ClientPayloadHandler.handle(ClientPayloadHandler.java:78) ~[neoforge-21.0.46-beta.jar%23191!/:?]
	at TRANSFORMER/neoforge@21.0.46-beta/net.neoforged.neoforge.network.handling.DirectionalPayloadHandler.handle(DirectionalPayloadHandler.java:17) ~[neoforge-21.0.46-beta.jar%23191!/:?]
	at TRANSFORMER/neoforge@21.0.46-beta/net.neoforged.neoforge.network.handling.MainThreadPayloadHandler.lambda$handle$0(MainThreadPayloadHandler.java:16) ~[neoforge-21.0.46-beta.jar%23191!/:?]
	at TRANSFORMER/minecraft@1.21/net.minecraft.util.thread.BlockableEventLoop.lambda$submitAsync$0(BlockableEventLoop.java:60) ~[neoforge-21.0.46-beta.jar%23190!/:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	... 22 more
```