### PR TITLE
[1.21] Fix accessibility screen not getting shown when dismissing the loading warnings screen

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -89,14 +89,11 @@
          );
          this.quickPlayLog = QuickPlayLog.of(p_91084_.quickPlay.path());
      }
-@@ -663,6 +_,11 @@
+@@ -663,6 +_,8 @@
              runnable = () -> this.setScreen(screen);
          }
  
-+        if (net.neoforged.neoforge.client.loading.ClientModLoader.completeModLoading())
-+        {
-+            runnable = () -> { }; //Forge: Do not override the error screen
-+        }
++        runnable = net.neoforged.neoforge.client.loading.ClientModLoader.completeModLoading(runnable);
 +
          return runnable;
      }

--- a/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
@@ -25,8 +25,10 @@ import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforge.client.gui.widget.ExtendedButton;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+@ApiStatus.Internal
 public class LoadingErrorScreen extends ErrorScreen {
     private static final Logger LOGGER = LogManager.getLogger();
     private final Path modsDir;

--- a/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/LoadingErrorScreen.java
@@ -35,11 +35,12 @@ public class LoadingErrorScreen extends ErrorScreen {
     private final List<FormattedIssue> modLoadWarnings;
     @Nullable
     private final Path dumpedLocation;
+    private final Runnable nextScreenTask;
     private LoadingEntryList entryList;
     private Component errorHeader;
     private Component warningHeader;
 
-    public LoadingErrorScreen(List<ModLoadingIssue> issues, @Nullable File dumpedLocation) {
+    public LoadingErrorScreen(List<ModLoadingIssue> issues, @Nullable File dumpedLocation, Runnable nextScreenTask) {
         super(Component.literal("Loading Error"), null);
         this.modLoadWarnings = issues.stream()
                 .filter(issue -> issue.severity() == ModLoadingIssue.Severity.WARNING)
@@ -52,6 +53,7 @@ public class LoadingErrorScreen extends ErrorScreen {
         this.modsDir = FMLPaths.MODSDIR.get();
         this.logFile = FMLPaths.GAMEDIR.get().resolve(Paths.get("logs", "latest.log"));
         this.dumpedLocation = dumpedLocation != null ? dumpedLocation.toPath() : null;
+        this.nextScreenTask = nextScreenTask;
     }
 
     @Override
@@ -67,7 +69,7 @@ public class LoadingErrorScreen extends ErrorScreen {
         this.addRenderableWidget(new ExtendedButton(this.width / 2 + 5, this.height - yOffset, this.width / 2 - 55, 20, Component.literal(FMLTranslations.parseMessage("fml.button.open.log")), b -> Util.getPlatform().openFile(logFile.toFile())));
         if (this.modLoadErrors.isEmpty()) {
             this.addRenderableWidget(new ExtendedButton(50, this.height - 24, this.width / 2 - 55, 20, Component.literal(FMLTranslations.parseMessage("fml.button.continue.launch")), b -> {
-                this.minecraft.setScreen(null);
+                this.nextScreenTask.run();
             }));
         } else {
             this.addRenderableWidget(new ExtendedButton(50, this.height - 24, this.width / 2 - 55, 20, Component.literal(FMLTranslations.parseMessage("fml.button.open.crashreport")), b -> Util.getPlatform().openFile(dumpedLocation.toFile())));

--- a/src/main/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
@@ -17,8 +17,6 @@ import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.DataPackConfig;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.Logging;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoader;
@@ -38,9 +36,10 @@ import net.neoforged.neoforge.resource.ResourcePackLoader;
 import net.neoforged.neoforge.server.LanguageHook;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-@OnlyIn(Dist.CLIENT)
+@ApiStatus.Internal
 public class ClientModLoader extends CommonModLoader {
     private static final Logger LOGGER = LogManager.getLogger();
     private static boolean loading;

--- a/src/main/java/net/neoforged/neoforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/data/loading/DatagenModLoader.java
@@ -21,6 +21,7 @@ import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.internal.CommonModLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
 
 public class DatagenModLoader extends CommonModLoader {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -32,6 +33,7 @@ public class DatagenModLoader extends CommonModLoader {
         return runningDataGen;
     }
 
+    @ApiStatus.Internal
     public static void begin(final Set<String> mods, final Path path, final Collection<Path> inputs, Collection<Path> existingPacks,
             Set<String> existingMods, final boolean serverGenerators, final boolean clientGenerators, final boolean devToolGenerators, final boolean reportsGenerator,
             final boolean structureValidator, final boolean flat, final String assetIndex, final File assetsDir) {

--- a/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
@@ -24,6 +24,7 @@ import net.neoforged.neoforge.client.loading.ClientModLoader;
 import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.registries.GameData;
 import net.neoforged.neoforge.registries.RegistryManager;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Internal class for handling the steps of mod loading that are common for client, data and server runs.
@@ -34,6 +35,7 @@ import net.neoforged.neoforge.registries.RegistryManager;
  * <li>Datagen only runs {@link #begin}.</li>
  * </ul>
  */
+@ApiStatus.Internal
 public abstract class CommonModLoader {
     private static boolean registriesLoaded = false;
 

--- a/src/main/java/net/neoforged/neoforge/server/loading/ServerModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/server/loading/ServerModLoader.java
@@ -18,7 +18,9 @@ import net.neoforged.neoforge.logging.CrashReportExtender;
 import net.neoforged.neoforge.server.LanguageHook;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class ServerModLoader extends CommonModLoader {
     private static final Logger LOGGER = LogManager.getLogger();
     private static boolean hasErrors = false;


### PR DESCRIPTION
This PR fixes the accessibility screen and other "initial screens" not showing after dismissing the loading warnings screen. This does not apply if any loading error is shown as the screen cannot be dismissed in that case.

Fixes #980