### PR TITLE
Check formatting local changes

### DIFF
--- a/.github/workflows/check-local-changes.yml
+++ b/.github/workflows/check-local-changes.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Setup with Gradle
         run: ./gradlew :neoforge:setup
 
+      - name: Gen package infos
+        run: ./gradlew generatePackageInfos
+
       - name: Gen patches
         run: ./gradlew :neoforge:unpackSourcePatches
 

--- a/src/main/java/net/neoforged/neoforge/client/gui/map/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/map/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.client.gui.map;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/package-info.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.debug.entity.vehicle;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;


### PR DESCRIPTION
`package-info` files generated by `applyAllFormatting` were skipped in PRs recently merged.

This PR adds them, and makes the local changes check check for those files too.