### PR TITLE
[1.21] Add the `applyEnchantments` hook

### DIFF
--- a/patches/net/minecraft/world/inventory/EnchantmentMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/EnchantmentMenu.java.patch
@@ -37,6 +37,24 @@
                      }
  
                      for (int l = 0; l < 3; l++) {
+@@ -163,14 +_,10 @@
+                             List<EnchantmentInstance> list = this.getEnchantmentList(p_347276_.registryAccess(), itemstack, p_39466_, this.costs[p_39466_]);
+                             if (!list.isEmpty()) {
+                                 p_39465_.onEnchantmentPerformed(itemstack, i);
+-                                if (itemstack.is(Items.BOOK)) {
+-                                    itemstack2 = itemstack.transmuteCopy(Items.ENCHANTED_BOOK);
+-                                    this.enchantSlots.setItem(0, itemstack2);
+-                                }
+ 
+-                                for (EnchantmentInstance enchantmentinstance : list) {
+-                                    itemstack2.enchant(enchantmentinstance.enchantment, enchantmentinstance.level);
+-                                }
++                                // Neo: Allow items to transform themselves when enchanted, instead of relying on hardcoded transformations for Items.BOOK
++                                itemstack2 = itemstack.getItem().applyEnchantments(itemstack, list);
++                                this.enchantSlots.setItem(0, itemstack2);
+ 
+                                 itemstack1.consume(i, p_39465_);
+                                 if (itemstack1.isEmpty()) {
 @@ -249,7 +_,7 @@
                  if (!this.moveItemStackTo(itemstack1, 2, 38, true)) {
                      return ItemStack.EMPTY;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -44,6 +45,7 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
@@ -730,5 +732,26 @@ public interface IItemExtension {
      */
     default boolean canBeHurtBy(ItemStack stack, DamageSource source) {
         return true;
+    }
+
+    /**
+     * Handles enchanting an item (i.e. in the enchanting table), potentially transforming it to a new item in the process.
+     * <p>
+     * {@linkplain Items#BOOK Books} use this functionality to transform themselves into enchanted books.
+     *
+     * @param stack        The stack being enchanted.
+     * @param enchantments The enchantments being applied.
+     * @return The newly-enchanted stack.
+     */
+    default ItemStack applyEnchantments(ItemStack stack, List<EnchantmentInstance> enchantments) {
+        if (stack.is(Items.BOOK)) {
+            stack = stack.transmuteCopy(Items.ENCHANTED_BOOK);
+        }
+
+        for (EnchantmentInstance inst : enchantments) {
+            stack.enchant(inst.enchantment, inst.level);
+        }
+
+        return stack;
     }
 }


### PR DESCRIPTION
This PR adds the new `IItemExtension#applyEnchantments` hook, which delegates transformation of the item when it is enchanted to the item itself, expanding on vanilla's hardcoded `Items.BOOK` -> `Items.ENCHANTED_BOOK` logic.

This hook enables the functionality used by Apotheosis's Enchantment Tomes, which turn themselves into enchanted books after being used in an enchanting table.