### PR TITLE
Enable keyboard navigation in mod list

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -359,7 +359,7 @@ public class ModListScreen extends Screen {
     }
 
     public void setSelected(ModListWidget.ModEntry entry) {
-        this.selected = entry == this.selected ? null : entry;
+        this.selected = entry;
         updateCache();
     }
 

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -93,9 +93,9 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
         }
 
         @Override
-        public void setFocused(boolean p_265302_) {
+        public void setFocused(boolean focused) {
             // ignore focus loss so the item stays selected when tabbing to the config button
-            if (p_265302_) {
+            if (focused) {
                 parent.setSelected(this);
                 ModListWidget.this.setSelected(this);
             }

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -86,9 +86,20 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
 
         @Override
         public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
-            parent.setSelected(this);
+            parent.setSelected(isFocused() ? null : this);
             ModListWidget.this.setSelected(this);
             return false;
+        }
+
+        @Override
+        public void setFocused(boolean p_265302_) {
+            parent.setSelected(p_265302_ ? this : null);
+            ModListWidget.this.setSelected(p_265302_ ? this : null);
+        }
+
+        @Override
+        public boolean isFocused() {
+            return ModListWidget.this.getSelected() == this;
         }
 
         public IModInfo getInfo() {

--- a/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -86,15 +86,19 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
 
         @Override
         public boolean mouseClicked(double p_mouseClicked_1_, double p_mouseClicked_3_, int p_mouseClicked_5_) {
+            // clicking on a selected item a second time unselects it
             parent.setSelected(isFocused() ? null : this);
-            ModListWidget.this.setSelected(this);
+            ModListWidget.this.setSelected(isFocused() ? null : this);
             return false;
         }
 
         @Override
         public void setFocused(boolean p_265302_) {
-            parent.setSelected(p_265302_ ? this : null);
-            ModListWidget.this.setSelected(p_265302_ ? this : null);
+            // ignore focus loss so the item stays selected when tabbing to the config button
+            if (p_265302_) {
+                parent.setSelected(this);
+                ModListWidget.this.setSelected(this);
+            }
         }
 
         @Override


### PR DESCRIPTION
fixes #1390

Fix is two-fold:

- Accept being selected by keyboard navigation
- Move "de-select by second click" logic to mouse handler so it doesn't interfere with keyboard selection