### PR TITLE
Modify default components during data generation mod loading

### DIFF
--- a/src/main/java/net/neoforged/neoforge/data/loading/DatagenModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/data/loading/DatagenModLoader.java
@@ -19,6 +19,7 @@ import net.neoforged.neoforge.client.ClientHooks;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.internal.CommonModLoader;
+import net.neoforged.neoforge.internal.RegistrationEvents;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -41,6 +42,8 @@ public class DatagenModLoader extends CommonModLoader {
         runningDataGen = true;
         Bootstrap.bootStrap();
         begin(() -> {}, true);
+        // Modify components as the (modified) defaults may be required in datagen, i.e. stack size
+        RegistrationEvents.modifyComponents();
         CompletableFuture<HolderLookup.Provider> lookupProvider = CompletableFuture.supplyAsync(VanillaRegistries::createLookup, Util.backgroundExecutor());
         dataGeneratorConfig = new GatherDataEvent.DataGeneratorConfig(mods, path, inputs, lookupProvider, serverGenerators,
                 clientGenerators, devToolGenerators, reportsGenerator, structureValidator, flat);

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -23,7 +23,7 @@ public class RegistrationEvents {
 
     private static boolean canModifyComponents;
 
-    private static void modifyComponents() {
+    public static void modifyComponents() {
         canModifyComponents = true;
         ModLoader.postEvent(new ModifyDefaultComponentsEvent());
         canModifyComponents = false;


### PR DESCRIPTION
If a mod modifies an item's default component values, that may need to be present before allowing certain data generation to occur. For example, making a recipe which outputs two `Items.MINECART` (which by default has stack size = 1), will crash, despite the mod unconditionally setting the stack size to 64 during `ModifyDefaultComponentsEvent`

Tested by running NeoForge's data gen - no issues. Also tested in a mod dev workspace by invoking the method via reflection at the start of `GatherDataEvent` - no issues, and solved the problematic recipe I was trying to generate.