### PR TITLE
[1.21] Fix HUD elements at high Z values vanishing when many elements are registered

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -390,13 +390,17 @@
                  this.toolHighlightTimer = (int)(40.0 * this.minecraft.options.notificationDisplayTime().get());
              } else if (this.toolHighlightTimer > 0) {
                  this.toolHighlightTimer--;
-@@ -1292,8 +_,13 @@
+@@ -1292,8 +_,17 @@
          }
      }
  
 +    @org.jetbrains.annotations.ApiStatus.Internal
 +    public void initModdedOverlays() {
 +        this.layerManager.initModdedLayers();
++    }
++
++    public int getLayerCount() {
++        return this.layerManager.getLayerCount();
 +    }
 +
      @OnlyIn(Dist.CLIENT)

--- a/patches/net/minecraft/client/renderer/PanoramaRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/PanoramaRenderer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/PanoramaRenderer.java
++++ b/net/minecraft/client/renderer/PanoramaRenderer.java
+@@ -30,6 +_,8 @@
+         p_334063_.blit(PANORAMA_OVERLAY, 0, 0, p_333839_, p_333923_, 0.0F, 0.0F, 16, 128, 16, 128);
+         p_334063_.setColor(1.0F, 1.0F, 1.0F, 1.0F);
+         RenderSystem.disableBlend();
++        // Neo: disable depth test again to prevent issues with extended far plane values for screen layers and HUD layers
++        RenderSystem.disableDepthTest();
+     }
+ 
+     private static float wrap(float p_249058_, float p_249548_) {

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -179,6 +179,7 @@ import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtension
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import net.neoforged.neoforge.client.extensions.common.IClientMobEffectExtensions;
 import net.neoforged.neoforge.client.gui.ClientTooltipComponentManager;
+import net.neoforged.neoforge.client.gui.GuiLayerManager;
 import net.neoforged.neoforge.client.gui.map.MapDecorationRendererManager;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.common.NeoForge;
@@ -245,10 +246,13 @@ public class ClientHooks {
     }
 
     public static float getGuiFarPlane() {
-        // 11000 units for the overlay background,
-        // and 10000 units for each layered Screen,
+        // 11000 units for the overlay background and 10000 units for each layered Screen or 200 units for each HUD layer, whichever ends up higher
 
-        return 11000.0F + 10000.0F * (1 + guiLayers.size());
+        float depth = 10_000F * (1 + guiLayers.size());
+        if (Minecraft.getInstance().level != null) {
+            depth = Math.max(depth, GuiLayerManager.Z_SEPARATION * Minecraft.getInstance().gui.getLayerCount());
+        }
+        return 11_000F + depth;
     }
 
     public static ResourceLocation getArmorTexture(Entity entity, ItemStack armor, ArmorMaterial.Layer layer, boolean innerModel, EquipmentSlot slot) {

--- a/src/main/java/net/neoforged/neoforge/client/gui/GuiLayerManager.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/GuiLayerManager.java
@@ -83,4 +83,8 @@ public class GuiLayerManager {
         initialized = true;
         ModLoader.postEvent(new RegisterGuiLayersEvent(this.layers));
     }
+
+    public int getLayerCount() {
+        return this.layers.size();
+    }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
@@ -167,4 +167,27 @@ public class GuiTests {
             gui.leftHeight += height + 1;
         };
     }
+
+    @TestHolder(description = "Checks that the depth budget for GUI layers gets adjusted as necessary")
+    static void testGuiLayerDepthBudget(DynamicTest test) {
+        test.framework().modEventBus().addListener((RegisterGuiLayersEvent event) -> {
+            // Register some placeholder layers
+            for (int i = 0; i < 50; i++) {
+                event.registerAboveAll(ResourceLocation.fromNamespaceAndPath(test.createModId(), "fake_" + i), (guiGraphics, deltaTracker) -> {});
+            }
+            // Register the real layer
+            event.registerAboveAll(ResourceLocation.fromNamespaceAndPath(test.createModId(), "high_depth_test"), (guiGraphics, deltaTracker) -> {
+                if (test.framework().tests().isEnabled(test.id())) {
+                    guiGraphics.fill(guiGraphics.guiWidth() - 50, 0, guiGraphics.guiWidth(), 50, 0xFFFF0000);
+                }
+            });
+        });
+
+        test.eventListeners().forge().addListener((ClientChatEvent chatEvent) -> {
+            if (chatEvent.getMessage().equalsIgnoreCase("gui layer depth test")) {
+                test.requestConfirmation(Minecraft.getInstance().player, Component.literal(
+                        "Do you see a red square in the top right corner of the screen?"));
+            }
+        });
+    }
 }


### PR DESCRIPTION
This PR fixes HUD elements vanishing when they are rendered at high Z offsets due to many HUD layers being registered.

When vanilla builds the projection matrix, it sets the near plane at 1000 and the far plane at 21000 and then translates the "model view matrix" by -11000. NeoForge adapts this to accommodate screen layers by calculating the far plane as `11_000 + 10_000 * (1 + layerCount)` (the layer count does not include the active screen, only the ones layered behind that) and then performs the aforementioned translation with `10_000 - farPlane`. This leads to the same far plane and z offset values as vanilla when no layered screens are present. The combination of the near plane, far plane and z offset provide a depth budget of around 10000 units to both screen and HUD layers (they both start at the same depth and then stack up from there). For HUD layers which translate by 200 units after every layer (this is a vanilla value) this allows for 50 layers to be rendered. Vanilla already occupies 25 of those layers and in even a medium sized modpack the other 25 layers are used up very quickly.

The suggested fix is to employ the same solution as screen layers (which do a similar Z translation, except by 10000 units, after each layer is rendered): calculate the depth required for the amount of registered HUD layers and use the larger of screen layer depth and HUD layer depth to calculate the far plane.

Also included is a fix for the out-of-world menu panorama in combination with the blur effect causing the foreground of screens using it to vanish when larger amounts of HUD layers are registered or a layered screen is stacked on such a screen.

Fixes #1400