### PR TITLE
Add ClientInformationUpdatedEvent

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1,5 +1,22 @@
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -126,6 +_,7 @@
+ import net.minecraft.resources.ResourceKey;
+ import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.level.ClientInformation;
+ import net.minecraft.server.level.ServerLevel;
+ import net.minecraft.server.level.ServerPlayer;
+ import net.minecraft.util.FutureChain;
+@@ -184,6 +_,8 @@
+ import net.minecraft.world.phys.shapes.BooleanOp;
+ import net.minecraft.world.phys.shapes.Shapes;
+ import net.minecraft.world.phys.shapes.VoxelShape;
++import net.neoforged.neoforge.common.NeoForge;
++import net.neoforged.neoforge.event.entity.player.ClientInformationUpdatedEvent;
+ import org.slf4j.Logger;
+ 
+ public class ServerGamePacketListenerImpl
 @@ -439,9 +_,11 @@
                  }
  
@@ -100,12 +117,20 @@
                          }
  
                          @Override
-@@ -1753,7 +_,7 @@
+@@ -1753,13 +_,15 @@
      @Override
      public void handlePlayerAbilities(ServerboundPlayerAbilitiesPacket p_9887_) {
          PacketUtils.ensureRunningOnSameThread(p_9887_, this, this.player.serverLevel());
 -        this.player.getAbilities().flying = p_9887_.isFlying() && this.player.getAbilities().mayfly;
 +        this.player.getAbilities().flying = p_9887_.isFlying() && this.player.mayFly();
+     }
+ 
+     @Override
+     public void handleClientInformation(ServerboundClientInformationPacket p_301979_) {
+         PacketUtils.ensureRunningOnSameThread(p_301979_, this, this.player.serverLevel());
++        ClientInformation oldInfo = this.player.clientInformation();
+         this.player.updateOptions(p_301979_.information());
++        NeoForge.EVENT_BUS.post(new ClientInformationUpdatedEvent(this.player, oldInfo, p_301979_.information()));
      }
  
      @Override

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1,22 +1,5 @@
 --- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -126,6 +_,7 @@
- import net.minecraft.resources.ResourceKey;
- import net.minecraft.resources.ResourceLocation;
- import net.minecraft.server.MinecraftServer;
-+import net.minecraft.server.level.ClientInformation;
- import net.minecraft.server.level.ServerLevel;
- import net.minecraft.server.level.ServerPlayer;
- import net.minecraft.util.FutureChain;
-@@ -184,6 +_,8 @@
- import net.minecraft.world.phys.shapes.BooleanOp;
- import net.minecraft.world.phys.shapes.Shapes;
- import net.minecraft.world.phys.shapes.VoxelShape;
-+import net.neoforged.neoforge.common.NeoForge;
-+import net.neoforged.neoforge.event.entity.player.ClientInformationUpdatedEvent;
- import org.slf4j.Logger;
- 
- public class ServerGamePacketListenerImpl
 @@ -439,9 +_,11 @@
                  }
  
@@ -128,9 +111,9 @@
      @Override
      public void handleClientInformation(ServerboundClientInformationPacket p_301979_) {
          PacketUtils.ensureRunningOnSameThread(p_301979_, this, this.player.serverLevel());
-+        ClientInformation oldInfo = this.player.clientInformation();
++        net.minecraft.server.level.ClientInformation oldInfo = this.player.clientInformation();
          this.player.updateOptions(p_301979_.information());
-+        NeoForge.EVENT_BUS.post(new ClientInformationUpdatedEvent(this.player, oldInfo, p_301979_.information()));
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.player.ClientInformationUpdatedEvent(this.player, oldInfo, p_301979_.information()));
      }
  
      @Override

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ClientInformationUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ClientInformationUpdatedEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.player;
+
+import net.minecraft.server.level.ClientInformation;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.common.NeoForge;
+
+/**
+ * ClientInformationUpdatedEvent is fired when a player changes server-synced client options,
+ * specifically those in {@link net.minecraft.server.level.ClientInformation}.
+ * <p>
+ * This event is fired on the {@link NeoForge#EVENT_BUS}.
+ **/
+public class ClientInformationUpdatedEvent extends PlayerEvent {
+	private final ClientInformation oldInformation;
+	private final ClientInformation updatedInformation;
+
+	public ClientInformationUpdatedEvent(ServerPlayer player, ClientInformation oldInfo, ClientInformation newInfo) {
+		super(player);
+		this.oldInformation = oldInfo;
+		this.updatedInformation = newInfo;
+	}
+
+	@Override
+	public ServerPlayer getEntity() {
+		return (ServerPlayer) super.getEntity();
+	}
+
+	/**
+	 * Returns the new client info to be applied to the player.
+	 * Sometimes the client resends unchanged options, so if that matters
+	 * for your use case, check equality with {@link #getOldInformation()}.
+	 *
+	 * @return updated information
+	 */
+	public ClientInformation getUpdatedInformation() {
+		return this.updatedInformation;
+	}
+
+	/**
+	 * Returns the existing client info from to the player.
+	 * <p>
+	 * May be blank or defaulted initial data on first event call for a player instance.
+	 *
+	 * @return updated information
+	 */
+	public ClientInformation getOldInformation() {
+		return this.oldInformation;
+	}
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ClientInformationUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ClientInformationUpdatedEvent.java
@@ -16,39 +16,39 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class ClientInformationUpdatedEvent extends PlayerEvent {
-	private final ClientInformation oldInformation;
-	private final ClientInformation updatedInformation;
+    private final ClientInformation oldInformation;
+    private final ClientInformation updatedInformation;
 
-	public ClientInformationUpdatedEvent(ServerPlayer player, ClientInformation oldInfo, ClientInformation newInfo) {
-		super(player);
-		this.oldInformation = oldInfo;
-		this.updatedInformation = newInfo;
-	}
+    public ClientInformationUpdatedEvent(ServerPlayer player, ClientInformation oldInfo, ClientInformation newInfo) {
+        super(player);
+        this.oldInformation = oldInfo;
+        this.updatedInformation = newInfo;
+    }
 
-	@Override
-	public ServerPlayer getEntity() {
-		return (ServerPlayer) super.getEntity();
-	}
+    @Override
+    public ServerPlayer getEntity() {
+        return (ServerPlayer) super.getEntity();
+    }
 
-	/**
-	 * Returns the new client info to be applied to the player.
-	 * Sometimes the client resends unchanged options, so if that matters
-	 * for your use case, check equality with {@link #getOldInformation()}.
-	 *
-	 * @return updated information
-	 */
-	public ClientInformation getUpdatedInformation() {
-		return this.updatedInformation;
-	}
+    /**
+     * Returns the new client info to be applied to the player.
+     * Sometimes the client resends unchanged options, so if that matters
+     * for your use case, check equality with {@link #getOldInformation()}.
+     *
+     * @return updated information
+     */
+    public ClientInformation getUpdatedInformation() {
+        return this.updatedInformation;
+    }
 
-	/**
-	 * Returns the existing client info from to the player.
-	 * <p>
-	 * May be blank or defaulted initial data on first event call for a player instance.
-	 *
-	 * @return updated information
-	 */
-	public ClientInformation getOldInformation() {
-		return this.oldInformation;
-	}
+    /**
+     * Returns the existing client info from to the player.
+     * <p>
+     * May be blank or defaulted initial data on first event call for a player instance.
+     *
+     * @return updated information
+     */
+    public ClientInformation getOldInformation() {
+        return this.oldInformation;
+    }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ClientInformationUpdatedTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ClientInformationUpdatedTest.java
@@ -16,12 +16,12 @@ import net.neoforged.neoforge.event.entity.player.ClientInformationUpdatedEvent;
  */
 @Mod(ClientInformationUpdatedTest.MOD_ID)
 public class ClientInformationUpdatedTest {
-	public static final String MOD_ID = "client_information_updated_test";
+    public static final String MOD_ID = "client_information_updated_test";
 
-	public ClientInformationUpdatedTest() {
-		NeoForge.EVENT_BUS.addListener((ClientInformationUpdatedEvent event) -> {
-			event.getEntity().sendSystemMessage(Component.literal("old: " + event.getOldInformation()));
-			event.getEntity().sendSystemMessage(Component.literal("new: " + event.getUpdatedInformation()));
-		});
-	}
+    public ClientInformationUpdatedTest() {
+        NeoForge.EVENT_BUS.addListener((ClientInformationUpdatedEvent event) -> {
+            event.getEntity().sendSystemMessage(Component.literal("old: " + event.getOldInformation()));
+            event.getEntity().sendSystemMessage(Component.literal("new: " + event.getUpdatedInformation()));
+        });
+    }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ClientInformationUpdatedTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/player/ClientInformationUpdatedTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.oldtest.entity.player;
+
+import net.minecraft.network.chat.Component;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.player.ClientInformationUpdatedEvent;
+
+/**
+ * Tests the client info update event by telling a player their new and old info on updates.
+ * Easiest thing to test is change your language or view distance.
+ */
+@Mod(ClientInformationUpdatedTest.MOD_ID)
+public class ClientInformationUpdatedTest {
+	public static final String MOD_ID = "client_information_updated_test";
+
+	public ClientInformationUpdatedTest() {
+		NeoForge.EVENT_BUS.addListener((ClientInformationUpdatedEvent event) -> {
+			event.getEntity().sendSystemMessage(Component.literal("old: " + event.getOldInformation()));
+			event.getEntity().sendSystemMessage(Component.literal("new: " + event.getUpdatedInformation()));
+		});
+	}
+}

--- a/tests/src/main/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/main/resources/META-INF/neoforge.mods.toml
@@ -246,5 +246,7 @@ modId="player_spawn_phantoms_event_test"
 modId="conditional_codec_test"
 [[mods]]
 modId="may_fly_attribute_item"
+[[mods]]
+modId="client_information_updated_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
Sometimes operations sensitive to the client's locale or other options need to take place on the server, for example when implementing server-side translations for client-optional mods. In these cases, we don't only need to know the current locale, but also when it has changed, for example, to update boss bar titles. ClientInformationUpdatedEvent provides a way for mods to listen for such changes.