### PR TITLE
Replace ConditionalOps with InterceptingOps that supports conditions on any level of a data structure

### DIFF
--- a/patches/net/minecraft/server/ServerAdvancementManager.java.patch
+++ b/patches/net/minecraft/server/ServerAdvancementManager.java.patch
@@ -5,7 +5,7 @@
  
      protected void apply(Map<ResourceLocation, JsonElement> p_136034_, ResourceManager p_136035_, ProfilerFiller p_136036_) {
 -        RegistryOps<JsonElement> registryops = this.registries.createSerializationContext(JsonOps.INSTANCE);
-+        RegistryOps<JsonElement> registryops = this.makeConditionalOps(); // Neo: add condition context
++        RegistryOps<JsonElement> registryops = this.createInterceptingConditionOps(); // Neo: add condition context
          Builder<ResourceLocation, AdvancementHolder> builder = ImmutableMap.builder();
          p_136034_.forEach((p_337529_, p_337530_) -> {
              try {

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -5,7 +5,7 @@
          Builder<RecipeType<?>, RecipeHolder<?>> builder = ImmutableMultimap.builder();
          com.google.common.collect.ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> builder1 = ImmutableMap.builder();
 -        RegistryOps<JsonElement> registryops = this.registries.createSerializationContext(JsonOps.INSTANCE);
-+        RegistryOps<JsonElement> registryops = this.makeConditionalOps(); // Neo: add condition context
++        RegistryOps<JsonElement> registryops = this.createInterceptingConditionOps(); // Neo: add condition context
  
          for (Entry<ResourceLocation, JsonElement> entry : p_44037_.entrySet()) {
              ResourceLocation resourcelocation = entry.getKey();

--- a/patches/net/minecraft/world/level/storage/loot/LootTable.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/LootTable.java.patch
@@ -1,13 +1,17 @@
 --- a/net/minecraft/world/level/storage/loot/LootTable.java
 +++ b/net/minecraft/world/level/storage/loot/LootTable.java
-@@ -38,8 +_,8 @@
+@@ -36,10 +_,10 @@
+     public static final long RANDOMIZE_SEED = 0L;
+     public static final Codec<LootTable> DIRECT_CODEC = RecordCodecBuilder.create(
          p_338123_ -> p_338123_.group(
-                     LootContextParamSets.CODEC.lenientOptionalFieldOf("type", DEFAULT_PARAM_SET).forGetter(p_298001_ -> p_298001_.paramSet),
-                     ResourceLocation.CODEC.optionalFieldOf("random_sequence").forGetter(p_297998_ -> p_297998_.randomSequence),
+-                    LootContextParamSets.CODEC.lenientOptionalFieldOf("type", DEFAULT_PARAM_SET).forGetter(p_298001_ -> p_298001_.paramSet),
+-                    ResourceLocation.CODEC.optionalFieldOf("random_sequence").forGetter(p_297998_ -> p_297998_.randomSequence),
 -                    LootPool.CODEC.listOf().optionalFieldOf("pools", List.of()).forGetter(p_298002_ -> p_298002_.pools),
 -                    LootItemFunctions.ROOT_CODEC.listOf().optionalFieldOf("functions", List.of()).forGetter(p_298000_ -> p_298000_.functions)
-+                    net.neoforged.neoforge.common.CommonHooks.lootPoolsCodec(LootPool::setName).optionalFieldOf("pools", List.of()).forGetter(p_298002_ -> p_298002_.pools),
-+                        net.neoforged.neoforge.common.conditions.ConditionalOps.decodeListWithElementConditions(LootItemFunctions.ROOT_CODEC).optionalFieldOf("functions", List.of()).forGetter(p_298000_ -> p_298000_.functions)
++                        LootContextParamSets.CODEC.lenientOptionalFieldOf("type", DEFAULT_PARAM_SET).forGetter(p_298001_ -> p_298001_.paramSet),
++                        ResourceLocation.CODEC.optionalFieldOf("random_sequence").forGetter(p_297998_ -> p_297998_.randomSequence),
++                        LootPool.CODEC.listOf().optionalFieldOf("pools", List.of()).forGetter(p_298002_ -> p_298002_.pools),
++                        LootItemFunctions.ROOT_CODEC.listOf().optionalFieldOf("functions", List.of()).forGetter(p_298000_ -> p_298000_.functions)
                  )
                  .apply(p_338123_, LootTable::new)
      );

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -92,6 +92,7 @@ import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPr
 import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEntityPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.SnowBootsEntityPredicate;
 import net.neoforged.neoforge.common.conditions.AndCondition;
+import net.neoforged.neoforge.common.conditions.ConditionalOperationCodecCache;
 import net.neoforged.neoforge.common.conditions.FalseCondition;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.conditions.ItemExistsCondition;
@@ -100,6 +101,9 @@ import net.neoforged.neoforge.common.conditions.NotCondition;
 import net.neoforged.neoforge.common.conditions.OrCondition;
 import net.neoforged.neoforge.common.conditions.TagEmptyCondition;
 import net.neoforged.neoforge.common.conditions.TrueCondition;
+import net.neoforged.neoforge.common.conditions.operations.FieldRemove;
+import net.neoforged.neoforge.common.conditions.operations.OrNull;
+import net.neoforged.neoforge.common.conditions.operations.SimpleAlternative;
 import net.neoforged.neoforge.common.crafting.BlockTagIngredient;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.DataComponentIngredient;
@@ -387,6 +391,11 @@ public class NeoForgeMod {
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<TagEmptyCondition>> TAG_EMPTY_CONDITION = CONDITION_CODECS.register("tag_empty", () -> TagEmptyCondition.CODEC);
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<TrueCondition>> TRUE_CONDITION = CONDITION_CODECS.register("true", () -> TrueCondition.CODEC);
 
+    private static final DeferredRegister<ConditionalOperationCodecCache> CONDITIONAL_OPERATION_CODECS = DeferredRegister.create(NeoForgeRegistries.Keys.CONDITIONAL_OPERATION_CODECS, NeoForgeVersion.MOD_ID);
+    public static final DeferredHolder<ConditionalOperationCodecCache, ConditionalOperationCodecCache> OR_NULL = CONDITIONAL_OPERATION_CODECS.register("or_null", () -> OrNull.CODECS);
+    public static final DeferredHolder<ConditionalOperationCodecCache, ConditionalOperationCodecCache> SIMPLE_ALTERNATIVE = CONDITIONAL_OPERATION_CODECS.register("alternative", () -> SimpleAlternative.CODECS);
+    public static final DeferredHolder<ConditionalOperationCodecCache, ConditionalOperationCodecCache> REMOVE_FIELDS = CONDITIONAL_OPERATION_CODECS.register("remove_fields", () -> FieldRemove.CODECS);
+
     private static final DeferredRegister<MapCodec<? extends EntitySubPredicate>> ENTITY_PREDICATE_CODECS = DeferredRegister.create(Registries.ENTITY_SUB_PREDICATE_TYPE, NeoForgeVersion.MOD_ID);
     public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<PiglinNeutralArmorEntityPredicate>> PIGLIN_NEUTRAL_ARMOR_PREDICATE = ENTITY_PREDICATE_CODECS.register("piglin_neutral_armor", () -> PiglinNeutralArmorEntityPredicate.CODEC);
     public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<SnowBootsEntityPredicate>> SNOW_BOOTS_PREDICATE = ENTITY_PREDICATE_CODECS.register("snow_boots", () -> SnowBootsEntityPredicate.CODEC);
@@ -600,6 +609,7 @@ public class NeoForgeMod {
         ITEM_SUB_PREDICATES.register(modEventBus);
         INGREDIENT_TYPES.register(modEventBus);
         CONDITION_CODECS.register(modEventBus);
+        CONDITIONAL_OPERATION_CODECS.register(modEventBus);
         GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
         container.registerConfig(ModConfig.Type.CLIENT, NeoForgeConfig.clientSpec);

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOperation.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOperation.java
@@ -1,0 +1,82 @@
+package net.neoforged.neoforge.common.conditions;
+
+import com.mojang.datafixers.kinds.App;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.Dynamic;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import java.util.function.Supplier;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.resources.DelegatingOps;
+import net.minecraft.resources.RegistryOps;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+
+/**
+ * A class representing some object {@link T} that is wrapped in one or more conditions and a modification operation on the {@link T}, if the conditions succeed.
+ *
+ * @param <T> The type of the held object. Note that you should NEVER be querying the type of this and should only interact with it through the provided {@link DynamicOps}{@code <}{@link T}{@code >}.
+ */
+public abstract class ConditionalOperation<T> implements InterceptingOps.Wrapped<T, ICondition.IContext> {
+    public static final String OLD_CONDITIONS_KEY = "neoforge:conditions";
+    public static final String CONDITIONS_KEY = "conditions";
+    public static final String VALUE_KEY = "value";
+    public static final String TYPE_KEY = "neoforge:conditional_operation_type";
+
+    public static <T> InterceptingOps<T, ICondition.IContext> getOps(RegistryOps<T> ops, Supplier<ICondition.IContext> contextSupplier) {
+        return new InterceptingOps<>(ops, NeoForgeRegistries.CONDITIONAL_OPERATION_CODECS.byNameCodec().<ConditionalOperation<T>>dispatch(TYPE_KEY, ConditionalOperation::getCodecCache, codecCache -> codecCache.getFromCache(ops)), contextSupplier);
+    }
+
+    public static <T> InterceptingOps<T, ICondition.IContext> getOps(DynamicOps<T> ops, RegistryOps.RegistryInfoLookup regInfo, Supplier<ICondition.IContext> contextSupplier) {
+        return new InterceptingOps<>(ops, regInfo, NeoForgeRegistries.CONDITIONAL_OPERATION_CODECS.byNameCodec().<ConditionalOperation<T>>dispatch(TYPE_KEY, ConditionalOperation::getCodecCache, codecCache -> codecCache.getFromCache(ops)), contextSupplier);
+    }
+
+    public static <T> InterceptingOps<T, ICondition.IContext> getOps(DynamicOps<T> ops, HolderLookup.Provider registryAccess, Supplier<ICondition.IContext> contextSupplier) {
+        return new InterceptingOps<>(ops, registryAccess, NeoForgeRegistries.CONDITIONAL_OPERATION_CODECS.byNameCodec().<ConditionalOperation<T>>dispatch(TYPE_KEY, ConditionalOperation::getCodecCache, codecCache -> codecCache.getFromCache(ops)), contextSupplier);
+    }
+
+    /**
+     * The raw ops for the type T. DO NOT expect this to be any sort of ops with extra data such as a RegistryOps.
+     * It should only be used for manipulating {@link T}
+     */
+    protected final DynamicOps<T> ops;
+    protected final List<ICondition> conditions;
+
+    public ConditionalOperation(DynamicOps<T> ops, List<ICondition> conditions) {
+        // unwrap delegating ops as we only care about the data structure manipulation methods
+        // this makes the codec cache more efficient as we will have a lot less codecs in ir
+        while (ops instanceof DelegatingOps<T> doo)
+            ops = doo.delegate;
+        this.ops = ops;
+        this.conditions = conditions;
+    }
+
+    protected List<ICondition> getConditions() {
+        return conditions;
+    }
+
+    protected abstract ConditionalOperationCodecCache getCodecCache();
+
+    /**
+     * Get the result if all conditions passed (evaluated to {@code true})
+     */
+    protected abstract T getSuccess();
+
+    /**
+     * Get the result if at least one condition did not pass (evaluated to {@code false})
+     */
+    protected abstract T getFail();
+
+    @Override
+    public T unwrap(ICondition.IContext context) {
+        return conditions.stream().allMatch(condition -> condition.test(context)) ? getSuccess() : getFail();
+    }
+
+    protected static <T extends ConditionalOperation<?>> App<RecordCodecBuilder.Mu<T>, List<ICondition>> conditionList() {
+        return ICondition.LIST_CODEC.fieldOf(CONDITIONS_KEY).forGetter(ConditionalOperation::getConditions);
+    }
+
+    protected static <T> Codec<T> typedPassThrough(DynamicOps<T> ops) {
+        return Codec.PASSTHROUGH.xmap(x -> x.cast(ops), x -> new Dynamic<>(ops, x));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOperationCodecCache.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOperationCodecCache.java
@@ -1,0 +1,33 @@
+package net.neoforged.neoforge.common.conditions;
+
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.MapCodec;
+import java.util.WeakHashMap;
+import java.util.function.Function;
+
+public class ConditionalOperationCodecCache {
+    public interface ConditionCodecConstructor extends Function<DynamicOps<?>, MapCodec<? extends ConditionalOperation<?>>> {
+        @Override
+        default MapCodec<? extends ConditionalOperation<?>> apply(DynamicOps<?> dynamicOps) {
+            return make(dynamicOps);
+        }
+
+        <T> MapCodec<? extends ConditionalOperation<T>> make(DynamicOps<T> ops);
+    }
+
+    private final ConditionCodecConstructor constructor;
+    private final WeakHashMap<DynamicOps<?>, MapCodec<? extends ConditionalOperation<?>>> map = new WeakHashMap<>();
+
+    public ConditionalOperationCodecCache(ConditionCodecConstructor constructor) {
+        this.constructor = constructor;
+    }
+
+    public <T> void putCodec(DynamicOps<T> key, MapCodec<? extends ConditionalOperation<T>> value) {
+        map.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked") // the cast is safe because we control all puts with the same generic contract enforced
+    public <T> MapCodec<? extends ConditionalOperation<T>> getFromCache(DynamicOps<T> key) {
+        return (MapCodec<? extends ConditionalOperation<T>>) map.computeIfAbsent(key, constructor);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
@@ -21,7 +21,11 @@ import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
 /**
  * Extension of {@link RegistryOps} that also encapsulates a {@link ICondition.IContext}.
  * This allows getting the {@link ICondition.IContext} while decoding an entry from within a codec.
+ *
+ * @deprecated Use {@link InterceptingOps} with {@link ConditionalOperation}
+ * @see ConditionalOperation#getOps
  */
+@Deprecated
 public class ConditionalOps<T> extends RegistryOps<T> {
     private final ICondition.IContext context;
 
@@ -46,7 +50,8 @@ public class ConditionalOps<T> extends RegistryOps<T> {
     /**
      * Key used for the conditions inside an object.
      */
-    public static final String DEFAULT_CONDITIONS_KEY = "neoforge:conditions";
+    @Deprecated
+    public static final String DEFAULT_CONDITIONS_KEY = ConditionalOperation.OLD_CONDITIONS_KEY;
     /**
      * Key used to store the value associated with conditions,
      * when the value is not represented as a map.
@@ -62,8 +67,10 @@ public class ConditionalOps<T> extends RegistryOps<T> {
     public static final String CONDITIONAL_VALUE_KEY = "neoforge:value";
 
     /**
-     * @see #createConditionalCodec(Codec, String)
+     * @deprecated Conditions are now automatically supported on all levels of all json structures parsed using an
+     *             ops from {@link net.neoforged.neoforge.common.conditions.ConditionalOperation#getOps}
      */
+    @Deprecated
     public static <T> Codec<Optional<T>> createConditionalCodec(final Codec<T> ownerCodec) {
         return createConditionalCodec(ownerCodec, DEFAULT_CONDITIONS_KEY);
     }
@@ -72,14 +79,22 @@ public class ConditionalOps<T> extends RegistryOps<T> {
      * Creates a conditional codec.
      *
      * <p>The conditional codec is generally not suitable for use as a dispatch target because it is never a {@link MapCodec.MapCodecCodec}.
+     *
+     * @deprecated Conditions are now automatically supported on all levels of all json structures parsed using an
+     *             ops from {@link net.neoforged.neoforge.common.conditions.ConditionalOperation#getOps}
      */
+    @Deprecated
     public static <T> Codec<Optional<T>> createConditionalCodec(final Codec<T> ownerCodec, String conditionalsKey) {
         return createConditionalCodecWithConditions(ownerCodec, conditionalsKey).xmap(r -> r.map(WithConditions::carrier), r -> r.map(i -> new WithConditions<>(List.of(), i)));
     }
 
     /**
      * Creates a codec that can decode a list of elements, and will check for conditions on each element.
+     *
+     * @deprecated Conditions are now automatically supported on all levels of all json structures parsed using an
+     *             ops from {@link net.neoforged.neoforge.common.conditions.ConditionalOperation#getOps}
      */
+    @Deprecated
     public static <T> Codec<List<T>> decodeListWithElementConditions(final Codec<T> ownerCodec) {
         return Codec.of(
                 ownerCodec.listOf(),
@@ -88,7 +103,11 @@ public class ConditionalOps<T> extends RegistryOps<T> {
 
     /**
      * @see #createConditionalCodecWithConditions(Codec, String)
+     *
+     * @deprecated Conditions are now automatically supported on all levels of all json structures parsed using an
+     *             ops from {@link net.neoforged.neoforge.common.conditions.ConditionalOperation#getOps}
      */
+    @Deprecated
     public static <T> Codec<Optional<WithConditions<T>>> createConditionalCodecWithConditions(final Codec<T> ownerCodec) {
         return createConditionalCodecWithConditions(ownerCodec, DEFAULT_CONDITIONS_KEY);
     }
@@ -97,7 +116,11 @@ public class ConditionalOps<T> extends RegistryOps<T> {
      * Creates a conditional codec.
      *
      * <p>The conditional codec is generally not suitable for use as a dispatch target because it is never a {@link MapCodec.MapCodecCodec}.
+     *
+     * @deprecated Conditions are now automatically supported on all levels of all json structures parsed using an
+     *             ops from {@link net.neoforged.neoforge.common.conditions.ConditionalOperation#getOps}
      */
+    @Deprecated
     public static <T> Codec<Optional<WithConditions<T>>> createConditionalCodecWithConditions(final Codec<T> ownerCodec, String conditionalsKey) {
         return Codec.of(
                 new ConditionalEncoder<>(conditionalsKey, ICondition.LIST_CODEC, ownerCodec),

--- a/src/main/java/net/neoforged/neoforge/common/conditions/InterceptingOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/InterceptingOps.java
@@ -1,0 +1,167 @@
+package net.neoforged.neoforge.common.conditions;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.logging.LogUtils;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.MapLike;
+import java.nio.ByteBuffer;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.resources.RegistryOps;
+import org.slf4j.Logger;
+
+/**
+ * Intercepts all calls to get something from a {@link T} using the wrapperCodec. If that codec succeeds the returned
+ * wrapper object is unwrapped with supplied context, and parsed in place of the original structure.
+ * If that fails to parse the structure then the input is just passed directly to the delegate codec.
+ * <p>
+ * Intended for use to allow dynamically modifying json on-parse based on the json itself, with additional outside context if needed.
+ *
+ * @param <T> The type of the ops, like {@link com.google.gson.JsonElement} if this wraps a {@link com.mojang.serialization.JsonOps}.
+ * @param <C> The type of the context. Can be {@link Void} for no context.
+ */
+public class InterceptingOps<T, C> extends RegistryOps<T> {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private final Codec<? extends Wrapped<T, C>> wrapperCodec;
+    private final Supplier<C> context;
+
+    /**
+     * @param delegate       The {@link DynamicOps <T>} that we are wrapping.
+     * @param lookupProvider The registry information. Required because we extend RegistryOps.
+     * @param wrapperCodec   The {@link Codec} for the wrapper object. This will try to parse every single value that this DynamicOps comes into contact with. Not used when encoding.
+     * @param context        The context that will be passed to the wrapper for each decode. Can be {@code null} and of type {@link Void} if no context is needed.
+     */
+    public InterceptingOps(DynamicOps<T> delegate, RegistryOps.RegistryInfoLookup lookupProvider, Codec<? extends Wrapped<T, C>> wrapperCodec, Supplier<C> context) {
+        super(delegate, lookupProvider);
+        if (delegate instanceof InterceptingOps<?, ?>) LOGGER.warn("Are you sure this is a good idea?");
+        this.wrapperCodec = wrapperCodec;
+        this.context = context;
+    }
+
+    /**
+     * @param delegate     The {@link DynamicOps <T>} that we are wrapping.
+     * @param regAccess    The registry access. Required because we extend RegistryOps.
+     * @param wrapperCodec The {@link Codec} for the wrapper object. This will try to parse every single value that this DynamicOps comes into contact with. Not used when encoding.
+     * @param context      The context that will be passed to the wrapper for each decode. Can be {@code null} and of type {@link Void} if no context is needed.
+     */
+    public InterceptingOps(DynamicOps<T> delegate, HolderLookup.Provider regAccess, Codec<? extends Wrapped<T, C>> wrapperCodec, Supplier<C> context) {
+        this(delegate, new RegistryOps.HolderLookupAdapter(regAccess), wrapperCodec, context);
+    }
+
+    /**
+     * @param delegate     The {@link RegistryOps} that we are wrapping. Will be split into its delegate and lookup provider.
+     * @param wrapperCodec The {@link Codec} for the wrapper object. This will try to parse every single value that this InterceptingOps comes into contact with. Not (currently) used when encoding.
+     * @param context      The context that will be passed to the {@link Wrapped} for unwrapping. Can be {@code null} and of type {@link Void} if no context is needed.
+     */
+    public InterceptingOps(RegistryOps<T> delegate, Codec<? extends Wrapped<T, C>> wrapperCodec, Supplier<C> context) {
+        this(delegate.delegate, delegate.lookupProvider, wrapperCodec, context);
+    }
+
+    /**
+     * Try to intercept a value.
+     * 
+     * @param intercepted The value that is being intercepted.
+     * @return The result of unwrapping the wrapper codec if the wrapper codec succeeds, else the {@code intercepted} is returned.
+     */
+    protected DataResult<T> intercept(T intercepted) {
+        // TODO: allow not suppressing errors from this. Maybe a secondary 'checker' codec, which for conditions would
+        //  just contain the type field, and use the result of that as a 'should try parse as Wrapped' check.
+        DataResult<? extends Wrapped<T, C>> parsed = wrapperCodec.parse(delegate, intercepted);
+        if (parsed.isSuccess())
+            return parsed.map(w -> w.unwrap(context.get()));
+        return DataResult.success(intercepted);
+    }
+
+    /**
+     * A {@link Function} returned from decoding a {@link Codec} which can modify the structure of part of a data
+     * structure, based on data parsed from the data structure itself.
+     *
+     * @param <T> The type of the wrapped object.
+     * @param <C> The context needed to unwrap the object. Can be {@link Void} if no context is required.
+     */
+    public interface Wrapped<T, C> extends Function<C, T> {
+        T unwrap(C c);
+
+        @Override
+        default T apply(C c) {
+            return unwrap(c);
+        }
+    }
+
+    public InterceptingOps<T, C> withContext(Supplier<C> newContext) {
+        return new InterceptingOps<>(this.delegate, this.lookupProvider, this.wrapperCodec, newContext);
+    }
+
+    @SuppressWarnings({ "unchecked" }) // the cast is fine as the ops match
+    public <U> InterceptingOps<U, C> withParent(RegistryOps<U> newOps, Codec<? extends Wrapped<U, C>> newCodec) {
+        return delegate == newOps ? (InterceptingOps<U, C>) this : new InterceptingOps<>(newOps, newCodec, this.context);
+    }
+
+    @SuppressWarnings({ "unchecked" }) // the cast is fine as the ops match
+    public <U> InterceptingOps<U, C> withParent(DynamicOps<U> newOps, RegistryInfoLookup lookupProvider, Codec<? extends Wrapped<U, C>> newCodec) {
+        return delegate == newOps ? (InterceptingOps<U, C>) this : new InterceptingOps<>(newOps, lookupProvider, newCodec, this.context);
+    }
+
+    @Override
+    public DataResult<Boolean> getBooleanValue(T input) {
+        return intercept(input).flatMap(super::getBooleanValue);
+    }
+
+    @Override
+    public DataResult<Stream<Pair<T, T>>> getMapValues(T input) {
+        return intercept(input).flatMap(super::getMapValues);
+    }
+
+    @Override
+    public DataResult<Number> getNumberValue(T input) {
+        return intercept(input).flatMap(super::getNumberValue);
+    }
+
+    @Override
+    public DataResult<String> getStringValue(T input) {
+        return intercept(input).flatMap(super::getStringValue);
+    }
+
+    @Override
+    public DataResult<ByteBuffer> getByteBuffer(T input) {
+        return intercept(input).flatMap(super::getByteBuffer);
+    }
+
+    @Override
+    public DataResult<IntStream> getIntStream(T input) {
+        return intercept(input).flatMap(super::getIntStream);
+    }
+
+    @Override
+    public DataResult<Consumer<Consumer<T>>> getList(T input) {
+        return intercept(input).flatMap(super::getList);
+    }
+
+    @Override
+    public DataResult<LongStream> getLongStream(T input) {
+        return intercept(input).flatMap(super::getLongStream);
+    }
+
+    @Override
+    public DataResult<MapLike<T>> getMap(T input) {
+        return intercept(input).flatMap(super::getMap);
+    }
+
+    @Override
+    public DataResult<Consumer<BiConsumer<T, T>>> getMapEntries(T input) {
+        return intercept(input).flatMap(super::getMapEntries);
+    }
+
+    @Override
+    public DataResult<Stream<T>> getStream(T input) {
+        return intercept(input).flatMap(super::getStream);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/operations/FieldRemove.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/operations/FieldRemove.java
@@ -1,0 +1,80 @@
+package net.neoforged.neoforge.common.conditions.operations;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Either;
+import com.mojang.datafixers.util.Function3;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import java.util.Set;
+import net.neoforged.neoforge.common.conditions.ConditionalOperation;
+import net.neoforged.neoforge.common.conditions.ConditionalOperationCodecCache;
+import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
+
+/**
+ * Removes fields from a map-like if the conditions are true.
+ */
+public class FieldRemove<T> extends ConditionalOperation<T> {
+    public static final Codec<Set<String>> SINGLE_OR_SET = Codec.either(Codec.STRING, NeoForgeExtraCodecs.setOf(Codec.STRING)).xmap(e -> Either.unwrap(e.mapLeft(Set::of)), Either::right);
+    public static final ConditionalOperationCodecCache CODECS = new ConditionalOperationCodecCache(FieldRemove::makeCodec);
+    static {
+        // a special implementation for json ops as they use a really inefficient method of removing if you are removing multiple things in a row.
+        CODECS.putCodec(JsonOps.INSTANCE, makeCodec(JsonOps.INSTANCE, (conditions, base, toRemove) -> new FieldRemove<>(JsonOps.INSTANCE, conditions, base, toRemove) {
+            @Override
+            protected JsonElement getSuccess() {
+                if (base instanceof JsonObject) {
+                    final JsonObject result = new JsonObject();
+                    base.getAsJsonObject().entrySet().stream()
+                            .filter(entry -> !fieldsToRemove.contains(entry.getKey()))
+                            .forEach(entry -> result.add(entry.getKey(), entry.getValue()));
+                    return result;
+                }
+                return base;
+            }
+        }));
+    }
+
+    protected final T base;
+    protected final Set<String> fieldsToRemove;
+
+    public FieldRemove(DynamicOps<T> ops, List<ICondition> conditions, T base, Set<String> fieldsToRemove) {
+        super(ops, conditions);
+        this.base = base;
+        this.fieldsToRemove = fieldsToRemove;
+    }
+
+    private static <T> MapCodec<FieldRemove<T>> makeCodec(DynamicOps<T> ops, Function3<List<ICondition>, T, Set<String>, FieldRemove<T>> applicator) {
+        return RecordCodecBuilder.mapCodec(instance -> instance.group(
+                conditionList(),
+                typedPassThrough(ops).fieldOf(VALUE_KEY).forGetter(fr -> fr.base),
+                SINGLE_OR_SET.fieldOf("to_remove").forGetter(fr -> fr.fieldsToRemove)).apply(instance, applicator));
+    }
+
+    private static <T> MapCodec<FieldRemove<T>> makeCodec(DynamicOps<T> ops) {
+        return makeCodec(ops, (conditions, base, toRemove) -> new FieldRemove<>(ops, conditions, base, toRemove));
+    }
+
+    @Override
+    public ConditionalOperationCodecCache getCodecCache() {
+        return CODECS;
+    }
+
+    @Override
+    protected T getSuccess() {
+        T value = base;
+        for (String field : fieldsToRemove) {
+            value = ops.remove(value, field);
+        }
+        return value;
+    }
+
+    @Override
+    protected T getFail() {
+        return base;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/operations/OrNull.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/operations/OrNull.java
@@ -1,0 +1,31 @@
+package net.neoforged.neoforge.common.conditions.operations;
+
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import net.neoforged.neoforge.common.conditions.ConditionalOperationCodecCache;
+import net.neoforged.neoforge.common.conditions.ICondition;
+
+/**
+ * A basic version of {@link SimpleAlternative} that returns the ops 'empty' as the alternative.
+ * Primarily used for a root level condition so that the entire result is empty (and thus ignored) if conditions are not met
+ */
+public class OrNull<T> extends SimpleAlternative<T> {
+    public static final ConditionalOperationCodecCache CODECS = new ConditionalOperationCodecCache(OrNull::makeCodec);
+
+    private static <T> MapCodec<OrNull<T>> makeCodec(DynamicOps<T> dops) {
+        return RecordCodecBuilder.mapCodec(instance -> instance.group(
+                conditionList(),
+                typedPassThrough(dops).fieldOf(VALUE_KEY).forGetter(OrNull::getSuccess)).apply(instance, (conditions, value) -> new OrNull<>(dops, conditions, value)));
+    }
+
+    public OrNull(DynamicOps<T> ops, List<ICondition> conditions, T value) {
+        super(ops, conditions, value, ops.empty());
+    }
+
+    @Override
+    public ConditionalOperationCodecCache getCodecCache() {
+        return CODECS;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/operations/SimpleAlternative.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/operations/SimpleAlternative.java
@@ -1,0 +1,46 @@
+package net.neoforged.neoforge.common.conditions.operations;
+
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import net.neoforged.neoforge.common.conditions.ConditionalOperation;
+import net.neoforged.neoforge.common.conditions.ConditionalOperationCodecCache;
+import net.neoforged.neoforge.common.conditions.ICondition;
+
+/**
+ * Returns one value if all conditions pass, or another if they do not.
+ */
+public class SimpleAlternative<T> extends ConditionalOperation<T> {
+    public static final ConditionalOperationCodecCache CODECS = new ConditionalOperationCodecCache(SimpleAlternative::makeCodec);
+    protected final T value;
+    protected final T orElse;
+
+    public SimpleAlternative(DynamicOps<T> ops, List<ICondition> conditions, T value, T orElse) {
+        super(ops, conditions);
+        this.value = value;
+        this.orElse = orElse;
+    }
+
+    private static <T> MapCodec<SimpleAlternative<T>> makeCodec(DynamicOps<T> ops) {
+        return RecordCodecBuilder.mapCodec(instance -> instance.group(
+                conditionList(),
+                typedPassThrough(ops).fieldOf(VALUE_KEY).forGetter(SimpleAlternative::getSuccess),
+                typedPassThrough(ops).fieldOf("or_else").forGetter(SimpleAlternative::getFail)).apply(instance, (c, v, oe) -> new SimpleAlternative<>(ops, c, v, oe)));
+    }
+
+    @Override
+    public ConditionalOperationCodecCache getCodecCache() {
+        return CODECS;
+    }
+
+    @Override
+    protected T getSuccess() {
+        return value;
+    }
+
+    @Override
+    protected T getFail() {
+        return orElse;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/operations/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/operations/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.common.conditions.operations;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/main/java/net/neoforged/neoforge/common/loot/IGlobalLootModifier.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/IGlobalLootModifier.java
@@ -27,6 +27,11 @@ import net.neoforged.neoforge.registries.NeoForgeRegistries;
 public interface IGlobalLootModifier {
     Codec<IGlobalLootModifier> DIRECT_CODEC = NeoForgeRegistries.GLOBAL_LOOT_MODIFIER_SERIALIZERS.byNameCodec()
             .dispatch(IGlobalLootModifier::codec, Function.identity());
+    /**
+     * @deprecated Conditions are now automatically supported on all levels of all json structures parsed using an
+     *             ops from {@link net.neoforged.neoforge.common.conditions.ConditionalOperation#getOps}
+     */
+    @Deprecated
     Codec<Optional<WithConditions<IGlobalLootModifier>>> CONDITIONAL_CODEC = ConditionalOps.createConditionalCodecWithConditions(DIRECT_CODEC);
 
     Codec<LootItemCondition[]> LOOT_CONDITIONS_CODEC = LootItemCondition.DIRECT_CODEC.listOf().xmap(list -> list.toArray(LootItemCondition[]::new), List::of);

--- a/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
@@ -73,7 +73,7 @@ public class LootModifierManager extends SimpleJsonResourceReloadListener {
 
     @Override
     protected void apply(Map<ResourceLocation, JsonElement> resourceList, ResourceManager resourceManagerIn, ProfilerFiller profilerIn) {
-        DynamicOps<JsonElement> ops = this.makeConditionalOps();
+        DynamicOps<JsonElement> ops = this.createInterceptingConditionOps();
         Builder<ResourceLocation, IGlobalLootModifier> builder = ImmutableMap.builder();
         for (Map.Entry<ResourceLocation, JsonElement> entry : resourceList.entrySet()) {
             ResourceLocation location = entry.getKey();

--- a/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
@@ -33,7 +33,7 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.conditions.ConditionalOps;
+import net.neoforged.neoforge.common.conditions.ConditionalOperation;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.registries.datamaps.AdvancedDataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapFile;
@@ -129,7 +129,7 @@ public class DataMapLoader implements PreparableReloadListener {
     }
 
     private static Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> load(ResourceManager manager, ProfilerFiller profiler, RegistryAccess access, ICondition.IContext context) {
-        final RegistryOps<JsonElement> ops = new ConditionalOps<>(RegistryOps.create(JsonOps.INSTANCE, access), context);
+        final RegistryOps<JsonElement> ops = ConditionalOperation.getOps(JsonOps.INSTANCE, access, () -> context);
 
         final Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> values = new HashMap<>();
         access.registries().forEach(registryEntry -> {

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
@@ -13,6 +13,7 @@ import net.minecraft.network.syncher.EntityDataSerializer;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.attachment.AttachmentType;
+import net.neoforged.neoforge.common.conditions.ConditionalOperationCodecCache;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.crafting.IngredientType;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
@@ -40,6 +41,7 @@ public class NeoForgeRegistries {
     public static final Registry<IngredientType<?>> INGREDIENT_TYPES = new RegistryBuilder<>(Keys.INGREDIENT_TYPES).sync(true).create();
     public static final Registry<FluidIngredientType<?>> FLUID_INGREDIENT_TYPES = new RegistryBuilder<>(Keys.FLUID_INGREDIENT_TYPES).sync(true).create();
     public static final Registry<MapCodec<? extends ICondition>> CONDITION_SERIALIZERS = new RegistryBuilder<>(Keys.CONDITION_CODECS).create();
+    public static final Registry<ConditionalOperationCodecCache> CONDITIONAL_OPERATION_CODECS = new RegistryBuilder<>(Keys.CONDITIONAL_OPERATION_CODECS).create();
     public static final Registry<AttachmentType<?>> ATTACHMENT_TYPES = new RegistryBuilder<>(Keys.ATTACHMENT_TYPES).create();
 
     // Reminder: If you add a registry to NeoForge itself, remember to add it to NeoForgeRegistriesSetup#registerRegistries.
@@ -55,6 +57,7 @@ public class NeoForgeRegistries {
         public static final ResourceKey<Registry<IngredientType<?>>> INGREDIENT_TYPES = key("ingredient_serializer");
         public static final ResourceKey<Registry<FluidIngredientType<?>>> FLUID_INGREDIENT_TYPES = key("fluid_ingredient_type");
         public static final ResourceKey<Registry<MapCodec<? extends ICondition>>> CONDITION_CODECS = key("condition_codecs");
+        public static final ResourceKey<Registry<ConditionalOperationCodecCache>> CONDITIONAL_OPERATION_CODECS = key("conditional_operation_codecs");
         public static final ResourceKey<Registry<AttachmentType<?>>> ATTACHMENT_TYPES = key("attachment_types");
 
         // NeoForge Dynamic

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -67,6 +67,7 @@ public class NeoForgeRegistriesSetup {
         event.register(NeoForgeRegistries.INGREDIENT_TYPES);
         event.register(NeoForgeRegistries.FLUID_INGREDIENT_TYPES);
         event.register(NeoForgeRegistries.CONDITION_SERIALIZERS);
+        event.register(NeoForgeRegistries.CONDITIONAL_OPERATION_CODECS);
         event.register(NeoForgeRegistries.ATTACHMENT_TYPES);
     }
 

--- a/src/main/java/net/neoforged/neoforge/resource/ContextAwareReloadListener.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ContextAwareReloadListener.java
@@ -11,9 +11,11 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.neoforged.neoforge.common.conditions.ConditionalOperation;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.conditions.ICondition.IContext;
+import net.neoforged.neoforge.common.conditions.InterceptingOps;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -50,8 +52,15 @@ public abstract class ContextAwareReloadListener implements PreparableReloadList
 
     /**
      * Creates a new {@link ConditionalOps} using {@link #getContext()} and {@link #getRegistryLookup()} ()}.
+     *
+     * @deprecated Use {@link ContextAwareReloadListener#createInterceptingConditionOps()} and the provided {@link InterceptingOps}
      */
+    @Deprecated
     protected final ConditionalOps<JsonElement> makeConditionalOps() {
         return new ConditionalOps<>(getRegistryLookup().createSerializationContext(JsonOps.INSTANCE), getContext());
+    }
+
+    protected final InterceptingOps<JsonElement, ICondition.IContext> createInterceptingConditionOps() {
+        return ConditionalOperation.getOps(JsonOps.INSTANCE, getRegistryLookup(), this::getContext);
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -148,6 +148,9 @@ public net.minecraft.gametest.framework.GameTestHelper testInfo # testInfo
 public net.minecraft.gametest.framework.GameTestInfo sequences # sequences
 public net.minecraft.gametest.framework.GameTestSequence <init>(Lnet/minecraft/gametest/framework/GameTestInfo;)V # <init>
 protected net.minecraft.resources.RegistryOps <init>(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/resources/RegistryOps$RegistryInfoLookup;)V # constructor
+protected net.minecraft.resources.RegistryOps$HolderLookupAdapter
+public net.minecraft.resources.RegistryOps lookupProvider
+public net.minecraft.resources.DelegatingOps delegate
 public net.minecraft.resources.ResourceLocation validNamespaceChar(C)Z # validNamespaceChar
 protected net.minecraft.server.MinecraftServer nextTickTimeNanos # nextTickTimeNanos
 public net.minecraft.server.MinecraftServer$ReloadableResources

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ConditionalOperationTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ConditionalOperationTest.java
@@ -1,0 +1,192 @@
+package net.neoforged.neoforge.unittest;
+
+import static net.neoforged.neoforge.common.conditions.ICondition.IContext.TAGS_INVALID;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import java.util.Optional;
+import net.minecraft.resources.RegistryOps;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.conditions.ConditionalOperation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class ConditionalOperationTest {
+    private static final String MOD_ID = "conditional_operation_test";
+    private static final RegistryOps<JsonElement> OPS = ConditionalOperation.getOps(JsonOps.INSTANCE, (RegistryOps.RegistryInfoLookup) null, () -> TAGS_INVALID);
+
+    @Test
+    void playground() {
+        Outer.CODEC.parse(OPS, JsonParser.parseString("""
+                {
+                    "string": "yes",
+                    "a": {
+                        "neoforge:conditional_operation_type": "neoforge:alternative",
+                        "conditions": [{"type": "neoforge:false"}],
+                        "value": "owoforge",
+                        "or_else": "neoforge"
+                    },
+                    inner: {
+                        "neoforge:conditional_operation_type": "neoforge:alternative",
+                        "value": {},
+                        "or_else": "neoforge"
+                    }
+                }
+                """));
+    }
+
+    @Test
+    @Deprecated
+    void testOldFormat() { // in order to not be a breaking change this needs to work
+        JsonElement toParse = JsonParser.parseString("""
+                {
+                    "neoforge:conditions": [{"type": "neoforge:false"}],
+                    "string": "boop",
+                    "a": 5,
+                    "inner": {
+                        "list": [],
+                        "doubloons": 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223176
+                    }
+                }
+                """);
+        Outer.CODEC.parse(OPS, toParse)
+                .mapError(Assertions::fail)
+                .ifSuccess(Assertions::assertNull);
+    }
+
+    @Test
+    void testAlternative() {
+        JsonElement toParse = JsonParser.parseString("""
+                {
+                    "string": {
+                        "neoforge:conditional_operation_type": "neoforge:alternative",
+                        "conditions": [{"type": "neoforge:false"}],
+                        "value": "owoforge",
+                        "or_else": "neoforge"
+                    },
+                    "a": 143,
+                    "inner": {
+                        "list": ["fox","momentum","boop"],
+                        "doubloons": 77
+                    }
+                }
+                """);
+        Outer expected = new Outer("neoforge", 143, new Inner(Optional.of(List.of("fox", "momentum", "boop")), 77));
+        Outer.CODEC.parse(OPS, toParse)
+                .mapError(Assertions::fail)
+                .ifSuccess(result -> Assertions.assertEquals(expected, result));
+    }
+
+    @Test
+    void testOrNull() {
+        JsonElement toParse = JsonParser.parseString("""
+                {
+                    "string": "or null test",
+                    "a": 2,
+                    "inner": {
+                        "list": {
+                            "neoforge:conditional_operation_type": "neoforge:or_null",
+                            "conditions": [{"type": "neoforge:false"}],
+                            "value": ["oh no"]
+                        },
+                        "doubloons": -1.2
+                    }
+                }
+                """);
+        Outer expected = new Outer("or null test", 2, new Inner(Optional.empty(), -1.2));
+        Outer.CODEC.parse(OPS, toParse)
+                .mapError(Assertions::fail)
+                .ifSuccess(result -> Assertions.assertEquals(expected, result));
+    }
+
+    @Test
+    void testListElement() {
+        JsonElement toParse = JsonParser.parseString("""
+                {
+                    "string": "this is a string",
+                    "a": -1,
+                    "inner": {
+                        "list": [
+                            "fox",
+                            {
+                                "neoforge:conditional_operation_type": "neoforge:alternative",
+                                "conditions": [{"type": "neoforge:true"}],
+                                "value": "run",
+                                "or_else": "walk"
+                            },
+                            "boop"
+                        ],
+                        "doubloons": 7.7
+                    }
+                }
+                """);
+        Outer expected = new Outer("this is a string", -1, new Inner(Optional.of(List.of("fox", "run", "boop")), 7.7));
+        Outer.CODEC.parse(OPS, toParse)
+                .mapError(Assertions::fail)
+                .ifSuccess(result -> Assertions.assertEquals(expected, result));
+    }
+
+    @Test
+    void testConditionCausingError() {
+        JsonElement toParse = JsonParser.parseString("""
+                {
+                    "string": "Witty comment unavailable :(",
+                    "a": 0,
+                    "inner": {
+                        "list": {
+                            "neoforge:conditional_operation_type": "neoforge:alternative",
+                            "conditions": [{"type": "neoforge:false"}],
+                            "value": ["You", "Once there was magic"],
+                            "or_else": {"Me": "But I killed it."}
+                        },
+                        "doubloons": 28
+                    }
+                }
+                """);
+        var result = Outer.CODEC.parse(OPS, toParse); // TODO: replace with actual error message check
+        Assertions.assertThrows(IllegalStateException.class, result::getOrThrow, "Expected parsing to fail due to an object in place of a list, but it succeeded!");
+    }
+
+    @Test
+    void testBadConditionsParse() {
+        JsonElement toParse = JsonParser.parseString("""
+                {
+                    "string": {
+                        "neoforge:conditional_operation_type": "neoforge:alternative",
+                        "value": "owoforge",
+                        "or_else": "neoforge"
+                    },
+                    "a": 8,
+                    "inner": {
+                        "list": [],
+                        "doubloons": 0
+                    }
+                }
+                """);
+        var result = Outer.CODEC.parse(OPS, toParse); // TODO: replace with actual error message check
+        Assertions.assertThrows(IllegalStateException.class, result::getOrThrow, "Expected parsing to fail due to missing conditions field, but it succeeded!");
+    }
+
+    @Mod(MOD_ID)
+    public static class ConditionalOperationTestMod {}
+
+    record Outer(String string, int a, Inner inner) {
+        public static final Codec<Outer> CODEC = RecordCodecBuilder.<Outer>mapCodec(instance -> instance.group(
+                Codec.STRING.fieldOf("string").forGetter(Outer::string),
+                Codec.INT.fieldOf("a").forGetter(Outer::a),
+                Inner.CODEC.fieldOf("inner").forGetter(Outer::inner)).apply(instance, Outer::new)).codec();
+    }
+
+    record Inner(Optional<List<String>> list, double doubloons) {
+        public static final Codec<Inner> CODEC = RecordCodecBuilder.<Inner>mapCodec(instance -> instance.group(
+                Codec.STRING.listOf().optionalFieldOf("list").forGetter(Inner::list),
+                Codec.DOUBLE.fieldOf("doubloons").forGetter(Inner::doubloons)).apply(instance, Inner::new)).codec();
+    }
+}

--- a/tests/src/junit/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/junit/resources/META-INF/neoforge.mods.toml
@@ -8,3 +8,5 @@ modId="block_entity_type_valid_blocks_event_test"
 modId="creative_tab_order_test"
 [[mods]]
 modId="startup_config_test"
+[[mods]]
+modId="conditional_operation_test"


### PR DESCRIPTION
This implements a condition system utilising the existing `ICondition` and `IContext` interfaces but replacing `ConditionalOps` and it's downisdes. This new system allows conditions on any level of a json structure, without having to modify the codec parsing the structure (like what the old system required).

### Example JSON
<details>
  <summary>Expand</summary> 

  ```json
  {
    "type": "minecraft:crafting_shaped",
    "category": "misc",
    "key": {"#":{"tag": "minecraft:planks"}},
    "pattern": [
      "##",
      {
        "neoforge:conditional_type": "neoforge:alternative",
        "conditions": [{
          "type": "neoforge:not",
          "value": {
            "type": "neoforge:mod_loaded",
            "modid": "fabric"
          }
        }],
        "value": " #",
        "or_else": "##"
      }
    ],
    "result": {
      "neoforge:conditional_type": "neoforge:alternative",
      "conditions": [{"type": "neoforge:false"}],
      "value": {
        "count": 1,
        "id": "minecraft:crafting_table"
      },
      "or_else": {
        "count": 64,
        "id": "crafting_table"
      }
    },
    "show_notification": false
  }
  ```
![image](https://github.com/user-attachments/assets/35cd8fe5-8ed3-42aa-83cc-428602d0e3d7)

</details>

### How it works
This PR achieves conditions on any level of a structure via a new `DynamicOps<T>` called `InterceptingOps<T, C>` that intercepts all calls to get a value from a `T`. Once intercepted it attempts to parse what was trying to be got using a `Codec<Wrapper<T, C>>`. If the codec does not successfully parse then the original result is returned, otherwise the Wrapper then unwraps with some context `C`. (**note that this means that any errors in the format of the conditional operation and condition are silently discarded. see [TODO](#TODO)**)
You would expect that double parsing everything nearly everything passing through codecs would cause performance issues, but from some rough testing with ~100 1.21 mods this does not have a noticeable impact on performance. I do want to do more thorough testing but need help with setting up the tooling to do that (for my roughs I just used log message times).

In this situation the `Wrapper` is `ConditionalOperation` and is used to modify `T` based on whether some conditions specified in the json are true or not. However, `InterceptingOps<T, C>` is very versatile and could also be used to do wacky things like invert all booleans, or even something more complicated like being able to define areas of datapack json that can be injected into from another datapack registry, allowing opt-in modifying of specific areas of json, like an api for datapacks, even if it is an area where you don't control the main codec (ie loot tables)!

### Non-breaking Changes
One of the aims is for this to try not to be a breaking change and therefore the existing format of using `neoforge:conditions` inline with the conditional data will still work, once I figure out how to do that. Unused classes from the old system are also not removed, just `Deprecated` with javadoc tags added to most of them to point to the new system.

### Tests
This PR also comes with some JUnit tests for the `ConditionalOperaion`s and it's use of `InterceptingOps`, including a test for the old system mentioned above still working.
The existing non JUnit test `ConditionalCodecTest` has not been modified yet, but I plan on moving it to JUnit tests and removing anything there that uses the old system's java-side stuff, whilst keeping all json formats currently there to prevent this breaking anything.
I am interested in anyone who currently uses the java-side parts of the old system to see what they use it for and if this pr needs changes to continue supporting those usecases.

### Datagen
When I brought this up in the Discord a major concern was datagen support.

Unfortunately due to the nature of datagen (black box codecs inside black box builders) this is near impossible to achieve well for any condition system more complicated than 'wrap the outer object in something'. Even rewriting datagen wouldn't help much as you still have to deal with the black boxes that are codecs.
The best solution I have come up with for this is a system that takes two builders finished outputs and a list of conditions, and works out the difference between the builders to generate a json using ConditionalOperations. However, that would get bulky when trying to use multiple sets of conditions to change different parts, and I personally would have trouble implementing this nicely. Also at that point you can just have a `SimpleAlternative` that swaps between the two jsons depending on conditions, therefore leaving out all the complicated diffing logic.

### Meta
Note this PR has not been opened with the explicit expectation that it will be merged, but rather to open discussion as its easier to do that when you have the code in front of you (especially for a complex to explain system like this). I would like to see this merged as it provides more flexibility at a low maintainability cost, but I also recognise that not many people need the flexibility that this offers, and that technically everything here can already be done using the existing system, this just makes it a ton less verbose.


### TODO
- [ ] Implement backwards compat support for top level neoforge:conditions.
- [ ] Implement basic top level datagen support.
- [x] Finish removing usage of old ConditionalOps.
- [ ] Move old condition tests to JUnit tests
- [ ] Add a Codec to be used as a initial parse test predicate, to allow returning the error if the full codec fails rather than suppressing it