### PR TITLE
Load client and common configs earlier (now immediately after registries)

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
@@ -58,7 +58,7 @@ public class ClientModLoader extends CommonModLoader {
         LogicalSidedProvider.setClient(() -> minecraft);
         LanguageHook.loadBuiltinLanguages();
         try {
-            begin(ImmediateWindowHandler::renderTick);
+            begin(ImmediateWindowHandler::renderTick, false);
         } catch (ModLoadingException e) {
             error = e;
         }

--- a/src/main/java/net/neoforged/neoforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/data/loading/DatagenModLoader.java
@@ -40,7 +40,7 @@ public class DatagenModLoader extends CommonModLoader {
         LOGGER.info("Initializing Data Gatherer for mods {}", mods);
         runningDataGen = true;
         Bootstrap.bootStrap();
-        begin(() -> {});
+        begin(() -> {}, true);
         CompletableFuture<HolderLookup.Provider> lookupProvider = CompletableFuture.supplyAsync(VanillaRegistries::createLookup, Util.backgroundExecutor());
         dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, lookupProvider, serverGenerators,
                 clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);

--- a/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
@@ -53,10 +53,6 @@ public abstract class CommonModLoader {
             GameData.freezeData();
             registriesLoaded = true;
         });
-    }
-
-    protected static void load(Executor syncExecutor, Executor parallelExecutor) {
-        Runnable periodicTask = () -> {}; // server: no progress screen; client: minecraft has already opened its loading screen and ticks it for us
 
         ModLoader.runInitTask("Config loading", syncExecutor, periodicTask, () -> {
             if (FMLEnvironment.dist == Dist.CLIENT) {
@@ -64,6 +60,10 @@ public abstract class CommonModLoader {
             }
             ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
         });
+    }
+
+    protected static void load(Executor syncExecutor, Executor parallelExecutor) {
+        Runnable periodicTask = () -> {}; // server: no progress screen; client: minecraft has already opened its loading screen and ticks it for us
 
         ModLoader.dispatchParallelEvent("Common setup", syncExecutor, parallelExecutor, periodicTask, FMLCommonSetupEvent::new);
         ModLoader.dispatchParallelEvent("Sided setup", syncExecutor, parallelExecutor, periodicTask,

--- a/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
@@ -41,7 +41,7 @@ public abstract class CommonModLoader {
         return registriesLoaded;
     }
 
-    protected static void begin(Runnable periodicTask) {
+    protected static void begin(Runnable periodicTask, boolean datagen) {
         var syncExecutor = ModWorkManager.syncExecutor();
 
         ModLoader.gatherAndInitializeMods(syncExecutor, ModWorkManager.parallelExecutor(), periodicTask);
@@ -54,12 +54,14 @@ public abstract class CommonModLoader {
             registriesLoaded = true;
         });
 
-        ModLoader.runInitTask("Config loading", syncExecutor, periodicTask, () -> {
-            if (FMLEnvironment.dist == Dist.CLIENT) {
-                ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get());
-            }
-            ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
-        });
+        if (!datagen) {
+            ModLoader.runInitTask("Config loading", syncExecutor, periodicTask, () -> {
+                if (FMLEnvironment.dist == Dist.CLIENT) {
+                    ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get());
+                }
+                ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
+            });
+        }
     }
 
     protected static void load(Executor syncExecutor, Executor parallelExecutor) {

--- a/src/main/java/net/neoforged/neoforge/server/loading/ServerModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/server/loading/ServerModLoader.java
@@ -29,7 +29,7 @@ public class ServerModLoader extends CommonModLoader {
         });
         LanguageHook.loadBuiltinLanguages();
         try {
-            begin(() -> {});
+            begin(() -> {}, false);
             load(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor());
             finish(ModWorkManager.syncExecutor(), ModWorkManager.parallelExecutor());
         } catch (ModLoadingException error) {


### PR DESCRIPTION
Notably, this makes config values accessible to a lot of the client-side registration events.