### PR TITLE
Add armadillo support for item ability `BRUSH_BRUSH`

### DIFF
--- a/patches/net/minecraft/world/entity/animal/armadillo/Armadillo.java.patch
+++ b/patches/net/minecraft/world/entity/animal/armadillo/Armadillo.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/armadillo/Armadillo.java
++++ b/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+@@ -300,7 +_,7 @@
+     @Override
+     public InteractionResult mobInteract(Player p_316559_, InteractionHand p_316119_) {
+         ItemStack itemstack = p_316559_.getItemInHand(p_316119_);
+-        if (itemstack.is(Items.BRUSH) && this.brushOffScute()) {
++        if (itemstack.canPerformAction(net.neoforged.neoforge.common.ItemAbilities.BRUSH_BRUSH) && this.brushOffScute()) {
+             itemstack.hurtAndBreak(16, p_316559_, getSlotForHand(p_316119_));
+             return InteractionResult.sidedSuccess(this.level().isClientSide);
+         } else {


### PR DESCRIPTION
As discussed in Discord, using the existing generic `BRUSH_BRUSH` is enough for brushing off armadillo scute, no need for a separate item ability.