### PR TITLE
Implement `Iterable` on `IItemHandler`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/ComponentItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ComponentItemHandler.java
@@ -6,6 +6,8 @@
 package net.neoforged.neoforge.items;
 
 import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.stream.IntStream;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
@@ -14,9 +16,6 @@ import net.minecraft.world.item.component.ItemContainerContents;
 import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.common.MutableDataComponentHolder;
-
-import java.util.List;
-import java.util.stream.IntStream;
 
 /**
  * Variant of {@link ItemStackHandler} for use with data components.

--- a/src/main/java/net/neoforged/neoforge/items/IItemHandlerModifiable.java
+++ b/src/main/java/net/neoforged/neoforge/items/IItemHandlerModifiable.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.items;
 
+import com.google.common.base.Preconditions;
 import net.minecraft.world.item.ItemStack;
 
 public interface IItemHandlerModifiable extends IItemHandler {
@@ -20,4 +21,64 @@ public interface IItemHandlerModifiable extends IItemHandler {
      *                          was not expecting.
      **/
     void setStackInSlot(int slot, ItemStack stack);
+
+    @Override
+    default Slot getSlot(int index) {
+        Preconditions.checkElementIndex(index, this.getSlots());
+        return new Slot() {
+            @Override
+            public boolean test(ItemStack stack) {
+                return IItemHandlerModifiable.this.isItemValid(index, stack);
+            }
+
+            @Override
+            public ItemStack get() {
+                return IItemHandlerModifiable.this.getStackInSlot(index);
+            }
+
+            @Override
+            public void set(ItemStack stack) {
+                IItemHandlerModifiable.this.setStackInSlot(index, stack);
+            }
+
+            @Override
+            public ItemStack insert(ItemStack stack, boolean simulate) {
+                return IItemHandlerModifiable.this.insertItem(index, stack, simulate);
+            }
+
+            @Override
+            public ItemStack extract(int amount, boolean simulate) {
+                return IItemHandlerModifiable.this.extractItem(index, amount, simulate);
+            }
+
+            @Override
+            public int limit() {
+                return IItemHandlerModifiable.this.getSlotLimit(index);
+            }
+
+            @Override
+            public int index() {
+                return index;
+            }
+
+            @Override
+            public IItemHandler handler() {
+                return IItemHandlerModifiable.this;
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                if (this == other)
+                    return true;
+                if (!(other instanceof Slot slot))
+                    return false;
+                return IItemHandlerModifiable.this == slot.handler() && index == slot.index();
+            }
+
+            @Override
+            public int hashCode() {
+                return IItemHandlerModifiable.this.hashCode() + index * 31;
+            }
+        };
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.items;
 
+import java.util.stream.IntStream;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
@@ -14,23 +15,54 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.util.INBTSerializable;
 
-public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, INBTSerializable<CompoundTag> {
+/**
+ * A basic implementation of {@link IItemHandlerModifiable}, representing a basic inventory with continuous indices and
+ * slot limit of {@link Item#ABSOLUTE_MAX_STACK_SIZE} (99), accepts any {@link ItemStack}.
+ * <p>
+ * Also implements {@link INBTSerializable} to support {@linkplain net.neoforged.neoforge.attachment.AttachmentType serializable attachment} usecase.
+ */
+public class ItemStackHandler implements IItemHandlerModifiable, INBTSerializable<CompoundTag> {
+    /**
+     * The backing list of {@link ItemStack}.
+     */
     protected NonNullList<ItemStack> stacks;
+    /**
+     * The backing list of {@link IItemHandler.Slot}, the size should be kept the same as {@link #stacks}.
+     */
+    protected NonNullList<Slot> slots;
 
     public ItemStackHandler() {
         this(1);
     }
 
     public ItemStackHandler(int size) {
-        stacks = NonNullList.withSize(size, ItemStack.EMPTY);
+        this(NonNullList.withSize(size, ItemStack.EMPTY));
     }
 
     public ItemStackHandler(NonNullList<ItemStack> stacks) {
         this.stacks = stacks;
+        this.slots = NonNullList.copyOf(IntStream.range(0, stacks.size()).mapToObj(Slot::new).toList());
     }
 
+    /**
+     * Set the {@link #stacks} with a new list of {@link ItemStack#EMPTY} with specified size.
+     * Also updates {@link #slots} to the new size for consistency.
+     * 
+     * @param size the size of the new list
+     */
     public void setSize(int size) {
-        stacks = NonNullList.withSize(size, ItemStack.EMPTY);
+        this.stacks = NonNullList.withSize(size, ItemStack.EMPTY);
+        final int slots = this.slots.size();
+        // The slots list also needs to update if new size is different
+        if (slots > size) {
+            // Replace the slots list with a smaller sublist if new size is smaller, avoids creating new slot instances
+            this.slots = NonNullList.copyOf(this.slots.subList(0, size));
+        } else if (slots < size) {
+            // Add new slots if new size is bigger, avoids creating new slots list
+            for (int i = slots; i < size; ++i) {
+                this.slots.add(i, new Slot(i));
+            }
+        }
     }
 
     @Override
@@ -166,12 +198,80 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
         onLoad();
     }
 
+    @Override
+    public IItemHandler.Slot getSlot(int slot) {
+        validateSlotIndex(slot);
+        return this.slots.get(slot);
+    }
+
     protected void validateSlotIndex(int slot) {
         if (slot < 0 || slot >= stacks.size())
-            throw new RuntimeException("Slot " + slot + " not in valid range - [0," + stacks.size() + ")");
+            throw new IndexOutOfBoundsException("Slot " + slot + " not in valid range - [0," + stacks.size() + ")");
     }
 
     protected void onLoad() {}
 
     protected void onContentsChanged(int slot) {}
+
+    protected class Slot implements IItemHandler.Slot {
+        private final int index;
+
+        protected Slot(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public boolean test(ItemStack stack) {
+            return ItemStackHandler.this.isItemValid(index, stack);
+        }
+
+        @Override
+        public ItemStack get() {
+            return ItemStackHandler.this.getStackInSlot(index);
+        }
+
+        @Override
+        public void set(ItemStack stack) {
+            ItemStackHandler.this.setStackInSlot(index, stack);
+        }
+
+        @Override
+        public ItemStack insert(ItemStack stack, boolean simulate) {
+            return ItemStackHandler.this.insertItem(index, stack, simulate);
+        }
+
+        @Override
+        public ItemStack extract(int amount, boolean simulate) {
+            return ItemStackHandler.this.extractItem(index, amount, simulate);
+        }
+
+        @Override
+        public int limit() {
+            return ItemStackHandler.this.getSlotLimit(index);
+        }
+
+        @Override
+        public int index() {
+            return index;
+        }
+
+        @Override
+        public IItemHandler handler() {
+            return ItemStackHandler.this;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other)
+                return true;
+            if (!(other instanceof IItemHandler.Slot slot))
+                return false;
+            return ItemStackHandler.this == slot.handler() && index == slot.index();
+        }
+
+        @Override
+        public int hashCode() {
+            return ItemStackHandler.this.hashCode() + index * 31;
+        }
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemStackHandler.java
@@ -199,7 +199,7 @@ public class ItemStackHandler implements IItemHandlerModifiable, INBTSerializabl
     }
 
     @Override
-    public IItemHandler.Slot getSlot(int slot) {
+    public Slot getSlot(int slot) {
         validateSlotIndex(slot);
         return this.slots.get(slot);
     }
@@ -213,7 +213,7 @@ public class ItemStackHandler implements IItemHandlerModifiable, INBTSerializabl
 
     protected void onContentsChanged(int slot) {}
 
-    protected class Slot implements IItemHandler.Slot {
+    public class Slot implements IItemHandler.Slot {
         private final int index;
 
         protected Slot(int index) {


### PR DESCRIPTION
Supersedes #1308.
This PR introduces the `IItemHandler.Slot` interface for exposing the `IItemHandler`'s functionality on a specific slot index, and made `IItemHandler` extends `Iterable<IItemHandler.Slot>`.
Introducing `Iterable` not only provides for-each and stream support for `IItemHandler`, but also opens the possibility of `IItemHandler` with non-continuous indices, which was not possible before with for-i loops.