### PR TITLE
Add more melee weapons to melee tag, add `c:fertilizers` tag, and Sparse Jungle to Sparse tag

### DIFF
--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -216,6 +216,7 @@
   "tag.item.c.fences": "Fences",
   "tag.item.c.fences.nether_brick": "Nether Brick Fences",
   "tag.item.c.fences.wooden": "Wooden Fences",
+  "tag.item.c.fertilizers": "Fertilizers",
   "tag.item.c.foods": "Foods",
   "tag.item.c.foods.berry": "Berries",
   "tag.item.c.foods.bread": "Breads",

--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -337,6 +337,7 @@
   "tag.item.c.tools.brush": "Brushes",
   "tag.item.c.tools.crossbow": "Crossbows",
   "tag.item.c.tools.fishing_rod": "Fishing Rods",
+  "tag.item.c.tools.igniter": "Igniters",
   "tag.item.c.tools.mace": "Maces",
   "tag.item.c.tools.melee_weapon": "Melee Weapons",
   "tag.item.c.tools.mining_tool": "Mining Tools",

--- a/src/generated/resources/data/c/tags/item/fertilizers.json
+++ b/src/generated/resources/data/c/tags/item/fertilizers.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:bone_meal"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/tools/melee_weapon.json
+++ b/src/generated/resources/data/c/tags/item/tools/melee_weapon.json
@@ -1,5 +1,7 @@
 {
   "values": [
+    "minecraft:mace",
+    "minecraft:trident",
     "minecraft:wooden_sword",
     "minecraft:stone_sword",
     "minecraft:golden_sword",
@@ -12,6 +14,23 @@
     "minecraft:iron_axe",
     "minecraft:diamond_axe",
     "minecraft:netherite_axe",
-    "minecraft:mace"
+    "minecraft:wooden_pickaxe",
+    "minecraft:stone_pickaxe",
+    "minecraft:golden_pickaxe",
+    "minecraft:iron_pickaxe",
+    "minecraft:diamond_pickaxe",
+    "minecraft:netherite_pickaxe",
+    "minecraft:wooden_shovel",
+    "minecraft:stone_shovel",
+    "minecraft:golden_shovel",
+    "minecraft:iron_shovel",
+    "minecraft:diamond_shovel",
+    "minecraft:netherite_shovel",
+    "minecraft:wooden_hoe",
+    "minecraft:stone_hoe",
+    "minecraft:golden_hoe",
+    "minecraft:iron_hoe",
+    "minecraft:diamond_hoe",
+    "minecraft:netherite_hoe"
   ]
 }

--- a/src/generated/resources/data/c/tags/worldgen/biome/is_sparse_vegetation/overworld.json
+++ b/src/generated/resources/data/c/tags/worldgen/biome/is_sparse_vegetation/overworld.json
@@ -3,6 +3,7 @@
     "minecraft:wooded_badlands",
     "minecraft:savanna",
     "minecraft:savanna_plateau",
+    "minecraft:sparse_jungle",
     "minecraft:windswept_savanna",
     "minecraft:windswept_forest",
     "minecraft:windswept_hills",

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -674,6 +674,7 @@ public class Tags {
         public static final TagKey<Item> TOOLS_MACE = tag("tools/mace");
         /**
          * A tag containing melee-based weapons for recipes and loot tables.
+         * Tools are considered melee if they contain an ATTACK_DAMAGE attribute.
          * Do not use this tag for determining a tool's behavior in-code.
          * Please use {@link ItemAbilities} instead for what action a tool can do.
          *
@@ -683,6 +684,7 @@ public class Tags {
         public static final TagKey<Item> MELEE_WEAPON_TOOLS = tag("tools/melee_weapon");
         /**
          * A tag containing ranged-based weapons for recipes and loot tables.
+         * Tools are considered ranged if they have the ability to damage targets at a distance.
          * Do not use this tag for determining a tool's behavior in-code.
          * Please use {@link ItemAbilities} instead for what action a tool can do.
          *

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -689,7 +689,7 @@ public class Tags {
         public static final TagKey<Item> MELEE_WEAPON_TOOLS = tag("tools/melee_weapon");
         /**
          * A tag containing ranged-based weapons for recipes and loot tables.
-         * Tools are considered ranged if they have the ability to damage targets at a distance.
+         * Tools are considered ranged if they can damage entities beyond the weapon's and player's melee attack range.
          * Do not use this tag for determining a tool's behavior in-code.
          * Please use {@link ItemAbilities} instead for what action a tool can do.
          *

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -382,7 +382,7 @@ public class Tags {
         public static final TagKey<Item> FENCES_WOODEN = tag("fences/wooden");
         /**
          * For bonemeal-like items that can grow plants.
-         * (Note: Could include durability-based modded bonemeal-like items. Check for durability DataComponent to handle them properly)
+         * (Note: Could include durability-based modded bonemeal-like items. Check for durability {@link net.minecraft.core.component.DataComponents#DAMAGE} DataComponent to handle them properly)
          */
         public static final TagKey<Item> FERTILIZERS = tag("fertilizers");
         public static final TagKey<Item> FOODS = tag("foods");
@@ -679,7 +679,7 @@ public class Tags {
         public static final TagKey<Item> TOOLS_MACE = tag("tools/mace");
         /**
          * A tag containing melee-based weapons for recipes and loot tables.
-         * Tools are considered melee if they contain an ATTACK_DAMAGE attribute.
+         * Tools are considered melee if they contain an {@link net.minecraft.world.entity.ai.attributes.Attributes#ATTACK_DAMAGE} attribute.
          * Do not use this tag for determining a tool's behavior in-code.
          * Please use {@link ItemAbilities} instead for what action a tool can do.
          *

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -380,6 +380,11 @@ public class Tags {
         public static final TagKey<Item> FENCES = tag("fences");
         public static final TagKey<Item> FENCES_NETHER_BRICK = tag("fences/nether_brick");
         public static final TagKey<Item> FENCES_WOODEN = tag("fences/wooden");
+        /**
+         * For bonemeal-like items that can grow plants.
+         * (Note: Could include durability-based modded bonemeal-like items. Check for durability DataComponent to handle them properly)
+         */
+        public static final TagKey<Item> FERTILIZERS = tag("fertilizers");
         public static final TagKey<Item> FOODS = tag("foods");
         /**
          * Apples and other foods that are considered fruits in the culinary field belong in this tag.

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBiomeTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBiomeTagsProvider.java
@@ -87,6 +87,7 @@ public final class NeoForgeBiomeTagsProvider extends BiomeTagsProvider {
                 .add(Biomes.WOODED_BADLANDS)
                 .add(Biomes.SAVANNA)
                 .add(Biomes.SAVANNA_PLATEAU)
+                .add(Biomes.SPARSE_JUNGLE)
                 .add(Biomes.WINDSWEPT_SAVANNA)
                 .add(Biomes.WINDSWEPT_FOREST)
                 .add(Biomes.WINDSWEPT_HILLS)

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -100,6 +100,7 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
         copy(Tags.Blocks.FENCES, Tags.Items.FENCES);
         copy(Tags.Blocks.FENCES_NETHER_BRICK, Tags.Items.FENCES_NETHER_BRICK);
         copy(Tags.Blocks.FENCES_WOODEN, Tags.Items.FENCES_WOODEN);
+        tag(Tags.Items.FERTILIZERS).add(Items.BONE_MEAL);
         tag(Tags.Items.FOODS_FRUIT).add(Items.APPLE, Items.GOLDEN_APPLE, Items.ENCHANTED_GOLDEN_APPLE);
         tag(Tags.Items.FOODS_VEGETABLE).add(Items.CARROT, Items.GOLDEN_CARROT, Items.POTATO, Items.MELON_SLICE, Items.BEETROOT);
         tag(Tags.Items.FOODS_BERRY).add(Items.SWEET_BERRIES, Items.GLOW_BERRIES);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -246,7 +246,13 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
         tag(Tags.Items.TOOLS_SPEAR).add(Items.TRIDENT);
         tag(Tags.Items.TOOLS_IGNITER).add(Items.FLINT_AND_STEEL);
         tag(Tags.Items.MINING_TOOL_TOOLS).add(Items.WOODEN_PICKAXE, Items.STONE_PICKAXE, Items.GOLDEN_PICKAXE, Items.IRON_PICKAXE, Items.DIAMOND_PICKAXE, Items.NETHERITE_PICKAXE);
-        tag(Tags.Items.MELEE_WEAPON_TOOLS).add(Items.WOODEN_SWORD, Items.STONE_SWORD, Items.GOLDEN_SWORD, Items.IRON_SWORD, Items.DIAMOND_SWORD, Items.NETHERITE_SWORD, Items.WOODEN_AXE, Items.STONE_AXE, Items.GOLDEN_AXE, Items.IRON_AXE, Items.DIAMOND_AXE, Items.NETHERITE_AXE, Items.MACE);
+        tag(Tags.Items.MELEE_WEAPON_TOOLS).add(
+                Items.MACE, Items.TRIDENT,
+                Items.WOODEN_SWORD, Items.STONE_SWORD, Items.GOLDEN_SWORD, Items.IRON_SWORD, Items.DIAMOND_SWORD, Items.NETHERITE_SWORD,
+                Items.WOODEN_AXE, Items.STONE_AXE, Items.GOLDEN_AXE, Items.IRON_AXE, Items.DIAMOND_AXE, Items.NETHERITE_AXE,
+                Items.WOODEN_PICKAXE, Items.STONE_PICKAXE, Items.GOLDEN_PICKAXE, Items.IRON_PICKAXE, Items.DIAMOND_PICKAXE, Items.NETHERITE_PICKAXE,
+                Items.WOODEN_SHOVEL, Items.STONE_SHOVEL, Items.GOLDEN_SHOVEL, Items.IRON_SHOVEL, Items.DIAMOND_SHOVEL, Items.NETHERITE_SHOVEL,
+                Items.WOODEN_HOE, Items.STONE_HOE, Items.GOLDEN_HOE, Items.IRON_HOE, Items.DIAMOND_HOE, Items.NETHERITE_HOE);
         tag(Tags.Items.RANGED_WEAPON_TOOLS).add(Items.BOW, Items.CROSSBOW, Items.TRIDENT);
         tag(Tags.Items.TOOLS)
                 .addTags(ItemTags.AXES, ItemTags.HOES, ItemTags.PICKAXES, ItemTags.SHOVELS, ItemTags.SWORDS)

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -313,6 +313,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Items.TOOLS_BRUSH, "Brushes");
         add(Tags.Items.TOOLS_MACE, "Maces");
         add(Tags.Items.TOOLS_SPEAR, "Spears");
+        add(Tags.Items.TOOLS_IGNITER, "Igniters");
         add(Tags.Items.MELEE_WEAPON_TOOLS, "Melee Weapons");
         add(Tags.Items.RANGED_WEAPON_TOOLS, "Ranged Weapons");
         add(Tags.Items.MINING_TOOL_TOOLS, "Mining Tools");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -188,6 +188,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Items.FENCES, "Fences");
         add(Tags.Items.FENCES_NETHER_BRICK, "Nether Brick Fences");
         add(Tags.Items.FENCES_WOODEN, "Wooden Fences");
+        add(Tags.Items.FERTILIZERS, "Fertilizers");
         add(Tags.Items.FOODS, "Foods");
         add(Tags.Items.FOODS_BERRY, "Berries");
         add(Tags.Items.FOODS_BREAD, "Breads");


### PR DESCRIPTION
- Adds Sparse Jungle to `c:is_sparse_vegetation/overworld` biome tag as it was missing from before. The biome belongs there. It got sparse in the name!

- Added Trident, Pickaxes, Shovels, and Hoes to the `c:tools/melee_weapon` item tag. Reason is to make it more clear of what is a melee weapon. The definition now is any item that has an ATTACK_DAMAGE attribute is considered melee as the damage increase is what the main thing that separates melee weapons from smacking a mob with a stick. Clarified the javadocs in these areas for what is in these tags.

- Added `c:fertilizers` tag so farming machines can know what items can be consumed/damaged in order to grow nearby crops/plants. This is needed as some mods do add their own bonemeal variant items such as Minecolonies Compost item. The growing logic is on the crop/plant so no hooks needed in item. Just need to know what item is a bonemeal-like item.

- Add missing lang entry for `c:tools/igniter`.

Fabric PR: https://github.com/FabricMC/fabric/pull/3957

closes https://github.com/neoforged/NeoForge/issues/1300
closes https://github.com/neoforged/NeoForge/issues/1327
closes https://github.com/neoforged/NeoForge/issues/1135