### PR TITLE
[1.21] Fix firing point for ItemStackedOnOtherEvent

### DIFF
--- a/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -1,10 +1,14 @@
 --- a/net/minecraft/world/inventory/AbstractContainerMenu.java
 +++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
-@@ -401,6 +_,7 @@
-                 ItemStack itemstack10 = this.getCarried();
-                 p_150434_.updateTutorialInventoryAction(itemstack10, slot7.getItem(), clickaction);
-                 if (!this.tryItemClickBehaviourOverride(p_150434_, clickaction, slot7, itemstack9, itemstack10)) {
-+                if (!net.neoforged.neoforge.common.CommonHooks.onItemStackedOn(itemstack9, itemstack10, slot7, clickaction, p_150434_, createCarriedSlotAccess()))
-                     if (itemstack9.isEmpty()) {
-                         if (!itemstack10.isEmpty()) {
-                             int i3 = clickaction == ClickAction.PRIMARY ? itemstack10.getCount() : 1;
+@@ -511,6 +_,11 @@
+     }
+ 
+     private boolean tryItemClickBehaviourOverride(Player p_249615_, ClickAction p_250300_, Slot p_249384_, ItemStack p_251073_, ItemStack p_252026_) {
++        // Neo: Fire the ItemStackedOnOtherEvent, and return true if it was cancelled (meaning the event was handled). Returning true will trigger the container to stop processing further logic.
++        if (net.neoforged.neoforge.common.CommonHooks.onItemStackedOn(p_251073_, p_252026_, p_249384_, p_250300_, p_249615_, createCarriedSlotAccess())) {
++            return true;
++        }
++
+         FeatureFlagSet featureflagset = p_249615_.level().enabledFeatures();
+         return p_252026_.isItemEnabled(featureflagset) && p_252026_.overrideStackedOnOther(p_249384_, p_250300_, p_249615_)
+             ? true

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -94,6 +94,7 @@ import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.ContainerLevelAccess;
@@ -126,6 +127,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.GameMasterBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -224,6 +226,20 @@ public class CommonHooks {
         return false;
     }
 
+    /**
+     * Fires the {@link ItemStackedOnOtherEvent}, allowing items to handle custom behavior relating to being stacked together (i.e. how the bundle operates).
+     * <p>
+     * Called from {@link AbstractContainerMenu#doClick} in the utility method {@link AbstractContainerMenu#tryItemClickBehaviourOverride} before either
+     * {@link ItemStack#overrideStackedOnOther} or {@link ItemStack#overrideOtherStackedOnMe} is called.
+     * 
+     * @param carriedItem       The item currently held by the player, being clicked <i>into</i> the slot
+     * @param stackedOnItem     The item currently present in the clicked slot
+     * @param slot              The {@link Slot} being clicked
+     * @param action            The click action being performed
+     * @param player            The player who clicked the slot
+     * @param carriedSlotAccess A slot access permitting changing the carried item.
+     * @return True if the event was cancelled, indicating that a mod has handled the click; false otherwise
+     */
     public static boolean onItemStackedOn(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess) {
         return NeoForge.EVENT_BUS.post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess)).isCanceled();
     }


### PR DESCRIPTION
This PR fixes the firing point for `ItemStackedOnOtherEvent`, which stipulates in its javadocs that it fires *before* both `Item#overrideOtherStackedOnMe` and `Item#overrideStackedOnOther`, but currently it fires after both.  

This PR updates the firing point to be before the vanilla hooks, adds a comment to the patch, and adds a javadoc to the `CommonHooks#onItemStackedOn` method responsible for firing the event.