### PR TITLE
Reimplement hook for CustomizeGuiOverlayEvent.Chat

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -127,7 +127,7 @@
 +            
 +            // The event is given the absolute Y position; account for chat component's own offsetting here
 +            p_316307_.pose().pushPose();
-+            p_316307_.pose().translate(event.getPosX(), event.getPosY() - (p_316307_.guiHeight() + chatBottomMargin) / this.chat.getScale(), 0.0F);
++            p_316307_.pose().translate(event.getPosX(), (event.getPosY() - p_316307_.guiHeight() + chatBottomMargin) / this.chat.getScale(), 0.0F);
              int i = Mth.floor(this.minecraft.mouseHandler.xpos() * (double)window.getGuiScaledWidth() / (double)window.getScreenWidth());
              int j = Mth.floor(this.minecraft.mouseHandler.ypos() * (double)window.getGuiScaledHeight() / (double)window.getScreenHeight());
              this.chat.render(p_316307_, this.tickCount, i, j, false);

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -115,6 +115,23 @@
                  int j;
                  if (this.animateOverlayMessageColor) {
                      j = Mth.hsvToArgb(f / 50.0F, 0.7F, 0.6F, i);
+@@ -323,9 +_,16 @@
+     private void renderChat(GuiGraphics p_316307_, DeltaTracker p_348631_) {
+         if (!this.chat.isChatFocused()) {
+             Window window = this.minecraft.getWindow();
++            // Neo: Allow customizing position of chat component
++            var chatBottomMargin = 40; // See ChatComponent#BOTTOM_MARGIN (used in translate calls in ChatComponent#render)
++            var event = new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.Chat(window, p_316307_, p_348631_, 0, p_316307_.guiHeight() - chatBottomMargin);
++            // The event is given the absolute Y position; account for chat component's own offsetting here
++            p_316307_.pose().pushPose();
++            p_316307_.pose().translate(event.getPosX(), event.getPosY() - (p_316307_.guiHeight() + chatBottomMargin) / this.chat.getScale(), 0.0F);
+             int i = Mth.floor(this.minecraft.mouseHandler.xpos() * (double)window.getGuiScaledWidth() / (double)window.getScreenWidth());
+             int j = Mth.floor(this.minecraft.mouseHandler.ypos() * (double)window.getGuiScaledHeight() / (double)window.getScreenHeight());
+             this.chat.render(p_316307_, this.tickCount, i, j, false);
++            p_316307_.pose().popPose();
+         }
+     }
+ 
 @@ -441,6 +_,8 @@
              List<Runnable> list = Lists.newArrayListWithExpectedSize(collection.size());
  

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -124,7 +124,7 @@
 +            var event = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(
 +                    new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.Chat(window, p_316307_, p_348631_, 0, p_316307_.guiHeight() - chatBottomMargin)
 +            );
-+            
++
 +            // The event is given the absolute Y position; account for chat component's own offsetting here
 +            p_316307_.pose().pushPose();
 +            p_316307_.pose().translate(event.getPosX(), (event.getPosY() - p_316307_.guiHeight() + chatBottomMargin) / this.chat.getScale(), 0.0F);

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -115,13 +115,16 @@
                  int j;
                  if (this.animateOverlayMessageColor) {
                      j = Mth.hsvToArgb(f / 50.0F, 0.7F, 0.6F, i);
-@@ -323,9 +_,16 @@
+@@ -323,9 +_,19 @@
      private void renderChat(GuiGraphics p_316307_, DeltaTracker p_348631_) {
          if (!this.chat.isChatFocused()) {
              Window window = this.minecraft.getWindow();
 +            // Neo: Allow customizing position of chat component
 +            var chatBottomMargin = 40; // See ChatComponent#BOTTOM_MARGIN (used in translate calls in ChatComponent#render)
-+            var event = new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.Chat(window, p_316307_, p_348631_, 0, p_316307_.guiHeight() - chatBottomMargin);
++            var event = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(
++                    new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.Chat(window, p_316307_, p_348631_, 0, p_316307_.guiHeight() - chatBottomMargin)
++            );
++            
 +            // The event is given the absolute Y position; account for chat component's own offsetting here
 +            p_316307_.pose().pushPose();
 +            p_316307_.pose().translate(event.getPosX(), event.getPosY() - (p_316307_.guiHeight() + chatBottomMargin) / this.chat.getScale(), 0.0F);


### PR DESCRIPTION
This PR fixes #1208 by re-implementing the hook for `CustomizeGuiOverlayEvent.Chat` in `Gui#renderChat`, as the previous hook which existed in `ExtendedGui` was removed alongside that class in 1.20.5.