### PR TITLE
Allow modded maps to render correctly in player hands

### DIFF
--- a/patches/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/renderer/ItemInHandRenderer.java
 +++ b/net/minecraft/client/renderer/ItemInHandRenderer.java
+@@ -226,7 +_,7 @@
+         p_109367_.translate(-0.5F, -0.5F, 0.0F);
+         p_109367_.scale(0.0078125F, 0.0078125F, 0.0078125F);
+         MapId mapid = p_109370_.get(DataComponents.MAP_ID);
+-        MapItemSavedData mapitemsaveddata = MapItem.getSavedData(mapid, this.minecraft.level);
++        MapItemSavedData mapitemsaveddata = MapItem.getSavedData(p_109370_, this.minecraft.level);
+         VertexConsumer vertexconsumer = p_109368_.getBuffer(mapitemsaveddata == null ? MAP_BACKGROUND : MAP_BACKGROUND_CHECKERBOARD);
+         Matrix4f matrix4f = p_109367_.last().pose();
+         vertexconsumer.addVertex(matrix4f, -7.0F, 135.0F, 0.0F).setColor(-1).setUv(0.0F, 1.0F).setLight(p_109369_);
 @@ -334,12 +_,14 @@
          if (iteminhandrenderer$handrenderselection.renderMainHand) {
              float f4 = interactionhand == InteractionHand.MAIN_HAND ? f : 0.0F;
@@ -15,7 +24,14 @@
              this.renderArmWithItem(p_109318_, p_109315_, f1, InteractionHand.OFF_HAND, f6, this.offHandItem, f7, p_109316_, p_109317_, p_109319_);
          }
  
-@@ -405,7 +_,7 @@
+@@ -399,13 +_,13 @@
+                 if (flag && !p_109372_.isInvisible()) {
+                     this.renderPlayerArm(p_109379_, p_109380_, p_109381_, p_109378_, p_109376_, humanoidarm);
+                 }
+-            } else if (p_109377_.is(Items.FILLED_MAP)) {
++            } else if (p_109377_.getItem() instanceof MapItem) {
+                 if (flag && this.offHandItem.isEmpty()) {
+                     this.renderTwoHandedMap(p_109379_, p_109380_, p_109381_, p_109374_, p_109378_, p_109376_);
                  } else {
                      this.renderOneHandedMap(p_109379_, p_109380_, p_109381_, p_109378_, humanoidarm, p_109376_, p_109377_);
                  }

--- a/patches/net/minecraft/world/entity/decoration/ItemFrame.java.patch
+++ b/patches/net/minecraft/world/entity/decoration/ItemFrame.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/decoration/ItemFrame.java
++++ b/net/minecraft/world/entity/decoration/ItemFrame.java
+@@ -212,7 +_,7 @@
+     private void removeFramedMap(ItemStack p_31811_) {
+         MapId mapid = this.getFramedMapId(p_31811_);
+         if (mapid != null) {
+-            MapItemSavedData mapitemsaveddata = MapItem.getSavedData(mapid, this.level());
++            MapItemSavedData mapitemsaveddata = MapItem.getSavedData(p_31811_, this.level());
+             if (mapitemsaveddata != null) {
+                 mapitemsaveddata.removedFromFrame(this.pos, this.getId());
+                 mapitemsaveddata.setDirty(true);


### PR DESCRIPTION
This PR makes 2 small changes to the ItemInHandRenderer to allow modded maps to render properly in the player's hand. 
The first removes the hardcoded check of `Items.FILLED_MAP` and replaces it with a `MapItem` check. Modded maps should in theory be extending MapItem so this should work fine. 
The second simply uses the `getSavedData` method that neo patches instead of the vanilla one. The neo check allows modded maps to add custom data and whatnot, while the original check just checks vanilla save data. 

If this warrants writing a test please let me know and I will look into that :)