### PR TITLE
Added modifier key states to TooltipFlag and Level to TooltipContext

### DIFF
--- a/patches/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/Screen.java.patch
@@ -17,6 +17,15 @@
      }
  
      protected <T extends GuiEventListener & Renderable & NarratableEntry> T addRenderableWidget(T p_169406_) {
+@@ -242,7 +_,7 @@
+         return p_282833_.getTooltipLines(
+             Item.TooltipContext.of(p_281881_.level),
+             p_281881_.player,
+-            p_281881_.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL
++            net.neoforged.neoforge.client.util.NeoTooltipFlag.of(p_281881_.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL)
+         );
+     }
+ 
 @@ -312,8 +_,11 @@
          this.width = p_96608_;
          this.height = p_96609_;

--- a/patches/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/Screen.java.patch
@@ -22,7 +22,7 @@
              Item.TooltipContext.of(p_281881_.level),
              p_281881_.player,
 -            p_281881_.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL
-+            net.neoforged.neoforge.client.util.NeoTooltipFlag.of(p_281881_.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL)
++            net.neoforged.neoforge.client.ClientTooltipFlag.of(p_281881_.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL)
          );
      }
  

--- a/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -185,7 +185,7 @@
          this.renderTooltip(p_283000_, p_281317_, p_282770_);
      }
  
-@@ -684,7 +_,7 @@
+@@ -684,10 +_,10 @@
      public List<Component> getTooltipFromContainerItem(ItemStack p_281769_) {
          boolean flag = this.hoveredSlot != null && this.hoveredSlot instanceof CreativeModeInventoryScreen.CustomCreativeSlot;
          boolean flag1 = selectedTab.getType() == CreativeModeTab.Type.CATEGORY;
@@ -193,7 +193,11 @@
 +        boolean flag2 = selectedTab.hasSearchBar();
          TooltipFlag.Default tooltipflag$default = this.minecraft.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL;
          TooltipFlag tooltipflag = flag ? tooltipflag$default.asCreative() : tooltipflag$default;
-         List<Component> list = p_281769_.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, tooltipflag);
+-        List<Component> list = p_281769_.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, tooltipflag);
++        List<Component> list = p_281769_.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, net.neoforged.neoforge.client.util.NeoTooltipFlag.of(tooltipflag));
+         if (flag1 && flag) {
+             return list;
+         } else {
 @@ -703,7 +_,7 @@
              int i = 1;
  

--- a/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -194,7 +194,7 @@
          TooltipFlag.Default tooltipflag$default = this.minecraft.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL;
          TooltipFlag tooltipflag = flag ? tooltipflag$default.asCreative() : tooltipflag$default;
 -        List<Component> list = p_281769_.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, tooltipflag);
-+        List<Component> list = p_281769_.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, net.neoforged.neoforge.client.util.NeoTooltipFlag.of(tooltipflag));
++        List<Component> list = p_281769_.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, net.neoforged.neoforge.client.ClientTooltipFlag.of(tooltipflag));
          if (flag1 && flag) {
              return list;
          } else {

--- a/patches/net/minecraft/client/multiplayer/SessionSearchTrees.java.patch
+++ b/patches/net/minecraft/client/multiplayer/SessionSearchTrees.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/multiplayer/SessionSearchTrees.java
 +++ b/net/minecraft/client/multiplayer/SessionSearchTrees.java
+@@ -60,7 +_,7 @@
+                 List<RecipeCollection> list = p_346233_.getCollections();
+                 Registry<Item> registry = p_345600_.registryOrThrow(Registries.ITEM);
+                 Item.TooltipContext item$tooltipcontext = Item.TooltipContext.of(p_345600_);
+-                TooltipFlag tooltipflag = TooltipFlag.Default.NORMAL;
++                TooltipFlag tooltipflag = net.neoforged.neoforge.client.util.NeoTooltipFlag.of(TooltipFlag.Default.NORMAL);
+                 CompletableFuture<?> completablefuture = this.recipeSearch;
+                 this.recipeSearch = CompletableFuture.supplyAsync(
+                     () -> new FullTextSearchTree<>(
 @@ -86,44 +_,60 @@
      }
  
@@ -43,9 +52,10 @@
 +            key,
              () -> {
                  Item.TooltipContext item$tooltipcontext = Item.TooltipContext.of(p_345391_);
-                 TooltipFlag tooltipflag = TooltipFlag.Default.NORMAL.asCreative();
+-                TooltipFlag tooltipflag = TooltipFlag.Default.NORMAL.asCreative();
 -                CompletableFuture<?> completablefuture = this.creativeByNameSearch;
 -                this.creativeByNameSearch = CompletableFuture.supplyAsync(
++                TooltipFlag tooltipflag = net.neoforged.neoforge.client.util.NeoTooltipFlag.of(TooltipFlag.Default.NORMAL.asCreative());
 +                CompletableFuture<?> completablefuture = net.neoforged.neoforge.client.CreativeModeTabSearchRegistry.getNameSearchTree(key);
 +                net.neoforged.neoforge.client.CreativeModeTabSearchRegistry.putNameSearchTree(key, CompletableFuture.supplyAsync(
                      () -> new FullTextSearchTree<>(

--- a/patches/net/minecraft/client/multiplayer/SessionSearchTrees.java.patch
+++ b/patches/net/minecraft/client/multiplayer/SessionSearchTrees.java.patch
@@ -5,7 +5,7 @@
                  Registry<Item> registry = p_345600_.registryOrThrow(Registries.ITEM);
                  Item.TooltipContext item$tooltipcontext = Item.TooltipContext.of(p_345600_);
 -                TooltipFlag tooltipflag = TooltipFlag.Default.NORMAL;
-+                TooltipFlag tooltipflag = net.neoforged.neoforge.client.util.NeoTooltipFlag.of(TooltipFlag.Default.NORMAL);
++                TooltipFlag tooltipflag = net.neoforged.neoforge.client.ClientTooltipFlag.of(TooltipFlag.Default.NORMAL);
                  CompletableFuture<?> completablefuture = this.recipeSearch;
                  this.recipeSearch = CompletableFuture.supplyAsync(
                      () -> new FullTextSearchTree<>(
@@ -55,7 +55,7 @@
 -                TooltipFlag tooltipflag = TooltipFlag.Default.NORMAL.asCreative();
 -                CompletableFuture<?> completablefuture = this.creativeByNameSearch;
 -                this.creativeByNameSearch = CompletableFuture.supplyAsync(
-+                TooltipFlag tooltipflag = net.neoforged.neoforge.client.util.NeoTooltipFlag.of(TooltipFlag.Default.NORMAL.asCreative());
++                TooltipFlag tooltipflag = net.neoforged.neoforge.client.ClientTooltipFlag.of(TooltipFlag.Default.NORMAL.asCreative());
 +                CompletableFuture<?> completablefuture = net.neoforged.neoforge.client.CreativeModeTabSearchRegistry.getNameSearchTree(key);
 +                net.neoforged.neoforge.client.CreativeModeTabSearchRegistry.putNameSearchTree(key, CompletableFuture.supplyAsync(
                      () -> new FullTextSearchTree<>(

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -196,3 +196,30 @@
              if (datacomponentmap.has(DataComponents.DAMAGE) && datacomponentmap.getOrDefault(DataComponents.MAX_STACK_SIZE, 1) > 1) {
                  throw new IllegalStateException("Item cannot have both durability and be stackable");
              } else {
+@@ -441,6 +_,14 @@
+         @Nullable
+         MapItemSavedData mapData(MapId p_339670_);
+ 
++        /**
++         * Neo: Returns the level if it's available.
++         */
++        @Nullable
++        default Level level() {
++            return null;
++        }
++
+         static Item.TooltipContext of(@Nullable final Level p_339599_) {
+             return p_339599_ == null ? EMPTY : new Item.TooltipContext() {
+                 @Override
+@@ -456,6 +_,11 @@
+                 @Override
+                 public MapItemSavedData mapData(MapId p_339628_) {
+                     return p_339599_.getMapData(p_339628_);
++                }
++
++                @Override
++                public Level level() {
++                    return p_339599_;
+                 }
+             };
+         }

--- a/patches/net/minecraft/world/item/TooltipFlag.java.patch
+++ b/patches/net/minecraft/world/item/TooltipFlag.java.patch
@@ -1,0 +1,30 @@
+--- a/net/minecraft/world/item/TooltipFlag.java
++++ b/net/minecraft/world/item/TooltipFlag.java
+@@ -8,6 +_,27 @@
+ 
+     boolean isCreative();
+ 
++    /**
++     * Neo: Returns the state of the Control key (as reported by Screen) on the client, or false on the server
++     */
++    default boolean hasControlDown() {
++        return false;
++    }
++
++    /**
++     * Neo: Returns the state of the Shift key (as reported by Screen) on the client, or false on the server
++     */
++    default boolean hasShiftDown() {
++        return false;
++    }
++
++    /**
++     * Neo: Returns the state of the Alt key (as reported by Screen) on the client, or false on the server
++     */
++    default boolean hasAltDown() {
++        return false;
++    }
++
+     public static record Default(boolean advanced, boolean creative) implements TooltipFlag {
+         @Override
+         public boolean isAdvanced() {

--- a/patches/net/minecraft/world/item/TooltipFlag.java.patch
+++ b/patches/net/minecraft/world/item/TooltipFlag.java.patch
@@ -5,21 +5,21 @@
      boolean isCreative();
  
 +    /**
-+     * Neo: Returns the state of the Control key (as reported by Screen) on the client, or false on the server
++     * Neo: Returns the state of the Control key (as reported by Screen) on the client, or {@code false} on the server.
 +     */
 +    default boolean hasControlDown() {
 +        return false;
 +    }
 +
 +    /**
-+     * Neo: Returns the state of the Shift key (as reported by Screen) on the client, or false on the server
++     * Neo: Returns the state of the Shift key (as reported by Screen) on the client, or {@code false} on the server.
 +     */
 +    default boolean hasShiftDown() {
 +        return false;
 +    }
 +
 +    /**
-+     * Neo: Returns the state of the Alt key (as reported by Screen) on the client, or false on the server
++     * Neo: Returns the state of the Alt key (as reported by Screen) on the client, or {@code false} on the server.
 +     */
 +    default boolean hasAltDown() {
 +        return false;

--- a/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
@@ -17,6 +17,8 @@ import org.jetbrains.annotations.ApiStatus;
 public record ClientTooltipFlag(boolean advanced, boolean creative, boolean shiftDown, boolean controlDown, boolean altDown) implements TooltipFlag {
     @ApiStatus.Internal
     public ClientTooltipFlag {}
+    @ApiStatus.Internal
+    public ClientTooltipFlag {}
 
     @Override
     public boolean isAdvanced() {

--- a/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
@@ -43,10 +43,6 @@ public record ClientTooltipFlag(boolean advanced, boolean creative, boolean shif
         return altDown;
     }
 
-    public ClientTooltipFlag asCreative() {
-        return new ClientTooltipFlag(advanced, true, shiftDown, controlDown, altDown);
-    }
-
     public static TooltipFlag of(TooltipFlag other) {
         return new ClientTooltipFlag(other.isAdvanced(), other.isCreative(), Screen.hasShiftDown(), Screen.hasControlDown(), Screen.hasAltDown());
     }

--- a/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
@@ -17,8 +17,6 @@ import org.jetbrains.annotations.ApiStatus;
 public record ClientTooltipFlag(boolean advanced, boolean creative, boolean shiftDown, boolean controlDown, boolean altDown) implements TooltipFlag {
     @ApiStatus.Internal
     public ClientTooltipFlag {}
-    @ApiStatus.Internal
-    public ClientTooltipFlag {}
 
     @Override
     public boolean isAdvanced() {

--- a/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientTooltipFlag.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
-package net.neoforged.neoforge.client.util;
+package net.neoforged.neoforge.client;
 
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.item.TooltipFlag;
@@ -14,9 +14,9 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>
  * When calling any tooltip method that needs a TooltipFlag yourself, use either this (by calling {@link #of(TooltipFlag)}) or {@link TooltipFlag.Default} depending on the <em>logical</em> side you're on.
  */
-public record NeoTooltipFlag(boolean advanced, boolean creative, boolean shiftDown, boolean controlDown, boolean altDown) implements TooltipFlag {
+public record ClientTooltipFlag(boolean advanced, boolean creative, boolean shiftDown, boolean controlDown, boolean altDown) implements TooltipFlag {
     @ApiStatus.Internal
-    public NeoTooltipFlag {}
+    public ClientTooltipFlag {}
 
     @Override
     public boolean isAdvanced() {
@@ -43,11 +43,11 @@ public record NeoTooltipFlag(boolean advanced, boolean creative, boolean shiftDo
         return altDown;
     }
 
-    public NeoTooltipFlag asCreative() {
-        return new NeoTooltipFlag(advanced, true, shiftDown, controlDown, altDown);
+    public ClientTooltipFlag asCreative() {
+        return new ClientTooltipFlag(advanced, true, shiftDown, controlDown, altDown);
     }
 
     public static TooltipFlag of(TooltipFlag other) {
-        return new NeoTooltipFlag(other.isAdvanced(), other.isCreative(), Screen.hasShiftDown(), Screen.hasControlDown(), Screen.hasAltDown());
+        return new ClientTooltipFlag(other.isAdvanced(), other.isCreative(), Screen.hasShiftDown(), Screen.hasControlDown(), Screen.hasAltDown());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/util/NeoTooltipFlag.java
+++ b/src/main/java/net/neoforged/neoforge/client/util/NeoTooltipFlag.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.util;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.world.item.TooltipFlag;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A version of {@link TooltipFlag} that knows about Screen and can provide modifier key states. It is patched into all vanilla uses of TooltipFlags in client classes.
+ * <p>
+ * When calling any tooltip method that needs a TooltipFlag yourself, use either this (by calling {@link #of(TooltipFlag)}) or {@link TooltipFlag.Default} depending on the <em>logical</em> side you're on.
+ */
+public record NeoTooltipFlag(boolean advanced, boolean creative, boolean shiftDown, boolean controlDown, boolean altDown) implements TooltipFlag {
+    @ApiStatus.Internal
+    public NeoTooltipFlag {}
+
+    @Override
+    public boolean isAdvanced() {
+        return this.advanced;
+    }
+
+    @Override
+    public boolean isCreative() {
+        return this.creative;
+    }
+
+    @Override
+    public boolean hasControlDown() {
+        return controlDown;
+    }
+
+    @Override
+    public boolean hasShiftDown() {
+        return shiftDown;
+    }
+
+    @Override
+    public boolean hasAltDown() {
+        return altDown;
+    }
+
+    public NeoTooltipFlag asCreative() {
+        return new NeoTooltipFlag(advanced, true, shiftDown, controlDown, altDown);
+    }
+
+    public static TooltipFlag of(TooltipFlag other) {
+        return new NeoTooltipFlag(other.isAdvanced(), other.isCreative(), Screen.hasShiftDown(), Screen.hasControlDown(), Screen.hasAltDown());
+    }
+}


### PR DESCRIPTION
appendHoverText seemingly is a client-only method on Item in which mods regularly will want to check the state of the shift and/or ctrl key. It is easy to write that in a way to crash on classloading on a dedicated server. Also, that method does exist on the server and even though it is only called by client code in vanilla, it is not unreasonable for mods to call it on the server, leading to more crashes.

While this can be circumvented in various ways, all of them are annoying to write and not immediately obvious unless you have run into such a crash before.

This patch makes it less likely that modders write non-server-safe code by providing the state of the modifier keys in the TooltipFlag.

---

This now also makes the Level accessible in the TooltipContext that already captures it.