### PR TITLE
Made day time flow variable

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -41,6 +41,15 @@
      }
  
      public void queueLightUpdate(Runnable p_194172_) {
+@@ -238,7 +_,7 @@
+     private void tickTime() {
+         this.setGameTime(this.levelData.getGameTime() + 1L);
+         if (this.levelData.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)) {
+-            this.setDayTime(this.levelData.getDayTime() + 1L);
++            this.setDayTime(this.levelData.getDayTime() + advanceDaytime());
+         }
+     }
+ 
 @@ -282,7 +_,11 @@
          p_104640_.setOldPosAndRot();
          p_104640_.tickCount++;
@@ -100,7 +109,7 @@
              this.difficulty = p_104852_;
          }
  
-@@ -1069,14 +_,51 @@
+@@ -1069,14 +_,75 @@
              if (p_171712_ instanceof AbstractClientPlayer) {
                  ClientLevel.this.players.add((AbstractClientPlayer)p_171712_);
              }
@@ -127,7 +136,7 @@
  
          public void onSectionChange(Entity p_233660_) {
          }
-+    }
+     }
 +
 +    @Override
 +    public java.util.Collection<net.neoforged.neoforge.entity.PartEntity<?>> getPartEntities() {
@@ -150,5 +159,29 @@
 +        if (!shade)
 +            return constantAmbientLight ? 0.9F : 1.0F;
 +        return net.neoforged.neoforge.client.model.lighting.QuadLighter.calculateShade(normalX, normalY, normalZ, constantAmbientLight);
-     }
++    }
++
++    // Neo: Variable day time code
++
++    private float dayTimeFraction = 0.0f;
++    private float dayTimePerTick = -1.0f;
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public void setDayTimeFraction(float dayTimeFraction) {
++		    this.dayTimeFraction = dayTimeFraction;
++		}
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++		public float getDayTimeFraction() {
++		    return dayTimeFraction;
++		}
++
++		public float getDayTimePerTick() {
++		    return dayTimePerTick;
++		}
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++		public void setDayTimePerTick(float dayTimePerTick) {
++		    this.dayTimePerTick = dayTimePerTick;
++		}
  }

--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -136,7 +136,7 @@
  
          public void onSectionChange(Entity p_233660_) {
          }
-     }
++    }
 +
 +    @Override
 +    public java.util.Collection<net.neoforged.neoforge.entity.PartEntity<?>> getPartEntities() {
@@ -168,20 +168,20 @@
 +
 +    @org.jetbrains.annotations.ApiStatus.Internal
 +    public void setDayTimeFraction(float dayTimeFraction) {
-+		    this.dayTimeFraction = dayTimeFraction;
-+		}
++        this.dayTimeFraction = dayTimeFraction;
++    }
 +
 +    @org.jetbrains.annotations.ApiStatus.Internal
-+		public float getDayTimeFraction() {
-+		    return dayTimeFraction;
-+		}
++    public float getDayTimeFraction() {
++        return dayTimeFraction;
++    }
 +
-+		public float getDayTimePerTick() {
-+		    return dayTimePerTick;
-+		}
++    public float getDayTimePerTick() {
++        return dayTimePerTick;
++    }
 +
 +    @org.jetbrains.annotations.ApiStatus.Internal
-+		public void setDayTimePerTick(float dayTimePerTick) {
-+		    this.dayTimePerTick = dayTimePerTick;
-+		}
++    public void setDayTimePerTick(float dayTimePerTick) {
++        this.dayTimePerTick = dayTimePerTick;
+     }
  }

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -173,6 +173,29 @@
              GameTestTicker.SINGLETON.tick();
          }
  
+@@ -1043,11 +_,17 @@
+     }
+ 
+     private void synchronizeTime(ServerLevel p_276371_) {
+-        this.playerList
+-            .broadcastAll(
+-                new ClientboundSetTimePacket(p_276371_.getGameTime(), p_276371_.getDayTime(), p_276371_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)),
+-                p_276371_.dimension()
+-            );
++        ClientboundSetTimePacket vanillaPacket = new ClientboundSetTimePacket(p_276371_.getGameTime(), p_276371_.getDayTime(), p_276371_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT));
++        net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload neoPacket = new net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload(p_276371_.getGameTime(), p_276371_.getDayTime(), p_276371_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), p_276371_.getDayTimeFraction(), p_276371_.getDayTimePerTick());
++        for (ServerPlayer serverplayer : playerList.getPlayers()) {
++            if (serverplayer.level().dimension() == p_276371_.dimension()) {
++          	    if (serverplayer.connection.hasChannel(net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload.TYPE)) {
++							      serverplayer.connection.send(neoPacket);
++          	    } else {
++                    serverplayer.connection.send(vanillaPacket);
++          	    }
++            }
++        }
+     }
+ 
+     public void forceTimeSynchronization() {
 @@ -1118,7 +_,7 @@
  
      @DontObfuscate

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -186,11 +186,11 @@
 +        net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload neoPacket = new net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload(p_276371_.getGameTime(), p_276371_.getDayTime(), p_276371_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), p_276371_.getDayTimeFraction(), p_276371_.getDayTimePerTick());
 +        for (ServerPlayer serverplayer : playerList.getPlayers()) {
 +            if (serverplayer.level().dimension() == p_276371_.dimension()) {
-+          	    if (serverplayer.connection.hasChannel(net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload.TYPE)) {
-+							      serverplayer.connection.send(neoPacket);
-+          	    } else {
++                if (serverplayer.connection.hasChannel(net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload.TYPE)) {
++                    serverplayer.connection.send(neoPacket);
++                } else {
 +                    serverplayer.connection.send(vanillaPacket);
-+          	    }
++                }
 +            }
 +        }
      }

--- a/patches/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/net/minecraft/server/level/ServerLevel.java.patch
@@ -47,6 +47,15 @@
                              profilerfiller.pop();
                          }
                      }
+@@ -438,7 +_,7 @@
+             this.serverLevelData.setGameTime(i);
+             this.serverLevelData.getScheduledEvents().tick(this.server, i);
+             if (this.levelData.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)) {
+-                this.setDayTime(this.levelData.getDayTime() + 1L);
++                this.setDayTime(this.levelData.getDayTime() + advanceDaytime());
+             }
+         }
+     }
 @@ -542,6 +_,7 @@
          BlockPos blockpos = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, p_295060_);
          BlockPos blockpos1 = blockpos.below();
@@ -194,7 +203,7 @@
                      ServerLevel.this.dragonParts.put(enderdragonpart.getId(), enderdragonpart);
                  }
              }
-@@ -1733,24 +_,61 @@
+@@ -1733,24 +_,104 @@
                  if (ServerLevel.this.isUpdatingNavigations) {
                      String s = "onTrackingStart called during navigation iteration";
                      Util.logAndPauseIfInIde(
@@ -223,7 +232,7 @@
          public void onSectionChange(Entity p_215086_) {
              p_215086_.updateDynamicGameEventListener(DynamicGameEventListener::move);
          }
-+    }
+     }
 +
 +    @Override
 +    public java.util.Collection<net.neoforged.neoforge.entity.PartEntity<?>> getPartEntities() {
@@ -257,5 +266,48 @@
 +    @org.jetbrains.annotations.ApiStatus.Internal
 +    public void cleanCapabilityListenerReferences() {
 +        capListenerHolder.clean();
-     }
++    }
++
++    // Neo: Variable day time code
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public void setDayTimeFraction(float dayTimeFraction) {
++    	serverLevelData.setDayTimeFraction(dayTimeFraction);
++		}
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++		public float getDayTimeFraction() {
++			return serverLevelData.getDayTimeFraction();
++		}
++
++    /**
++     * Returns the current ratio between game ticks and clock ticks. If this value is negative, no
++     * speed has been set and those two are coupled 1:1 (i.e. vanilla mode).
++     */
++		public float getDayTimePerTick() {
++			return serverLevelData.getDayTimePerTick();
++		}
++
++    /**
++     * This allows mods to set the rate time flows in a level. By default, each game tick the clock time
++     * also advances by one tick, with {@link Level#TICKS_PER_DAY} clock ticks (or 20 real-life minutes)
++     * forming a Minecraft day.
++     * <p>
++     * This can be sped up for shorter days by giving a higher number, or slowed down for longer days
++     * with a smaller number.
++     * <p>
++     * This value can also be changed with the command <code>/neoforge day</code>, where you can set
++     * either the speed or a day length in minutes.
++     * <p>
++     * This has no effect when time progression is stopped.
++     * <p>
++     * While this still technically works when vanilla clients are connected, those will desync and
++     * experience a time jump once per second.
++     */
++    @Override
++    public void setDayTimePerTick(float dayTimePerTick) {
++    	  serverLevelData.setDayTimePerTick(dayTimePerTick);
++        server.forceTimeSynchronization();
++    }
++
  }

--- a/patches/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/net/minecraft/server/level/ServerLevel.java.patch
@@ -203,7 +203,7 @@
                      ServerLevel.this.dragonParts.put(enderdragonpart.getId(), enderdragonpart);
                  }
              }
-@@ -1733,24 +_,104 @@
+@@ -1733,24 +_,106 @@
                  if (ServerLevel.this.isUpdatingNavigations) {
                      String s = "onTrackingStart called during navigation iteration";
                      Util.logAndPauseIfInIde(
@@ -272,21 +272,21 @@
 +
 +    @org.jetbrains.annotations.ApiStatus.Internal
 +    public void setDayTimeFraction(float dayTimeFraction) {
-+    	serverLevelData.setDayTimeFraction(dayTimeFraction);
-+		}
++        serverLevelData.setDayTimeFraction(dayTimeFraction);
++    }
 +
 +    @org.jetbrains.annotations.ApiStatus.Internal
-+		public float getDayTimeFraction() {
-+			return serverLevelData.getDayTimeFraction();
-+		}
++    public float getDayTimeFraction() {
++        return serverLevelData.getDayTimeFraction();
++    }
 +
 +    /**
 +     * Returns the current ratio between game ticks and clock ticks. If this value is negative, no
 +     * speed has been set and those two are coupled 1:1 (i.e. vanilla mode).
 +     */
-+		public float getDayTimePerTick() {
-+			return serverLevelData.getDayTimePerTick();
-+		}
++    public float getDayTimePerTick() {
++        return serverLevelData.getDayTimePerTick();
++    }
 +
 +    /**
 +     * This allows mods to set the rate time flows in a level. By default, each game tick the clock time
@@ -294,7 +294,7 @@
 +     * forming a Minecraft day.
 +     * <p>
 +     * This can be sped up for shorter days by giving a higher number, or slowed down for longer days
-+     * with a smaller number.
++     * with a smaller number. A negative value will reset it back to vanilla logic.
 +     * <p>
 +     * This value can also be changed with the command <code>/neoforge day</code>, where you can set
 +     * either the speed or a day length in minutes.
@@ -306,8 +306,10 @@
 +     */
 +    @Override
 +    public void setDayTimePerTick(float dayTimePerTick) {
-+    	  serverLevelData.setDayTimePerTick(dayTimePerTick);
-+        server.forceTimeSynchronization();
++        if (dayTimePerTick != getDayTimePerTick() && dayTimePerTick != 0f) {
++            serverLevelData.setDayTimePerTick(dayTimePerTick);
++            server.forceTimeSynchronization();
++        }
 +    }
 +
  }

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -108,7 +108,7 @@
          WorldBorder worldborder = this.server.overworld().getWorldBorder();
          p_11230_.connection.send(new ClientboundInitializeBorderPacket(worldborder));
 +        if (p_11230_.connection.hasChannel(net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload.TYPE)) {
-+          p_11230_.connection.send(new net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload(p_11231_.getGameTime(), p_11231_.getDayTime(), p_11231_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), p_11231_.getDayTimeFraction(), p_11231_.getDayTimePerTick()));
++            p_11230_.connection.send(new net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload(p_11231_.getGameTime(), p_11231_.getDayTime(), p_11231_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), p_11231_.getDayTimeFraction(), p_11231_.getDayTimePerTick()));
 +        } else {
          p_11230_.connection
              .send(new ClientboundSetTimePacket(p_11231_.getGameTime(), p_11231_.getDayTime(), p_11231_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)));

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -103,6 +103,19 @@
          this.ops.remove(p_11281_);
          ServerPlayer serverplayer = this.getPlayer(p_11281_.getId());
          if (serverplayer != null) {
+@@ -682,8 +_,12 @@
+     public void sendLevelInfo(ServerPlayer p_11230_, ServerLevel p_11231_) {
+         WorldBorder worldborder = this.server.overworld().getWorldBorder();
+         p_11230_.connection.send(new ClientboundInitializeBorderPacket(worldborder));
++        if (p_11230_.connection.hasChannel(net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload.TYPE)) {
++          p_11230_.connection.send(new net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload(p_11231_.getGameTime(), p_11231_.getDayTime(), p_11231_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT), p_11231_.getDayTimeFraction(), p_11231_.getDayTimePerTick()));
++        } else {
+         p_11230_.connection
+             .send(new ClientboundSetTimePacket(p_11231_.getGameTime(), p_11231_.getDayTime(), p_11231_.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT)));
++        }
+         p_11230_.connection.send(new ClientboundSetDefaultSpawnPositionPacket(p_11231_.getSharedSpawnPos(), p_11231_.getSharedSpawnAngle()));
+         if (p_11231_.isRaining()) {
+             p_11230_.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.START_RAINING, 0.0F));
 @@ -808,13 +_,6 @@
          if (serverstatscounter == null) {
              File file1 = this.server.getWorldPath(LevelResource.PLAYER_STATS_DIR).toFile();

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -10,13 +10,14 @@
      private static final Logger LOGGER = LogUtils.getLogger();
      public static final HumanoidArm DEFAULT_MAIN_HAND = HumanoidArm.RIGHT;
      public static final int DEFAULT_MODEL_CUSTOMIZATION = 0;
-@@ -193,6 +_,9 @@
+@@ -193,6 +_,10 @@
      public Entity currentExplosionCause;
      private boolean ignoreFallDamageFromCurrentImpulse;
      private int currentImpulseContextResetGraceTime;
 +    private final java.util.Collection<MutableComponent> prefixes = new java.util.LinkedList<>();
 +    private final java.util.Collection<MutableComponent> suffixes = new java.util.LinkedList<>();
 +    @Nullable private Pose forcedPose;
++    private long lastDayTimeTick = -1L; // Neo: Used to limit TIME_SINCE_REST increases when day length is non-standard. No need to persist, at most Phantoms will spawn one tick too early for each save/load cycle.
  
      public Player(Level p_250508_, BlockPos p_250289_, float p_251702_, GameProfile p_252153_) {
          super(EntityType.PLAYER, p_250508_);
@@ -47,6 +48,19 @@
                  this.stopSleepInBed(false, true);
              }
          } else if (this.sleepCounter > 0) {
+@@ -291,7 +_,11 @@
+             }
+ 
+             if (!this.isSleeping()) {
+-                this.awardStat(Stats.TIME_SINCE_REST);
++                // Neo: Advance TIME_SINCE_REST if (a) vanilla daytime handling in effect, or (b) days are shorter, or (c) dayTime has ticked, or (d) dayTime advances are off and we need to ignore day length
++                if (level().getDayTimeFraction() < 0 || level().getDayTimeFraction() >= 1 || lastDayTimeTick != level().getDayTime() || !level().getGameRules().getRule(GameRules.RULE_DAYLIGHT).get()) {
++                    lastDayTimeTick = level().getDayTime();
++                    this.awardStat(Stats.TIME_SINCE_REST);
++                }
+             }
+         }
+ 
 @@ -318,6 +_,7 @@
          if (this.currentImpulseContextResetGraceTime > 0) {
              this.currentImpulseContextResetGraceTime--;

--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -219,12 +219,10 @@
                          this.neighborChanged(blockstate, blockpos, p_46719_, p_46718_, false);
                      }
                  }
-@@ -1076,6 +_,18 @@
-     @Override
-     public BiomeManager getBiomeManager() {
+@@ -1078,6 +_,18 @@
          return this.biomeManager;
-+    }
-+
+     }
+ 
 +    private double maxEntityRadius = 2.0D;
 +    @Override
 +    public double getMaxEntityRadius() {
@@ -235,6 +233,47 @@
 +        if (value > maxEntityRadius)
 +            maxEntityRadius = value;
 +        return maxEntityRadius;
-     }
- 
++    }
++
      public final boolean isDebug() {
+         return this.isDebug;
+     }
+@@ -1118,5 +_,38 @@
+         public String getSerializedName() {
+             return this.id;
+         }
++    }
++
++    // Neo: Variable day time code
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public abstract void setDayTimeFraction(float dayTimeFraction);
++
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public abstract float getDayTimeFraction();
++
++    /**
++     * Returns the current ratio between game ticks and clock ticks. If this value is negative, no
++     * speed has been set and those two are coupled 1:1 (i.e. vanilla mode).
++     */
++    public abstract float getDayTimePerTick();
++
++    /**
++     * DO NOT CALL.
++     * <p>
++     * Use {@link net.minecraft.server.level.ServerLevel#setDayTimePerTick(float)} instead.
++     */
++    public abstract void setDayTimePerTick(float dayTimePerTick);
++
++    // advances the fractional daytime, returns the integer part of it
++    @org.jetbrains.annotations.ApiStatus.Internal
++    protected long advanceDaytime() {
++        if (getDayTimePerTick() < 0) {
++            return 1L; // avoid doing math (and rounding errors) if no speed has been set
++        }
++        float dayTimeStep = getDayTimeFraction() + getDayTimePerTick();
++        long result = (long)dayTimeStep;
++        setDayTimeFraction(dayTimeStep - result);
++        return result;
+     }
+ }

--- a/patches/net/minecraft/world/level/storage/DerivedLevelData.java.patch
+++ b/patches/net/minecraft/world/level/storage/DerivedLevelData.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/world/level/storage/DerivedLevelData.java
++++ b/net/minecraft/world/level/storage/DerivedLevelData.java
+@@ -191,4 +_,26 @@
+         p_164852_.setDetail("Derived", true);
+         this.wrapped.fillCrashReportCategory(p_164852_, p_164853_);
+     }
++
++    // Neo: Variable day time code
++
++    @Override
++    public float getDayTimeFraction() {
++        return wrapped.getDayTimeFraction();
++    }
++
++    @Override
++    public float getDayTimePerTick() {
++        return wrapped.getDayTimePerTick();
++    }
++
++    @Override
++    public void setDayTimeFraction(float dayTimeFraction) {
++        wrapped.setDayTimeFraction(dayTimeFraction);
++    }
++
++    @Override
++    public void setDayTimePerTick(float dayTimePerTick) {
++        wrapped.setDayTimePerTick(dayTimePerTick);
++    }
+ }

--- a/patches/net/minecraft/world/level/storage/PrimaryLevelData.java.patch
+++ b/patches/net/minecraft/world/level/storage/PrimaryLevelData.java.patch
@@ -8,30 +8,44 @@
  
      private PrimaryLevelData(
          @Nullable CompoundTag p_277888_,
-@@ -200,7 +_,7 @@
+@@ -169,7 +_,7 @@
+         Dynamic<T> p_78531_, LevelSettings p_78535_, PrimaryLevelData.SpecialWorldProperty p_250651_, WorldOptions p_251864_, Lifecycle p_78538_
+     ) {
+         long i = p_78531_.get("Time").asLong(0L);
+-        return new PrimaryLevelData(
++        PrimaryLevelData result = new PrimaryLevelData(
+             p_78531_.get("Player").flatMap(CompoundTag.CODEC::parse).result().orElse(null),
+             p_78531_.get("WasModded").asBoolean(false),
+             new BlockPos(p_78531_.get("SpawnX").asInt(0), p_78531_.get("SpawnY").asInt(0), p_78531_.get("SpawnZ").asInt(0)),
+@@ -200,7 +_,11 @@
              p_251864_,
              p_250651_,
              p_78538_
 -        );
 +        ).withConfirmedWarning(p_78538_ != Lifecycle.stable() && p_78531_.get("confirmedExperimentalSettings").asBoolean(false));
++        // Neo:
++        result.setDayTimeFraction(p_78531_.get("neoDayTimeFraction").asFloat(0f));
++        result.setDayTimePerTick(p_78531_.get("neoDayTimePerTick").asFloat(-1f));
++        return result;
      }
  
      @Override
-@@ -273,6 +_,8 @@
+@@ -273,6 +_,11 @@
          if (this.wanderingTraderId != null) {
              p_78547_.putUUID("WanderingTraderId", this.wanderingTraderId);
          }
 +        p_78547_.putString("forgeLifecycle", net.neoforged.neoforge.common.CommonHooks.encodeLifecycle(this.settings.getLifecycle()));
 +        p_78547_.putBoolean("confirmedExperimentalSettings", this.confirmedExperimentalWarning);
++        // Neo:
++        p_78547_.putFloat("neoDayTimeFraction", dayTimeFraction);
++        p_78547_.putFloat("neoDayTimePerTick", dayTimePerTick);
      }
  
      private static ListTag stringCollectionToTag(Set<String> p_277880_) {
-@@ -570,6 +_,15 @@
-     @Override
-     public LevelSettings getLevelSettings() {
+@@ -572,10 +_,44 @@
          return this.settings.copy();
-+    }
-+
+     }
+ 
 +    public boolean hasConfirmedExperimentalWarning() {
 +        return this.confirmedExperimentalWarning;
 +    }
@@ -39,6 +53,37 @@
 +    public PrimaryLevelData withConfirmedWarning(boolean confirmedWarning) { // Builder-like to not patch ctor
 +        this.confirmedExperimentalWarning = confirmedWarning;
 +        return this;
-     }
- 
++    }
++
      @Deprecated
+     public static enum SpecialWorldProperty {
+         NONE,
+         FLAT,
+         DEBUG;
++    }
++
++    // Neo: Variable day time code
++
++    private float dayTimeFraction = 0.0f;
++    private float dayTimePerTick = -1.0f;
++
++    @Override
++    public float getDayTimeFraction() {
++        return dayTimeFraction;
++    }
++
++    @Override
++    public float getDayTimePerTick() {
++        return dayTimePerTick;
++    }
++
++    @Override
++    public void setDayTimeFraction(float dayTimeFraction) {
++        this.dayTimeFraction = dayTimeFraction;
++    }
++
++    @Override
++    public void setDayTimePerTick(float dayTimePerTick) {
++        this.dayTimePerTick = dayTimePerTick;
+     }
+ }

--- a/patches/net/minecraft/world/level/storage/ServerLevelData.java.patch
+++ b/patches/net/minecraft/world/level/storage/ServerLevelData.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/storage/ServerLevelData.java
++++ b/net/minecraft/world/level/storage/ServerLevelData.java
+@@ -87,4 +_,10 @@
+     void setGameTime(long p_78617_);
+ 
+     void setDayTime(long p_78624_);
++
++    //Neo
++    float getDayTimeFraction();
++    float getDayTimePerTick();
++    void setDayTimeFraction(float dayTimeFraction);
++    void setDayTimePerTick(float dayTimePerTick);
+ }

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -16,6 +16,7 @@ import net.neoforged.neoforge.network.payload.AdvancedAddEntityPayload;
 import net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
 import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
+import net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
@@ -78,6 +79,10 @@ public class NetworkInitialization {
                         ClientRegistryManager::handleDataMapSync)
                 .playToClient(AdvancedContainerSetDataPayload.TYPE,
                         AdvancedContainerSetDataPayload.STREAM_CODEC,
+                        ClientPayloadHandler::handle)
+                .playToClient(
+                        ClientboundCustomSetTimePayload.TYPE,
+                        ClientboundCustomSetTimePayload.STREAM_CODEC,
                         ClientPayloadHandler::handle);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -15,6 +15,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.MenuAccess;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -23,6 +24,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.level.GameRules;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager;
 import net.neoforged.neoforge.entity.IEntityWithComplexSpawn;
@@ -32,6 +34,7 @@ import net.neoforged.neoforge.network.payload.AdvancedAddEntityPayload;
 import net.neoforged.neoforge.network.payload.AdvancedContainerSetDataPayload;
 import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
 import net.neoforged.neoforge.network.payload.AuxiliaryLightDataPayload;
+import net.neoforged.neoforge.network.payload.ClientboundCustomSetTimePayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
@@ -144,5 +147,15 @@ public final class ClientPayloadHandler {
 
     public static void handle(AdvancedContainerSetDataPayload msg, IPayloadContext context) {
         context.handle(msg.toVanillaPacket());
+    }
+
+    public static void handle(final ClientboundCustomSetTimePayload payload, final IPayloadContext context) {
+        @SuppressWarnings("resource")
+        final ClientLevel level = Minecraft.getInstance().level;
+        level.setGameTime(payload.gameTime());
+        level.setDayTime(payload.dayTime());
+        level.getGameRules().getRule(GameRules.RULE_DAYLIGHT).set(payload.gameRule(), null);
+        level.setDayTimeFraction(payload.dayTimeFraction());
+        level.setDayTimePerTick(payload.dayTimePerTick());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/payload/ClientboundCustomSetTimePayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ClientboundCustomSetTimePayload.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.payload;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public record ClientboundCustomSetTimePayload(long gameTime, long dayTime, boolean gameRule, float dayTimeFraction, float dayTimePerTick) implements CustomPacketPayload {
+
+    public static final Type<ClientboundCustomSetTimePayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "custom_time_packet"));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundCustomSetTimePayload> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.VAR_LONG, ClientboundCustomSetTimePayload::gameTime,
+            ByteBufCodecs.VAR_LONG, ClientboundCustomSetTimePayload::dayTime,
+            ByteBufCodecs.BOOL, ClientboundCustomSetTimePayload::gameRule,
+            ByteBufCodecs.FLOAT, ClientboundCustomSetTimePayload::dayTimeFraction,
+            ByteBufCodecs.FLOAT, ClientboundCustomSetTimePayload::dayTimePerTick,
+            ClientboundCustomSetTimePayload::new);
+    @Override
+    public Type<ClientboundCustomSetTimePayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/server/command/NeoForgeCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/NeoForgeCommand.java
@@ -22,6 +22,7 @@ public class NeoForgeCommand {
                         .then(DimensionsCommand.register())
                         .then(ModListCommand.register())
                         .then(TagsCommand.register())
-                        .then(DumpCommand.register()));
+                        .then(DumpCommand.register())
+                        .then(TimeSpeedCommand.register()));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/server/command/TimeSpeedCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TimeSpeedCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.server.command;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.FloatArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.GameRules.BooleanValue;
+
+class TimeSpeedCommand {
+    static ArgumentBuilder<CommandSourceStack, ?> register() {
+        return Commands.literal("day")
+                .then(Commands.literal("speed")
+                        .then(Commands.literal("set").requires(cs -> cs.hasPermission(Commands.LEVEL_GAMEMASTERS)) // same as /gamerule
+                                .then(Commands.literal("default").executes(context -> setDefault(context.getSource())))
+                                .then(Commands.literal("realtime").executes(context -> setDaylength(context.getSource(), 1440)))
+                                .then(Commands.argument("speed", FloatArgumentType.floatArg(0f, 1000f)).executes(context -> setSpeed(context.getSource(), FloatArgumentType.getFloat(context, "speed")))))
+                        .executes(context -> query(context.getSource())))
+                .then(Commands.literal("length")
+                        .then(Commands.literal("set").requires(cs -> cs.hasPermission(Commands.LEVEL_GAMEMASTERS))
+                                .then(Commands.literal("default").executes(context -> setDefault(context.getSource())))
+                                .then(Commands.literal("realtime").executes(context -> setDaylength(context.getSource(), 1440)))
+                                .then(Commands.argument("minutes", IntegerArgumentType.integer(1, 1440)).executes(context -> setDaylength(context.getSource(), IntegerArgumentType.getInteger(context, "minutes")))))
+                        .executes(context -> query(context.getSource())))
+                .executes(context -> query(context.getSource()));
+    }
+
+    private static int query(CommandSourceStack source) {
+        final float speed = source.getLevel().getDayTimePerTick();
+        if (speed < 0) {
+            source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.query.default", levelName(source)), true);
+        } else {
+            source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.query", levelName(source), speed, minutes(speed)), true);
+        }
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static String levelName(CommandSourceStack source) {
+        return source.getLevel().dimension().location().toLanguageKey();
+    }
+
+    private static float minutes(final float speed) {
+        return (int) (200f / speed) / 10f;
+    }
+
+    private static int setSpeed(CommandSourceStack source, float speed) {
+        final BooleanValue rule = source.getLevel().getGameRules().getRule(GameRules.RULE_DAYLIGHT);
+        if (!rule.get() && speed > 0) {
+            rule.set(true, null);
+            source.sendSuccess(() -> Component.translatable("commands.gamerule.set", GameRules.RULE_DAYLIGHT.getId(), rule.toString()), true);
+        } else if (rule.get() && speed == 0) {
+            rule.set(false, null);
+            source.sendSuccess(() -> Component.translatable("commands.gamerule.set", GameRules.RULE_DAYLIGHT.getId(), rule.toString()), true);
+            return Command.SINGLE_SUCCESS;
+        }
+        source.getLevel().setDayTimePerTick(speed);
+        source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.set", levelName(source), speed, minutes(speed)), true);
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int setDaylength(CommandSourceStack source, int minutes) {
+        if (minutes == 20) {
+            return setDefault(source);
+        }
+        return setSpeed(source, 20f / minutes);
+    }
+
+    private static int setDefault(CommandSourceStack source) {
+        source.getLevel().setDayTimePerTick(-1f);
+        source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.set.default", levelName(source)), true);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -115,6 +115,10 @@
   "commands.neoforge.chunkgen.status": "Generation status! %1$s out of %2$s chunks generated. (%3$s%%)",
   "commands.neoforge.chunkgen.not_running": "No pregeneration currently running. Run `/neoforge generate help` to see commands for starting generation.",
   "commands.neoforge.chunkgen.help_line": "§2/neoforge generate start <x> <y> <z> <chunkRadius> [progressBar] §r§f- Generates a square centered on the given position that is chunkRadius * 2 on each side.\n§2/neoforge generate stop §r§f- Stops the current generation and displays progress that it had completed.\n§2/neoforge generate status §r- Displays the progress completed for the currently running generation.\n§2/neoforge generate help §r- Displays this message.\nGeneral tips: If running from a server console, you can run generate in different dimensions by using /execute in <dimension> neoforge generate...",
+  "commands.neoforge.timespeed.query": "Time in %s flows at a rate of %sx (%s minutes per day).",
+  "commands.neoforge.timespeed.query.default": "Time in %s flows normally (20 minutes per day).",
+  "commands.neoforge.timespeed.set": "Set flow of time in %s to %sx (%s minutes per day).",
+  "commands.neoforge.timespeed.set.default": "Set flow of time in %s to default (20 minutes per day).",
 
   "commands.config.getwithtype": "Config for %s of type %s found at %s",
   "commands.config.noconfig": "Config for %s of type %s not found",


### PR DESCRIPTION
This lets mods control the ratio between game ticks and day ticks on a per-level level(*).

The changed ratio is also properly synced to clients, although vanilla clients will experience the sun rubber-banding/jumping once per second---but at least they still can connect (tested!).

This also adds a new command in 2 flavours:

```
/neoforge day speed set [default|realtime|<float>]
/neoforge day length set [default|realtime|<minutes>]
```

Where "default" disables the system, giving you the normal 20-minute day, and "realtime" sets the day length to 24 hours (just because it's trivial...). Leaving out the last parameter(s) will query the current value. This is available to all players, unlike the set commands that require the same access level as the `/gamerule` command (which can stop/start time).

For mods, the API entry point is `ServerLevel#setDayTimePerTick(float)`. Methods to query the value and to query the fractional part of the current day time are also available (also on client levels).

As Phantom spawning can be an issue with different day lengths than in vanilla, this PR also tweaks counting the time since a player last slept. When days are as long or shorter than in vanilla, Phantoms spawn based on _game_ ticks (as before). When days are longer, they spawn based on _day_ ticks (i.e. after 3 missed nights). Mods naturally can change that as they wish, they do have access to that stat anyway.

Help wanted: I'm not happy with the translations for the command feedback.

---

(*) For levels that do have independent daytime. Which is only the overworld in vanilla.