### PR TITLE
Restore CustomizeGuiOverlayEvent.DebugText's ability to modify text

### DIFF
--- a/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
@@ -1,45 +1,54 @@
 --- a/net/minecraft/client/gui/components/DebugScreenOverlay.java
 +++ b/net/minecraft/client/gui/components/DebugScreenOverlay.java
-@@ -135,8 +_,13 @@
+@@ -135,8 +_,15 @@
          this.block = entity.pick(20.0, 0.0F, false);
          this.liquid = entity.pick(20.0, 0.0F, true);
          p_281427_.drawManaged(() -> {
 -            this.drawGameInformation(p_281427_);
 -            this.drawSystemInformation(p_281427_);
-+            final List<String> gameInformation = new java.util.ArrayList<>();
-+            final List<String> systemInformation = new java.util.ArrayList<>();
++            final List<String> gameInformation = this.drawGameInformation(p_281427_);
++            final List<String> systemInformation = this.drawSystemInformation(p_281427_);
++
 +            var event = new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText(minecraft.getWindow(), p_281427_, minecraft.getTimer(), gameInformation, systemInformation);
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
 +
-+            this.drawGameInformation(p_281427_, gameInformation);
-+            this.drawSystemInformation(p_281427_, systemInformation);
++            this.renderLines(p_281427_, gameInformation, true);
++            this.renderLines(p_281427_, systemInformation, false);
++
              if (this.renderFpsCharts) {
                  int i = p_281427_.guiWidth();
                  int j = i / 2;
-@@ -161,7 +_,7 @@
+@@ -161,7 +_,10 @@
          this.minecraft.getProfiler().pop();
      }
  
 -    protected void drawGameInformation(GuiGraphics p_281525_) {
-+    protected void drawGameInformation(GuiGraphics p_281525_, List<String> gameInformation) {
++    /**
++     * Neo: Patched to not draw and instead return game information for {@link net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText} to modify
++     */
++    protected List<String> drawGameInformation(GuiGraphics p_281525_) {
          List<String> list = this.getGameInformation();
          list.add("");
          boolean flag = this.minecraft.getSingleplayerServer() != null;
-@@ -176,11 +_,13 @@
+@@ -176,12 +_,15 @@
                  + (this.renderNetworkCharts ? " visible" : " hidden")
          );
          list.add("For help: press F3 + Q");
-+        list.addAll(gameInformation);
-         this.renderLines(p_281525_, list, true);
+-        this.renderLines(p_281525_, list, true);
++        return list;
      }
  
 -    protected void drawSystemInformation(GuiGraphics p_281261_) {
-+    protected void drawSystemInformation(GuiGraphics p_281261_, List<String> systemInformation) {
++    /**
++     * Neo: Patched to not draw and instead return system information for {@link net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText} to modify
++     */
++    protected List<String> drawSystemInformation(GuiGraphics p_281261_) {
          List<String> list = this.getSystemInformation();
-+        list.addAll(systemInformation);
-         this.renderLines(p_281261_, list, false);
+-        this.renderLines(p_281261_, list, false);
++        return list;
      }
  
+     private void renderLines(GuiGraphics p_286519_, List<String> p_286665_, boolean p_286644_) {
 @@ -509,6 +_,13 @@
              GlUtil.getRenderer(),
              GlUtil.getOpenGLVersion()

--- a/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch
@@ -6,8 +6,8 @@
          p_281427_.drawManaged(() -> {
 -            this.drawGameInformation(p_281427_);
 -            this.drawSystemInformation(p_281427_);
-+            final List<String> gameInformation = this.drawGameInformation(p_281427_);
-+            final List<String> systemInformation = this.drawSystemInformation(p_281427_);
++            final List<String> gameInformation = this.collectGameInformationText();
++            final List<String> systemInformation = this.collectSystemInformationText();
 +
 +            var event = new net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText(minecraft.getWindow(), p_281427_, minecraft.getTimer(), gameInformation, systemInformation);
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
@@ -18,37 +18,46 @@
              if (this.renderFpsCharts) {
                  int i = p_281427_.guiWidth();
                  int j = i / 2;
-@@ -161,7 +_,10 @@
+@@ -161,7 +_,11 @@
          this.minecraft.getProfiler().pop();
      }
  
 -    protected void drawGameInformation(GuiGraphics p_281525_) {
 +    /**
-+     * Neo: Patched to not draw and instead return game information for {@link net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText} to modify
++     * Neo: Extracted body of {@link DebugScreenOverlay#drawGameInformation} to return game information
++     * without drawing for {@link net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText} to modify
 +     */
-+    protected List<String> drawGameInformation(GuiGraphics p_281525_) {
++    protected List<String> collectGameInformationText() {
          List<String> list = this.getGameInformation();
          list.add("");
          boolean flag = this.minecraft.getSingleplayerServer() != null;
-@@ -176,12 +_,15 @@
+@@ -176,11 +_,25 @@
                  + (this.renderNetworkCharts ? " visible" : " hidden")
          );
          list.add("For help: press F3 + Q");
--        this.renderLines(p_281525_, list, true);
 +        return list;
++    }
++
++    protected void drawGameInformation(GuiGraphics p_281525_) {
++        List<String> list = this.collectGameInformationText();
+         this.renderLines(p_281525_, list, true);
      }
  
 -    protected void drawSystemInformation(GuiGraphics p_281261_) {
 +    /**
-+     * Neo: Patched to not draw and instead return system information for {@link net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText} to modify
++     * Neo: Extracted body of {@link DebugScreenOverlay#drawSystemInformation} to return system information
++     * without drawing for {@link net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent.DebugText} to modify
 +     */
-+    protected List<String> drawSystemInformation(GuiGraphics p_281261_) {
++    protected List<String> collectSystemInformationText() {
          List<String> list = this.getSystemInformation();
--        this.renderLines(p_281261_, list, false);
 +        return list;
++    }
++
++    protected void drawSystemInformation(GuiGraphics p_281261_) {
++        List<String> list = this.collectSystemInformationText();
+         this.renderLines(p_281261_, list, false);
      }
  
-     private void renderLines(GuiGraphics p_286519_, List<String> p_286665_, boolean p_286644_) {
 @@ -509,6 +_,13 @@
              GlUtil.getRenderer(),
              GlUtil.getOpenGLVersion()


### PR DESCRIPTION
This was the best way I could think of to make this event functional again for editing/removing debug text. Make the vanilla methods not draw but return their list of text. Feed it to event. And then draw after event is done. Simple to follow. I added comment on the modified methods so we can remember why we modified their returns.

Closes https://github.com/neoforged/NeoForge/issues/1065