### PR TITLE
Add `ProjectileWeaponLoadEvent` and `ProjectileWeaponShootEvent`

### DIFF
--- a/patches/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java.patch
+++ b/patches/net/minecraft/world/entity/ai/goal/RangedBowAttackGoal.java.patch
@@ -29,12 +29,15 @@
      }
  
      @Override
-@@ -132,7 +_,7 @@
+@@ -132,7 +_,10 @@
                      }
                  }
              } else if (--this.attackTime <= 0 && this.seeTime >= -60) {
 -                this.mob.startUsingItem(ProjectileUtil.getWeaponHoldingHand(this.mob, Items.BOW));
-+                this.mob.startUsingItem(ProjectileUtil.getWeaponHoldingHand(this.mob, item -> item instanceof BowItem));
++                var hand = ProjectileUtil.getWeaponHoldingHand(this.mob, item -> item instanceof BowItem);
++                var bow = this.mob.getItemInHand(hand);
++                if (net.neoforged.neoforge.event.EventHooks.onProjectileWeaponLoadPre(this.mob, bow, this.mob.getProjectile(bow), hand, true))
++                this.mob.startUsingItem(hand);
              }
          }
      }

--- a/patches/net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal.java.patch
+++ b/patches/net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal.java.patch
@@ -29,12 +29,18 @@
      }
  
      @Override
-@@ -99,7 +_,7 @@
+@@ -99,9 +_,13 @@
              this.mob.getLookControl().setLookAt(livingentity, 30.0F, 30.0F);
              if (this.crossbowState == RangedCrossbowAttackGoal.CrossbowState.UNCHARGED) {
                  if (!flag2) {
 -                    this.mob.startUsingItem(ProjectileUtil.getWeaponHoldingHand(this.mob, Items.CROSSBOW));
-+                    this.mob.startUsingItem(ProjectileUtil.getWeaponHoldingHand(this.mob, item -> item instanceof CrossbowItem));
++                    var hand = ProjectileUtil.getWeaponHoldingHand(this.mob, item -> item instanceof CrossbowItem);
++                    var crossbow = this.mob.getItemInHand(hand);
++                    if (net.neoforged.neoforge.event.EventHooks.onProjectileWeaponLoadPre(this.mob, crossbow, this.mob.getProjectile(crossbow), hand, true)) {
++                    this.mob.startUsingItem(hand);
                      this.crossbowState = RangedCrossbowAttackGoal.CrossbowState.CHARGING;
                      this.mob.setChargingCrossbow(true);
++                    }
                  }
+             } else if (this.crossbowState == RangedCrossbowAttackGoal.CrossbowState.CHARGING) {
+                 if (!this.mob.isUsingItem()) {

--- a/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -1,15 +1,17 @@
 --- a/net/minecraft/world/entity/monster/AbstractSkeleton.java
 +++ b/net/minecraft/world/entity/monster/AbstractSkeleton.java
-@@ -157,7 +_,7 @@
+@@ -157,8 +_,8 @@
          if (this.level() != null && !this.level().isClientSide) {
              this.goalSelector.removeGoal(this.meleeGoal);
              this.goalSelector.removeGoal(this.bowGoal);
 -            ItemStack itemstack = this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, Items.BOW));
+-            if (itemstack.is(Items.BOW)) {
 +            ItemStack itemstack = this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, item -> item instanceof net.minecraft.world.item.BowItem));
-             if (itemstack.is(Items.BOW)) {
++            if (itemstack.getItem() instanceof net.minecraft.world.item.BowItem) {
                  int i = this.getHardAttackInterval();
                  if (this.level().getDifficulty() != Difficulty.HARD) {
-@@ -182,9 +_,11 @@
+                     i = this.getAttackInterval();
+@@ -182,16 +_,28 @@
  
      @Override
      public void performRangedAttack(LivingEntity p_32141_, float p_32142_) {
@@ -24,3 +26,22 @@
          double d0 = p_32141_.getX() - this.getX();
          double d1 = p_32141_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32141_.getZ() - this.getZ();
+         double d3 = Math.sqrt(d0 * d0 + d2 * d2);
+-        abstractarrow.shoot(d0, d1 + d3 * 0.2F, d2, 1.6F, (float)(14 - this.level().getDifficulty().getId() * 4));
++        var event = net.neoforged.neoforge.event.EventHooks.onProjectileWeaponShootPre(this, abstractarrow, p_32141_, weapon, itemstack1, 1.6F, (float)(14 - this.level().getDifficulty().getId() * 4));
++        if (event.isCanceled()) return;
++        net.minecraft.world.entity.projectile.Projectile projectile = event.getProjectile();
++        if (projectile instanceof AbstractArrow) {
++            abstractarrow = (AbstractArrow) projectile;
++            // Neo: keep the original AbstractArrow#shoot call, so we don't break old/multiloader mixins
++            abstractarrow.shoot(d0, d1 + d3 * 0.2F, d2, event.getPower(), event.getDivergence());
++        } else {
++            projectile.shoot(d0, d1 + d3 * 0.2F, d2, event.getPower(), event.getDivergence());
++        }
+         this.playSound(SoundEvents.SKELETON_SHOOT, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
+-        this.level().addFreshEntity(abstractarrow);
++        this.level().addFreshEntity(projectile);
++        net.neoforged.neoforge.event.EventHooks.onProjectileWeaponShootPost(this, projectile, p_32141_, weapon, itemstack1, 0);
+     }
+ 
+     protected AbstractArrow getArrow(ItemStack p_32156_, float p_32157_, @Nullable ItemStack p_346155_) {

--- a/patches/net/minecraft/world/entity/monster/Illusioner.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Illusioner.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/monster/Illusioner.java
 +++ b/net/minecraft/world/entity/monster/Illusioner.java
-@@ -174,9 +_,11 @@
+@@ -174,16 +_,28 @@
  
      @Override
      public void performRangedAttack(LivingEntity p_32918_, float p_32919_) {
@@ -13,3 +13,22 @@
          double d0 = p_32918_.getX() - this.getX();
          double d1 = p_32918_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32918_.getZ() - this.getZ();
+         double d3 = Math.sqrt(d0 * d0 + d2 * d2);
+-        abstractarrow.shoot(d0, d1 + d3 * 0.2F, d2, 1.6F, (float)(14 - this.level().getDifficulty().getId() * 4));
++        var event = net.neoforged.neoforge.event.EventHooks.onProjectileWeaponShootPre(this, abstractarrow, p_32918_, itemstack, itemstack1, 1.6F, (float)(14 - this.level().getDifficulty().getId() * 4));
++        if (event.isCanceled()) return;
++        net.minecraft.world.entity.projectile.Projectile projectile = event.getProjectile();
++        if (projectile instanceof AbstractArrow) {
++            abstractarrow = (AbstractArrow) projectile;
++            // Neo: keep the original AbstractArrow#shoot call, so we don't break old/multiloader mixins
++            abstractarrow.shoot(d0, d1 + d3 * 0.2F, d2, event.getPower(), event.getDivergence());
++        } else {
++            projectile.shoot(d0, d1 + d3 * 0.2F, d2, event.getPower(), event.getDivergence());
++        }
+         this.playSound(SoundEvents.SKELETON_SHOOT, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
+-        this.level().addFreshEntity(abstractarrow);
++        this.level().addFreshEntity(projectile);
++        net.neoforged.neoforge.event.EventHooks.onProjectileWeaponShootPost(this, projectile, p_32918_, itemstack, itemstack1, 0);
+     }
+ 
+     @Override

--- a/patches/net/minecraft/world/item/BowItem.java.patch
+++ b/patches/net/minecraft/world/item/BowItem.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/BowItem.java
 +++ b/net/minecraft/world/item/BowItem.java
-@@ -28,6 +_,8 @@
+@@ -28,9 +_,11 @@
              ItemStack itemstack = player.getProjectile(p_40667_);
              if (!itemstack.isEmpty()) {
                  int i = this.getUseDuration(p_40667_, p_40669_) - p_40670_;
@@ -8,15 +8,24 @@
 +                if (i < 0) return;
                  float f = getPowerForTime(i);
                  if (!((double)f < 0.1)) {
-                     List<ItemStack> list = draw(p_40667_, itemstack, player);
-@@ -82,6 +_,10 @@
+-                    List<ItemStack> list = draw(p_40667_, itemstack, player);
++                    List<ItemStack> list = net.neoforged.neoforge.event.EventHooks.onProjectileWeaponLoadPost(p_40669_, p_40667_, itemstack, draw(p_40667_, itemstack, player));
+                     if (p_40668_ instanceof ServerLevel serverlevel && !list.isEmpty()) {
+                         this.shoot(serverlevel, player, player.getUsedItemHand(), p_40667_, list, f * 3.0F, 1.0F, f == 1.0F, null);
+                     }
+@@ -81,8 +_,13 @@
+     @Override
      public InteractionResultHolder<ItemStack> use(Level p_40672_, Player p_40673_, InteractionHand p_40674_) {
          ItemStack itemstack = p_40673_.getItemInHand(p_40674_);
-         boolean flag = !p_40673_.getProjectile(itemstack).isEmpty();
+-        boolean flag = !p_40673_.getProjectile(itemstack).isEmpty();
+-        if (!p_40673_.hasInfiniteMaterials() && !flag) {
++        ItemStack projectile = p_40673_.getProjectile(itemstack);
++        boolean flag = !projectile.isEmpty();
 +
 +        InteractionResultHolder<ItemStack> ret = net.neoforged.neoforge.event.EventHooks.onArrowNock(itemstack, p_40672_, p_40673_, p_40674_, flag);
 +        if (ret != null) return ret;
 +
-         if (!p_40673_.hasInfiniteMaterials() && !flag) {
++        if (net.neoforged.neoforge.event.EventHooks.onProjectileWeaponLoadPre(p_40673_, itemstack, projectile, p_40674_, p_40673_.hasInfiniteMaterials() || flag)) {
              return InteractionResultHolder.fail(itemstack);
          } else {
+             p_40673_.startUsingItem(p_40674_);

--- a/patches/net/minecraft/world/item/CrossbowItem.java.patch
+++ b/patches/net/minecraft/world/item/CrossbowItem.java.patch
@@ -1,5 +1,26 @@
 --- a/net/minecraft/world/item/CrossbowItem.java
 +++ b/net/minecraft/world/item/CrossbowItem.java
+@@ -72,7 +_,9 @@
+         if (chargedprojectiles != null && !chargedprojectiles.isEmpty()) {
+             this.performShooting(p_40920_, p_40921_, p_40922_, itemstack, getShootingPower(chargedprojectiles), 1.0F, null);
+             return InteractionResultHolder.consume(itemstack);
+-        } else if (!p_40921_.getProjectile(itemstack).isEmpty()) {
++        }
++        ItemStack projectile = p_40921_.getProjectile(itemstack);
++        if (net.neoforged.neoforge.event.EventHooks.onProjectileWeaponLoadPre(p_40921_, itemstack, projectile, p_40922_, !projectile.isEmpty())) {
+             this.startSoundPlayed = false;
+             this.midLoadSoundPlayed = false;
+             p_40921_.startUsingItem(p_40922_);
+@@ -109,7 +_,8 @@
+     }
+ 
+     private static boolean tryLoadProjectiles(LivingEntity p_40860_, ItemStack p_40861_) {
+-        List<ItemStack> list = draw(p_40861_, p_40860_.getProjectile(p_40861_), p_40860_);
++        ItemStack projectile = p_40860_.getProjectile(p_40861_);
++        List<ItemStack> list = net.neoforged.neoforge.event.EventHooks.onProjectileWeaponLoadPost(p_40860_, p_40861_, projectile, draw(p_40861_, projectile, p_40860_));
+         if (!list.isEmpty()) {
+             p_40861_.set(DataComponents.CHARGED_PROJECTILES, ChargedProjectiles.of(list));
+             return true;
 @@ -181,6 +_,7 @@
          Level p_40888_, LivingEntity p_40889_, InteractionHand p_40890_, ItemStack p_40891_, float p_40892_, float p_40893_, @Nullable LivingEntity p_331602_
      ) {

--- a/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
+++ b/patches/net/minecraft/world/item/ProjectileWeaponItem.java.patch
@@ -1,5 +1,23 @@
 --- a/net/minecraft/world/item/ProjectileWeaponItem.java
 +++ b/net/minecraft/world/item/ProjectileWeaponItem.java
+@@ -67,9 +_,16 @@
+                 float f4 = f2 + f3 * (float)((i + 1) / 2) * f1;
+                 f3 = -f3;
+                 Projectile projectile = this.createProjectile(p_346125_, p_330728_, p_330646_, itemstack, p_331107_);
++                var event = net.neoforged.neoforge.event.EventHooks.onProjectileWeaponShootPre(p_330728_, projectile, p_331167_, p_330646_, itemstack, p_331007_, p_331445_);
++                if (event.isCanceled()) continue;
++                projectile = event.getProjectile();
++                p_331007_ = event.getPower();
++                p_331445_ = event.getDivergence();
+                 this.shootProjectile(p_330728_, projectile, i, p_331007_, p_331445_, f4, p_331167_);
+                 p_346125_.addFreshEntity(projectile);
+-                p_330646_.hurtAndBreak(this.getDurabilityUse(itemstack), p_330728_, LivingEntity.getSlotForHand(p_331152_));
++                int damage = net.neoforged.neoforge.event.EventHooks.onProjectileWeaponShootPost(p_330728_, projectile, p_331167_, p_330646_, itemstack, this.getDurabilityUse(itemstack));
++                if (damage > 0)
++                    p_330646_.hurtAndBreak(damage, p_330728_, LivingEntity.getSlotForHand(p_331152_));
+                 if (p_330646_.isEmpty()) {
+                     break;
+                 }
 @@ -92,7 +_,7 @@
              abstractarrow.setCritArrow(true);
          }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -10,6 +10,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.DynamicOps;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -135,6 +136,8 @@ import net.neoforged.neoforge.event.entity.living.MobEffectEvent;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent.PositionCheck;
 import net.neoforged.neoforge.event.entity.living.MobSpawnEvent.SpawnPlacementCheck;
 import net.neoforged.neoforge.event.entity.living.MobSplitEvent;
+import net.neoforged.neoforge.event.entity.living.ProjectileWeaponLoadEvent;
+import net.neoforged.neoforge.event.entity.living.ProjectileWeaponShootEvent;
 import net.neoforged.neoforge.event.entity.living.SpawnClusterSizeEvent;
 import net.neoforged.neoforge.event.entity.player.AdvancementEvent.AdvancementEarnEvent;
 import net.neoforged.neoforge.event.entity.player.AdvancementEvent.AdvancementProgressEvent;
@@ -1119,5 +1122,29 @@ public class EventHooks {
         var event = new MobSplitEvent(parent, children);
         NeoForge.EVENT_BUS.post(event);
         return event;
+    }
+
+    public static boolean onProjectileWeaponLoadPre(LivingEntity entity, ItemStack weaponItem, ItemStack projectileItem, InteractionHand hand, boolean canLoad) {
+        var event = new ProjectileWeaponLoadEvent.Pre(entity, weaponItem, projectileItem, hand, canLoad);
+        NeoForge.EVENT_BUS.post(event);
+        return event.canLoad();
+    }
+
+    public static List<ItemStack> onProjectileWeaponLoadPost(LivingEntity entity, ItemStack weapon, ItemStack projectile, List<ItemStack> loadedProjectiles) {
+        var event = new ProjectileWeaponLoadEvent.Post(entity, weapon, projectile, loadedProjectiles instanceof ArrayList ? loadedProjectiles : new ArrayList<>(loadedProjectiles));
+        NeoForge.EVENT_BUS.post(event);
+        return event.isCanceled() ? List.of() : event.getLoadedProjectiles();
+    }
+
+    public static ProjectileWeaponShootEvent.Pre onProjectileWeaponShootPre(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, float power, float divergence) {
+        var event = new ProjectileWeaponShootEvent.Pre(entity, projectile, target, weaponItem, projectileItem, power, divergence);
+        NeoForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static int onProjectileWeaponShootPost(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, int weaponDamage) {
+        var event = new ProjectileWeaponShootEvent.Post(entity, projectile, target, weaponItem, projectileItem, weaponDamage);
+        NeoForge.EVENT_BUS.post(event);
+        return event.getWeaponDamage();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1124,24 +1124,62 @@ public class EventHooks {
         return event;
     }
 
+    /**
+     * Fires the {@link ProjectileWeaponLoadEvent.Pre}. Returns if the event is cancelled.
+     * @param entity The living entity using the projectile weapon.
+     * @param weaponItem The projectile weapon item stack.
+     * @param projectileItem The projectile weapon item stack.
+     * @param hand The hand helding the projectile weapon.
+     * @param canLoad If the projectile weapon can start loading.
+     * @return If the event is cancelled.
+     */
     public static boolean onProjectileWeaponLoadPre(LivingEntity entity, ItemStack weaponItem, ItemStack projectileItem, InteractionHand hand, boolean canLoad) {
         var event = new ProjectileWeaponLoadEvent.Pre(entity, weaponItem, projectileItem, hand, canLoad);
         NeoForge.EVENT_BUS.post(event);
         return event.canLoad();
     }
 
-    public static List<ItemStack> onProjectileWeaponLoadPost(LivingEntity entity, ItemStack weapon, ItemStack projectile, List<ItemStack> loadedProjectiles) {
-        var event = new ProjectileWeaponLoadEvent.Post(entity, weapon, projectile, loadedProjectiles instanceof ArrayList ? loadedProjectiles : new ArrayList<>(loadedProjectiles));
+    /**
+     * Fires the {@link ProjectileWeaponLoadEvent.Post}. Returns the loaded projectile item stacks.
+     * @param entity The living entity using the projectile weapon.
+     * @param weaponItem The projectile weapon item stack.
+     * @param projectileItem The projectile item stack.
+     * @param loadedProjectiles The loaded projectile weapon item stacks.
+     * @return The loaded projectile item stacks.
+     */
+    public static List<ItemStack> onProjectileWeaponLoadPost(LivingEntity entity, ItemStack weaponItem, ItemStack projectileItem, List<ItemStack> loadedProjectiles) {
+        var event = new ProjectileWeaponLoadEvent.Post(entity, weaponItem, projectileItem, loadedProjectiles instanceof ArrayList ? loadedProjectiles : new ArrayList<>(loadedProjectiles));
         NeoForge.EVENT_BUS.post(event);
         return event.isCanceled() ? List.of() : event.getLoadedProjectiles();
     }
 
+    /**
+     * Fires the {@link ProjectileWeaponShootEvent.Pre}. Returns the event object.
+     * @param entity The living entity using the projectile weapon.
+     * @param projectile The projectile entity to shoot.
+     * @param target The target of the living entity, could be null.
+     * @param weaponItem The projectile weapon item stack.
+     * @param projectileItem The projectile item stack.
+     * @param power The power of the projectile.
+     * @param divergence The divergence of the projectile.
+     * @return The event object.
+     */
     public static ProjectileWeaponShootEvent.Pre onProjectileWeaponShootPre(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, float power, float divergence) {
         var event = new ProjectileWeaponShootEvent.Pre(entity, projectile, target, weaponItem, projectileItem, power, divergence);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }
 
+    /**
+     * Fires the {@link ProjectileWeaponShootEvent.Post}. Returns the damage to the projectile weapon item stack.
+     * @param entity The living entity using the projectile weapon.
+     * @param projectile he projectile entity to shoot.
+     * @param target The target of the living entity, could be null.
+     * @param weaponItem The projectile weapon item stack.
+     * @param projectileItem The projectile item stack.
+     * @param weaponDamage The damage to the projectile weapon item stack.
+     * @return The damage to the projectile weapon item stack, could be ignored if the damage should not be applied anyway (like in {@link net.minecraft.world.entity.monster.AbstractSkeleton#performRangedAttack(LivingEntity, float)}).
+     */
     public static int onProjectileWeaponShootPost(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, int weaponDamage) {
         var event = new ProjectileWeaponShootEvent.Post(entity, projectile, target, weaponItem, projectileItem, weaponDamage);
         NeoForge.EVENT_BUS.post(event);

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1126,11 +1126,12 @@ public class EventHooks {
 
     /**
      * Fires the {@link ProjectileWeaponLoadEvent.Pre}. Returns if the event is cancelled.
-     * @param entity The living entity using the projectile weapon.
-     * @param weaponItem The projectile weapon item stack.
+     * 
+     * @param entity         The living entity using the projectile weapon.
+     * @param weaponItem     The projectile weapon item stack.
      * @param projectileItem The projectile weapon item stack.
-     * @param hand The hand helding the projectile weapon.
-     * @param canLoad If the projectile weapon can start loading.
+     * @param hand           The hand helding the projectile weapon.
+     * @param canLoad        If the projectile weapon can start loading.
      * @return If the event is cancelled.
      */
     public static boolean onProjectileWeaponLoadPre(LivingEntity entity, ItemStack weaponItem, ItemStack projectileItem, InteractionHand hand, boolean canLoad) {
@@ -1141,9 +1142,10 @@ public class EventHooks {
 
     /**
      * Fires the {@link ProjectileWeaponLoadEvent.Post}. Returns the loaded projectile item stacks.
-     * @param entity The living entity using the projectile weapon.
-     * @param weaponItem The projectile weapon item stack.
-     * @param projectileItem The projectile item stack.
+     * 
+     * @param entity            The living entity using the projectile weapon.
+     * @param weaponItem        The projectile weapon item stack.
+     * @param projectileItem    The projectile item stack.
      * @param loadedProjectiles The loaded projectile weapon item stacks.
      * @return The loaded projectile item stacks.
      */
@@ -1155,13 +1157,14 @@ public class EventHooks {
 
     /**
      * Fires the {@link ProjectileWeaponShootEvent.Pre}. Returns the event object.
-     * @param entity The living entity using the projectile weapon.
-     * @param projectile The projectile entity to shoot.
-     * @param target The target of the living entity, could be null.
-     * @param weaponItem The projectile weapon item stack.
+     * 
+     * @param entity         The living entity using the projectile weapon.
+     * @param projectile     The projectile entity to shoot.
+     * @param target         The target of the living entity, could be null.
+     * @param weaponItem     The projectile weapon item stack.
      * @param projectileItem The projectile item stack.
-     * @param power The power of the projectile.
-     * @param divergence The divergence of the projectile.
+     * @param power          The power of the projectile.
+     * @param divergence     The divergence of the projectile.
      * @return The event object.
      */
     public static ProjectileWeaponShootEvent.Pre onProjectileWeaponShootPre(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, float power, float divergence) {
@@ -1172,12 +1175,13 @@ public class EventHooks {
 
     /**
      * Fires the {@link ProjectileWeaponShootEvent.Post}. Returns the damage to the projectile weapon item stack.
-     * @param entity The living entity using the projectile weapon.
-     * @param projectile he projectile entity to shoot.
-     * @param target The target of the living entity, could be null.
-     * @param weaponItem The projectile weapon item stack.
+     * 
+     * @param entity         The living entity using the projectile weapon.
+     * @param projectile     he projectile entity to shoot.
+     * @param target         The target of the living entity, could be null.
+     * @param weaponItem     The projectile weapon item stack.
      * @param projectileItem The projectile item stack.
-     * @param weaponDamage The damage to the projectile weapon item stack.
+     * @param weaponDamage   The damage to the projectile weapon item stack.
      * @return The damage to the projectile weapon item stack, could be ignored if the damage should not be applied anyway (like in {@link net.minecraft.world.entity.monster.AbstractSkeleton#performRangedAttack(LivingEntity, float)}).
      */
     public static int onProjectileWeaponShootPost(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, int weaponDamage) {

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1132,7 +1132,7 @@ public class EventHooks {
      * @param projectileItem The projectile weapon item stack.
      * @param hand           The hand helding the projectile weapon.
      * @param canLoad        If the projectile weapon can start loading.
-     * @return If the event is cancelled.
+     * @return If the projectile weapon can start loading.
      */
     public static boolean onProjectileWeaponLoadPre(LivingEntity entity, ItemStack weaponItem, ItemStack projectileItem, InteractionHand hand, boolean canLoad) {
         var event = new ProjectileWeaponLoadEvent.Pre(entity, weaponItem, projectileItem, hand, canLoad);

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponLoadEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponLoadEvent.java
@@ -23,7 +23,7 @@ public abstract class ProjectileWeaponLoadEvent extends LivingEvent {
     private final ItemStack weaponItem;
     private final ItemStack projectileItem;
 
-    ProjectileWeaponLoadEvent(LivingEntity entity, ItemStack weaponItem, ItemStack projectile) {
+    private ProjectileWeaponLoadEvent(LivingEntity entity, ItemStack weaponItem, ItemStack projectile) {
         super(entity);
         this.weaponItem = weaponItem;
         this.projectileItem = projectile;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponLoadEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponLoadEvent.java
@@ -23,7 +23,7 @@ public abstract class ProjectileWeaponLoadEvent extends LivingEvent {
     private final ItemStack weaponItem;
     private final ItemStack projectileItem;
 
-    public ProjectileWeaponLoadEvent(LivingEntity entity, ItemStack weaponItem, ItemStack projectile) {
+    ProjectileWeaponLoadEvent(LivingEntity entity, ItemStack weaponItem, ItemStack projectile) {
         super(entity);
         this.weaponItem = weaponItem;
         this.projectileItem = projectile;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponLoadEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponLoadEvent.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.living;
+
+import java.util.List;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BowItem;
+import net.minecraft.world.item.CrossbowItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ProjectileWeaponItem;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.ICancellableEvent;
+
+/**
+ * ProjectileWeaponLoadEvent is fired when a living entity is loading projectiles for a {@link ProjectileWeaponItem}.
+ */
+public abstract class ProjectileWeaponLoadEvent extends LivingEvent {
+    private final ItemStack weaponItem;
+    private final ItemStack projectileItem;
+
+    public ProjectileWeaponLoadEvent(LivingEntity entity, ItemStack weaponItem, ItemStack projectile) {
+        super(entity);
+        this.weaponItem = weaponItem;
+        this.projectileItem = projectile;
+    }
+
+    /**
+     * @return the {@link ProjectileWeaponItem} used by the entity.
+     */
+    public ItemStack getWeaponItem() {
+        return this.weaponItem;
+    }
+
+    /**
+     * @return the projectile item to be loaded.
+     *         <br>
+     *         With vanilla behavior, this usually returns the result {@link LivingEntity#getProjectile(ItemStack)},
+     *         but it's possible for that to not be the case if modder uses a different implementation of the {@link ProjectileWeaponItem}.
+     *         <br>
+     *         Modifying the returned projectile has no effect,
+     *         subscribe to {@link LivingGetProjectileEvent} instead for controlling the projectile.
+     */
+    public ItemStack getProjectileItem() {
+        return this.projectileItem;
+    }
+
+    /**
+     * ProjectileWeaponLoadEvent.Pre is fired when a living entity is about to start loading the {@link ProjectileWeaponItem},
+     * before {@link LivingEntity#startUsingItem(InteractionHand)} is called.
+     * <p>
+     * This event is not {@link ICancellableEvent cancellable} and does not have a result,
+     * instead, use {@link #setCanLoad(boolean)} to determine if the projectile weapon can start loading.
+     */
+    public static class Pre extends ProjectileWeaponLoadEvent {
+        private final InteractionHand hand;
+        private boolean canLoad;
+
+        public Pre(LivingEntity entity, ItemStack weapon, ItemStack projectile, InteractionHand hand, boolean canLoad) {
+            super(entity, weapon, projectile);
+            this.hand = hand;
+            this.canLoad = canLoad;
+        }
+
+        /**
+         * @return the {@link InteractionHand hand} helding the projectile weapon.
+         */
+        public InteractionHand getHand() {
+            return this.hand;
+        }
+
+        /**
+         * @return if the {@link ProjectileWeaponItem} can load.
+         *         <br>
+         *         With vanilla behavior, this usually returns true if {@link #getProjectileItem()} is not empty,
+         *         or the living entity is player with {@link Player#hasInfiniteMaterials()} returning true.
+         *         <br>
+         *         but it's possible for that to not be the case if modder uses a different implementation of the {@link ProjectileWeaponItem}.
+         */
+        public boolean canLoad() {
+            return this.canLoad;
+        }
+
+        /**
+         * Set if the {@link ProjectileWeaponItem} can load.
+         */
+        public void setCanLoad(boolean canLoad) {
+            this.canLoad = canLoad;
+        }
+    }
+
+    /**
+     * ProjectileWeaponLoadEvent.Post is fired when a living entity finish loading the projectiles in {@link ProjectileWeaponItem#releaseUsing(ItemStack, Level, LivingEntity, int)}.
+     * <p>
+     * This event is {@link ICancellableEvent cancellable} and does not have a result.
+     * <p>
+     * When the event is cancelled or {@link #getLoadedProjectiles()} returns an empty list, the {@link ProjectileWeaponItem} fails to load.
+     * <br>
+     * For {@link BowItem}, no arrows are shot.
+     * <br>
+     * For {@link CrossbowItem}, the crossbow is not charged.
+     */
+    public static class Post extends ProjectileWeaponLoadEvent implements ICancellableEvent {
+        private final List<ItemStack> loadedProjectiles;
+
+        public Post(LivingEntity entity, ItemStack weapon, ItemStack projectile, List<ItemStack> loadedProjectiles) {
+            super(entity, weapon, projectile);
+            this.loadedProjectiles = loadedProjectiles;
+        }
+
+        /**
+         * @return a modifiable list of the loaded projectiles.
+         *         With vanilla behavior, this usually returns the result of {@link ProjectileWeaponItem#draw(ItemStack, ItemStack, LivingEntity)},
+         *         but it's also possible for that to not be the case if modder uses a different implementation of {@link ProjectileWeaponItem}.
+         */
+        public List<ItemStack> getLoadedProjectiles() {
+            return this.loadedProjectiles;
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponShootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponShootEvent.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.living;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.item.BowItem;
+import net.minecraft.world.item.CrossbowItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ProjectileWeaponItem;
+import net.minecraft.world.item.component.ChargedProjectiles;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.ICancellableEvent;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * ProjectileWeaponShootEvent is fired when a living entity shoots a {@link Projectile} with a {@link ProjectileWeaponItem}.
+ */
+public abstract class ProjectileWeaponShootEvent extends LivingEvent {
+    private final @Nullable LivingEntity target;
+    private final ItemStack weaponItem;
+    private final ItemStack projectileItem;
+
+    public ProjectileWeaponShootEvent(LivingEntity entity, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem) {
+        super(entity);
+        this.target = target;
+        this.weaponItem = weaponItem;
+        this.projectileItem = projectileItem;
+    }
+
+    /**
+     * @return the target of the living entity, could be null.
+     */
+    public @Nullable LivingEntity getTarget() {
+        return this.target;
+    }
+
+    /**
+     * @return the {@link ProjectileWeaponItem} used for shooting.
+     */
+    public ItemStack getWeaponItem() {
+        return weaponItem;
+    }
+
+    /**
+     * @return the projectile item representing the projectile.
+     */
+    public ItemStack getProjectileItem() {
+        return projectileItem;
+    }
+
+    /**
+     * ProjectileWeaponShootEvent.Pre is fired when a living entity shoots a {@link Projectile} using a {@link ProjectileWeaponItem},
+     * before the movement of the {@link Projectile} is set by {@link Projectile#shoot(double, double, double, float, float)}.
+     * <p>
+     * This event is {@link ICancellableEvent cancellable} and does not have a result.
+     * <p>
+     * When the event is cancelled, the {@link Projectile} will not be shot, the ProjectileWeaponShootEvent.Post will not be fired, and the {@link ProjectileWeaponItem} will not be damaged.
+     */
+    public static class Pre extends ProjectileWeaponShootEvent implements ICancellableEvent {
+        private Projectile projectile;
+        private float power;
+        private float divergence;
+
+        public Pre(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, float power, float divergence) {
+            super(entity, target, weaponItem, projectileItem);
+            this.projectile = projectile;
+            this.power = power;
+            this.divergence = divergence;
+        }
+
+        /**
+         * @return the projectile entity
+         */
+        public Projectile getProjectile() {
+            return this.projectile;
+        }
+
+        /**
+         * Set the projectile entity.
+         * 
+         * @param projectile the new projectile entity.
+         */
+        public void setProjectile(Projectile projectile) {
+            this.projectile = projectile;
+        }
+
+        /**
+         * @return the power of the projectile.
+         *         With the default implementation of {@link Projectile}, this equals to the speed (m/tick) of the projectile when {@link #getDivergence()} is 0.
+         *         <br>
+         *         For vanilla {@link BowItem}, the power is 3 when fully charged.
+         *         <br>
+         *         For vanilla {@link CrossbowItem}, the power is 1.6 for firework rockets, 3.15 for arrows.
+         * @see Projectile#getMovementToShoot(double, double, double, float, float)
+         * @see BowItem#getPowerForTime(int)
+         * @see CrossbowItem#getShootingPower(ChargedProjectiles)
+         */
+        public float getPower() {
+            return this.power;
+        }
+
+        /**
+         * Set the power of the projectile.
+         * 
+         * @param power the new power.
+         */
+        public void setPower(float power) {
+            this.power = power;
+        }
+
+        /**
+         * @return the divergence of the projectile.
+         *         With the default implementation of {@link Projectile}, this will add a random offset of ±(1.72275 * divergence)%
+         *         to each dimension of the {@link Projectile}'s movement vector.
+         * @see Projectile#getMovementToShoot(double, double, double, float, float)
+         */
+        public float getDivergence() {
+            return this.divergence;
+        }
+
+        /**
+         * Set the divergence of the projectile.
+         * 
+         * @param divergence the new divergence.
+         */
+        public void setDivergence(float divergence) {
+            this.divergence = divergence;
+        }
+    }
+
+    /**
+     * ProjectileWeaponShootEvent.Post is fired when a living entity has shot a {@link Projectile} using a {@link ProjectileWeaponItem},
+     * after the {@link Projectile} has its movement set and joined the {@link Level}, before the {@link ProjectileWeaponItem} is damaged.
+     * <p>
+     * This event is not {@link ICancellableEvent cancellable} and does not have a result.
+     */
+    public static class Post extends ProjectileWeaponShootEvent {
+        private final Projectile projectile;
+        private int weaponDamage;
+
+        public Post(LivingEntity entity, Projectile projectile, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem, int weaponDamage) {
+            super(entity, target, weaponItem, projectileItem);
+            this.projectile = projectile;
+        }
+
+        /**
+         * @return the projectile entity
+         */
+        public Projectile getProjectile() {
+            return this.projectile;
+        }
+
+        /**
+         * @return the damage to the {@link ProjectileWeaponItem}.
+         */
+        public int getWeaponDamage() {
+            return this.weaponDamage;
+        }
+
+        /**
+         * Set the damage to the {@link ProjectileWeaponItem}.
+         * 
+         * @param weaponDamage the new damage, 0 or negative value result in the item not damaged.
+         */
+        public void setWeaponDamage(int weaponDamage) {
+            this.weaponDamage = weaponDamage;
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponShootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponShootEvent.java
@@ -24,7 +24,7 @@ public abstract class ProjectileWeaponShootEvent extends LivingEvent {
     private final ItemStack weaponItem;
     private final ItemStack projectileItem;
 
-    public ProjectileWeaponShootEvent(LivingEntity entity, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem) {
+    ProjectileWeaponShootEvent(LivingEntity entity, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem) {
         super(entity);
         this.target = target;
         this.weaponItem = weaponItem;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponShootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ProjectileWeaponShootEvent.java
@@ -24,7 +24,7 @@ public abstract class ProjectileWeaponShootEvent extends LivingEvent {
     private final ItemStack weaponItem;
     private final ItemStack projectileItem;
 
-    ProjectileWeaponShootEvent(LivingEntity entity, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem) {
+    private ProjectileWeaponShootEvent(LivingEntity entity, @Nullable LivingEntity target, ItemStack weaponItem, ItemStack projectileItem) {
         super(entity);
         this.target = target;
         this.weaponItem = weaponItem;


### PR DESCRIPTION
The non-breaking change part for #1330, introduced 4 new events for `LivingEntity` and `ProjectileWeaponItem`.

- `ProjectileWeaponLoadEvent.Pre` - an advanced version of the original `ArrowNockEvent`, supports `Player` and mobs who uses `RangedBowAttackGoal` or `RangedCrossbowAttackGoal` and provides the projectile item (was not supported in `ArrowNockEvent`). Currently co-exists with `ArrowNockEvent` to avoid breaking changes, we should look into if we should completely replace the `ArrowNockEvent` with this event in the next version for breaking changes.
- `ProjectileWeaponLoadEvent.Post` - a new event for modifying the loaded projectile items, supports `Player` used `BowItem` and `LivingEntity` used `CrossbowItem`.
- `ProjectileWeaponShootEvent.Pre` - a new event for modifying the projectile entity, power and divergence or completely cancels the shooting of a projectile shot by `ProjectileWeaponItem`. Unlike the original `ArrowLooseEvent`, this event fires for every projectile in a shot, and modifies the actual power of the projectile instead of the charge percentage. We should also look into if this should completely replace the old `ArrowLooseEvent`, or at least cleanup the `ArrowLooseEvent` to serve its own unique functionality.
- `ProjectileWeaponShootEvent.Post` - a new event for modifying the damage to the `ProjectileWeaponItem` after the projectile is shot, may also be used to make any post process to the projectile entity with the weapon context. This also fires for every projectile in a shot like `ProjectileWeaponShootEvent.Pre`

Ideas for more `ProjectileWeaponItem` related events may be posted in #1330, this PR will not close that issue as the rework of `ArrowNockEvent` and `ArrowLooseEvent` are yet to be done in the future updates.