### PR TITLE
Add getCraftingRemainingItem with level param

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -725,9 +725,17 @@ public class CommonHooks {
         return craftingPlayer.get();
     }
 
+    /**
+     * Use {@link CommonHooks#getCraftingRemainingItem(ItemStack, Level)} instead.
+     */
+    @Deprecated(since = "1.20")
     public static ItemStack getCraftingRemainingItem(ItemStack stack) {
+        return getCraftingRemainingItem(stack, null);
+    }
+
+    public static ItemStack getCraftingRemainingItem(ItemStack stack, @Nullable Level level) {
         if (stack.getItem().hasCraftingRemainingItem(stack)) {
-            stack = stack.getItem().getCraftingRemainingItem(stack);
+            stack = stack.getItem().getCraftingRemainingItem(stack, level);
             if (!stack.isEmpty() && stack.isDamageableItem() && stack.getDamageValue() > stack.getMaxDamage()) {
                 EventHooks.onPlayerDestroyItem(craftingPlayer.get(), stack, null);
                 return ItemStack.EMPTY;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -184,14 +184,29 @@ public interface IItemExtension {
      *
      * @param itemStack The current ItemStack
      * @return The resulting ItemStack
+     *
+     * @deprecated Use {@link IItemExtension#getCraftingRemainingItem(ItemStack, Level)} instead.
+     */
+    @Deprecated(since = "1.20")
+    default ItemStack getCraftingRemainingItem(ItemStack itemStack) {
+        return getCraftingRemainingItem(itemStack, null);
+    }
+
+    /**
+     * ItemStack sensitive version of {@link Item#getCraftingRemainingItem()}.
+     * Returns a full ItemStack instance of the result.
+     *
+     * @param itemStack The current ItemStack
+     * @return The resulting ItemStack
      */
     @SuppressWarnings("deprecation")
-    default ItemStack getCraftingRemainingItem(ItemStack itemStack) {
+    default ItemStack getCraftingRemainingItem(ItemStack itemStack, @Nullable Level level) {
         if (!hasCraftingRemainingItem(itemStack)) {
             return ItemStack.EMPTY;
         }
         return new ItemStack(self().getCraftingRemainingItem());
     }
+
 
     /**
      * ItemStack sensitive version of {@link Item#hasCraftingRemainingItem()}.

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -46,7 +46,7 @@ import net.neoforged.neoforge.event.EventHooks;
 import org.jetbrains.annotations.Nullable;
 
 /*
- * Extension added to ItemStack that bounces to ItemSack sensitive Item methods. Typically this is just for convince.
+ * Extension added to ItemStack that bounces to ItemStack sensitive Item methods. Typically, this is just for convince.
  */
 public interface IItemStackExtension {
     // Helpers for accessing Item data
@@ -59,9 +59,22 @@ public interface IItemStackExtension {
      * Returns a full ItemStack instance of the result.
      *
      * @return The resulting ItemStack
+     *
+     * @deprecated Use {@link IItemExtension#getCraftingRemainingItem(ItemStack, Level)} instead.
      */
+    @Deprecated(since = "1.20")
     default ItemStack getCraftingRemainingItem() {
-        return self().getItem().getCraftingRemainingItem(self());
+        return getCraftingRemainingItem(null);
+    }
+
+    /**
+     * ItemStack sensitive version of {@link Item#getCraftingRemainingItem()}.
+     * Returns a full ItemStack instance of the result.
+     *
+     * @return The resulting ItemStack
+     */
+    default ItemStack getCraftingRemainingItem(@Nullable Level level) {
+        return self().getItem().getCraftingRemainingItem(self(), level);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -16,6 +16,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.EventHooks;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
  * {@link Player#attack(Entity)},
  * {@code Player#hurtCurrentlyUsedShield(float)},
  * {@link Player#interactOn(Entity, InteractionHand)},
- * {@link CommonHooks#getCraftingRemainingItem(ItemStack)},
+ * {@link CommonHooks#getCraftingRemainingItem(ItemStack, Level)},
  * {@link ServerPlayerGameMode#useItem(ServerPlayer, Level, ItemStack, InteractionHand)} ,
  * {@link ServerPlayerGameMode#useItemOn(ServerPlayer, Level, ItemStack, InteractionHand, BlockHitResult)}
  * and {@link ServerPlayerGameMode#destroyBlock(BlockPos)}.<br>


### PR DESCRIPTION
The getCraftingRemainingItem we have is itemstack sensitive but is not usable with Unbreaking enchantment that requires a level. So if someone has a tool or catalyst that they want to be usable in crafting, but also set itself as a remainder with damage as a result of crafting while also applying Unbreaking's effect, they won't be easily able to. Ideally, they would have a level passed in for getCraftingRemainingItem, copy the current itemstack, take the damage data component, calculate the new damage using Unbreaking's effect if item is enchanted with it, and then return a new itemstack with the new damage result. And any mod using getCraftingRemainingItem will now get the proper itemstack for the other mod's catalyst or whatever.

Closes https://github.com/neoforged/NeoForge/issues/1377