### PR TITLE
Make BooleanAttribute public

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/BooleanAttribute.java
+++ b/src/main/java/net/neoforged/neoforge/common/BooleanAttribute.java
@@ -23,7 +23,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier;
  * @apiNote Use of other operations and/or values will trigger undefined behavior, where no guarantees can be made if the attribute will be enabled or not.
  */
 public class BooleanAttribute extends Attribute {
-    protected BooleanAttribute(String descriptionId, boolean defaultValue) {
+    public BooleanAttribute(String descriptionId, boolean defaultValue) {
         super(descriptionId, defaultValue ? 1 : 0);
     }
 


### PR DESCRIPTION
It was an oversight that made it protected. Modders want to use it so we should expose it properly. Shouldn't break anything

Original PR: https://github.com/neoforged/NeoForge/pull/1246