### PR TITLE
[1.21] Add ATs needed to support custom enchantments

### DIFF
--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -21,7 +21,7 @@
          return itemenchantments.getLevel(p_346179_);
      }
 @@ -122,6 +_,12 @@
-     private static void runIterationOnItem(ItemStack p_345425_, EnchantmentHelper.EnchantmentVisitor p_345023_) {
+     public static void runIterationOnItem(ItemStack p_345425_, EnchantmentHelper.EnchantmentVisitor p_345023_) {
          ItemEnchantments itemenchantments = p_345425_.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);
  
 +        // Neo: Respect gameplay-only enchantments when doing iterations

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -474,3 +474,10 @@ protected net.minecraft.client.particle.VibrationSignalParticle <init>(Lnet/mine
 protected net.minecraft.client.particle.WakeParticle <init>(Lnet/minecraft/client/multiplayer/ClientLevel;DDDDDDLnet/minecraft/client/particle/SpriteSet;)V # constructor
 protected net.minecraft.client.particle.WaterCurrentDownParticle <init>(Lnet/minecraft/client/multiplayer/ClientLevel;DDD)V # constructor
 # End of particle constructor ATs group
+
+public net.minecraft.world.item.enchantment.EnchantmentHelper runIterationOnItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor;)V
+public net.minecraft.world.item.enchantment.EnchantmentHelper runIterationOnItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/EquipmentSlot;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor;)V
+public net.minecraft.world.item.enchantment.EnchantmentHelper runIterationOnEquipment(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor;)V
+public net.minecraft.world.item.enchantment.EnchantmentHelper getComponentType(Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/core/component/DataComponentType;
+public net.minecraft.world.item.enchantment.EnchantmentHelper$EnchantmentInSlotVisitor
+public net.minecraft.world.item.enchantment.EnchantmentHelper$EnchantmentVisitor

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -475,9 +475,20 @@ protected net.minecraft.client.particle.WakeParticle <init>(Lnet/minecraft/clien
 protected net.minecraft.client.particle.WaterCurrentDownParticle <init>(Lnet/minecraft/client/multiplayer/ClientLevel;DDD)V # constructor
 # End of particle constructor ATs group
 
+# EnchantmentHelper methods needed for adding custom enchantments
 public net.minecraft.world.item.enchantment.EnchantmentHelper runIterationOnItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor;)V
 public net.minecraft.world.item.enchantment.EnchantmentHelper runIterationOnItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/EquipmentSlot;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor;)V
 public net.minecraft.world.item.enchantment.EnchantmentHelper runIterationOnEquipment(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentInSlotVisitor;)V
 public net.minecraft.world.item.enchantment.EnchantmentHelper getComponentType(Lnet/minecraft/world/item/ItemStack;)Lnet/minecraft/core/component/DataComponentType;
 public net.minecraft.world.item.enchantment.EnchantmentHelper$EnchantmentInSlotVisitor
 public net.minecraft.world.item.enchantment.EnchantmentHelper$EnchantmentVisitor
+
+# Enchantment methods needed for adding custom enchantments
+public net.minecraft.world.item.enchantment.Enchantment modifyItemFilteredCount(Lnet/minecraft/core/component/DataComponentType;Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/item/ItemStack;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+public net.minecraft.world.item.enchantment.Enchantment modifyEntityFilteredValue(Lnet/minecraft/core/component/DataComponentType;Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/Entity;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+public net.minecraft.world.item.enchantment.Enchantment modifyDamageFilteredValue(Lnet/minecraft/core/component/DataComponentType;Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/damagesource/DamageSource;Lorg/apache/commons/lang3/mutable/MutableFloat;)V
+public net.minecraft.world.item.enchantment.Enchantment itemContext(Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/item/ItemStack;)Lnet/minecraft/world/level/storage/loot/LootContext;
+public net.minecraft.world.item.enchantment.Enchantment locationContext(Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/entity/Entity;Z)Lnet/minecraft/world/level/storage/loot/LootContext;
+public net.minecraft.world.item.enchantment.Enchantment entityContext(Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/level/storage/loot/LootContext;
+public net.minecraft.world.item.enchantment.Enchantment blockHitContext(Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/storage/loot/LootContext;
+public net.minecraft.world.item.enchantment.Enchantment applyEffects(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/LootContext;Ljava/util/function/Consumer;)V


### PR DESCRIPTION
This PR adds ATs for the various `runIterationOnXYZ` methods in `EnchantmentHelper`, and the functional interfaces required to actually call those methods (`EnchantmentVisitor` and `EnchantmentInSlotVisitor`).  It also adds an AT for `getComponentType`, which is useful when working with enchanted books externally.

The vast majority of vanilla enchantment effects are implemented using these iterator methods, which means any mod wishing to implement an enchantment component will need access to them.  Since this is a fairly common operation, we should provide these ATs ourselves.