### PR TITLE
[1.21] Update documentation for the Creative Flight attribute

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/BooleanAttribute.java
+++ b/src/main/java/net/neoforged/neoforge/common/BooleanAttribute.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common;
+
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+
+/**
+ * A boolean attribute only has two states, on or off, represented by a value of 0 (false) or 1 (true).
+ * <p>
+ * For boolean attributes, only use the following modifier values:
+ * <ul>
+ * <li>A value of 1 with {@link AttributeModifier.Operation#ADD_VALUE} to enable the effect.</li>
+ * <li>A value of -1 with {@link AttributeModifier.Operation#ADD_MULTIPLIED_TOTAL} to forcibly disable the effect.</li>
+ * </ul>
+ * This behavior allows for multiple enabling modifiers to coexist, not removing the effect unless all enabling modifiers are removed.
+ * <p>
+ * Additionally, it permits forcibly disabling the effect through multiply total.
+ */
+public class BooleanAttribute extends Attribute {
+    protected BooleanAttribute(String descriptionId, boolean defaultValue) {
+        super(descriptionId, defaultValue ? 1 : 0);
+    }
+
+    @Override
+    public double sanitizeValue(double value) {
+        if (Double.isNaN(value)) {
+            return 0;
+        }
+        return value > 0 ? 1 : 0;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/BooleanAttribute.java
+++ b/src/main/java/net/neoforged/neoforge/common/BooleanAttribute.java
@@ -19,6 +19,8 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
  * This behavior allows for multiple enabling modifiers to coexist, not removing the effect unless all enabling modifiers are removed.
  * <p>
  * Additionally, it permits forcibly disabling the effect through multiply total.
+ * 
+ * @apiNote Use of other operations and/or values will trigger undefined behavior, where no guarantees can be made if the attribute will be enabled or not.
  */
 public class BooleanAttribute extends Attribute {
     protected BooleanAttribute(String descriptionId, boolean defaultValue) {

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -200,23 +200,15 @@ public class NeoForgeMod {
     public static final Holder<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("neoforge.name_tag_distance", 64.0D, 0.0D, 64.0).setSyncable(true));
 
     /**
-     * Grants the player the ability to use creative flight when not in creative mode.
-     * Anything above zero allows flight.
+     * This attribute controls if the player may use creative flight when not in creative mode.
      * <p>
-     * For this attribute, you should only use the following modifier values:
-     * <ul>
-     * <li>A value of 1 with {@link net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation#ADDITION} to enable the effect.</li>
-     * <li>A value of -1 with {@link net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation#MULTIPLY_TOTAL} to forcibly disable the effect.</li>
-     * </ul>
-     * This behavior allows for multiple enables to coexist, not removing the effect unless all enabling modifiers are removed.
+     * This is a {@link BooleanAttribute}, and should only be modified using the standards established by that class.
      * <p>
-     * Additionally, it permits forcibly disabling the attribute through multiply total.
-     * <p>
-     * To determine if a player has flight access via game mode or attribute, use {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#mayFly}
+     * To determine if a player may fly (either via game mode or attribute), use {@link IPlayerExtension#mayFly}
      * <p>
      * Game mode flight cannot be disabled via this attribute.
      */
-    public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new RangedAttribute("neoforge.creative_flight", 0D, 0D, Double.MAX_VALUE).setSyncable(true));
+    public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new BooleanAttribute("neoforge.creative_flight", false).setSyncable(true));
 
     /**
      * Stock loot modifier type that adds loot from a subtable to the final loot.

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -122,6 +122,7 @@ import net.neoforged.neoforge.common.data.internal.NeoForgeRegistryOrderReportPr
 import net.neoforged.neoforge.common.data.internal.NeoForgeSpriteSourceProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeStructureTagsProvider;
 import net.neoforged.neoforge.common.data.internal.VanillaSoundDefinitionsProvider;
+import net.neoforged.neoforge.common.extensions.IPlayerExtension;
 import net.neoforged.neoforge.common.loot.AddTableLootModifier;
 import net.neoforged.neoforge.common.loot.CanItemPerformAbility;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;


### PR DESCRIPTION
The documentation on the creative flight attribute has gone stale after the naming updates to the constants in `AttributeModifier$Operation`.  Rather than just update the names, I have moved some things around to make the code more understandable, and also permit introduction of similar attributes by mods without needing to clone the entire javadoc.

To that end, I have added the new `BooleanAttribute` class, which retains the relevant information about having an attribute that can only be enabled or disabled, and the standards for modifying attributes of this type.  In addition, the javadoc for `NeoForgeMod#CREATIVE_FLIGHT` has been updated to account for this.