### PR TITLE
Allow setting if the critical hit should disable sweep attack in `CriticalHitEvent`

### DIFF
--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -240,12 +240,12 @@
                  if (p_36347_.getType().is(EntityTypeTags.REDIRECTABLE_PROJECTILE)
                      && p_36347_ instanceof Projectile projectile
                      && projectile.deflect(ProjectileDeflection.AIM_DEFLECT, this, this, true)) {
-@@ -1170,8 +_,12 @@
+@@ -1170,18 +_,20 @@
                          && !this.isPassenger()
                          && p_36347_ instanceof LivingEntity
                          && !this.isSprinting();
 +                    // Neo: Fire the critical hit event and override the critical hit status and damage multiplier based on the event.
-+                    // The boolean local above (flag2) is the vanilla critical hit result.
++                    // The boolean local above (flag1) is the vanilla critical hit result.
 +                    var critEvent = net.neoforged.neoforge.common.CommonHooks.fireCriticalHit(this, p_36347_, flag1, flag1 ? 1.5F : 1.0F);
 +                    flag1 = critEvent.isCriticalHit();
                      if (flag1) {
@@ -254,9 +254,10 @@
                      }
  
                      float f3 = f + f1;
-@@ -1179,9 +_,7 @@
+                     boolean flag2 = false;
                      double d0 = (double)(this.walkDist - this.walkDistO);
-                     if (flag4 && !flag1 && !flag && this.onGround() && d0 < (double)this.getSpeed()) {
+-                    if (flag4 && !flag1 && !flag && this.onGround() && d0 < (double)this.getSpeed()) {
++                    if (flag4 && !(flag1 && critEvent.disableSweepAttack()) && !flag && this.onGround() && d0 < (double)this.getSpeed()) {
                          ItemStack itemstack1 = this.getItemInHand(InteractionHand.MAIN_HAND);
 -                        if (itemstack1.getItem() instanceof SwordItem) {
 -                            flag2 = true;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/CriticalHitEvent.java
@@ -22,6 +22,7 @@ public class CriticalHitEvent extends PlayerEvent {
 
     private float dmgMultiplier;
     private boolean isCriticalHit;
+    private boolean disableSweepAttack;
 
     /**
      * Fire via {@link CommonHooks#fireCriticalHit(Player, Entity, boolean, float)}
@@ -30,7 +31,7 @@ public class CriticalHitEvent extends PlayerEvent {
         super(player);
         this.target = target;
         this.dmgMultiplier = this.vanillaDmgMultiplier = dmgMultiplier;
-        this.isCriticalHit = this.isVanillaCritical = isCriticalHit;
+        this.disableSweepAttack = this.isCriticalHit = this.isVanillaCritical = isCriticalHit;
     }
 
     /**
@@ -80,6 +81,24 @@ public class CriticalHitEvent extends PlayerEvent {
      */
     public void setCriticalHit(boolean isCriticalHit) {
         this.isCriticalHit = isCriticalHit;
+    }
+
+    /**
+     * {@return if the attack disables sweep attack like vanilla critical hit}
+     * Not used if {@link #isCriticalHit()} is false.
+     */
+    public boolean disableSweepAttack() {
+        return this.disableSweepAttack;
+    }
+
+    /**
+     * Set if the attack should disable sweep attack like vanilla critical hit.
+     * Not used if {@link #isCriticalHit()} is false.
+     * 
+     * @param disableSweepAttack true if the attack disables sweep attack.
+     */
+    public void setDisableSweepAttack(boolean disableSweepAttack) {
+        this.disableSweepAttack = disableSweepAttack;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/CriticalHitEvent.java
@@ -45,8 +45,6 @@ public class CriticalHitEvent extends PlayerEvent {
      * The damage multiplier is applied to the base attack's damage if the attack {@linkplain #isCriticalHit() critically hits}.
      * <p>
      * A damage multiplier of 1.0 will not change the damage, a value of 1.5 will increase the damage by 50%, and so on.
-     * 
-     * @param modifier The new damage modifier.
      */
     public float getDamageMultiplier() {
         return this.dmgMultiplier;
@@ -57,7 +55,7 @@ public class CriticalHitEvent extends PlayerEvent {
      * <p>
      * Changing the damage modifier to zero does not guarantee that the attack does zero damage.
      * 
-     * @param modifier The new damage modifier. Must not be negative.
+     * @param dmgMultiplier The new damage modifier. Must not be negative.
      * @see #getDamageMultiplier()
      */
     public void setDamageMultiplier(float dmgMultiplier) {


### PR DESCRIPTION
Closes #1313.
Introduce a `disableSweepAttack` field to the `CriticalHitEvent`, equals to `isVanillaCritical` by default, matching vanilla behavior.
Now the sweep attack will only be disabled when `isCriticalHit()` and `disableSweepAttack()` both returns `true`.
This would change the behavior of existing subscriber of this event who set `isCriticalHit` to `true`, as now these modded critical would allow sweep attack when they are not vanilla critical. It's now up to these mod's decision to disable the sweep attack or not for their modded critical hit.