### PR TITLE
[1.21] Add IItemExtension#supportsEnchantment

### DIFF
--- a/patches/net/minecraft/server/commands/EnchantCommand.java.patch
+++ b/patches/net/minecraft/server/commands/EnchantCommand.java.patch
@@ -5,7 +5,7 @@
                      ItemStack itemstack = livingentity.getMainHandItem();
                      if (!itemstack.isEmpty()) {
 -                        if (enchantment.canEnchant(itemstack)
-+                        if (itemstack.isSupportedItemFor(p_251252_) // Neo: Respect IItemExtension#isSupportedItemFor
++                        if (itemstack.supportsEnchantment(p_251252_) // Neo: Respect IItemExtension#supportsEnchantment
                              && EnchantmentHelper.isEnchantmentCompatible(EnchantmentHelper.getEnchantmentsForCrafting(itemstack).keySet(), p_251252_)) {
                              itemstack.enchant(p_251252_, p_249941_);
                              i++;

--- a/patches/net/minecraft/server/commands/EnchantCommand.java.patch
+++ b/patches/net/minecraft/server/commands/EnchantCommand.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/commands/EnchantCommand.java
++++ b/net/minecraft/server/commands/EnchantCommand.java
+@@ -81,7 +_,7 @@
+                     LivingEntity livingentity = (LivingEntity)entity;
+                     ItemStack itemstack = livingentity.getMainHandItem();
+                     if (!itemstack.isEmpty()) {
+-                        if (enchantment.canEnchant(itemstack)
++                        if (itemstack.isSupportedItemFor(p_251252_) // Neo: Respect IItemExtension#isSupportedItemFor
+                             && EnchantmentHelper.isEnchantmentCompatible(EnchantmentHelper.getEnchantmentsForCrafting(itemstack).keySet(), p_251252_)) {
+                             itemstack.enchant(p_251252_, p_249941_);
+                             i++;

--- a/patches/net/minecraft/world/inventory/AnvilMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AnvilMenu.java.patch
@@ -30,6 +30,19 @@
                  if (itemstack1.isDamageableItem() && itemstack1.getItem().isValidRepairItem(itemstack, itemstack2)) {
                      int l2 = Math.min(itemstack1.getDamageValue(), itemstack1.getMaxDamage() / 4);
                      if (l2 <= 0) {
+@@ -176,8 +_,10 @@
+                         int j2 = entry.getIntValue();
+                         j2 = i2 == j2 ? j2 + 1 : Math.max(j2, i2);
+                         Enchantment enchantment = holder.value();
+-                        boolean flag1 = enchantment.canEnchant(itemstack);
+-                        if (this.player.getAbilities().instabuild || itemstack.is(Items.ENCHANTED_BOOK)) {
++                        // Neo: Respect IItemExtension#isSupportedItemFor - we also delegate the logic for Enchanted Books to this method.
++                        // Though we still allow creative players to combine any item with any enchantment in the anvil here.
++                        boolean flag1 = itemstack.isSupportedItemFor(holder);
++                        if (this.player.getAbilities().instabuild) {
+                             flag1 = true;
+                         }
+ 
 @@ -228,6 +_,7 @@
                  i += k;
                  itemstack1.remove(DataComponents.CUSTOM_NAME);

--- a/patches/net/minecraft/world/inventory/AnvilMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AnvilMenu.java.patch
@@ -36,9 +36,9 @@
                          Enchantment enchantment = holder.value();
 -                        boolean flag1 = enchantment.canEnchant(itemstack);
 -                        if (this.player.getAbilities().instabuild || itemstack.is(Items.ENCHANTED_BOOK)) {
-+                        // Neo: Respect IItemExtension#isSupportedItemFor - we also delegate the logic for Enchanted Books to this method.
++                        // Neo: Respect IItemExtension#supportsEnchantment - we also delegate the logic for Enchanted Books to this method.
 +                        // Though we still allow creative players to combine any item with any enchantment in the anvil here.
-+                        boolean flag1 = itemstack.isSupportedItemFor(holder);
++                        boolean flag1 = itemstack.supportsEnchantment(holder);
 +                        if (this.player.getAbilities().instabuild) {
                              flag1 = true;
                          }

--- a/patches/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -5,7 +5,7 @@
      }
  
 +    /**
-+     * @deprecated Neo: Use {@link ItemStack#isSupportedItemFor(Holder)}
++     * @deprecated Neo: Use {@link ItemStack#supportsEnchantment(Holder)}
 +     */
 +    @Deprecated
      public HolderSet<Item> getSupportedItems() {
@@ -18,7 +18,7 @@
 +    /**
 +     * @deprecated Neo: Use {@link ItemStack#isPrimaryItemFor(Holder)}
 +     *
-+     * This method does not respect {@link ItemStack#isSupportedItemFor(Holder)} since the {@link Holder} is not available, which makes the result of calling it invalid.
++     * This method does not respect {@link ItemStack#supportsEnchantment(Holder)} since the {@link Holder} is not available, which makes the result of calling it invalid.
 +     */
 +    @Deprecated
      public boolean isPrimaryItem(ItemStack p_336088_) {
@@ -26,7 +26,7 @@
      }
  
 +    /**
-+     * @deprecated Neo: Use {@link ItemStack#isSupportedItemFor(Holder)}
++     * @deprecated Neo: Use {@link ItemStack#supportsEnchantment(Holder)}
 +     */
 +    @Deprecated
      public boolean isSupportedItem(ItemStack p_344865_) {
@@ -37,7 +37,7 @@
      }
  
 +    /**
-+     * @deprecated Neo: Use {@link ItemStack#isSupportedItemFor(Holder)}
++     * @deprecated Neo: Use {@link ItemStack#supportsEnchantment(Holder)}
 +     */
 +    @Deprecated
      public boolean canEnchant(ItemStack p_44689_) {

--- a/patches/net/minecraft/world/item/enchantment/Enchantment.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/Enchantment.java.patch
@@ -1,15 +1,47 @@
 --- a/net/minecraft/world/item/enchantment/Enchantment.java
 +++ b/net/minecraft/world/item/enchantment/Enchantment.java
-@@ -132,6 +_,10 @@
+@@ -124,6 +_,10 @@
+         return map;
+     }
+ 
++    /**
++     * @deprecated Neo: Use {@link ItemStack#isSupportedItemFor(Holder)}
++     */
++    @Deprecated
+     public HolderSet<Item> getSupportedItems() {
+         return this.definition.supportedItems();
+     }
+@@ -132,10 +_,20 @@
          return this.definition.slots().stream().anyMatch(p_345027_ -> p_345027_.test(p_345146_));
      }
  
 +    /**
 +     * @deprecated Neo: Use {@link ItemStack#isPrimaryItemFor(Holder)}
++     *
++     * This method does not respect {@link ItemStack#isSupportedItemFor(Holder)} since the {@link Holder} is not available, which makes the result of calling it invalid.
 +     */
 +    @Deprecated
      public boolean isPrimaryItem(ItemStack p_336088_) {
          return this.isSupportedItem(p_336088_) && (this.definition.primaryItems.isEmpty() || p_336088_.is(this.definition.primaryItems.get()));
+     }
+ 
++    /**
++     * @deprecated Neo: Use {@link ItemStack#isSupportedItemFor(Holder)}
++     */
++    @Deprecated
+     public boolean isSupportedItem(ItemStack p_344865_) {
+         return p_344865_.is(this.definition.supportedItems);
+     }
+@@ -188,6 +_,10 @@
+         return mutablecomponent;
+     }
+ 
++    /**
++     * @deprecated Neo: Use {@link ItemStack#isSupportedItemFor(Holder)}
++     */
++    @Deprecated
+     public boolean canEnchant(ItemStack p_44689_) {
+         return this.definition.supportedItems().contains(p_44689_.getItemHolder());
      }
 @@ -503,6 +_,15 @@
      public static Enchantment.Builder enchantment(Enchantment.EnchantmentDefinition p_345873_) {

--- a/patches/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java.patch
@@ -5,7 +5,7 @@
              .map(HolderSet::stream)
              .orElseGet(() -> p_80430_.getLevel().registryAccess().registryOrThrow(Registries.ENCHANTMENT).holders().map(Function.identity()))
 -            .filter(p_344686_ -> !flag1 || p_344686_.value().canEnchant(p_80429_));
-+            .filter(p_344686_ -> !flag1 || p_80429_.isSupportedItemFor(p_344686_)); // Neo: Respect IItemExtension#isSupportedItemFor
++            .filter(p_344686_ -> !flag1 || p_80429_.supportsEnchantment(p_344686_)); // Neo: Respect IItemExtension#supportsEnchantment
          List<Holder<Enchantment>> list = stream.toList();
          Optional<Holder<Enchantment>> optional = Util.getRandomSafe(list, randomsource);
          if (optional.isEmpty()) {

--- a/patches/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java
++++ b/net/minecraft/world/level/storage/loot/functions/EnchantRandomlyFunction.java
+@@ -59,7 +_,7 @@
+         Stream<Holder<Enchantment>> stream = this.options
+             .map(HolderSet::stream)
+             .orElseGet(() -> p_80430_.getLevel().registryAccess().registryOrThrow(Registries.ENCHANTMENT).holders().map(Function.identity()))
+-            .filter(p_344686_ -> !flag1 || p_344686_.value().canEnchant(p_80429_));
++            .filter(p_344686_ -> !flag1 || p_80429_.isSupportedItemFor(p_344686_)); // Neo: Respect IItemExtension#isSupportedItemFor
+         List<Holder<Enchantment>> list = stream.toList();
+         Optional<Holder<Enchantment>> optional = Util.getRandomSafe(list, randomsource);
+         if (optional.isEmpty()) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -425,7 +425,7 @@ public interface IItemExtension {
      * either from the enchantment table or other random enchantment mechanisms.
      * As a special case, books are primary items for every enchantment.
      * <p>
-     * Other application mechanisms, such as the anvil, check {@link #isSupportedItemFor(ItemStack, Holder)} instead.
+     * Other application mechanisms, such as the anvil, check {@link #supportsEnchantment(ItemStack, Holder)} instead.
      * If you want those mechanisms to be able to apply an enchantment, you will need to add your item to the relevant tag or override that method.
      *
      * @param stack       the item stack to be enchanted
@@ -433,7 +433,7 @@ public interface IItemExtension {
      * @return true if this item should be treated as a primary item for the enchantment
      * @apiNote Call via {@link IItemStackExtension#isPrimaryItemFor(Holder)}
      * 
-     * @see #isSupportedItemFor(ItemStack, Holder)
+     * @see #supportsEnchantment(ItemStack, Holder)
      */
     @ApiStatus.OverrideOnly
     default boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
@@ -441,7 +441,7 @@ public interface IItemExtension {
             return true;
         }
         Optional<HolderSet<Item>> primaryItems = enchantment.value().definition().primaryItems();
-        return this.isSupportedItemFor(stack, enchantment) && (primaryItems.isEmpty() || stack.is(primaryItems.get()));
+        return this.supportsEnchantment(stack, enchantment) && (primaryItems.isEmpty() || stack.is(primaryItems.get()));
     }
 
     /**
@@ -455,12 +455,12 @@ public interface IItemExtension {
      * @param stack       the item stack to be enchanted
      * @param enchantment the enchantment to be applied
      * @return true if this item can accept the enchantment
-     * @apiNote Call via {@link IItemStackExtension#isSupportedItemFor(Holder)}
+     * @apiNote Call via {@link IItemStackExtension#supportsEnchantment(Holder)}
      * 
      * @see #isPrimaryItemFor(ItemStack, Holder)
      */
     @ApiStatus.OverrideOnly
-    default boolean isSupportedItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
+    default boolean supportsEnchantment(ItemStack stack, Holder<Enchantment> enchantment) {
         return stack.is(Items.ENCHANTED_BOOK) || enchantment.value().isSupportedItem(stack);
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -8,11 +8,13 @@ package net.neoforged.neoforge.common.extensions;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup.RegistryLookup;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
@@ -45,6 +47,7 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantment.EnchantmentDefinition;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
@@ -422,17 +425,43 @@ public interface IItemExtension {
      * either from the enchantment table or other random enchantment mechanisms.
      * As a special case, books are primary items for every enchantment.
      * <p>
-     * Other application mechanisms, such as the anvil, check {@link Enchantment#isSupportedItem(ItemStack)} instead.
-     * If you want those mechanisms to be able to apply an enchantment, you will need to add your item to the relevant tag.
+     * Other application mechanisms, such as the anvil, check {@link #isSupportedItemFor(ItemStack, Holder)} instead.
+     * If you want those mechanisms to be able to apply an enchantment, you will need to add your item to the relevant tag or override that method.
      *
      * @param stack       the item stack to be enchanted
      * @param enchantment the enchantment to be applied
      * @return true if this item should be treated as a primary item for the enchantment
      * @apiNote Call via {@link IItemStackExtension#isPrimaryItemFor(Holder)}
+     * 
+     * @see #isSupportedItemFor(ItemStack, Holder)
      */
     @ApiStatus.OverrideOnly
     default boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
-        return stack.getItem() == Items.BOOK || enchantment.value().isPrimaryItem(stack);
+        if (stack.getItem() == Items.BOOK) {
+            return true;
+        }
+        Optional<HolderSet<Item>> primaryItems = enchantment.value().definition().primaryItems();
+        return this.isSupportedItemFor(stack, enchantment) && (primaryItems.isEmpty() || stack.is(primaryItems.get()));
+    }
+
+    /**
+     * Checks if the provided enchantment is applicable to the passed item stack.
+     * <p>
+     * By default, this checks if the {@link EnchantmentDefinition#supportedItems()} contains this item,
+     * special casing enchanted books as they may receive any enchantment.
+     * <p>
+     * Overriding this method allows for dynamic logic that would not be possible using the tag system.
+     *
+     * @param stack       the item stack to be enchanted
+     * @param enchantment the enchantment to be applied
+     * @return true if this item can accept the enchantment
+     * @apiNote Call via {@link IItemStackExtension#isSupportedItemFor(Holder)}
+     * 
+     * @see #isPrimaryItemFor(ItemStack, Holder)
+     */
+    @ApiStatus.OverrideOnly
+    default boolean isSupportedItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
+        return stack.is(Items.ENCHANTED_BOOK) || enchantment.value().isSupportedItem(stack);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -141,6 +141,13 @@ public interface IItemStackExtension {
     }
 
     /**
+     * @see {@link IItemExtension#isSupportedItemFor(ItemStack, Holder)}
+     */
+    default boolean isSupportedItemFor(Holder<Enchantment> enchantment) {
+        return self().getItem().isSupportedItemFor(self(), enchantment);
+    }
+
+    /**
      * Gets the gameplay level of the target enchantment on this stack.
      * <p>
      * Use in place of {@link EnchantmentHelper#getTagEnchantmentLevel} for gameplay logic.

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -141,10 +141,10 @@ public interface IItemStackExtension {
     }
 
     /**
-     * @see {@link IItemExtension#isSupportedItemFor(ItemStack, Holder)}
+     * @see {@link IItemExtension#supportsEnchantment(ItemStack, Holder)}
      */
-    default boolean isSupportedItemFor(Holder<Enchantment> enchantment) {
-        return self().getItem().isSupportedItemFor(self(), enchantment);
+    default boolean supportsEnchantment(Holder<Enchantment> enchantment) {
+        return self().getItem().supportsEnchantment(self(), enchantment);
     }
 
     /**


### PR DESCRIPTION
This PR adds the hook `IItemExtension#supportsEnchantment`, which is an analogue to the old `IForgeItem#canApplyAtEnchantingTable` from before the changes.  Currently, we only have `IItemExtension#isPrimaryItemFor`, which handles a portion of that functionality, but not enough to satisfy many use cases.

Closes #1397 