### PR TITLE
[1.21] Make Boat.Type enum extensible

### DIFF
--- a/patches/net/minecraft/client/model/geom/LayerDefinitions.java.patch
+++ b/patches/net/minecraft/client/model/geom/LayerDefinitions.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/model/geom/LayerDefinitions.java
 +++ b/net/minecraft/client/model/geom/LayerDefinitions.java
+@@ -316,7 +_,7 @@
+         LayerDefinition layerdefinition22 = ChestRaftModel.createBodyModel();
+ 
+         for (Boat.Type boat$type : Boat.Type.values()) {
+-            if (boat$type == Boat.Type.BAMBOO) {
++            if (boat$type.isRaft()) {
+                 builder.put(ModelLayers.createBoatModelName(boat$type), layerdefinition21);
+                 builder.put(ModelLayers.createChestBoatModelName(boat$type), layerdefinition22);
+             } else {
 @@ -329,6 +_,7 @@
          WoodType.values().forEach(p_171114_ -> builder.put(ModelLayers.createSignModelName(p_171114_), layerdefinition23));
          LayerDefinition layerdefinition24 = HangingSignRenderer.createHangingSignLayer();

--- a/patches/net/minecraft/client/model/geom/ModelLayers.java.patch
+++ b/patches/net/minecraft/client/model/geom/ModelLayers.java.patch
@@ -1,6 +1,30 @@
 --- a/net/minecraft/client/model/geom/ModelLayers.java
 +++ b/net/minecraft/client/model/geom/ModelLayers.java
-@@ -229,11 +_,13 @@
+@@ -213,27 +_,33 @@
+     }
+ 
+     public static ModelLayerLocation createRaftModelName(Boat.Type p_252002_) {
+-        return createLocation("raft/" + p_252002_.getName(), "main");
++        ResourceLocation location = ResourceLocation.parse(p_252002_.getName());
++        return new ModelLayerLocation(location.withPrefix("raft/"), "main");
+     }
+ 
+     public static ModelLayerLocation createChestRaftModelName(Boat.Type p_248520_) {
+-        return createLocation("chest_raft/" + p_248520_.getName(), "main");
++        ResourceLocation location = ResourceLocation.parse(p_248520_.getName());
++        return new ModelLayerLocation(location.withPrefix("chest_raft/"), "main");
+     }
+ 
+     public static ModelLayerLocation createBoatModelName(Boat.Type p_171290_) {
+-        return createLocation("boat/" + p_171290_.getName(), "main");
++        ResourceLocation location = ResourceLocation.parse(p_171290_.getName());
++        return new ModelLayerLocation(location.withPrefix("boat/"), "main");
+     }
+ 
+     public static ModelLayerLocation createChestBoatModelName(Boat.Type p_233551_) {
+-        return createLocation("chest_boat/" + p_233551_.getName(), "main");
++        ResourceLocation location = ResourceLocation.parse(p_233551_.getName());
++        return new ModelLayerLocation(location.withPrefix("chest_boat/"), "main");
      }
  
      public static ModelLayerLocation createSignModelName(WoodType p_171292_) {

--- a/patches/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
@@ -1,5 +1,25 @@
 --- a/net/minecraft/client/renderer/entity/BoatRenderer.java
 +++ b/net/minecraft/client/renderer/entity/BoatRenderer.java
+@@ -45,7 +_,7 @@
+     private ListModel<Boat> createBoatModel(EntityRendererProvider.Context p_248834_, Boat.Type p_249317_, boolean p_250093_) {
+         ModelLayerLocation modellayerlocation = p_250093_ ? ModelLayers.createChestBoatModelName(p_249317_) : ModelLayers.createBoatModelName(p_249317_);
+         ModelPart modelpart = p_248834_.bakeLayer(modellayerlocation);
+-        if (p_249317_ == Boat.Type.BAMBOO) {
++        if (p_249317_.isRaft()) {
+             return (ListModel<Boat>)(p_250093_ ? new ChestRaftModel(modelpart) : new RaftModel(modelpart));
+         } else {
+             return (ListModel<Boat>)(p_250093_ ? new ChestBoatModel(modelpart) : new BoatModel(modelpart));
+@@ -54,8 +_,8 @@
+ 
+     private static ResourceLocation getTextureLocation(Boat.Type p_234566_, boolean p_234567_) {
+         return p_234567_
+-            ? ResourceLocation.withDefaultNamespace("textures/entity/chest_boat/" + p_234566_.getName() + ".png")
+-            : ResourceLocation.withDefaultNamespace("textures/entity/boat/" + p_234566_.getName() + ".png");
++            ? ResourceLocation.parse(p_234566_.getName()).withPrefix("textures/entity/chest_boat/").withSuffix(".png")
++            : ResourceLocation.parse(p_234566_.getName()).withPrefix("textures/entity/boat/").withSuffix(".png");
+     }
+ 
+     public void render(Boat p_113929_, float p_113930_, float p_113931_, PoseStack p_113932_, MultiBufferSource p_113933_, int p_113934_) {
 @@ -77,7 +_,7 @@
              p_113932_.mulPose(new Quaternionf().setAngleAxis(p_113929_.getBubbleAngle(p_113931_) * (float) (Math.PI / 180.0), 1.0F, 0.0F, 1.0F));
          }
@@ -9,7 +29,7 @@
          ResourceLocation resourcelocation = pair.getFirst();
          ListModel<Boat> listmodel = pair.getSecond();
          p_113932_.scale(-1.0F, -1.0F, 1.0F);
-@@ -96,7 +_,10 @@
+@@ -96,7 +_,12 @@
          super.render(p_113929_, p_113930_, p_113931_, p_113932_, p_113933_, p_113934_);
      }
  
@@ -17,7 +37,9 @@
      public ResourceLocation getTextureLocation(Boat p_113927_) {
 -        return this.boatResources.get(p_113927_.getVariant()).getFirst();
 +        return getModelWithLocation(p_113927_).getFirst();
-     }
++    }
 +
-+    public Pair<ResourceLocation, ListModel<Boat>> getModelWithLocation(Boat boat) { return this.boatResources.get(boat.getVariant()); }
++    public Pair<ResourceLocation, ListModel<Boat>> getModelWithLocation(Boat boat) {
++        return this.boatResources.get(boat.getVariant());
+     }
  }

--- a/patches/net/minecraft/world/entity/vehicle/Boat.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/Boat.java.patch
@@ -9,6 +9,25 @@
      private static final EntityDataAccessor<Integer> DATA_ID_TYPE = SynchedEntityData.defineId(Boat.class, EntityDataSerializers.INT);
      private static final EntityDataAccessor<Boolean> DATA_ID_PADDLE_LEFT = SynchedEntityData.defineId(Boat.class, EntityDataSerializers.BOOLEAN);
      private static final EntityDataAccessor<Boolean> DATA_ID_PADDLE_RIGHT = SynchedEntityData.defineId(Boat.class, EntityDataSerializers.BOOLEAN);
+@@ -157,7 +_,7 @@
+             }
+         }
+ 
+-        return new Vec3(0.0, this.getVariant() == Boat.Type.BAMBOO ? (double)(p_295933_.height() * 0.8888889F) : (double)(p_295933_.height() / 3.0F), (double)f)
++        return new Vec3(0.0, this.getVariant().isRaft() ? (double)(p_295933_.height() * 0.8888889F) : (double)(p_295933_.height() / 3.0F), (double)f)
+             .yRot(-this.getYRot() * (float) (Math.PI / 180.0));
+     }
+ 
+@@ -212,7 +_,8 @@
+             case DARK_OAK -> Items.DARK_OAK_BOAT;
+             case MANGROVE -> Items.MANGROVE_BOAT;
+             case BAMBOO -> Items.BAMBOO_RAFT;
+-            default -> Items.OAK_BOAT;
++            case OAK -> Items.OAK_BOAT;
++            default -> this.getVariant().boatItem.get();
+         };
+     }
+ 
 @@ -498,7 +_,7 @@
                  for (int i2 = i1; i2 < j1; i2++) {
                      blockpos$mutableblockpos.set(l1, k1, i2);
@@ -63,3 +82,88 @@
      }
  
      protected int getMaxPassengers() {
+@@ -914,7 +_,9 @@
+         IN_AIR;
+     }
+ 
+-    public static enum Type implements StringRepresentable {
++    @net.neoforged.fml.common.asm.enumextension.NamedEnum(1)
++    @net.neoforged.fml.common.asm.enumextension.NetworkedEnum(net.neoforged.fml.common.asm.enumextension.NetworkedEnum.NetworkCheck.CLIENTBOUND)
++    public static enum Type implements StringRepresentable, net.neoforged.fml.common.asm.enumextension.IExtensibleEnum {
+         OAK(Blocks.OAK_PLANKS, "oak"),
+         SPRUCE(Blocks.SPRUCE_PLANKS, "spruce"),
+         BIRCH(Blocks.BIRCH_PLANKS, "birch"),
+@@ -923,16 +_,48 @@
+         CHERRY(Blocks.CHERRY_PLANKS, "cherry"),
+         DARK_OAK(Blocks.DARK_OAK_PLANKS, "dark_oak"),
+         MANGROVE(Blocks.MANGROVE_PLANKS, "mangrove"),
+-        BAMBOO(Blocks.BAMBOO_PLANKS, "bamboo");
++        BAMBOO(Blocks.BAMBOO_PLANKS, "bamboo", true);
+ 
+         private final String name;
++        /** @deprecated Neo: Will be {@link Blocks#AIR} for modded boat types, use {@link #planksSupplier} instead */
++        @Deprecated
+         private final Block planks;
++        private final java.util.function.Supplier<Block> planksSupplier;
++        final java.util.function.Supplier<Item> boatItem;
++        final java.util.function.Supplier<Item> chestBoatItem;
++        private final boolean raft;
+         public static final StringRepresentable.EnumCodec<Boat.Type> CODEC = StringRepresentable.fromEnum(Boat.Type::values);
+         private static final IntFunction<Boat.Type> BY_ID = ByIdMap.continuous(Enum::ordinal, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
+ 
++        @net.neoforged.fml.common.asm.enumextension.ReservedConstructor
+         private Type(Block p_38427_, String p_38428_) {
++            this(p_38427_, p_38428_, false);
++        }
++
++        @net.neoforged.fml.common.asm.enumextension.ReservedConstructor
++        private Type(Block p_38427_, String p_38428_, boolean raft) {
+             this.name = p_38428_;
+             this.planks = p_38427_;
++            this.planksSupplier = () -> p_38427_;
++            this.boatItem = () -> Items.AIR;
++            this.chestBoatItem = () -> Items.AIR;
++            this.raft = raft;
++        }
++
++        /**
++         * @param planks A supplier of the block to be dropped when the boat is destroyed by fall damage
++         * @param name The name of this boat type
++         * @param boatItem A supplier of the item to be dropped when a normal boat or raft of this type is picked up
++         * @param chestBoatItem A supplier of the item to be dropped when a chest boat or raft of this type is picked up
++         * @param raft Whether this boat type is a "standard" boat or a raft
++         */
++        private Type(java.util.function.Supplier<Block> planks, String name, java.util.function.Supplier<Item> boatItem, java.util.function.Supplier<Item> chestBoatItem, boolean raft) {
++            this.name = name;
++            this.planks = Blocks.AIR;
++            this.planksSupplier = planks;
++            this.boatItem = boatItem;
++            this.chestBoatItem = chestBoatItem;
++            this.raft = raft;
+         }
+ 
+         @Override
+@@ -945,7 +_,11 @@
+         }
+ 
+         public Block getPlanks() {
+-            return this.planks;
++            return this.planksSupplier.get();
++        }
++
++        public boolean isRaft() {
++            return this.raft;
+         }
+ 
+         @Override
+@@ -959,6 +_,10 @@
+ 
+         public static Boat.Type byName(String p_38433_) {
+             return CODEC.byName(p_38433_, OAK);
++        }
++
++        public static net.neoforged.fml.common.asm.enumextension.ExtensionInfo getExtensionInfo() {
++            return net.neoforged.fml.common.asm.enumextension.ExtensionInfo.nonExtended(Boat.Type.class);
+         }
+     }
+ }

--- a/patches/net/minecraft/world/entity/vehicle/Boat.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/Boat.java.patch
@@ -64,7 +64,16 @@
                          && d0 < (double)((float)blockpos$mutableblockpos.getY() + fluidstate.getHeight(this.level(), blockpos$mutableblockpos))) {
                          if (!fluidstate.isSource()) {
                              return Boat.Status.UNDER_FLOWING_WATER;
-@@ -839,7 +_,7 @@
+@@ -832,14 +_,15 @@
+                             }
+ 
+                             for (int j = 0; j < 2; j++) {
+-                                this.spawnAtLocation(Items.STICK);
++                                // Neo: allow dropping material-specific sticks instead of just generic wooden sticks
++                                this.spawnAtLocation(this.getVariant().getSticks());
+                             }
+                         }
+                     }
                  }
  
                  this.resetFallDistance();
@@ -93,7 +102,7 @@
          OAK(Blocks.OAK_PLANKS, "oak"),
          SPRUCE(Blocks.SPRUCE_PLANKS, "spruce"),
          BIRCH(Blocks.BIRCH_PLANKS, "birch"),
-@@ -923,16 +_,48 @@
+@@ -923,16 +_,59 @@
          CHERRY(Blocks.CHERRY_PLANKS, "cherry"),
          DARK_OAK(Blocks.DARK_OAK_PLANKS, "dark_oak"),
          MANGROVE(Blocks.MANGROVE_PLANKS, "mangrove"),
@@ -107,6 +116,7 @@
 +        private final java.util.function.Supplier<Block> planksSupplier;
 +        final java.util.function.Supplier<Item> boatItem;
 +        final java.util.function.Supplier<Item> chestBoatItem;
++        private final java.util.function.Supplier<Item> stickItem;
 +        private final boolean raft;
          public static final StringRepresentable.EnumCodec<Boat.Type> CODEC = StringRepresentable.fromEnum(Boat.Type::values);
          private static final IntFunction<Boat.Type> BY_ID = ByIdMap.continuous(Enum::ordinal, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
@@ -123,6 +133,7 @@
 +            this.planksSupplier = () -> p_38427_;
 +            this.boatItem = () -> Items.AIR;
 +            this.chestBoatItem = () -> Items.AIR;
++            this.stickItem = () -> Items.STICK;
 +            this.raft = raft;
 +        }
 +
@@ -131,24 +142,37 @@
 +         * @param name The name of this boat type
 +         * @param boatItem A supplier of the item to be dropped when a normal boat or raft of this type is picked up
 +         * @param chestBoatItem A supplier of the item to be dropped when a chest boat or raft of this type is picked up
++         * @param stickItem A supplier of the stick item to be dropped when the boat is destroyed by fall damage
 +         * @param raft Whether this boat type is a "standard" boat or a raft
 +         */
-+        private Type(java.util.function.Supplier<Block> planks, String name, java.util.function.Supplier<Item> boatItem, java.util.function.Supplier<Item> chestBoatItem, boolean raft) {
++        private Type(
++                java.util.function.Supplier<Block> planks,
++                String name,
++                java.util.function.Supplier<Item> boatItem,
++                java.util.function.Supplier<Item> chestBoatItem,
++                java.util.function.Supplier<Item> stickItem,
++                boolean raft
++        ) {
 +            this.name = name;
 +            this.planks = Blocks.AIR;
 +            this.planksSupplier = planks;
 +            this.boatItem = boatItem;
 +            this.chestBoatItem = chestBoatItem;
++            this.stickItem = stickItem;
 +            this.raft = raft;
          }
  
          @Override
-@@ -945,7 +_,11 @@
+@@ -945,7 +_,15 @@
          }
  
          public Block getPlanks() {
 -            return this.planks;
 +            return this.planksSupplier.get();
++        }
++
++        public Item getSticks() {
++            return this.stickItem.get();
 +        }
 +
 +        public boolean isRaft() {

--- a/patches/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/world/entity/vehicle/ChestBoat.java
++++ b/net/minecraft/world/entity/vehicle/ChestBoat.java
+@@ -122,7 +_,8 @@
+             case DARK_OAK -> Items.DARK_OAK_CHEST_BOAT;
+             case MANGROVE -> Items.MANGROVE_CHEST_BOAT;
+             case BAMBOO -> Items.BAMBOO_CHEST_RAFT;
+-            default -> Items.OAK_CHEST_BOAT;
++            case OAK -> Items.OAK_CHEST_BOAT;
++            default -> this.getVariant().chestBoatItem.get();
+         };
+     }
+ 

--- a/tests/src/generated/resources/assets/neotests_custom_boat_type/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_custom_boat_type/lang/en_us.json
@@ -3,5 +3,6 @@
   "item.neotests_custom_boat_type.paper_boat": "Paper Boat",
   "item.neotests_custom_boat_type.paper_chest_boat": "Paper Chest Boat",
   "item.neotests_custom_boat_type.paper_chest_raft": "Paper Chest Raft",
-  "item.neotests_custom_boat_type.paper_raft": "Paper Raft"
+  "item.neotests_custom_boat_type.paper_raft": "Paper Raft",
+  "item.neotests_custom_boat_type.paper_stick": "Paper Stick"
 }

--- a/tests/src/generated/resources/assets/neotests_custom_boat_type/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_custom_boat_type/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "block.neotests_custom_boat_type.paper": "Paper",
+  "item.neotests_custom_boat_type.paper_boat": "Paper Boat",
+  "item.neotests_custom_boat_type.paper_chest_boat": "Paper Chest Boat",
+  "item.neotests_custom_boat_type.paper_chest_raft": "Paper Chest Raft",
+  "item.neotests_custom_boat_type.paper_raft": "Paper Raft"
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
@@ -1,5 +1,11 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.debug.entity.vehicle;
 
+import java.util.function.Supplier;
 import net.minecraft.world.entity.vehicle.Boat;
 import net.minecraft.world.item.BoatItem;
 import net.minecraft.world.item.Item;
@@ -11,8 +17,6 @@ import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.registration.RegistrationHelper;
-
-import java.util.function.Supplier;
 
 @ForEachTest(groups = CustomBoatTest.GROUP)
 public class CustomBoatTest {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
@@ -1,0 +1,69 @@
+package net.neoforged.neoforge.debug.entity.vehicle;
+
+import net.minecraft.world.entity.vehicle.Boat;
+import net.minecraft.world.item.BoatItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.Test;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.registration.RegistrationHelper;
+
+import java.util.function.Supplier;
+
+@ForEachTest(groups = CustomBoatTest.GROUP)
+public class CustomBoatTest {
+    public static final String GROUP = "level.entity.vehicle.boat";
+    private static final String BOAT_NAME = "neotests:paper";
+    private static final String RAFT_NAME = "neotests:paper_raft";
+    private static Supplier<Block> paperBlock;
+    private static Supplier<BoatItem> paperBoatItem;
+    private static Supplier<BoatItem> paperChestBoatItem;
+    private static Supplier<BoatItem> paperRaftItem;
+    private static Supplier<BoatItem> paperChestRaftItem;
+
+    @EmptyTemplate
+    @TestHolder(description = "Tests that custom boat types work")
+    static void customBoatType(final DynamicTest test, final RegistrationHelper reg) {
+        paperBlock = reg.blocks().registerSimpleBlock("paper", BlockBehaviour.Properties.of()).withBlockItem().withLang("Paper");
+
+        paperBoatItem = reg.items().registerItem("paper_boat", props -> new BoatItem(false, Boat.Type.byName(BOAT_NAME), props))
+                .withLang("Paper Boat");
+        paperChestBoatItem = reg.items().registerItem("paper_chest_boat", props -> new BoatItem(true, Boat.Type.byName(BOAT_NAME), props))
+                .withLang("Paper Chest Boat");
+
+        paperRaftItem = reg.items().registerItem("paper_raft", props -> new BoatItem(false, Boat.Type.byName(RAFT_NAME), props))
+                .withLang("Paper Raft");
+        paperChestRaftItem = reg.items().registerItem("paper_chest_raft", props -> new BoatItem(true, Boat.Type.byName(RAFT_NAME), props))
+                .withLang("Paper Chest Raft");
+
+        test.updateStatus(Test.Status.PASSED, null);
+    }
+
+    @SuppressWarnings("unused") // Referenced by enumextensions.json
+    public static Object getBoatTypeParameter(int idx, Class<?> type) {
+        return switch (idx) {
+            case 0 -> type.cast((Supplier<Block>) () -> paperBlock.get());
+            case 1 -> type.cast(BOAT_NAME);
+            case 2 -> type.cast((Supplier<Item>) () -> paperBoatItem.get());
+            case 3 -> type.cast((Supplier<Item>) () -> paperChestBoatItem.get());
+            case 4 -> false;
+            default -> throw new IllegalArgumentException("Unexpected parameter index: " + idx);
+        };
+    }
+
+    @SuppressWarnings("unused") // Referenced by enumextensions.json
+    public static Object getRaftTypeParameter(int idx, Class<?> type) {
+        return switch (idx) {
+            case 0 -> type.cast((Supplier<Block>) () -> paperBlock.get());
+            case 1 -> type.cast(RAFT_NAME);
+            case 2 -> type.cast((Supplier<Item>) () -> paperRaftItem.get());
+            case 3 -> type.cast((Supplier<Item>) () -> paperChestRaftItem.get());
+            case 4 -> true;
+            default -> throw new IllegalArgumentException("Unexpected parameter index: " + idx);
+        };
+    }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
@@ -24,6 +24,7 @@ public class CustomBoatTest {
     private static final String BOAT_NAME = "neotests:paper";
     private static final String RAFT_NAME = "neotests:paper_raft";
     private static Supplier<Block> paperBlock;
+    private static Supplier<Item> paperStickItem;
     private static Supplier<BoatItem> paperBoatItem;
     private static Supplier<BoatItem> paperChestBoatItem;
     private static Supplier<BoatItem> paperRaftItem;
@@ -33,6 +34,7 @@ public class CustomBoatTest {
     @TestHolder(description = "Tests that custom boat types work")
     static void customBoatType(final DynamicTest test, final RegistrationHelper reg) {
         paperBlock = reg.blocks().registerSimpleBlock("paper", BlockBehaviour.Properties.of()).withBlockItem().withLang("Paper");
+        paperStickItem = reg.items().registerSimpleItem("paper_stick").withLang("Paper Stick");
 
         paperBoatItem = reg.items().registerItem("paper_boat", props -> new BoatItem(false, Boat.Type.byName(BOAT_NAME), props))
                 .withLang("Paper Boat");
@@ -54,7 +56,8 @@ public class CustomBoatTest {
             case 1 -> type.cast(BOAT_NAME);
             case 2 -> type.cast((Supplier<Item>) () -> paperBoatItem.get());
             case 3 -> type.cast((Supplier<Item>) () -> paperChestBoatItem.get());
-            case 4 -> false;
+            case 4 -> type.cast((Supplier<Item>) () -> paperStickItem.get());
+            case 5 -> false;
             default -> throw new IllegalArgumentException("Unexpected parameter index: " + idx);
         };
     }
@@ -66,7 +69,8 @@ public class CustomBoatTest {
             case 1 -> type.cast(RAFT_NAME);
             case 2 -> type.cast((Supplier<Item>) () -> paperRaftItem.get());
             case 3 -> type.cast((Supplier<Item>) () -> paperChestRaftItem.get());
-            case 4 -> true;
+            case 4 -> type.cast((Supplier<Item>) () -> paperStickItem.get());
+            case 5 -> true;
             default -> throw new IllegalArgumentException("Unexpected parameter index: " + idx);
         };
     }

--- a/tests/src/main/resources/META-INF/enumextensions.json
+++ b/tests/src/main/resources/META-INF/enumextensions.json
@@ -107,6 +107,24 @@
                 "class": "net/neoforged/neoforge/oldtest/world/RaidEnumTest",
                 "field": "RAIDER_ENUM_PARAMS"
             }
+        },
+        {
+            "enum": "net/minecraft/world/entity/vehicle/Boat$Type",
+            "name": "NEOTESTS_PAPER",
+            "constructor": "(Ljava/util/function/Supplier;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Z)V",
+            "parameters": {
+                "class": "net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest",
+                "method": "getBoatTypeParameter"
+            }
+        },
+        {
+            "enum": "net/minecraft/world/entity/vehicle/Boat$Type",
+            "name": "NEOTESTS_PAPER_RAFT",
+            "constructor": "(Ljava/util/function/Supplier;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Z)V",
+            "parameters": {
+                "class": "net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest",
+                "method": "getRaftTypeParameter"
+            }
         }
     ]
 }

--- a/tests/src/main/resources/META-INF/enumextensions.json
+++ b/tests/src/main/resources/META-INF/enumextensions.json
@@ -111,7 +111,7 @@
         {
             "enum": "net/minecraft/world/entity/vehicle/Boat$Type",
             "name": "NEOTESTS_PAPER",
-            "constructor": "(Ljava/util/function/Supplier;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Z)V",
+            "constructor": "(Ljava/util/function/Supplier;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Z)V",
             "parameters": {
                 "class": "net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest",
                 "method": "getBoatTypeParameter"
@@ -120,7 +120,7 @@
         {
             "enum": "net/minecraft/world/entity/vehicle/Boat$Type",
             "name": "NEOTESTS_PAPER_RAFT",
-            "constructor": "(Ljava/util/function/Supplier;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Z)V",
+            "constructor": "(Ljava/util/function/Supplier;Ljava/lang/String;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Ljava/util/function/Supplier;Z)V",
             "parameters": {
                 "class": "net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest",
                 "method": "getRaftTypeParameter"


### PR DESCRIPTION
This PR makes the `Boat.Type` enum extensible to make it easier for mods to provide custom boats and rafts.

Fixes #491