### PR TITLE
Run CapabilityHooks::registerVanillaProviders at LOW priority

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
@@ -112,26 +112,7 @@ public class CapabilityHooks {
             event.registerEntity(Capabilities.ItemHandler.ENTITY_AUTOMATION, entityType, (entity, ctx) -> new InvWrapper(entity));
         }
         event.registerEntity(Capabilities.ItemHandler.ENTITY, EntityType.PLAYER, (player, ctx) -> new PlayerInvWrapper(player.getInventory()));
-        // Register to all entity types to make sure we support all living entity subclasses.
-        for (EntityType<?> entityType : BuiltInRegistries.ENTITY_TYPE) {
-            event.registerEntity(Capabilities.ItemHandler.ENTITY, entityType, (entity, ctx) -> {
-                if (entity instanceof AbstractHorse horse)
-                    return new InvWrapper(horse.getInventory());
-                else if (entity instanceof LivingEntity livingEntity)
-                    return new CombinedInvWrapper(new EntityHandsInvWrapper(livingEntity), new EntityArmorInvWrapper(livingEntity));
 
-                return null;
-            });
-        }
-
-        // Items
-        for (Item item : BuiltInRegistries.ITEM) {
-            if (item.getClass() == BucketItem.class)
-                event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidBucketWrapper(stack), item);
-        }
-        if (NeoForgeMod.MILK.isBound()) {
-            event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidBucketWrapper(stack), Items.MILK_BUCKET);
-        }
         event.registerItem(Capabilities.ItemHandler.ITEM, (stack, ctx) -> new ComponentItemHandler(stack, DataComponents.CONTAINER, 27),
                 Items.SHULKER_BOX,
                 Items.BLACK_SHULKER_BOX,
@@ -150,6 +131,31 @@ public class CapabilityHooks {
                 Items.RED_SHULKER_BOX,
                 Items.WHITE_SHULKER_BOX,
                 Items.YELLOW_SHULKER_BOX);
+    }
+
+    public static void registerFallbackVanillaProviders(RegisterCapabilitiesEvent event) {
+        // Register to all entity types to make sure we support all living entity subclasses.
+        for (EntityType<?> entityType : BuiltInRegistries.ENTITY_TYPE) {
+            event.registerEntity(Capabilities.ItemHandler.ENTITY, entityType, (entity, ctx) -> {
+                if (entity instanceof AbstractHorse horse)
+                    return new InvWrapper(horse.getInventory());
+                else if (entity instanceof LivingEntity livingEntity)
+                    return new CombinedInvWrapper(new EntityHandsInvWrapper(livingEntity), new EntityArmorInvWrapper(livingEntity));
+
+                return null;
+            });
+        }
+
+        // Items
+        for (Item item : BuiltInRegistries.ITEM) {
+            if (item.getClass() == BucketItem.class)
+                event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidBucketWrapper(stack), item);
+        }
+
+        // We want mods to be able to override our milk cap by default
+        if (NeoForgeMod.MILK.isBound()) {
+            event.registerItem(Capabilities.FluidHandler.ITEM, (stack, ctx) -> new FluidBucketWrapper(stack), Items.MILK_BUCKET);
+        }
     }
 
     public static void invalidateCapsOnChunkLoad(ChunkEvent.Load event) {

--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
@@ -113,6 +113,7 @@ public class CapabilityHooks {
         }
         event.registerEntity(Capabilities.ItemHandler.ENTITY, EntityType.PLAYER, (player, ctx) -> new PlayerInvWrapper(player.getInventory()));
 
+        // Items
         event.registerItem(Capabilities.ItemHandler.ITEM, (stack, ctx) -> new ComponentItemHandler(stack, DataComponents.CONTAINER, 27),
                 Items.SHULKER_BOX,
                 Items.BLACK_SHULKER_BOX,
@@ -134,6 +135,7 @@ public class CapabilityHooks {
     }
 
     public static void registerFallbackVanillaProviders(RegisterCapabilitiesEvent event) {
+        // Entities
         // Register to all entity types to make sure we support all living entity subclasses.
         for (EntityType<?> entityType : BuiltInRegistries.ENTITY_TYPE) {
             event.registerEntity(Capabilities.ItemHandler.ENTITY, entityType, (entity, ctx) -> {

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -617,7 +617,8 @@ public class NeoForgeMod {
         DualStackUtils.initialise();
         TagConventionLogWarning.init();
 
-        modEventBus.addListener(EventPriority.LOW, CapabilityHooks::registerVanillaProviders);
+        modEventBus.addListener(CapabilityHooks::registerVanillaProviders);
+        modEventBus.addListener(EventPriority.LOW, CapabilityHooks::registerFallbackVanillaProviders);
         modEventBus.addListener(CauldronFluidContent::registerCapabilities);
         // These 3 listeners use the default priority for now, can be re-evaluated later.
         NeoForge.EVENT_BUS.addListener(CapabilityHooks::invalidateCapsOnChunkLoad);

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -73,6 +73,7 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.pathfinder.PathType;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.CrashReportCallables;
 import net.neoforged.fml.ModContainer;
@@ -616,7 +617,7 @@ public class NeoForgeMod {
         DualStackUtils.initialise();
         TagConventionLogWarning.init();
 
-        modEventBus.addListener(CapabilityHooks::registerVanillaProviders);
+        modEventBus.addListener(EventPriority.LOW, CapabilityHooks::registerVanillaProviders);
         modEventBus.addListener(CauldronFluidContent::registerCapabilities);
         // These 3 listeners use the default priority for now, can be re-evaluated later.
         NeoForge.EVENT_BUS.addListener(CapabilityHooks::invalidateCapsOnChunkLoad);


### PR DESCRIPTION
Closes https://github.com/neoforged/NeoForge/issues/1288

Having it at NORMAL was causing hard-to-diagnosis issues in prod where a mod's cap is overwritten by neo or not depending on load order. Putting it at LOW allows mods to work out of the box without needing to dig into priorities