### PR TITLE
Fix AO shadows being computed wrongly (MC-43968)

### DIFF
--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -194,3 +194,30 @@
      }
  
      private static void renderQuadList(
+@@ -724,22 +_,22 @@
+             int l = modelblockrenderer$cache.getLightColor(blockstate3, p_111168_, blockpos$mutableblockpos);
+             float f3 = modelblockrenderer$cache.getShadeBrightness(blockstate3, p_111168_, blockpos$mutableblockpos);
+             BlockState blockstate4 = p_111168_.getBlockState(
+-                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[0]).move(p_111171_)
++                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[0]) // Neo: remove move() to avoid oversampling (MC-43968)
+             );
+             boolean flag = !blockstate4.isViewBlocking(p_111168_, blockpos$mutableblockpos)
+                 || blockstate4.getLightBlock(p_111168_, blockpos$mutableblockpos) == 0;
+             BlockState blockstate5 = p_111168_.getBlockState(
+-                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[1]).move(p_111171_)
++                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[1]) // Neo: remove move() to avoid oversampling (MC-43968)
+             );
+             boolean flag1 = !blockstate5.isViewBlocking(p_111168_, blockpos$mutableblockpos)
+                 || blockstate5.getLightBlock(p_111168_, blockpos$mutableblockpos) == 0;
+             BlockState blockstate6 = p_111168_.getBlockState(
+-                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[2]).move(p_111171_)
++                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[2]) // Neo: remove move() to avoid oversampling (MC-43968)
+             );
+             boolean flag2 = !blockstate6.isViewBlocking(p_111168_, blockpos$mutableblockpos)
+                 || blockstate6.getLightBlock(p_111168_, blockpos$mutableblockpos) == 0;
+             BlockState blockstate7 = p_111168_.getBlockState(
+-                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[3]).move(p_111171_)
++                blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[3]) // Neo: remove move() to avoid oversampling (MC-43968)
+             );
+             boolean flag3 = !blockstate7.isViewBlocking(p_111168_, blockpos$mutableblockpos)
+                 || blockstate7.getLightBlock(p_111168_, blockpos$mutableblockpos) == 0;


### PR DESCRIPTION
This PR fixes [MC-43968](https://bugs.mojang.com/browse/MC-43968), a fairly annoying issue in the vanilla AO system that causes visual artifacts when mining underground in a staircase pattern. This is an issue that has been present in the game for over a decade at this point.

Fortunately, while the original fix proposed in that bug report is long since obsolete due to it being written for 1.7.10, the solution remains essentially the same. We still just need to remove the AO system's unnecessary offset logic that causes the wrong block position to be used for determining which neighbor blocks are opaque. This PR implements that solution.

This fix has no effect if the experimental light pipeline is enabled, as it bypasses vanilla logic.

Before:

![2024-07-24_20 54 25](https://github.com/user-attachments/assets/695628b0-5750-48b1-bc39-16a650eea54a)

After:

![2024-07-24_21 02 14](https://github.com/user-attachments/assets/aa07ab40-5676-4232-9c21-88fd7eee8006)
