### PR TITLE
Fix capability nullness annotations

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -569,12 +569,12 @@
 +
 +    // Neo: Hookup Capabilities getters to entities
 +    @Nullable
-+    public final <T, C> T getCapability(net.neoforged.neoforge.capabilities.EntityCapability<T, C> capability, @org.jetbrains.annotations.UnknownNullability C context) {
++    public final <T, C extends @org.jetbrains.annotations.Nullable Object> T getCapability(net.neoforged.neoforge.capabilities.EntityCapability<T, C> capability, C context) {
 +        return capability.getCapability(this, context);
 +    }
 +
 +    @Nullable
-+    public final <T> T getCapability(net.neoforged.neoforge.capabilities.EntityCapability<T, Void> capability) {
++    public final <T> T getCapability(net.neoforged.neoforge.capabilities.EntityCapability<T, @org.jetbrains.annotations.Nullable Void> capability) {
 +        return capability.getCapability(this, null);
      }
  

--- a/src/main/java/net/neoforged/neoforge/capabilities/BaseCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/BaseCapability.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.capabilities;
 
 import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Base class to reuse code common between most/all {@code *Capability} implementation.
@@ -18,7 +19,7 @@ import net.minecraft.resources.ResourceLocation;
  * @param <T> Type of queried objects.
  * @param <C> Type of the additional context.
  */
-public abstract class BaseCapability<T, C> {
+public abstract class BaseCapability<T, C extends @Nullable Object> {
     private final ResourceLocation name;
     private final Class<T> typeClass;
     private final Class<C> contextClass;

--- a/src/main/java/net/neoforged/neoforge/capabilities/BlockCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/BlockCapability.java
@@ -89,7 +89,7 @@ import org.jetbrains.annotations.Nullable;
  * @param <T> type of queried objects
  * @param <C> type of the additional context
  */
-public final class BlockCapability<T, C> extends BaseCapability<T, C> {
+public final class BlockCapability<T, C extends @Nullable Object> extends BaseCapability<T, C> {
     /**
      * Creates a new block capability, or gets it if it already exists.
      *
@@ -97,7 +97,7 @@ public final class BlockCapability<T, C> extends BaseCapability<T, C> {
      * @param typeClass    type of the queried API
      * @param contextClass type of the additional context
      */
-    public static <T, C> BlockCapability<T, C> create(ResourceLocation name, Class<T> typeClass, Class<C> contextClass) {
+    public static <T, C extends @Nullable Object> BlockCapability<T, C> create(ResourceLocation name, Class<T> typeClass, Class<C> contextClass) {
         return (BlockCapability<T, C>) registry.create(name, typeClass, contextClass);
     }
 
@@ -107,7 +107,7 @@ public final class BlockCapability<T, C> extends BaseCapability<T, C> {
      *
      * @see #create(ResourceLocation, Class, Class)
      */
-    public static <T> BlockCapability<T, Void> createVoid(ResourceLocation name, Class<T> typeClass) {
+    public static <T> BlockCapability<T, @Nullable Void> createVoid(ResourceLocation name, Class<T> typeClass) {
         return create(name, typeClass, void.class);
     }
 

--- a/src/main/java/net/neoforged/neoforge/capabilities/BlockCapabilityCache.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/BlockCapabilityCache.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Instances are automatically cleared by the garbage collector when they are no longer in use.
  */
-public final class BlockCapabilityCache<T, C> {
+public final class BlockCapabilityCache<T, C extends @Nullable Object> {
     /**
      * Creates a new cache instance and registers it to the level.
      *
@@ -28,7 +28,7 @@ public final class BlockCapabilityCache<T, C> {
      * @param pos        the position
      * @param context    extra context for the query
      */
-    public static <T, C> BlockCapabilityCache<T, C> create(BlockCapability<T, C> capability, ServerLevel level, BlockPos pos, C context) {
+    public static <T, C extends @Nullable Object> BlockCapabilityCache<T, C> create(BlockCapability<T, C> capability, ServerLevel level, BlockPos pos, C context) {
         return create(capability, level, pos, context, () -> true, () -> {});
     }
 
@@ -56,7 +56,7 @@ public final class BlockCapabilityCache<T, C> {
      *                             that should not receive invalidation notifications anymore once it is removed.
      * @param invalidationListener the invalidation listener. Will be called whenever the capability of the cache might have changed.
      */
-    public static <T, C> BlockCapabilityCache<T, C> create(BlockCapability<T, C> capability, ServerLevel level, BlockPos pos, C context, BooleanSupplier isValid, Runnable invalidationListener) {
+    public static <T, C extends @Nullable Object> BlockCapabilityCache<T, C> create(BlockCapability<T, C> capability, ServerLevel level, BlockPos pos, C context, BooleanSupplier isValid, Runnable invalidationListener) {
         Objects.requireNonNull(capability);
         Objects.requireNonNull(isValid);
         Objects.requireNonNull(invalidationListener);

--- a/src/main/java/net/neoforged/neoforge/capabilities/Capabilities.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/Capabilities.java
@@ -20,7 +20,7 @@ public final class Capabilities {
     public static final class EnergyStorage {
         public static final BlockCapability<IEnergyStorage, @Nullable Direction> BLOCK = BlockCapability.createSided(create("energy"), IEnergyStorage.class);
         public static final EntityCapability<IEnergyStorage, @Nullable Direction> ENTITY = EntityCapability.createSided(create("energy"), IEnergyStorage.class);
-        public static final ItemCapability<IEnergyStorage, Void> ITEM = ItemCapability.createVoid(create("energy"), IEnergyStorage.class);
+        public static final ItemCapability<IEnergyStorage, @Nullable Void> ITEM = ItemCapability.createVoid(create("energy"), IEnergyStorage.class);
 
         private EnergyStorage() {}
     }
@@ -28,7 +28,7 @@ public final class Capabilities {
     public static final class FluidHandler {
         public static final BlockCapability<IFluidHandler, @Nullable Direction> BLOCK = BlockCapability.createSided(create("fluid_handler"), IFluidHandler.class);
         public static final EntityCapability<IFluidHandler, @Nullable Direction> ENTITY = EntityCapability.createSided(create("fluid_handler"), IFluidHandler.class);
-        public static final ItemCapability<IFluidHandlerItem, Void> ITEM = ItemCapability.createVoid(create("fluid_handler"), IFluidHandlerItem.class);
+        public static final ItemCapability<IFluidHandlerItem, @Nullable Void> ITEM = ItemCapability.createVoid(create("fluid_handler"), IFluidHandlerItem.class);
 
         private FluidHandler() {}
     }
@@ -39,13 +39,13 @@ public final class Capabilities {
          * Capability for the inventory of an entity.
          * If an entity has multiple inventory "subparts", this capability should give a combined view of all the subparts.
          */
-        public static final EntityCapability<IItemHandler, Void> ENTITY = EntityCapability.createVoid(create("item_handler"), IItemHandler.class);
+        public static final EntityCapability<IItemHandler, @Nullable Void> ENTITY = EntityCapability.createVoid(create("item_handler"), IItemHandler.class);
         /**
          * Capability for an inventory of entity that should be accessible to automation,
          * in the sense that droppers, hoppers, and similar modded devices will try to use it.
          */
         public static final EntityCapability<IItemHandler, @Nullable Direction> ENTITY_AUTOMATION = EntityCapability.createSided(create("item_handler_automation"), IItemHandler.class);
-        public static final ItemCapability<IItemHandler, Void> ITEM = ItemCapability.createVoid(create("item_handler"), IItemHandler.class);
+        public static final ItemCapability<IItemHandler, @Nullable Void> ITEM = ItemCapability.createVoid(create("item_handler"), IItemHandler.class);
 
         private ItemHandler() {}
     }

--- a/src/main/java/net/neoforged/neoforge/capabilities/EntityCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/EntityCapability.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.Nullable;
  * @param <T> type of queried objects
  * @param <C> type of the additional context
  */
-public final class EntityCapability<T, C> extends BaseCapability<T, C> {
+public final class EntityCapability<T, C extends @Nullable Object> extends BaseCapability<T, C> {
     /**
      * Creates a new entity capability, or gets it if it already exists.
      *
@@ -54,7 +54,7 @@ public final class EntityCapability<T, C> extends BaseCapability<T, C> {
      * @param typeClass    type of the queried API
      * @param contextClass type of the additional context
      */
-    public static <T, C> EntityCapability<T, C> create(ResourceLocation name, Class<T> typeClass, Class<C> contextClass) {
+    public static <T, C extends @Nullable Object> EntityCapability<T, C> create(ResourceLocation name, Class<T> typeClass, Class<C> contextClass) {
         return (EntityCapability<T, C>) registry.create(name, typeClass, contextClass);
     }
 
@@ -64,7 +64,7 @@ public final class EntityCapability<T, C> extends BaseCapability<T, C> {
      *
      * @see #create(ResourceLocation, Class, Class)
      */
-    public static <T> EntityCapability<T, Void> createVoid(ResourceLocation name, Class<T> typeClass) {
+    public static <T> EntityCapability<T, @Nullable Void> createVoid(ResourceLocation name, Class<T> typeClass) {
         return create(name, typeClass, void.class);
     }
 

--- a/src/main/java/net/neoforged/neoforge/capabilities/IBlockCapabilityProvider.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/IBlockCapabilityProvider.java
@@ -13,7 +13,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
-public interface IBlockCapabilityProvider<T, C> {
+public interface IBlockCapabilityProvider<T, C extends @Nullable Object> {
     /**
      * Returns the capability, or {@code null} if not available.
      *

--- a/src/main/java/net/neoforged/neoforge/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/ICapabilityProvider.java
@@ -10,7 +10,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 @FunctionalInterface
-public interface ICapabilityProvider<O, C, T> {
+public interface ICapabilityProvider<O, C extends @Nullable Object, T> {
     /**
      * Returns the capability, or {@code null} if not available.
      *

--- a/src/main/java/net/neoforged/neoforge/capabilities/ItemCapability.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/ItemCapability.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
  * @param <T> type of queried objects
  * @param <C> type of the additional context
  */
-public final class ItemCapability<T, C> extends BaseCapability<T, C> {
+public final class ItemCapability<T, C extends @Nullable Object> extends BaseCapability<T, C> {
     /**
      * Creates a new item capability, or gets it if it already exists.
      *
@@ -53,7 +53,7 @@ public final class ItemCapability<T, C> extends BaseCapability<T, C> {
      * @param typeClass    type of the queried API
      * @param contextClass type of the additional context
      */
-    public static <T, C> ItemCapability<T, C> create(ResourceLocation name, Class<T> typeClass, Class<C> contextClass) {
+    public static <T, C extends @Nullable Object> ItemCapability<T, C> create(ResourceLocation name, Class<T> typeClass, Class<C> contextClass) {
         return (ItemCapability<T, C>) registry.create(name, typeClass, contextClass);
     }
 
@@ -63,7 +63,7 @@ public final class ItemCapability<T, C> extends BaseCapability<T, C> {
      *
      * @see #create(ResourceLocation, Class, Class)
      */
-    public static <T> ItemCapability<T, Void> createVoid(ResourceLocation name, Class<T> typeClass) {
+    public static <T> ItemCapability<T, @Nullable Void> createVoid(ResourceLocation name, Class<T> typeClass) {
         return create(name, typeClass, void.class);
     }
 

--- a/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilitiesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/RegisterCapabilitiesEvent.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Fired to register capability providers at an appropriate time.
@@ -35,7 +36,7 @@ public class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
      * {@link Level#invalidateCapabilities(BlockPos)} MUST be called to notify the caches.</b>
      * See {@link IBlockCapabilityProvider} for details.
      */
-    public <T, C> void registerBlock(BlockCapability<T, C> capability, IBlockCapabilityProvider<T, C> provider, Block... blocks) {
+    public <T, C extends @Nullable Object> void registerBlock(BlockCapability<T, C> capability, IBlockCapabilityProvider<T, C> provider, Block... blocks) {
         Objects.requireNonNull(provider);
         // Probably a programmer error
         if (blocks.length == 0)
@@ -54,7 +55,7 @@ public class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
      * {@link Level#invalidateCapabilities(BlockPos)} MUST be called to notify the caches.</b>
      * See {@link IBlockCapabilityProvider} for details.
      */
-    public <T, C, BE extends BlockEntity> void registerBlockEntity(BlockCapability<T, C> capability, BlockEntityType<BE> blockEntityType, ICapabilityProvider<? super BE, C, T> provider) {
+    public <T, C extends @Nullable Object, BE extends BlockEntity> void registerBlockEntity(BlockCapability<T, C> capability, BlockEntityType<BE> blockEntityType, ICapabilityProvider<? super BE, C, T> provider) {
         Objects.requireNonNull(provider);
 
         IBlockCapabilityProvider<T, C> adaptedProvider = (level, pos, state, blockEntity, context) -> {
@@ -83,7 +84,7 @@ public class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
     /**
      * Register a capability provider for some entity type.
      */
-    public <T, C, E extends Entity> void registerEntity(EntityCapability<T, C> capability, EntityType<E> entityType, ICapabilityProvider<? super E, C, T> provider) {
+    public <T, C extends @Nullable Object, E extends Entity> void registerEntity(EntityCapability<T, C> capability, EntityType<E> entityType, ICapabilityProvider<? super E, C, T> provider) {
         Objects.requireNonNull(provider);
         capability.providers.computeIfAbsent(entityType, et -> new ArrayList<>()).add((ICapabilityProvider<Entity, C, T>) provider);
     }
@@ -101,7 +102,7 @@ public class RegisterCapabilitiesEvent extends Event implements IModBusEvent {
     /**
      * Register a capability provider for some items.
      */
-    public <T, C> void registerItem(ItemCapability<T, C> capability, ICapabilityProvider<ItemStack, C, T> provider, ItemLike... items) {
+    public <T, C extends @Nullable Object> void registerItem(ItemCapability<T, C> capability, ICapabilityProvider<ItemStack, C, T> provider, ItemLike... items) {
         Objects.requireNonNull(provider);
         // Probably a programmer error
         if (items.length == 0)

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -463,12 +463,12 @@ public interface IItemStackExtension {
     }
 
     @Nullable
-    default <T, C> T getCapability(ItemCapability<T, C> capability, C context) {
+    default <T, C extends @Nullable Object> T getCapability(ItemCapability<T, C> capability, C context) {
         return capability.getCapability(self(), context);
     }
 
     @Nullable
-    default <T> T getCapability(ItemCapability<T, Void> capability) {
+    default <T> T getCapability(ItemCapability<T, @Nullable Void> capability) {
         return capability.getCapability(self(), null);
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -64,7 +64,7 @@ public interface ILevelExtension {
      * pass them via {@link #getCapability(BlockCapability, BlockPos, BlockState, BlockEntity, Object)} instead.
      */
     @Nullable
-    default <T, C> T getCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
+    default <T, C extends @Nullable Object> T getCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
         return cap.getCapability(self(), pos, null, null, context);
     }
 
@@ -82,8 +82,37 @@ public interface ILevelExtension {
      * @param blockEntity the block entity, if known, or {@code null} if unknown
      */
     @Nullable
-    default <T, C> T getCapability(BlockCapability<T, C> cap, BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity, C context) {
+    default <T, C extends @Nullable Object> T getCapability(BlockCapability<T, C> cap, BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity, C context) {
         return cap.getCapability(self(), pos, state, blockEntity, context);
+    }
+
+    /**
+     * Retrieve a block capability with no context.
+     *
+     * <p>If the block state and/or the block entity is known,
+     * pass them via {@link #getCapability(BlockCapability, BlockPos, BlockState, BlockEntity)} instead.
+     */
+    @Nullable
+    default <T> T getCapability(BlockCapability<T, @Nullable Void> cap, BlockPos pos) {
+        return cap.getCapability(self(), pos, null, null, null);
+    }
+
+    /**
+     * Retrieve a block capability with no context.
+     *
+     * <p>Use this override if the block state and/or the block entity is known,
+     * otherwise prefer the shorter {@link #getCapability(BlockCapability, BlockPos)}.
+     *
+     * <p>If either the block state or the block entity is unknown, simply pass {@code null}.
+     * This function will fetch {@code null} parameters from the level,
+     * with some extra checks to attempt to skip unnecessary fetches.
+     *
+     * @param state       the block state, if known, or {@code null} if unknown
+     * @param blockEntity the block entity, if known, or {@code null} if unknown
+     */
+    @Nullable
+    default <T> T getCapability(BlockCapability<T, @Nullable Void> cap, BlockPos pos, @Nullable BlockState state, @Nullable BlockEntity blockEntity) {
+        return cap.getCapability(self(), pos, state, blockEntity, null);
     }
 
     /**

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -193,11 +193,11 @@ public class ExtendedGameTestHelper extends GameTestHelper {
     }
 
     @Nullable
-    public <T, C> T getCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
+    public <T, C extends @Nullable Object> T getCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
         return getLevel().getCapability(cap, absolutePos(pos), context);
     }
 
-    public <T, C> T requireCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
+    public <T, C extends @Nullable Object> T requireCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
         final var capability = getCapability(cap, pos, context);
         if (capability == null) {
             throw new GameTestAssertPosException("Expected capability " + cap + " but there was none", absolutePos(pos), pos, getTick());


### PR DESCRIPTION
- Fix nullness annotations:
  - The correct way to annotate "generic that might be nullable or not" is `C extends @Nullable Object` according to JSpecify. My IntelliJ seems to recognize that. This fixes the warning when passing a `null` context to a block capability.
  - Contextless caps now use `@Nullable Void` instead of `Void`.
- Add context-less overloads for block capabilities. This already exists for entity and item capabilities, but somehow not for blocks.
  - For example: `level.getCapability(CAP, pos)`. Only works for capabilities with `@Nullable Void` context, of course.