### PR TITLE
AT pattern fields in ShapedRecipe class

### DIFF
--- a/patches/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
@@ -1,19 +1,6 @@
 --- a/net/minecraft/world/item/crafting/ShapedRecipe.java
 +++ b/net/minecraft/world/item/crafting/ShapedRecipe.java
-@@ -81,10 +_,20 @@
-         return this.pattern.height();
-     }
- 
-+    // Neo: Expose a getter for pattern field.
-+    public ShapedRecipePattern getPattern() {
-+        return this.pattern;
-+    }
-+
-+    // Neo: Expose a getter for result field without needing a provider param.
-+    public ItemStack getResultItem() {
-+        return this.result;
-+    }
-+
+@@ -84,7 +_,7 @@
      @Override
      public boolean isIncomplete() {
          NonNullList<Ingredient> nonnulllist = this.getIngredients();

--- a/patches/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/ShapedRecipe.java.patch
@@ -1,6 +1,19 @@
 --- a/net/minecraft/world/item/crafting/ShapedRecipe.java
 +++ b/net/minecraft/world/item/crafting/ShapedRecipe.java
-@@ -84,7 +_,7 @@
+@@ -81,10 +_,20 @@
+         return this.pattern.height();
+     }
+ 
++    // Neo: Expose a getter for pattern field.
++    public ShapedRecipePattern getPattern() {
++        return this.pattern;
++    }
++
++    // Neo: Expose a getter for result field without needing a provider param.
++    public ItemStack getResultItem() {
++        return this.result;
++    }
++
      @Override
      public boolean isIncomplete() {
          NonNullList<Ingredient> nonnulllist = this.getIngredients();

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -412,3 +412,5 @@ public net.minecraft.world.item.BucketItem content
 public net.minecraft.world.item.ItemStack addToTooltip(Lnet/minecraft/core/component/DataComponentType;Lnet/minecraft/world/item/Item$TooltipContext;Ljava/util/function/Consumer;Lnet/minecraft/world/item/TooltipFlag;)V
 public net.minecraft.world.item.SwordItem createToolProperties()Lnet/minecraft/world/item/component/Tool;
 public net.minecraft.world.level.block.CropBlock hasSufficientLight(Lnet/minecraft/world/level/LevelReader;Lnet/minecraft/core/BlockPos;)Z # hasSufficientLight
+public net.minecraft.world.item.crafting.ShapedRecipe pattern # pattern
+public net.minecraft.world.item.crafting.ShapedRecipe result # result

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -413,4 +413,3 @@ public net.minecraft.world.item.ItemStack addToTooltip(Lnet/minecraft/core/compo
 public net.minecraft.world.item.SwordItem createToolProperties()Lnet/minecraft/world/item/component/Tool;
 public net.minecraft.world.level.block.CropBlock hasSufficientLight(Lnet/minecraft/world/level/LevelReader;Lnet/minecraft/core/BlockPos;)Z # hasSufficientLight
 public net.minecraft.world.item.crafting.ShapedRecipe pattern # pattern
-public net.minecraft.world.item.crafting.ShapedRecipe result # result


### PR DESCRIPTION
Adds ATs for pattern ~~and result fields~~ for easier serialization by modders. ~~The result is because the original one requires a Provider param and someone's worry was passing null might crash other mods or mojang starts using Provider in future in a non-null safe way.~~

The fields are still final so no setting is added. Just getting