### PR TITLE
Add missing Neo config gui translations

### DIFF
--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -216,6 +216,13 @@
   "neoforge.configuration.uitext.restart.server.text": "One or more of the configuration option that were changed only take effect when a world is started or loaded.",
   "neoforge.configuration.uitext.restart.return": "Not yet...",
 
+  "neoforge.configuration.title": "NeoForge Configuration",
+  "neoforge.configuration.section.neoforge.client.toml": "Client settings",
+  "neoforge.configuration.section.neoforge.client.toml.title": "Client settings",
+  "neoforge.configuration.section.neoforge.common.toml": "Common settings",
+  "neoforge.configuration.section.neoforge.common.toml.title": "Common settings",
+  "neoforge.configuration.section.neoforge.server.toml": "Server settings",
+  "neoforge.configuration.section.neoforge.server.toml.title": "Server settings",
   "neoforge.configgui.advertiseDedicatedServerToLan": "Advertise Dedicated Server To LAN",
   "neoforge.configgui.advertiseDedicatedServerToLan.tooltip": "Set this to true to enable advertising the dedicated server to local LAN clients so that it shows up in the Multiplayer screen automatically.",
   "neoforge.configgui.forgeLightPipelineEnabled": "NeoForge Light Pipeline",


### PR DESCRIPTION
If you run your mod or Neo in dev and visit Neoforge's configs, and then back out to mod list, Neoforge will print its config category translation keys saying it is untranslated. This adds the translations so the log message stops in dev.