### PR TITLE
Add `canBeHurtBy` back to item

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -242,3 +242,11 @@
      public void onDestroyed(ItemEntity p_150925_) {
          this.getItem().onDestroyed(p_150925_);
      }
+@@ -1031,6 +_,7 @@
+     }
+ 
+     public boolean canBeHurtBy(DamageSource p_335431_) {
++        if (!getItem().canBeHurtBy(this, p_335431_)) return false;
+         return !this.has(DataComponents.FIRE_RESISTANT) || !p_335431_.is(DamageTypeTags.IS_FIRE);
+     }
+ }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -726,7 +726,7 @@ public interface IItemExtension {
     }
 
     /**
-     * @return false to make item entity immune to the damage.
+     * {@return false to make item entity immune to the damage.}
      */
     default boolean canBeHurtBy(ItemStack stack, DamageSource source) {
         return true;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -724,4 +724,11 @@ public interface IItemExtension {
     default boolean canGrindstoneRepair(ItemStack stack) {
         return false;
     }
+
+    /**
+     * @return false to make item entity immune to the damage.
+     */
+    default boolean canBeHurtBy(ItemStack stack, DamageSource source) {
+        return true;
+    }
 }


### PR DESCRIPTION
`Item::canBeHurtBy` is a vanilla method in 1.20. However it's removed in 1.21 and only exist in `ItemStack`. This PR adds it back for modders to override so that modders can make their items immune to certain damage.