### PR TITLE
Remove deprecation on `Block#BLOCK_STATE_REGISTRY`

### DIFF
--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/Block.java
 +++ b/net/minecraft/world/level/block/Block.java
-@@ -61,11 +_,12 @@
+@@ -61,11 +_,11 @@
  import net.minecraft.world.phys.shapes.VoxelShape;
  import org.slf4j.Logger;
  
@@ -10,7 +10,6 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      private final Holder.Reference<Block> builtInRegistryHolder = BuiltInRegistries.BLOCK.createIntrusiveHolder(this);
 -    public static final IdMapper<BlockState> BLOCK_STATE_REGISTRY = new IdMapper<>();
-+    @Deprecated //Forge: Do not use, use GameRegistry
 +    public static final IdMapper<BlockState> BLOCK_STATE_REGISTRY = net.neoforged.neoforge.registries.GameData.getBlockStateIDMap();
      private static final LoadingCache<VoxelShape, Boolean> SHAPE_FULL_BLOCK_CACHE = CacheBuilder.newBuilder()
          .maximumSize(512L)


### PR DESCRIPTION
Currently `Block#BLOCK_STATE_REGISTRY` is deprecated with a comment, but the mentioned class no longer exists and there doesn't seem to be a replacement.
Furthermore there is no other way to access that map, except for the static method in `GameData`, but that class is marked as internal, so it's _arguably_ even worse to use.
So I just removed the deprecation. If there is a replacement people should use, please tell me and I can just edit the comment instead.