### PR TITLE
[1.21] Fix `EntityTravelToDimensionEvent` not firing for player entities under some circumstances

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -40,14 +40,14 @@
          } else {
              boolean flag = block.isPossibleToRespawnInThis(blockstate);
              BlockState blockstate1 = p_348505_.getBlockState(p_348607_.above());
-@@ -870,6 +_,7 @@
-                 p_350472_.postDimensionTransition().onTransition(this);
-                 return this;
-             } else {
-+                if (!net.neoforged.neoforge.common.CommonHooks.onTravelToDimension(this, p_350472_.newLevel().dimension())) return null;
-                 this.isChangingDimension = true;
-                 LevelData leveldata = serverlevel.getLevelData();
-                 this.connection.send(new ClientboundRespawnPacket(this.createCommonSpawnInfo(serverlevel), (byte)3));
+@@ -854,6 +_,7 @@
+     @Nullable
+     @Override
+     public Entity changeDimension(DimensionTransition p_350472_) {
++        if (!net.neoforged.neoforge.common.CommonHooks.onTravelToDimension(this, p_350472_.newLevel().dimension())) return null;
+         if (this.isRemoved()) {
+             return null;
+         } else {
 @@ -877,7 +_,7 @@
                  PlayerList playerlist = this.server.getPlayerList();
                  playerlist.sendPlayerPermissionLevel(this);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityEventTests.java
@@ -21,10 +21,12 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.portal.DimensionTransition;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.event.entity.EntityAttributeModificationEvent;
 import net.neoforged.neoforge.event.entity.EntityInvulnerabilityCheckEvent;
 import net.neoforged.neoforge.event.entity.EntityTeleportEvent;
+import net.neoforged.neoforge.event.entity.EntityTravelToDimensionEvent;
 import net.neoforged.neoforge.event.level.ExplosionKnockbackEvent;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
@@ -117,6 +119,49 @@ public class EntityEventTests {
                 .thenExecute(pig -> helper.getLevel().explode(null, helper.getLevel().damageSources().generic(), null, helper.absolutePos(new BlockPos(7, 2, 7)).getCenter(), 2f, false, Level.ExplosionInteraction.TNT))
                 .thenExecute(pig -> helper.assertEntityProperty(pig, p -> pig.getDeltaMovement().x() == 0 && pig.getDeltaMovement().y() != 0 && pig.getDeltaMovement().z() == 0, "Check explosion Knockback"))
                 .thenIdle(10)
+                .thenExecute(helper::killAllEntities)
+                .thenSucceed());
+    }
+
+    @GameTest
+    @EmptyTemplate(floor = true)
+    @TestHolder(description = "Tests if the EntityTravelToDimensionEvent fires correctly and if cancelling it prevents the transition")
+    static void entityTravelToDimensionEvent(final DynamicTest test) {
+        test.eventListeners().forge().addListener((final EntityTravelToDimensionEvent event) -> {
+            // Only affect the entities with a custom name to not interfere with other tests
+            if (!Objects.equals(event.getEntity().getCustomName(), Component.literal("travel-to-dimension-test"))) {
+                return;
+            }
+            event.setCanceled(true);
+            test.pass();
+        });
+
+        test.onGameTest(helper -> helper.startSequence()
+                .thenSequence(seq -> seq
+                        .thenMap(() -> helper.spawnWithNoFreeWill(EntityType.PIG, 0, 2, 0))
+                        .thenExecute(pig -> pig.setCustomName(Component.literal("travel-to-dimension-test")))
+                        .thenExecute(pig -> pig.changeDimension(new DimensionTransition(helper.getLevel(), pig.position().add(1.0, 0.0, 0.0), Vec3.ZERO, 0.0f, 0.0f,
+                                DimensionTransition.DO_NOTHING)))
+                        .thenExecute(() -> {
+                            helper.assertEntityPresent(EntityType.PIG, 0, 2, 0);
+                            helper.assertEntityNotPresent(EntityType.PIG, 1, 2, 0);
+                        })
+                        .thenExecute(pig -> pig.changeDimension(new DimensionTransition(helper.getLevel().getServer().getLevel(Level.NETHER), Vec3.ZERO, Vec3.ZERO, 0.0f, 0.0f, DimensionTransition.DO_NOTHING)))
+                        .thenExecute(pig -> helper.assertTrue(pig.level().dimension() == Level.OVERWORLD, "Dimension change was not prevented")))
+
+                .thenSequence(seq -> seq
+                        .thenMap(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL))
+                        .thenExecute(player -> player.setCustomName(Component.literal("travel-to-dimension-test")))
+                        .thenExecute(player -> player.changeDimension(new DimensionTransition(helper.getLevel(), player.position().add(1.0, 0.0, 0.0), Vec3.ZERO, 0.0f, 0.0f, DimensionTransition.DO_NOTHING)))
+                        .thenExecute(() -> {
+                            helper.assertEntityPresent(EntityType.PLAYER, 0, 2, 0);
+                            helper.assertEntityNotPresent(EntityType.PLAYER, 1, 2, 0);
+                        })
+                        .thenExecute(player -> player.changeDimension(new DimensionTransition(helper.getLevel().getServer().getLevel(Level.NETHER), Vec3.ZERO, Vec3.ZERO, 0.0f, 0.0f, DimensionTransition.DO_NOTHING)))
+                        .thenExecute(player -> {
+                            helper.assertEntityPresent(EntityType.PLAYER, 0, 2, 0);
+                            helper.assertTrue(player.level().dimension() == Level.OVERWORLD, "Dimension change was not prevented");
+                        }))
                 .thenExecute(helper::killAllEntities)
                 .thenSucceed());
     }


### PR DESCRIPTION
With the 1.21 port, the hook for the `EntityTravelToDimensionEvent` in `ServerPlayer#changeDimension` was moved with the effect that the event is now only fired if the target dimension is different from the player's current dimension. For all other entites, the event is still fired unconditionally, regardless of the target dimension and whether the entity is marked as removed. See the discussion in #1263 

This PR moves the hook back to the beginning of `ServerPlayer#changeDimension` with the effect that the event is now again fired unconditionally. It also adds a gametest to test whether the event is fired correctly for player and non-player entities.

Closes #1263 