### PR TITLE
[1.21] Fix circularity issue in RecipeBookSettings static init

### DIFF
--- a/patches/net/minecraft/stats/RecipeBookSettings.java.patch
+++ b/patches/net/minecraft/stats/RecipeBookSettings.java.patch
@@ -1,13 +1,11 @@
 --- a/net/minecraft/stats/RecipeBookSettings.java
 +++ b/net/minecraft/stats/RecipeBookSettings.java
-@@ -11,7 +_,9 @@
+@@ -11,7 +_,7 @@
  import net.minecraft.world.inventory.RecipeBookType;
  
  public final class RecipeBookSettings {
 -    private static final Map<RecipeBookType, Pair<String, String>> TAG_FIELDS = ImmutableMap.of(
-+
-+    //PATCH 1.20.2: Turn this into an event, and make it immutable again........
-+    private static final Map<RecipeBookType, Pair<String, String>> TAG_FIELDS = new java.util.HashMap<>(ImmutableMap.of(
++    private static final Map<RecipeBookType, Pair<String, String>> TAG_FIELDS = net.neoforged.neoforge.common.CommonHooks.buildRecipeBookTypeTagFields(ImmutableMap.of(
          RecipeBookType.CRAFTING,
          Pair.of("isGuiOpen", "isFilteringCraftable"),
          RecipeBookType.FURNACE,
@@ -20,13 +18,3 @@
      private final Map<RecipeBookType, RecipeBookSettings.TypeSettings> states;
  
      private RecipeBookSettings(Map<RecipeBookType, RecipeBookSettings.TypeSettings> p_12730_) {
-@@ -158,5 +_,9 @@
-         public String toString() {
-             return "[open=" + this.open + ", filtering=" + this.filtering + "]";
-         }
-+    }
-+    //FORGE -- called automatically on Enum creation - used for serialization
-+    public static void addTagsForType(RecipeBookType type, String openTag, String filteringTag) {
-+        TAG_FIELDS.put(type, Pair.of(openTag, filteringTag));
-     }
- }

--- a/patches/net/minecraft/world/inventory/RecipeBookType.java.patch
+++ b/patches/net/minecraft/world/inventory/RecipeBookType.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/inventory/RecipeBookType.java
 +++ b/net/minecraft/world/inventory/RecipeBookType.java
-@@ -1,8 +_,20 @@
+@@ -1,8 +_,13 @@
  package net.minecraft.world.inventory;
  
 -public enum RecipeBookType {
@@ -10,13 +10,6 @@
      FURNACE,
      BLAST_FURNACE,
      SMOKER;
-+
-+    RecipeBookType() {
-+        if (ordinal() >= 4) {
-+            String name = this.name().toLowerCase(java.util.Locale.ROOT).replace("_", "");
-+            net.minecraft.stats.RecipeBookSettings.addTagsForType(this, "is" + name + "GuiOpen", "is" + name + "FilteringCraftable");
-+        }
-+    }
 +
 +    public static net.neoforged.fml.common.asm.enumextension.ExtensionInfo getExtensionInfo() {
 +        return net.neoforged.fml.common.asm.enumextension.ExtensionInfo.nonExtended(RecipeBookType.class);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -5,10 +5,12 @@
 
 package net.neoforged.neoforge.common;
 
+import com.google.common.base.CaseFormat;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Lifecycle;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -100,6 +102,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.AdventureModePredicate;
 import net.minecraft.world.item.ArmorItem;
@@ -148,6 +151,7 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoader;
+import net.neoforged.fml.common.asm.enumextension.ExtensionInfo;
 import net.neoforged.fml.i18n.MavenVersionTranslator;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.ClientHooks;
@@ -1537,5 +1541,21 @@ public class CommonHooks {
         level.setBlock(pos, blockstate, 3);
         level.gameEvent(null, GameEvent.SHEAR, pos);
         return true;
+    }
+
+    public static Map<RecipeBookType, Pair<String, String>> buildRecipeBookTypeTagFields(Map<RecipeBookType, Pair<String, String>> vanillaMap) {
+        ExtensionInfo extInfo = RecipeBookType.getExtensionInfo();
+        if (extInfo.extended()) {
+            vanillaMap = new HashMap<>(vanillaMap);
+            for (RecipeBookType type : RecipeBookType.values()) {
+                if (type.ordinal() < extInfo.vanillaCount()) {
+                    continue;
+                }
+                String name = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, type.name());
+                vanillaMap.put(type, Pair.of("is" + name + "GuiOpen", "is" + name + "FilteringCraftable"));
+            }
+            vanillaMap = Map.copyOf(vanillaMap);
+        }
+        return vanillaMap;
     }
 }


### PR DESCRIPTION
This PR fixes a circularity issue during static init of `RecipeBookSettings`. When `RecipeBookSettings` starts static init before `RecipeBookType` was initialized by other means, the construction of the `TAG_FIELDS` map triggers init of `RecipeBookType`. When the `RecipeBookType` enum has extended values, then these constructor tries to append these to the `TAG_FIELDS` map whose construction is waiting for the static init of `RecipeBookType` to complete and is therefore still null. To fix this, adding the extended entries to the map is moved to a `CommonHooks` method. This issue was introduced during the enum extension rework and went unnoticed because the recipe book test mod eagerly retrieves the `RecipeBookType` it adds. The static init of `RecipeBookSettings` only happens significantly later when the connecting to a server or loading an SP world.