### PR TITLE
[1.21] Move client extension registration to an event

### DIFF
--- a/patches/net/minecraft/world/effect/MobEffect.java.patch
+++ b/patches/net/minecraft/world/effect/MobEffect.java.patch
@@ -9,40 +9,17 @@
      public static final Codec<Holder<MobEffect>> CODEC = BuiltInRegistries.MOB_EFFECT.holderByNameCodec();
      public static final StreamCodec<RegistryFriendlyByteBuf, Holder<MobEffect>> STREAM_CODEC = ByteBufCodecs.holderRegistry(Registries.MOB_EFFECT);
      private static final int AMBIENT_ALPHA = Mth.floor(38.25F);
-@@ -56,6 +_,7 @@
-             int i = p_333517_.isAmbient() ? AMBIENT_ALPHA : 255;
-             return ColorParticleOption.create(ParticleTypes.ENTITY_EFFECT, FastColor.ARGB32.color(i, p_19452_));
-         };
-+        initClient();
-     }
- 
-     protected MobEffect(MobEffectCategory p_333963_, int p_333864_, ParticleOptions p_333716_) {
-@@ -179,6 +_,29 @@
+@@ -179,6 +_,14 @@
      @Override
      public FeatureFlagSet requiredFeatures() {
          return this.requiredFeatures;
 +    }
 +
-+    // Neo: Client rendering for MobEffects
-+    private Object effectRenderer;
-+
 +    /**
-+     * Neo: DO NOT CALL, IT WILL DISAPPEAR IN THE FUTURE
-+     * TODO: Replace this with a better solution
-+     * Call {@link net.neoforged.neoforge.client.extensions.common.IClientMobEffectExtensions#of(MobEffect)} instead
++     * Neo: Allowing mods to define client behavior for their MobEffects
++     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
 +     */
-+    public Object getEffectRendererInternal() {
-+        return effectRenderer;
-+    }
-+
-+    // Neo: Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
-+    private void initClient() {
-+        if (net.neoforged.fml.loading.FMLEnvironment.dist == net.neoforged.api.distmarker.Dist.CLIENT && !net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) {
-+            initializeClient(properties -> this.effectRenderer = properties);
-+        }
-+    }
-+
-+    // Neo: Allowing mods to define client behavior for their MobEffects
++    @Deprecated(forRemoval = true)
 +    public void initializeClient(java.util.function.Consumer<net.neoforged.neoforge.client.extensions.common.IClientMobEffectExtensions> consumer) {
      }
  

--- a/patches/net/minecraft/world/effect/MobEffect.java.patch
+++ b/patches/net/minecraft/world/effect/MobEffect.java.patch
@@ -19,7 +19,7 @@
 +     * Neo: Allowing mods to define client behavior for their MobEffects
 +     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.21")
 +    public void initializeClient(java.util.function.Consumer<net.neoforged.neoforge.client.extensions.common.IClientMobEffectExtensions> consumer) {
      }
  

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -12,7 +12,7 @@
      public static final ResourceLocation BASE_ATTACK_DAMAGE_ID = ResourceLocation.withDefaultNamespace("base_attack_damage");
      public static final ResourceLocation BASE_ATTACK_SPEED_ID = ResourceLocation.withDefaultNamespace("base_attack_speed");
      public static final int DEFAULT_MAX_STACK_SIZE = 64;
-@@ -89,12 +_,14 @@
+@@ -89,12 +_,13 @@
          this.components = p_41383_.buildAndValidateComponents();
          this.craftingRemainingItem = p_41383_.craftingRemainingItem;
          this.requiredFeatures = p_41383_.requiredFeatures;
@@ -24,7 +24,6 @@
              }
          }
 +        this.canRepair = p_41383_.canRepair;
-+        initClient();
      }
  
      @Deprecated
@@ -143,35 +142,16 @@
      }
  
      public ItemStack getDefaultInstance() {
-@@ -341,13 +_,41 @@
+@@ -341,13 +_,22 @@
          return this.requiredFeatures;
      }
  
 -    public static class Properties {
-+    // Neo: Client rendering for Items
-+    private Object renderProperties;
-+
 +    /**
-+     * Neo: DO NOT CALL, IT WILL DISAPPEAR IN THE FUTURE
-+     * TODO: Replace this with a better solution
-+     * Call {@link net.neoforged.neoforge.client.extensions.common.IClientItemExtensions#of(Item)} instead
++     * Neo: Allowing mods to define client behavior for their Items
++     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
 +     */
-+    public Object getRenderPropertiesInternal() {
-+        return renderProperties;
-+    }
-+
-+    // Neo: Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
-+    private void initClient() {
-+        if (net.neoforged.fml.loading.FMLEnvironment.dist == net.neoforged.api.distmarker.Dist.CLIENT && !net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) {
-+            initializeClient(properties -> {
-+                if (properties == this)
-+                    throw new IllegalStateException("Don't extend IItemRenderProperties in your item, use an anonymous class instead.");
-+                this.renderProperties = properties;
-+            });
-+        }
-+    }
-+
-+    // Neo: Allowing mods to define client behavior for their Items
++    @Deprecated(forRemoval = true)
 +    public void initializeClient(java.util.function.Consumer<net.neoforged.neoforge.client.extensions.common.IClientItemExtensions> consumer) {
 +    }
 +

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -151,7 +151,7 @@
 +     * Neo: Allowing mods to define client behavior for their Items
 +     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.21")
 +    public void initializeClient(java.util.function.Consumer<net.neoforged.neoforge.client.extensions.common.IClientItemExtensions> consumer) {
 +    }
 +

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -152,7 +152,7 @@
 +     * Neo: Allowing mods to define client behavior for their Blocks
 +     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
 +     */
-+    @Deprecated(forRemoval = true)
++    @Deprecated(forRemoval = true, since = "1.21")
 +    public void initializeClient(java.util.function.Consumer<net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions> consumer) {
 +    }
 +

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -14,7 +14,7 @@
      private static final LoadingCache<VoxelShape, Boolean> SHAPE_FULL_BLOCK_CACHE = CacheBuilder.newBuilder()
          .maximumSize(512L)
          .weakKeys()
-@@ -186,12 +_,13 @@
+@@ -186,7 +_,7 @@
          this.createBlockStateDefinition(builder);
          this.stateDefinition = builder.create(Block::defaultBlockState, BlockState::new);
          this.registerDefaultState(this.stateDefinition.any());
@@ -23,12 +23,6 @@
              String s = this.getClass().getSimpleName();
              if (!s.endsWith("Block")) {
                  LOGGER.error("Block classes should end with Block and {} doesn't.", s);
-             }
-         }
-+        initClient();
-     }
- 
-     public static boolean isExceptionForConnection(BlockState p_152464_) {
 @@ -208,6 +_,8 @@
          BlockState blockstate = p_152446_.getBlockState(p_152449_);
          if (p_152445_.skipRendering(blockstate, p_152448_)) {
@@ -122,7 +116,7 @@
      public boolean dropFromExplosion(Explosion p_49826_) {
          return true;
      }
-@@ -485,6 +_,62 @@
+@@ -485,6 +_,43 @@
          return this.stateDefinition.getPossibleStates().stream().collect(ImmutableMap.toImmutableMap(Function.identity(), p_152459_));
      }
  
@@ -154,30 +148,11 @@
 +        return drops;
 +    }
 +
-+    // Neo: Client rendering for Blocks
-+    private Object renderProperties;
-+
 +    /**
-+     * Neo: DO NOT CALL, IT WILL DISAPPEAR IN THE FUTURE
-+     * TODO: Replace this with a better solution
-+     * Call {@link net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions#of(Block)}  instead
++     * Neo: Allowing mods to define client behavior for their Blocks
++     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
 +     */
-+    public Object getRenderPropertiesInternal() {
-+        return renderProperties;
-+    }
-+
-+    // Neo: Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
-+    private void initClient() {
-+        if (net.neoforged.fml.loading.FMLEnvironment.dist == net.neoforged.api.distmarker.Dist.CLIENT && !net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) {
-+            initializeClient(properties -> {
-+                if (properties == this)
-+                    throw new IllegalStateException("Don't extend IBlockRenderProperties in your block, use an anonymous class instead.");
-+                this.renderProperties = properties;
-+            });
-+        }
-+    }
-+
-+    // Neo: Allowing mods to define client behavior for their Blocks
++    @Deprecated(forRemoval = true)
 +    public void initializeClient(java.util.function.Consumer<net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions> consumer) {
 +    }
 +

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -170,6 +170,7 @@ import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
 import net.neoforged.neoforge.client.event.ToastAddEvent;
 import net.neoforged.neoforge.client.event.ViewportEvent;
 import net.neoforged.neoforge.client.event.sound.PlaySoundEvent;
+import net.neoforged.neoforge.client.extensions.common.ClientExtensionsManager;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import net.neoforged.neoforge.client.extensions.common.IClientMobEffectExtensions;
@@ -1003,6 +1004,7 @@ public class ClientHooks {
         }
         initializedClientHooks = true;
 
+        ClientExtensionsManager.init();
         GameTestHooks.registerGametests();
         registerSpriteSourceTypes();
         MenuScreens.init();

--- a/src/main/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -5,8 +5,13 @@
 
 package net.neoforged.neoforge.client;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BiomeColors;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.material.FluidState;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -14,6 +19,8 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.RegisterClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.RegisterNamedRenderTypesEvent;
+import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
 import net.neoforged.neoforge.client.model.CompositeModel;
 import net.neoforged.neoforge.client.model.DynamicFluidContainerModel;
 import net.neoforged.neoforge.client.model.ElementsModel;
@@ -21,6 +28,8 @@ import net.neoforged.neoforge.client.model.EmptyModel;
 import net.neoforged.neoforge.client.model.ItemLayerModel;
 import net.neoforged.neoforge.client.model.SeparateTransformsModel;
 import net.neoforged.neoforge.client.model.obj.ObjLoader;
+import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
 @Mod(value = "neoforge", dist = Dist.CLIENT)
 public class ClientNeoForgeMod {
@@ -50,5 +59,75 @@ public class ClientNeoForgeMod {
     @SubscribeEvent
     static void onRegisterNamedRenderTypes(RegisterNamedRenderTypesEvent event) {
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "item_unlit"), RenderType.translucent(), NeoForgeRenderTypes.ITEM_UNSORTED_UNLIT_TRANSLUCENT.get());
+    }
+
+    @SubscribeEvent
+    static void onRegisterClientExtensions(RegisterClientExtensionsEvent event) {
+        event.registerFluidType(new IClientFluidTypeExtensions() {
+            private static final ResourceLocation UNDERWATER_LOCATION = ResourceLocation.withDefaultNamespace("textures/misc/underwater.png");
+            private static final ResourceLocation WATER_STILL = ResourceLocation.withDefaultNamespace("block/water_still");
+            private static final ResourceLocation WATER_FLOW = ResourceLocation.withDefaultNamespace("block/water_flow");
+            private static final ResourceLocation WATER_OVERLAY = ResourceLocation.withDefaultNamespace("block/water_overlay");
+
+            @Override
+            public ResourceLocation getStillTexture() {
+                return WATER_STILL;
+            }
+
+            @Override
+            public ResourceLocation getFlowingTexture() {
+                return WATER_FLOW;
+            }
+
+            @Override
+            public ResourceLocation getOverlayTexture() {
+                return WATER_OVERLAY;
+            }
+
+            @Override
+            public ResourceLocation getRenderOverlayTexture(Minecraft mc) {
+                return UNDERWATER_LOCATION;
+            }
+
+            @Override
+            public int getTintColor() {
+                return 0xFF3F76E4;
+            }
+
+            @Override
+            public int getTintColor(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
+                return BiomeColors.getAverageWaterColor(getter, pos) | 0xFF000000;
+            }
+        }, NeoForgeMod.WATER_TYPE.value());
+
+        event.registerFluidType(new IClientFluidTypeExtensions() {
+            private static final ResourceLocation LAVA_STILL = ResourceLocation.withDefaultNamespace("block/lava_still");
+            private static final ResourceLocation LAVA_FLOW = ResourceLocation.withDefaultNamespace("block/lava_flow");
+
+            @Override
+            public ResourceLocation getStillTexture() {
+                return LAVA_STILL;
+            }
+
+            @Override
+            public ResourceLocation getFlowingTexture() {
+                return LAVA_FLOW;
+            }
+        }, NeoForgeMod.LAVA_TYPE.value());
+
+        NeoForgeMod.MILK_TYPE.asOptional().ifPresent(milkType -> event.registerFluidType(new IClientFluidTypeExtensions() {
+            private static final ResourceLocation MILK_STILL = ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "block/milk_still");
+            private static final ResourceLocation MILK_FLOW = ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "block/milk_flowing");
+
+            @Override
+            public ResourceLocation getStillTexture() {
+                return MILK_STILL;
+            }
+
+            @Override
+            public ResourceLocation getFlowingTexture() {
+                return MILK_FLOW;
+            }
+        }, milkType));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/ClientExtensionsManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/ClientExtensionsManager.java
@@ -14,6 +14,7 @@ import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.data.loading.DatagenModLoader;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import org.jetbrains.annotations.ApiStatus;
@@ -50,13 +51,13 @@ public final class ClientExtensionsManager {
         }
     }
 
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "1.21")
     public static void earlyInit() {
         // Minecraft instance isn't available in datagen, so don't initialize client extensions in datagen
-        if (net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) return;
+        if (DatagenModLoader.isRunningDataGen()) return;
 
         if (earlyInitialized) {
-            throw new IllegalStateException("Duplicate initialization of ClientExtensionsManager");
+            throw new IllegalStateException("Duplicate early initialization of ClientExtensionsManager");
         }
 
         earlyInitialized = true;
@@ -68,7 +69,7 @@ public final class ClientExtensionsManager {
 
     public static void init() {
         // Minecraft instance isn't available in datagen, so don't initialize client extensions in datagen
-        if (net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) return;
+        if (DatagenModLoader.isRunningDataGen()) return;
 
         if (initialized) {
             throw new IllegalStateException("Duplicate initialization of ClientExtensionsManager");

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/ClientExtensionsManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/ClientExtensionsManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions.common;
+
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.fluids.FluidType;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class ClientExtensionsManager {
+    static final Map<Block, IClientBlockExtensions> BLOCK_EXTENSIONS = new Reference2ObjectOpenHashMap<>();
+    static final Map<Item, IClientItemExtensions> ITEM_EXTENSIONS = new Reference2ObjectOpenHashMap<>();
+    static final Map<MobEffect, IClientMobEffectExtensions> MOB_EFFECT_EXTENSIONS = new Reference2ObjectOpenHashMap<>();
+    static final Map<FluidType, IClientFluidTypeExtensions> FLUID_TYPE_EXTENSIONS = new Reference2ObjectOpenHashMap<>();
+    private static boolean earlyInitialized = false;
+    private static boolean initialized = false;
+
+    private ClientExtensionsManager() {}
+
+    @SafeVarargs
+    static <T, E> void register(E extensions, Map<T, E> target, T... objects) {
+        if (objects.length == 0) {
+            throw new IllegalArgumentException("At least one target must be provided");
+        }
+        Objects.requireNonNull(extensions, "Extensions must not be null");
+
+        for (T object : objects) {
+            Objects.requireNonNull(objects, "Target must not be null");
+            E oldExtensions = target.put(object, extensions);
+            if (oldExtensions != null) {
+                throw new IllegalStateException(String.format(
+                        Locale.ROOT,
+                        "Duplicate client extensions registration for %s (old: %s, new: %s)",
+                        object,
+                        oldExtensions,
+                        extensions));
+            }
+        }
+    }
+
+    @Deprecated(forRemoval = true)
+    public static void earlyInit() {
+        // Minecraft instance isn't available in datagen, so don't initialize client extensions in datagen
+        if (net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) return;
+
+        if (earlyInitialized) {
+            throw new IllegalStateException("Duplicate initialization of ClientExtensionsManager");
+        }
+
+        earlyInitialized = true;
+        BuiltInRegistries.BLOCK.forEach(block -> block.initializeClient(ext -> register(ext, BLOCK_EXTENSIONS, block)));
+        BuiltInRegistries.ITEM.forEach(item -> item.initializeClient(ext -> register(ext, ITEM_EXTENSIONS, item)));
+        BuiltInRegistries.MOB_EFFECT.forEach(mobEffect -> mobEffect.initializeClient(ext -> register(ext, MOB_EFFECT_EXTENSIONS, mobEffect)));
+        NeoForgeRegistries.FLUID_TYPES.forEach(fluidType -> fluidType.initializeClient(ext -> register(ext, FLUID_TYPE_EXTENSIONS, fluidType)));
+    }
+
+    public static void init() {
+        // Minecraft instance isn't available in datagen, so don't initialize client extensions in datagen
+        if (net.neoforged.neoforge.data.loading.DatagenModLoader.isRunningDataGen()) return;
+
+        if (initialized) {
+            throw new IllegalStateException("Duplicate initialization of ClientExtensionsManager");
+        }
+
+        initialized = true;
+        ModLoader.postEvent(new RegisterClientExtensionsEvent());
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
@@ -38,7 +38,7 @@ public interface IClientBlockExtensions {
     }
 
     static IClientBlockExtensions of(Block block) {
-        return block.getRenderPropertiesInternal() instanceof IClientBlockExtensions e ? e : DEFAULT;
+        return ClientExtensionsManager.BLOCK_EXTENSIONS.getOrDefault(block, DEFAULT);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions.java
@@ -44,7 +44,7 @@ public interface IClientFluidTypeExtensions {
     }
 
     static IClientFluidTypeExtensions of(FluidType type) {
-        return type.getRenderPropertiesInternal() instanceof IClientFluidTypeExtensions props ? props : DEFAULT;
+        return ClientExtensionsManager.FLUID_TYPE_EXTENSIONS.getOrDefault(type, DEFAULT);
     }
 
     /* Default Accessors */

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -40,7 +40,7 @@ public interface IClientItemExtensions {
     }
 
     static IClientItemExtensions of(Item item) {
-        return item.getRenderPropertiesInternal() instanceof IClientItemExtensions e ? e : DEFAULT;
+        return ClientExtensionsManager.ITEM_EXTENSIONS.getOrDefault(item, DEFAULT);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientMobEffectExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientMobEffectExtensions.java
@@ -26,7 +26,7 @@ public interface IClientMobEffectExtensions {
     }
 
     static IClientMobEffectExtensions of(MobEffect effect) {
-        return effect.getEffectRendererInternal() instanceof IClientMobEffectExtensions r ? r : DEFAULT;
+        return ClientExtensionsManager.MOB_EFFECT_EXTENSIONS.getOrDefault(effect, DEFAULT);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions.common;
+
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.neoforge.fluids.FluidType;
+
+/**
+ * Allows registering client extensions for various game objects.
+ *
+ * <p>
+ * This event is not {@linkplain ICancellableEvent cancellable}.
+ *
+ * <p>
+ * This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.
+ */
+public final class RegisterClientExtensionsEvent extends Event implements IModBusEvent {
+    RegisterClientExtensionsEvent() {}
+
+    /**
+     * Register the given {@link IClientBlockExtensions} for the given {@link Block}s
+     */
+    public void registerBlock(IClientBlockExtensions extensions, Block... blocks) {
+        ClientExtensionsManager.register(extensions, ClientExtensionsManager.BLOCK_EXTENSIONS, blocks);
+    }
+
+    /**
+     * Register the given {@link IClientItemExtensions} for the given {@link Item}s
+     */
+    public void registerItem(IClientItemExtensions extensions, Item... items) {
+        ClientExtensionsManager.register(extensions, ClientExtensionsManager.ITEM_EXTENSIONS, items);
+    }
+
+    /**
+     * Register the given {@link IClientMobEffectExtensions} for the given {@link MobEffect}s
+     */
+    public void registerMobEffect(IClientMobEffectExtensions extensions, MobEffect... mobEffects) {
+        ClientExtensionsManager.register(extensions, ClientExtensionsManager.MOB_EFFECT_EXTENSIONS, mobEffects);
+    }
+
+    /**
+     * Register the given {@link IClientFluidTypeExtensions} for the given {@link FluidType}s
+     */
+    public void registerFluidType(IClientFluidTypeExtensions extensions, FluidType... fluidTypes) {
+        ClientExtensionsManager.register(extensions, ClientExtensionsManager.FLUID_TYPE_EXTENSIONS, fluidTypes);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -15,13 +15,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import net.minecraft.DetectedVersion;
 import net.minecraft.advancements.critereon.EntitySubPredicate;
 import net.minecraft.advancements.critereon.ItemSubPredicate;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.BiomeColors;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
 import net.minecraft.commands.synchronization.ArgumentTypeInfos;
@@ -53,7 +50,6 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
@@ -86,7 +82,6 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
-import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.neoforged.neoforge.common.advancements.critereon.ItemAbilityPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEntityPredicate;
@@ -438,46 +433,6 @@ public class NeoForgeMod {
         public @Nullable PathType getBlockPathType(FluidState state, BlockGetter level, BlockPos pos, @Nullable Mob mob, boolean canFluidLog) {
             return canFluidLog ? super.getBlockPathType(state, level, pos, mob, true) : null;
         }
-
-        @Override
-        public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {
-            consumer.accept(new IClientFluidTypeExtensions() {
-                private static final ResourceLocation UNDERWATER_LOCATION = ResourceLocation.withDefaultNamespace("textures/misc/underwater.png"),
-                        WATER_STILL = ResourceLocation.withDefaultNamespace("block/water_still"),
-                        WATER_FLOW = ResourceLocation.withDefaultNamespace("block/water_flow"),
-                        WATER_OVERLAY = ResourceLocation.withDefaultNamespace("block/water_overlay");
-
-                @Override
-                public ResourceLocation getStillTexture() {
-                    return WATER_STILL;
-                }
-
-                @Override
-                public ResourceLocation getFlowingTexture() {
-                    return WATER_FLOW;
-                }
-
-                @Override
-                public ResourceLocation getOverlayTexture() {
-                    return WATER_OVERLAY;
-                }
-
-                @Override
-                public ResourceLocation getRenderOverlayTexture(Minecraft mc) {
-                    return UNDERWATER_LOCATION;
-                }
-
-                @Override
-                public int getTintColor() {
-                    return 0xFF3F76E4;
-                }
-
-                @Override
-                public int getTintColor(FluidState state, BlockAndTintGetter getter, BlockPos pos) {
-                    return BiomeColors.getAverageWaterColor(getter, pos) | 0xFF000000;
-                }
-            });
-        }
     });
     public static final Holder<FluidType> LAVA_TYPE = VANILLA_FLUID_TYPES.register("lava", () -> new FluidType(FluidType.Properties.create()
             .descriptionId("block.minecraft.lava")
@@ -510,24 +465,6 @@ public class NeoForgeMod {
         public void setItemMovement(ItemEntity entity) {
             Vec3 vec3 = entity.getDeltaMovement();
             entity.setDeltaMovement(vec3.x * (double) 0.95F, vec3.y + (double) (vec3.y < (double) 0.06F ? 5.0E-4F : 0.0F), vec3.z * (double) 0.95F);
-        }
-
-        @Override
-        public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {
-            consumer.accept(new IClientFluidTypeExtensions() {
-                private static final ResourceLocation LAVA_STILL = ResourceLocation.withDefaultNamespace("block/lava_still"),
-                        LAVA_FLOW = ResourceLocation.withDefaultNamespace("block/lava_flow");
-
-                @Override
-                public ResourceLocation getStillTexture() {
-                    return LAVA_STILL;
-                }
-
-                @Override
-                public ResourceLocation getFlowingTexture() {
-                    return LAVA_FLOW;
-                }
-            });
         }
     });
 
@@ -687,25 +624,7 @@ public class NeoForgeMod {
             event.register(NeoForgeRegistries.Keys.FLUID_TYPES, helper -> helper.register(MILK_TYPE.unwrapKey().orElseThrow(), new FluidType(
                     FluidType.Properties.create().density(1024).viscosity(1024)
                             .sound(SoundActions.BUCKET_FILL, BUCKET_FILL_MILK.value())
-                            .sound(SoundActions.BUCKET_EMPTY, BUCKET_EMPTY_MILK.value())) {
-                @Override
-                public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {
-                    consumer.accept(new IClientFluidTypeExtensions() {
-                        private static final ResourceLocation MILK_STILL = ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "block/milk_still"),
-                                MILK_FLOW = ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "block/milk_flowing");
-
-                        @Override
-                        public ResourceLocation getStillTexture() {
-                            return MILK_STILL;
-                        }
-
-                        @Override
-                        public ResourceLocation getFlowingTexture() {
-                            return MILK_FLOW;
-                        }
-                    });
-                }
-            }));
+                            .sound(SoundActions.BUCKET_EMPTY, BUCKET_EMPTY_MILK.value()))));
 
             // register fluids
             event.register(Registries.FLUID, helper -> {

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidType.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidType.java
@@ -849,7 +849,7 @@ public class FluidType {
     /**
      * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "1.21")
     public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {}
 
     /**

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidType.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidType.java
@@ -47,7 +47,6 @@ import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.common.SoundAction;
 import net.neoforged.neoforge.common.SoundActions;
 import net.neoforged.neoforge.common.util.Lazy;
-import net.neoforged.neoforge.data.loading.DatagenModLoader;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import org.jetbrains.annotations.Nullable;
 
@@ -124,8 +123,6 @@ public class FluidType {
         this.viscosity = properties.viscosity;
         this.rarity = properties.rarity;
         this.dripInfo = properties.dripInfo;
-
-        this.initClient();
     }
 
     /* Default Accessors */
@@ -849,28 +846,10 @@ public class FluidType {
         return name != null ? name.toString() : "Unregistered FluidType";
     }
 
-    private Object renderProperties;
-
     /**
-     * DO NOT CALL, IT WILL DISAPPEAR IN THE FUTURE
-     * TODO: Replace this with a better solution
-     * Call {@link IClientFluidTypeExtensions#of(FluidType)} instead
+     * @deprecated Use {@link net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent} instead
      */
-    public Object getRenderPropertiesInternal() {
-        return renderProperties;
-    }
-
-    private void initClient() {
-        // Minecraft instance isn't available in datagen, so don't call initializeClient if in datagen
-        if (net.neoforged.fml.loading.FMLEnvironment.dist == net.neoforged.api.distmarker.Dist.CLIENT && !DatagenModLoader.isRunningDataGen()) {
-            initializeClient(properties -> {
-                if (properties == this)
-                    throw new IllegalStateException("Don't extend IFluidTypeRenderProperties in your fluid type, use an anonymous class instead.");
-                this.renderProperties = properties;
-            });
-        }
-    }
-
+    @Deprecated(forRemoval = true)
     public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {}
 
     /**

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -25,7 +25,9 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.ModLoader;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
+import net.neoforged.neoforge.client.extensions.common.ClientExtensionsManager;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.CreativeModeTabRegistry;
 import net.neoforged.neoforge.common.NeoForge;
@@ -102,6 +104,9 @@ public class GameData {
             SpawnPlacements.fireSpawnPlacementEvent();
             ModLoader.postEvent(new BlockEntityTypeAddBlocksEvent());
             CreativeModeTabRegistry.sortTabs();
+            if (FMLEnvironment.dist.isClient()) {
+                ClientExtensionsManager.earlyInit();
+            }
         }
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ItemUseAnimationTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ItemUseAnimationTest.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.oldtest.entity.player;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import java.util.function.Consumer;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.InteractionHand;
@@ -20,8 +19,10 @@ import net.minecraft.world.item.UseAnim;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.common.asm.enumextension.EnumProxy;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.IArmPoseTransformer;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
+import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -43,6 +44,10 @@ public class ItemUseAnimationTest {
     public ItemUseAnimationTest(IEventBus modBus) {
         ITEMS.register(modBus);
         modBus.addListener(this::addCreative);
+
+        if (FMLEnvironment.dist.isClient()) {
+            modBus.addListener(ClientEvents::onRegisterClientExtensions);
+        }
     }
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
@@ -71,10 +76,11 @@ public class ItemUseAnimationTest {
         public UseAnim getUseAnimation(ItemStack stack) {
             return UseAnim.CUSTOM;
         }
+    }
 
-        @Override
-        public void initializeClient(Consumer<IClientItemExtensions> consumer) {
-            consumer.accept(new IClientItemExtensions() {
+    private static final class ClientEvents {
+        private static void onRegisterClientExtensions(RegisterClientExtensionsEvent event) {
+            event.registerItem(new IClientItemExtensions() {
                 private static final HumanoidModel.ArmPose SWING_POSE = EnumParams.ARM_POSE_ENUM_PARAMS.getValue();
 
                 @Override
@@ -103,7 +109,7 @@ public class ItemUseAnimationTest {
                     int i = arm == HumanoidArm.RIGHT ? 1 : -1;
                     poseStack.translate(i * 0.56F, -0.52F, -0.72F);
                 }
-            });
+            }, THING.get());
         }
     }
 }


### PR DESCRIPTION
This PR moves the registration of client extensions (`IClientBlockExtensions`, `IClientItemExtensions`, `IClientMobEffectExtensions` and `IClientFluidTypeExtensions`) to a dedicated event instead of performing it from the constructor of the respective base class (`Block`, `Item`, `MobEffect` and `FluidType`). This improves separation of client-only code, makes it possible to use context passed to subclasses of the respective types when constructing the extensions and removes one more barrier towards split source sets.
The old API is still available as deprecated for now to avoid introducing another major breaking change so far into the lifecycle of 1.21.