### PR TITLE
Make the attacking_entity loot parameter optional again for fishing

### DIFF
--- a/patches/net/minecraft/world/level/storage/loot/parameters/LootContextParamSets.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/parameters/LootContextParamSets.java.patch
@@ -14,7 +14,7 @@
      );
      public static final LootContextParamSet FISHING = register(
 -        "fishing", p_81446_ -> p_81446_.required(LootContextParams.ORIGIN).required(LootContextParams.TOOL).optional(LootContextParams.THIS_ENTITY)
-+        "fishing", p_81446_ -> p_81446_.required(LootContextParams.ORIGIN).required(LootContextParams.TOOL).optional(LootContextParams.THIS_ENTITY).required(LootContextParams.ATTACKING_ENTITY) //Forge: Add the fisher as a killer.
++        "fishing", p_81446_ -> p_81446_.required(LootContextParams.ORIGIN).required(LootContextParams.TOOL).optional(LootContextParams.THIS_ENTITY).optional(LootContextParams.ATTACKING_ENTITY) //Forge: Add the fisher as a killer.
      );
      public static final LootContextParamSet ENTITY = register(
          "entity",


### PR DESCRIPTION
In the port from 1.20.1 to 1.20.2, we - likely accidentally - made the "attacking_entity" parameter of the fishing loot param context `required`, even though we patch this in ourselves.

Fixes #1328 

![image](https://github.com/user-attachments/assets/7439582e-cc96-44fa-b207-1b8e660d4ea5)
