### PR TITLE
Exclude trapped chests from chest only recipes in Neo's recipe replacements

### DIFF
--- a/src/generated/resources/data/minecraft/recipe/acacia_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/acacia_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:acacia_boat"

--- a/src/generated/resources/data/minecraft/recipe/bamboo_chest_raft.json
+++ b/src/generated/resources/data/minecraft/recipe/bamboo_chest_raft.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:bamboo_raft"

--- a/src/generated/resources/data/minecraft/recipe/birch_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/birch_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:birch_boat"

--- a/src/generated/resources/data/minecraft/recipe/cherry_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/cherry_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:cherry_boat"

--- a/src/generated/resources/data/minecraft/recipe/chest_minecart.json
+++ b/src/generated/resources/data/minecraft/recipe/chest_minecart.json
@@ -3,7 +3,13 @@
   "category": "misc",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:minecart"

--- a/src/generated/resources/data/minecraft/recipe/dark_oak_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/dark_oak_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:dark_oak_boat"

--- a/src/generated/resources/data/minecraft/recipe/hopper.json
+++ b/src/generated/resources/data/minecraft/recipe/hopper.json
@@ -3,7 +3,13 @@
   "category": "redstone",
   "key": {
     "C": {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     "I": {
       "tag": "c:ingots/iron"

--- a/src/generated/resources/data/minecraft/recipe/jungle_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/jungle_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:jungle_boat"

--- a/src/generated/resources/data/minecraft/recipe/mangrove_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/mangrove_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:mangrove_boat"

--- a/src/generated/resources/data/minecraft/recipe/oak_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/oak_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:oak_boat"

--- a/src/generated/resources/data/minecraft/recipe/shulker_box.json
+++ b/src/generated/resources/data/minecraft/recipe/shulker_box.json
@@ -3,7 +3,13 @@
   "category": "misc",
   "key": {
     "#": {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     "-": {
       "item": "minecraft:shulker_shell"

--- a/src/generated/resources/data/minecraft/recipe/spruce_chest_boat.json
+++ b/src/generated/resources/data/minecraft/recipe/spruce_chest_boat.json
@@ -4,7 +4,13 @@
   "group": "chest_boat",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:spruce_boat"

--- a/src/generated/resources/data/minecraft/recipe/trapped_chest.json
+++ b/src/generated/resources/data/minecraft/recipe/trapped_chest.json
@@ -3,7 +3,13 @@
   "category": "redstone",
   "ingredients": [
     {
-      "tag": "c:chests/wooden"
+      "type": "neoforge:difference",
+      "base": {
+        "tag": "c:chests/wooden"
+      },
+      "subtracted": {
+        "tag": "c:chests/trapped"
+      }
     },
     {
       "item": "minecraft:tripwire_hook"

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
@@ -39,10 +39,12 @@ import net.minecraft.world.level.block.Blocks;
 import net.neoforged.fml.util.ObfuscationReflectionHelper;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.common.crafting.DifferenceIngredient;
 import org.jetbrains.annotations.Nullable;
 
 public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
     private final Map<Item, TagKey<Item>> replacements = new HashMap<>();
+    private final Map<Item, Ingredient> specialReplacements = new HashMap<>();
     private final Set<ResourceLocation> excludes = new HashSet<>();
 
     public NeoForgeRecipeProvider(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> provider) {
@@ -73,7 +75,7 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
         replace(Items.AMETHYST_SHARD, Tags.Items.GEMS_AMETHYST);
         replace(Items.DIAMOND, Tags.Items.GEMS_DIAMOND);
         replace(Items.EMERALD, Tags.Items.GEMS_EMERALD);
-        replace(Items.CHEST, Tags.Items.CHESTS_WOODEN);
+
         replace(Blocks.COBBLESTONE, Tags.Items.COBBLESTONES_NORMAL);
         replace(Blocks.COBBLED_DEEPSLATE, Tags.Items.COBBLESTONES_DEEPSLATE);
 
@@ -96,6 +98,8 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
         exclude(Blocks.COBBLED_DEEPSLATE_STAIRS);
         exclude(Blocks.COBBLED_DEEPSLATE_SLAB);
         exclude(Blocks.COBBLED_DEEPSLATE_WALL);
+
+        specialReplacements.put(Items.CHEST, DifferenceIngredient.of(Ingredient.of(Tags.Items.CHESTS_WOODEN), Ingredient.of(Tags.Items.CHESTS_TRAPPED)));
 
         super.buildRecipes(new RecipeOutput() {
             @Override
@@ -166,6 +170,14 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
         boolean modified = false;
         List<Value> items = new ArrayList<>();
         Value[] vanillaItems = vanilla.getValues();
+        if (vanillaItems.length == 1 && vanillaItems[0] instanceof ItemValue itemValue) {
+            Item item = itemValue.item().getItem();
+            Ingredient replacement = specialReplacements.get(item);
+            if (replacement != null) {
+                return replacement;
+            }
+        }
+
         for (Value entry : vanillaItems) {
             if (entry instanceof ItemValue) {
                 ItemStack stack = entry.getItems().stream().findFirst().orElse(ItemStack.EMPTY);


### PR DESCRIPTION
The following vanilla recipes do NOT accept trapped chests but in Neo, they do:
- Chest Minecart recipe
- Hopper recipe
- Chest Boat recipe
- Shulker Box recipe
- Trapped Chest recipe

This PR fixes that by making the tag replacement now use a difference ingredient that using `c:chests/wooden` as base and subtracts out `c:chests/trapped` items. This will now restore vanilla behavior while still allowing mod compat

Fun fact, this bug seemed to have existed for years!