### PR TITLE
Avoid Optional allocation in patched-in Holder equals functions

### DIFF
--- a/patches/net/minecraft/core/Holder.java.patch
+++ b/patches/net/minecraft/core/Holder.java.patch
@@ -24,12 +24,19 @@
          void bindTags(Collection<TagKey<T>> p_205770_) {
              this.tags = Set.copyOf(p_205770_);
          }
-@@ -233,6 +_,28 @@
+@@ -233,6 +_,35 @@
          public String toString() {
              return "Reference{" + this.key + "=" + this.value + "}";
          }
 +
 +        // Neo Start
++
++        // Neo: Add key getter that doesn't allocate
++        @Override
++        @org.jetbrains.annotations.Nullable
++        public ResourceKey<T> getKey() {
++            return this.key;
++        }
 +
 +        // Neo: Add DeferredHolder-compatible hashCode() and equals() overrides
 +        @Override
@@ -40,7 +47,7 @@
 +        @Override
 +        public boolean equals(Object obj) {
 +            if (this == obj) return true;
-+            return obj instanceof Holder<?> h && h.kind() == Kind.REFERENCE && h.unwrapKey().orElseThrow() == this.key();
++            return obj instanceof Holder<?> h && h.kind() == Kind.REFERENCE && h.getKey() == this.key();
 +        }
 +
 +        @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.common.extensions;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import net.neoforged.neoforge.registries.datamaps.IWithData;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,5 +33,14 @@ public interface IHolderExtension<T> extends IWithData<T> {
     @Nullable
     default HolderLookup.RegistryLookup<T> unwrapLookup() {
         return null;
+    }
+
+    /**
+     * Get the resource key held by this Holder, or null if none is present. This method will be overriden
+     * by Holder implementations to avoid allocation associated with {@link Holder#unwrapKey()}
+     */
+    @Nullable
+    default ResourceKey<T> getKey() {
+        return ((Holder<T>)this).unwrapKey().orElse(null);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderExtension.java
@@ -41,6 +41,6 @@ public interface IHolderExtension<T> extends IWithData<T> {
      */
     @Nullable
     default ResourceKey<T> getKey() {
-        return ((Holder<T>)this).unwrapKey().orElse(null);
+        return ((Holder<T>) this).unwrapKey().orElse(null);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredHolder.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredHolder.java
@@ -166,6 +166,7 @@ public class DeferredHolder<R, T extends R> implements Holder<R>, Supplier<T> {
     /**
      * @return The ResourceKey of the object pointed to by this DeferredHolder.
      */
+    @Override
     public ResourceKey<R> getKey() {
         return this.key;
     }
@@ -173,7 +174,7 @@ public class DeferredHolder<R, T extends R> implements Holder<R>, Supplier<T> {
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
-        return obj instanceof Holder<?> h && h.kind() == Kind.REFERENCE && h.unwrapKey().orElseThrow() == this.key;
+        return obj instanceof Holder<?> h && h.kind() == Kind.REFERENCE && h.getKey() == this.key;
     }
 
     @Override


### PR DESCRIPTION
Motivation: `Holder.Reference#unwrapKey()` performs an `Optional` allocation on every call, and is used by our patched-in implementation of `equals`. This causes `equals` calls to be rather expensive allocation-wise, which is not good since  `Holder.Reference` objects are likely to be used as keys in a potentially hot map (For example, vanilla does this in `AttributeSupplier`.)

We solve this problem by introducing a new getter that uses nullability and thus has no allocation cost, and using it in `equals`.

A screenshot showing an example of the problem in YourKit is attached below.

![2024-07-05_21-33](https://github.com/neoforged/NeoForge/assets/42941056/5ea54a05-690c-4883-8f02-279737080556)
