### PR TITLE
[1.21] Include component and stack data when Itemstack#save and Fluidstack#save throws from codec errors

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -63,7 +63,7 @@
          } else {
 -            return CODEC.encode(this, p_331900_.createSerializationContext(NbtOps.INSTANCE), p_330830_).getOrThrow();
 +            // Neo: Logs extra information about this ItemStack on error
-+            return this.encode(p_331900_, p_330830_);
++            return net.neoforged.neoforge.common.util.DataComponentUtil.wrapEncodingExceptions(this, CODEC, p_331900_, p_330830_);
          }
      }
  
@@ -73,7 +73,7 @@
          } else {
 -            return CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), this).getOrThrow();
 +            // Neo: Logs extra information about this ItemStack on error
-+            return this.encode(p_332160_);
++            return net.neoforged.neoforge.common.util.DataComponentUtil.wrapEncodingExceptions(this, CODEC, p_332160_);
          }
      }
  

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -57,20 +57,22 @@
              if (player != null && interactionresult.indicateItemUse()) {
                  player.awardStat(Stats.ITEM_USED.get(item));
              }
-@@ -382,7 +_,7 @@
+@@ -382,7 +_,8 @@
          if (this.isEmpty()) {
              throw new IllegalStateException("Cannot encode empty ItemStack");
          } else {
 -            return CODEC.encode(this, p_331900_.createSerializationContext(NbtOps.INSTANCE), p_330830_).getOrThrow();
++            // Neo: Logs extra information about this ItemStack on error
 +            return this.encode(p_331900_, p_330830_);
          }
      }
  
-@@ -390,7 +_,7 @@
+@@ -390,7 +_,8 @@
          if (this.isEmpty()) {
              throw new IllegalStateException("Cannot encode empty ItemStack");
          } else {
 -            return CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), this).getOrThrow();
++            // Neo: Logs extra information about this ItemStack on error
 +            return this.encode(p_332160_);
          }
      }

--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -57,6 +57,24 @@
              if (player != null && interactionresult.indicateItemUse()) {
                  player.awardStat(Stats.ITEM_USED.get(item));
              }
+@@ -382,7 +_,7 @@
+         if (this.isEmpty()) {
+             throw new IllegalStateException("Cannot encode empty ItemStack");
+         } else {
+-            return CODEC.encode(this, p_331900_.createSerializationContext(NbtOps.INSTANCE), p_330830_).getOrThrow();
++            return this.encode(p_331900_, p_330830_);
+         }
+     }
+ 
+@@ -390,7 +_,7 @@
+         if (this.isEmpty()) {
+             throw new IllegalStateException("Cannot encode empty ItemStack");
+         } else {
+-            return CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), this).getOrThrow();
++            return this.encode(p_332160_);
+         }
+     }
+ 
 @@ -399,7 +_,7 @@
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -494,11 +494,10 @@ public interface IItemStackExtension {
         return CommonHooks.computeModifiedAttributes(self(), defaultModifiers);
     }
 
-
     default Tag encode(HolderLookup.Provider provider, Tag tag) {
-        try{
+        try {
             return self().CODEC.encode(self(), provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
-        }catch (Exception exception){
+        } catch (Exception exception) {
             throw new RuntimeException(formatItemSaveException(exception, tag));
         }
     }
@@ -506,7 +505,7 @@ public interface IItemStackExtension {
     default Tag encode(HolderLookup.Provider p_332160_) {
         try {
             return self().CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), self()).getOrThrow();
-        }catch (Exception exception) {
+        } catch (Exception exception) {
             throw new RuntimeException(formatItemSaveException(exception, null));
         }
     }
@@ -514,6 +513,7 @@ public interface IItemStackExtension {
     /**
      * Wraps an exception thrown during itemstack serialization with additional context
      * on the itemstack, components, and tag.
+     * 
      * <pre>
      * Example:
      * Caused by: java.lang.Exception: Error saving itemstack 1 minecraft:dirt with components:
@@ -527,13 +527,13 @@ public interface IItemStackExtension {
      * With tag: {}
      * </pre>
      */
-    private Exception formatItemSaveException(Exception e, @Nullable Tag tag){
+    private Exception formatItemSaveException(Exception e, @Nullable Tag tag) {
         StringBuilder cause = new StringBuilder("Error saving itemstack (" + self() + ") with components:");
         cause.append("\nItem:").append(self());
-        self().getComponents().forEach((component) ->{
+        self().getComponents().forEach((component) -> {
             cause.append("\n").append(component);
         });
-        if(tag != null) {
+        if (tag != null) {
             cause.append("\nWith tag: ").append(tag);
         }
         return new Exception(cause.toString(), e);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -42,7 +42,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.capabilities.ItemCapability;
-import net.neoforged.neoforge.common.*;
+import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.common.ItemAbilities;
+import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.event.EventHooks;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
@@ -519,6 +521,7 @@ public interface IItemStackExtension {
 
     /**
      * Logs component information and tag data for an itemstack that failed to save.
+     * 
      * <pre>
      * Example:
      * Error saving itemstack [1 minecraft:dirt]. Original cause: java.lang.NullPointerException

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -7,12 +7,9 @@ package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.core.HolderLookup.RegistryLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.nbt.NbtOps;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionResult;
@@ -46,7 +43,6 @@ import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.event.EventHooks;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 
 /*
@@ -493,62 +489,5 @@ public interface IItemStackExtension {
         }
 
         return CommonHooks.computeModifiedAttributes(self(), defaultModifiers);
-    }
-
-    /**
-     * Wraps the original {@link ItemStack#save} encoding behavior and logs additional information if an exception is thrown.
-     */
-    default Tag encode(HolderLookup.Provider provider, Tag tag) {
-        try {
-            return ItemStack.CODEC.encode(self(), provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
-        } catch (Exception exception) {
-            logItemInfo(exception, tag);
-            throw exception;
-        }
-    }
-
-    /**
-     * Wraps the original {@link ItemStack#save} encoding behavior and logs additional information if an exception is thrown.
-     */
-    default Tag encode(HolderLookup.Provider p_332160_) {
-        try {
-            return ItemStack.CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), self()).getOrThrow();
-        } catch (Exception exception) {
-            logItemInfo(exception, null);
-            throw exception;
-        }
-    }
-
-    /**
-     * Logs component information and tag data for an itemstack that failed to save.
-     * 
-     * <pre>
-     * Example:
-     * Error saving itemstack [1 minecraft:dirt]. Original cause: java.lang.NullPointerException
-     * With components:
-     * {
-     *    neoforge:test=>Test[s=null]
-     *    minecraft:max_stack_size=>64
-     *    minecraft:lore=>ItemLore[lines=[], styledLines=[]]
-     *    minecraft:enchantments=>ItemEnchantments{enchantments={}, showInTooltip=true}
-     *    minecraft:repair_cost=>0
-     *    minecraft:attribute_modifiers=>ItemAttributeModifiers[modifiers=[], showInTooltip=true]
-     *    minecraft:rarity=>COMMON
-     * }
-     * With tag: {}
-     * </pre>
-     */
-    private void logItemInfo(Exception original, @Nullable Tag tag) {
-        StringBuilder cause = new StringBuilder("Error saving itemstack [" + self() + "]. Original cause: " + original);
-
-        cause.append("\nWith components:\n{");
-        self().getComponents().forEach((component) -> {
-            cause.append("\n\t").append(component);
-        });
-        cause.append("\n}");
-        if (tag != null) {
-            cause.append("\nWith tag: ").append(tag);
-        }
-        LogManager.getLogger().error(cause.toString());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -500,7 +500,7 @@ public interface IItemStackExtension {
      */
     default Tag encode(HolderLookup.Provider provider, Tag tag) {
         try {
-            return self().CODEC.encode(self(), provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
+            return ItemStack.CODEC.encode(self(), provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
         } catch (Exception exception) {
             logItemInfo(exception, tag);
             throw exception;
@@ -512,7 +512,7 @@ public interface IItemStackExtension {
      */
     default Tag encode(HolderLookup.Provider p_332160_) {
         try {
-            return self().CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), self()).getOrThrow();
+            return ItemStack.CODEC.encodeStart(p_332160_.createSerializationContext(NbtOps.INSTANCE), self()).getOrThrow();
         } catch (Exception exception) {
             logItemInfo(exception, null);
             throw exception;

--- a/src/main/java/net/neoforged/neoforge/common/util/DataComponentUtil.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/DataComponentUtil.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.util;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.Util;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponentHolder;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+
+public class DataComponentUtil {
+    /**
+     * Wraps encoding exceptions and adds additional logging for a DataComponentHolder that failed to save.
+     */
+    public static <T extends DataComponentHolder> Tag wrapEncodingExceptions(T componentHolder, Codec<T> codec, HolderLookup.Provider provider, Tag tag) {
+        try {
+            return codec.encode(componentHolder, provider.createSerializationContext(NbtOps.INSTANCE), tag).getOrThrow();
+        } catch (Exception exception) {
+            logDataComponentSaveError(componentHolder, exception, tag);
+            throw exception;
+        }
+    }
+
+    /**
+     * Wraps encoding exceptions and adds additional logging for a DataComponentHolder that failed to save.
+     */
+    public static <T extends DataComponentHolder> Tag wrapEncodingExceptions(T componentHolder, Codec<T> codec, HolderLookup.Provider provider) {
+        try {
+            return codec.encodeStart(provider.createSerializationContext(NbtOps.INSTANCE), componentHolder).getOrThrow();
+        } catch (Exception exception) {
+            logDataComponentSaveError(componentHolder, exception, null);
+            throw exception;
+        }
+    }
+
+    /**
+     * Logs component information and tag data for a DataComponentHolder that failed to save.
+     * See {@link ItemStack#save } or {@link FluidStack#save }
+     * 
+     * <pre>
+     * Example:
+     * Error saving [1 minecraft:dirt]. Original cause: java.lang.NullPointerException
+     * With components:
+     * {
+     *    neoforge:test=>Test[s=null]
+     *    minecraft:max_stack_size=>64
+     *    minecraft:lore=>ItemLore[lines=[], styledLines=[]]
+     *    minecraft:enchantments=>ItemEnchantments{enchantments={}, showInTooltip=true}
+     *    minecraft:repair_cost=>0
+     *    minecraft:attribute_modifiers=>ItemAttributeModifiers[modifiers=[], showInTooltip=true]
+     *    minecraft:rarity=>COMMON
+     * }
+     * With tag: {}
+     * </pre>
+     */
+    public static void logDataComponentSaveError(DataComponentHolder componentHolder, Exception original, @Nullable Tag tag) {
+        StringBuilder cause = new StringBuilder("Error saving itemstack [" + componentHolder + "]. Original cause: " + original);
+
+        cause.append("\nWith components:\n{");
+        componentHolder.getComponents().forEach((component) -> {
+            cause.append("\n\t").append(component);
+        });
+        cause.append("\n}");
+        if (tag != null) {
+            cause.append("\nWith tag: ").append(tag);
+        }
+        Util.logAndPauseIfInIde(cause.toString());
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/util/DataComponentUtil.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/DataComponentUtil.java
@@ -61,7 +61,7 @@ public class DataComponentUtil {
      * </pre>
      */
     public static void logDataComponentSaveError(DataComponentHolder componentHolder, Exception original, @Nullable Tag tag) {
-        StringBuilder cause = new StringBuilder("Error saving itemstack [" + componentHolder + "]. Original cause: " + original);
+        StringBuilder cause = new StringBuilder("Error saving [" + componentHolder + "]. Original cause: " + original);
 
         cause.append("\nWith components:\n{");
         componentHolder.getComponents().forEach((component) -> {

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -38,6 +38,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.MutableDataComponentHolder;
+import net.neoforged.neoforge.common.util.DataComponentUtil;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -270,7 +271,7 @@ public final class FluidStack implements MutableDataComponentHolder {
         if (this.isEmpty()) {
             throw new IllegalStateException("Cannot encode empty FluidStack");
         } else {
-            return CODEC.encode(this, lookupProvider.createSerializationContext(NbtOps.INSTANCE), prefix).getOrThrow();
+            return DataComponentUtil.wrapEncodingExceptions(this, CODEC, lookupProvider, prefix);
         }
     }
 
@@ -283,7 +284,7 @@ public final class FluidStack implements MutableDataComponentHolder {
         if (this.isEmpty()) {
             throw new IllegalStateException("Cannot encode empty FluidStack");
         } else {
-            return CODEC.encodeStart(lookupProvider.createSerializationContext(NbtOps.INSTANCE), this).getOrThrow();
+            return DataComponentUtil.wrapEncodingExceptions(this, CODEC, lookupProvider);
         }
     }
 


### PR DESCRIPTION
When errors occur inside a codecs DataResult handling, the trace is lost and any original information about the cause is gone. This is really bad in the case of ItemStack#save. If any DataComponent added by a mod is invalid, most notably with a Null value when using OptionalFieldOf, the only trace will be a NullPointerException around Mojangs call to `Optional.of` inside OptionalFieldCodec
```java

    @Override
    public <T> DataResult<Optional<A>> decode(final DynamicOps<T> ops, final MapLike<T> input) {
        final T value = input.get(name);
        if (value == null) {
            return DataResult.success(Optional.empty());
        }
        final DataResult<A> parsed = elementCodec.parse(ops, value);
        if (parsed.isError() && lenient) {
            return DataResult.success(Optional.empty());
        }
       // Going to throw instead of returning a result if Lenient == false and value == null.
        return parsed.map(Optional::of).setPartial(parsed.resultOrPartial());
    }
```

This change captures the Codec encoding behavior around Items, and logs the itemstack, all DataComponents on the item, and the tag that was passed in if relevant. Instead of receiving the error:
```
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.Optional.of(Optional.java:113)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Codec.lambda$optionalFieldOf$12(Codec.java:299)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapEncoder$1.encode(MapEncoder.java:26)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$2.encode(MapCodec.java:82)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$Instance$6.encode(RecordCodecBuilder.java:295)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$2.encode(RecordCodecBuilder.java:112)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$MapCodecCodec.encode(MapCodec.java:163)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder.encodeStart(Encoder.java:14)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.DispatchedMapCodec.encodeValue(DispatchedMapCodec.java:35)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.DispatchedMapCodec.encode(DispatchedMapCodec.java:28)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.DispatchedMapCodec.encode(DispatchedMapCodec.java:20)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder$1.encode(Encoder.java:25)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Codec$2.encode(Codec.java:80)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder.encodeStart(Encoder.java:14)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.OptionalFieldCodec.encode(OptionalFieldCodec.java:44)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.OptionalFieldCodec.encode(OptionalFieldCodec.java:17)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapEncoder$1.encode(MapEncoder.java:26)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$2.encode(MapCodec.java:82)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$Instance$6.encode(RecordCodecBuilder.java:297)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$2.encode(RecordCodecBuilder.java:112)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$MapCodecCodec.encode(MapCodec.java:163)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Codec$RecursiveCodec.encode(Codec.java:217)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder.encodeStart(Encoder.java:14)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.item.ItemStack.save(ItemStack.java:426)
	at TRANSFORMER/ars_nouveau@0.0NONE/com.hollingsworth.arsnouveau.common.block.tile.SingleItemTile.saveAdditional(SingleItemTile.java:104)
	at TRANSFORMER/ars_nouveau@0.0NONE/com.hollingsworth.arsnouveau.common.block.tile.EnchantingApparatusTile.saveAdditional(EnchantingApparatusTile.java:185)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.level.block.entity.BlockEntity.saveWithoutMetadata(BlockEntity.java:102)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.level.block.entity.BlockEntity.saveWithFullMetadata(BlockEntity.java:89)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.level.chunk.LevelChunk.getBlockEntityNbtForSaving(LevelChunk.java:415)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.level.chunk.storage.ChunkSerializer.write(ChunkSerializer.java:360)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.level.ChunkMap.save(ChunkMap.java:783)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.level.ChunkMap.lambda$scheduleUnload$12(ChunkMap.java:540)
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire$$$capture(CompletableFuture.java:787)
	at java.base/java.util.concurrent.CompletableFuture$UniRun.tryFire(CompletableFuture.java)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.level.ChunkMap.processUnloads(ChunkMap.java:513)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.level.ChunkMap.tick(ChunkMap.java:469)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.level.ServerChunkCache.tick(ServerChunkCache.java:329)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:619)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.server.IntegratedServer.stopServer(IntegratedServer.java:227)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:748)
	at TRANSFORMER/minecraft@1.21/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:267)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

This change now logs:

```
[21:17:55] [Render thread/ERROR] [ne.ne.ne.co.ex.IItemStackExtension/]: Error saving itemstack [1 minecraft:dirt]. Original cause: java.lang.NullPointerException
With components:
{
	neoforge:test=>Test[s=null]
	minecraft:max_stack_size=>64
	minecraft:lore=>ItemLore[lines=[], styledLines=[]]
	minecraft:enchantments=>ItemEnchantments{enchantments={}, showInTooltip=true}
	minecraft:repair_cost=>0
	minecraft:attribute_modifiers=>ItemAttributeModifiers[modifiers=[], showInTooltip=true]
	minecraft:rarity=>COMMON
}
java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at java.base/java.util.Optional.of(Optional.java:113)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Codec.lambda$optionalFieldOf$12(Codec.java:299)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapEncoder$1.encode(MapEncoder.java:26)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$2.encode(MapCodec.java:82)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$Instance$2.encode(RecordCodecBuilder.java:163)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$2.encode(RecordCodecBuilder.java:112)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$MapCodecCodec.encode(MapCodec.java:163)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder.encodeStart(Encoder.java:14)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.DispatchedMapCodec.encodeValue(DispatchedMapCodec.java:35)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.DispatchedMapCodec.encode(DispatchedMapCodec.java:28)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.DispatchedMapCodec.encode(DispatchedMapCodec.java:20)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder$1.encode(Encoder.java:25)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Codec$2.encode(Codec.java:80)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder.encodeStart(Encoder.java:14)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.OptionalFieldCodec.encode(OptionalFieldCodec.java:44)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.OptionalFieldCodec.encode(OptionalFieldCodec.java:17)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapEncoder$1.encode(MapEncoder.java:26)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$2.encode(MapCodec.java:82)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$Instance$6.encode(RecordCodecBuilder.java:297)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.codecs.RecordCodecBuilder$2.encode(RecordCodecBuilder.java:112)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.MapCodec$MapCodecCodec.encode(MapCodec.java:163)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Codec$RecursiveCodec.encode(Codec.java:217)
	at MC-BOOTSTRAP/datafixerupper@8.0.16/com.mojang.serialization.Encoder.encodeStart(Encoder.java:14)
	at TRANSFORMER/neoforge@21.0.88-beta-stack-saving/net.neoforged.neoforge.common.extensions.IItemStackExtension.encode(IItemStackExtension.java:508)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.item.ItemStack.save(ItemStack.java:410)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.item.DebugStickItem.useOn(DebugStickItem.java:48)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.item.ItemStack.lambda$useOn$16(ItemStack.java:361)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.item.ItemStack.onItemUse(ItemStack.java:377)
	at TRANSFORMER/minecraft@1.21/net.minecraft.world.item.ItemStack.useOn(ItemStack.java:361)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.multiplayer.MultiPlayerGameMode.performUseItemOn(MultiPlayerGameMode.java:352)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.multiplayer.MultiPlayerGameMode.lambda$useItemOn$4(MultiPlayerGameMode.java:298)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.multiplayer.MultiPlayerGameMode.startPrediction(MultiPlayerGameMode.java:264)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.multiplayer.MultiPlayerGameMode.useItemOn(MultiPlayerGameMode.java:297)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.startUseItem(Minecraft.java:1747)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.handleKeybinds(Minecraft.java:2026)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.tick(Minecraft.java:1840)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.runTick(Minecraft.java:1164)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.Minecraft.run(Minecraft.java:810)
	at TRANSFORMER/minecraft@1.21/net.minecraft.client.main.Main.main(Main.java:230)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at MC-BOOTSTRAP/fml_loader@4.0.18/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:136)
	at MC-BOOTSTRAP/fml_loader@4.0.18/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:124)
	at MC-BOOTSTRAP/fml_loader@4.0.18/net.neoforged.fml.loading.targets.NeoForgeClientDevLaunchHandler.runService(NeoForgeClientDevLaunchHandler.java:23)
	at MC-BOOTSTRAP/fml_loader@4.0.18/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:118)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:30)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:53)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:71)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.Launcher.run(Launcher.java:103)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.Launcher.main(Launcher.java:74)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:26)
	at MC-BOOTSTRAP/cpw.mods.modlauncher@11.0.4/cpw.mods.modlauncher.BootstrapLaunchConsumer.accept(BootstrapLaunchConsumer.java:23)
	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:210)
	at cpw.mods.bootstraplauncher@2.0.2/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:69)
```

Giving players a list of mods they can report to, when previously they would have nothing. And gives mod authors inspection into the data components at crash time, rather than needing to recreate, breakpoint, and log for their component data. 

I was unsure how Neoforge handles logging inside extensions, as the NeoforgeMod logger was private. I opted to recreate one here since we are about to throw and crash anyway, but can change it if needed.