### PR TITLE
Fix Realms notification positioning

### DIFF
--- a/patches/com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen.java.patch
+++ b/patches/com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen.java.patch
@@ -1,0 +1,11 @@
+--- a/com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen.java
++++ b/com/mojang/realmsclient/gui/screens/RealmsNotificationsScreen.java
+@@ -127,7 +_,7 @@
+     private void drawIcons(GuiGraphics p_282966_) {
+         int i = this.numberOfPendingInvites;
+         int j = 24;
+-        int k = this.height / 4 + 48;
++        int k = this.height / 4 + (inTitleScreen() ? 32 : 48);
+         int l = this.width / 2 + 100;
+         int i1 = k + 48 + 2;
+         int j1 = l - 3;


### PR DESCRIPTION
Fixes #1222 introduced by #997

The notification screen doesn't *seem* to be used anywhere else, but I included the `inTitleScreen()` check anyways to be sure. That check must be there for a reason, its must?