### PR TITLE
[1.21] Add GatherEffectScreenTooltipsEvent

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/EffectRenderingInventoryScreen.java.patch
@@ -19,6 +19,15 @@
              this.renderBackgrounds(p_281945_, i, k, iterable, flag);
              this.renderIcons(p_281945_, i, k, iterable, flag);
              if (flag) {
+@@ -74,6 +_,8 @@
+                         this.getEffectName(mobeffectinstance),
+                         MobEffectUtil.formatDuration(mobeffectinstance, 1.0F, this.minecraft.level.tickRateManager().tickrate())
+                     );
++                    // Neo: Allow mods to adjust the tooltip shown when hovering a mob effect.
++                    list = net.neoforged.neoforge.client.ClientHooks.getEffectTooltip(this, mobeffectinstance, list);
+                     p_281945_.renderTooltip(this.font, list, Optional.empty(), p_282601_, p_282335_);
+                 }
+             }
 @@ -99,6 +_,11 @@
          int i = this.topPos;
  

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -49,6 +49,7 @@ import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipPositioner;
 import net.minecraft.client.model.HumanoidModel;
@@ -143,6 +144,7 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
 import net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.GatherEffectScreenTooltipsEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.MovementInputUpdateEvent;
@@ -1054,5 +1056,21 @@ public class ClientHooks {
             return level.registryAccess().lookup(key).orElse(null);
         }
         return null;
+    }
+
+    /**
+     * Fires the {@link GatherEffectScreenTooltipsEvent} and returns the resulting tooltip lines.
+     * <p>
+     * Called from {@link EffectRenderingInventoryScreen#renderEffects} just before {@link GuiGraphics#renderTooltip(Font, List, Optional, int, int)} is called.
+     * 
+     * @param screen     The screen rendering the tooltip.
+     * @param effectInst The effect instance whose tooltip is being rendered.
+     * @param tooltip    An immutable list containing the existing tooltip lines, which consist of the name and the duration.
+     * @return The new tooltip lines, modified by the event.
+     */
+    public static List<Component> getEffectTooltip(EffectRenderingInventoryScreen<?> screen, MobEffectInstance effectInst, List<Component> tooltip) {
+        var event = new GatherEffectScreenTooltipsEvent(screen, effectInst, tooltip);
+        NeoForge.EVENT_BUS.post(event);
+        return event.getTooltip();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/event/GatherEffectScreenTooltipsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/GatherEffectScreenTooltipsEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.client.gui.screens.inventory.EffectRenderingInventoryScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.Event;
+
+/**
+ * This event is called when an {@link EffectRenderingInventoryScreen} draws the tooltip lines for a hovered {@link MobEffectInstance}.
+ * It can be used to modify the tooltip.
+ * <p>
+ * This event is only fired on the {@linkplain Dist#CLIENT physical client}.
+ */
+public class GatherEffectScreenTooltipsEvent extends Event {
+    protected final EffectRenderingInventoryScreen<?> screen;
+    protected final MobEffectInstance effectInst;
+    protected final List<Component> tooltip;
+
+    public GatherEffectScreenTooltipsEvent(EffectRenderingInventoryScreen<?> screen, MobEffectInstance effectInst, List<Component> tooltip) {
+        this.screen = screen;
+        this.effectInst = effectInst;
+        this.tooltip = new ArrayList<>(tooltip);
+    }
+
+    /**
+     * @return The screen which will be rendering the tooltip lines.
+     */
+    public EffectRenderingInventoryScreen<?> getScreen() {
+        return this.screen;
+    }
+
+    /**
+     * @return The effect whose tooltip is being drawn.
+     */
+    public MobEffectInstance getEffectInstance() {
+        return this.effectInst;
+    }
+
+    /**
+     * @return A mutable list of tooltip lines.
+     */
+    public List<Component> getTooltip() {
+        return this.tooltip;
+    }
+}


### PR DESCRIPTION
This PR adds the `GatherEffectScreenTooltipsEvent`, which allows modifying the rendered tooltip shown when hovering a `MobEffectInstance` in an `EffectRenderingInventoryScreen` (i.e. the player's inventory).

This is useful for adding additional text, such as descriptions, to the tooltip:   
![](https://i.imgur.com/Yk5WxtU.png)