### PR TITLE
Make `Ingredient#getItems` and `FluidIngredient#getStacks` distinct

### DIFF
--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -59,7 +59,7 @@
  
      private Ingredient(Stream<? extends Ingredient.Value> p_43907_) {
          this.values = p_43907_.toArray(Ingredient.Value[]::new);
-@@ -47,9 +_,20 @@
+@@ -47,9 +_,23 @@
          this.values = p_301044_;
      }
  
@@ -70,13 +70,17 @@
 +
      public ItemStack[] getItems() {
          if (this.itemStacks == null) {
+-            this.itemStacks = Arrays.stream(this.values).flatMap(p_43916_ -> p_43916_.getItems().stream()).distinct().toArray(ItemStack[]::new);
++            // Neo: vanilla used Stream.distinct() here which has basically no effect as ItemStack does not override equals().
++            // Using ItemStackLinkedSet here instead for a REAL distinct result.
++            // ItemStackLinkedSet#TYPE_AND_TAG strategy does not check for count, might worth re-evaluation once we support ingredient with count
++            final java.util.Set<ItemStack> itemStacks = net.minecraft.world.item.ItemStackLinkedSet.createTypeAndComponentsSet();
 +            if (this.customIngredient != null) {
-+                this.itemStacks = this.customIngredient.getItems()
-+                        .distinct()//Mimic vanilla that calls distinct on the stacks
-+                        .toArray(ItemStack[]::new);
++                this.customIngredient.getItems().forEach(itemStacks::add);
 +            } else {
-             this.itemStacks = Arrays.stream(this.values).flatMap(p_43916_ -> p_43916_.getItems().stream()).distinct().toArray(ItemStack[]::new);
++                Arrays.stream(this.values).flatMap(p_43916_ -> p_43916_.getItems().stream()).forEach(itemStacks::add);
 +            }
++            this.itemStacks = itemStacks.toArray(ItemStack[]::new);
          }
  
          return this.itemStacks;

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -59,7 +59,7 @@
  
      private Ingredient(Stream<? extends Ingredient.Value> p_43907_) {
          this.values = p_43907_.toArray(Ingredient.Value[]::new);
-@@ -47,9 +_,23 @@
+@@ -47,9 +_,19 @@
          this.values = p_301044_;
      }
  
@@ -71,16 +71,12 @@
      public ItemStack[] getItems() {
          if (this.itemStacks == null) {
 -            this.itemStacks = Arrays.stream(this.values).flatMap(p_43916_ -> p_43916_.getItems().stream()).distinct().toArray(ItemStack[]::new);
-+            // Neo: vanilla used Stream.distinct() here which has basically no effect as ItemStack does not override equals().
-+            // Using ItemStackLinkedSet here instead for a REAL distinct result.
-+            // ItemStackLinkedSet#TYPE_AND_TAG strategy does not check for count, might worth re-evaluation once we support ingredient with count
-+            final java.util.Set<ItemStack> itemStacks = net.minecraft.world.item.ItemStackLinkedSet.createTypeAndComponentsSet();
-+            if (this.customIngredient != null) {
-+                this.customIngredient.getItems().forEach(itemStacks::add);
-+            } else {
-+                Arrays.stream(this.values).flatMap(p_43916_ -> p_43916_.getItems().stream()).forEach(itemStacks::add);
-+            }
-+            this.itemStacks = itemStacks.toArray(ItemStack[]::new);
++            // Neo: vanilla used Stream.distinct() here which has basically no effect as ItemStack does not override hashCode() and equals().
++            // Using ItemStackLinkedSet::createTypeAndComponentsSet instead for a real distinct result.
++            final Stream<ItemStack> stream = this.customIngredient == null
++                    ? Arrays.stream(this.values).flatMap(value -> value.getItems().stream())
++                    : this.customIngredient.getItems();
++            this.itemStacks = stream.collect(java.util.stream.Collectors.toCollection(net.minecraft.world.item.ItemStackLinkedSet::createTypeAndComponentsSet)).toArray(ItemStack[]::new);
          }
  
          return this.itemStacks;

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStackLinkedSet.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStackLinkedSet.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.fluids;
+
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
+import java.util.Set;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Utility class for creating {@linkplain ObjectLinkedOpenCustomHashSet linked set} for {@link FluidStack}
+ * with specific {@linkplain Hash.Strategy hash strategy} as {@link FluidStack} does not override {@link #hashCode()} and {@link #equals(Object)}.
+ * 
+ * @see net.minecraft.world.item.ItemStackLinkedSet
+ */
+public class FluidStackLinkedSet {
+    public static final Hash.Strategy<? super FluidStack> TYPE_AND_COMPONENTS = new Hash.Strategy<>() {
+        public int hashCode(@Nullable FluidStack stack) {
+            return FluidStack.hashFluidAndComponents(stack);
+        }
+
+        public boolean equals(@Nullable FluidStack first, @Nullable FluidStack second) {
+            return first == second
+                    || first != null
+                            && second != null
+                            && first.isEmpty() == second.isEmpty()
+                            && FluidStack.isSameFluidSameComponents(first, second);
+        }
+    };
+
+    public static Set<FluidStack> createTypeAndComponentsSet() {
+        return new ObjectLinkedOpenCustomHashSet<>(TYPE_AND_COMPONENTS);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredient.java
@@ -12,6 +12,7 @@ import com.mojang.serialization.MapCodec;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.minecraft.core.Holder;
 import net.minecraft.core.NonNullList;
@@ -24,6 +25,7 @@ import net.minecraft.world.level.material.Fluid;
 import net.neoforged.neoforge.common.crafting.ICustomIngredient;
 import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidStackLinkedSet;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
@@ -127,7 +129,9 @@ public abstract class FluidIngredient implements Predicate<FluidStack> {
      */
     public final FluidStack[] getStacks() {
         if (stacks == null) {
-            stacks = generateStacks().toArray(FluidStack[]::new);
+            stacks = generateStacks()
+                    .collect(Collectors.toCollection(FluidStackLinkedSet::createTypeAndComponentsSet))
+                    .toArray(FluidStack[]::new);
         }
 
         return stacks;


### PR DESCRIPTION
Closes #1236.
Replaced `Stream.distinct()` with `ItemStackLinkedSet` in `Ingredient.getItems()` for a **real** distinct result.