### PR TITLE
Implement hashCode() on Ingredient.ItemValue

### DIFF
--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -182,7 +182,7 @@
                  : ingredient$itemvalue.item.getItem().equals(this.item.getItem()) && ingredient$itemvalue.item.getCount() == this.item.getCount();
          }
  
-+        // Neo: Add a hashCode() implementation that matches equals() to avoid violating contract
++        // Neo: Add a hashCode() implementation that matches equals()
 +        @Override
 +        public int hashCode() {
 +            return 31 * item.getItem().hashCode() + item.getCount();

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -178,6 +178,19 @@
  
          @Override
          public boolean equals(Object p_301316_) {
+@@ -156,6 +_,12 @@
+                 : ingredient$itemvalue.item.getItem().equals(this.item.getItem()) && ingredient$itemvalue.item.getCount() == this.item.getCount();
+         }
+ 
++        // Neo: Add a hashCode() implementation that matches equals() to avoid violating contract
++        @Override
++        public int hashCode() {
++            return 31 * item.getItem().hashCode() + item.getCount();
++        }
++
+         @Override
+         public Collection<ItemStack> getItems() {
+             return Collections.singleton(this.item);
 @@ -163,10 +_,11 @@
      }
  


### PR DESCRIPTION
This record overrides `equals` to operate based on the item & count, but will then use the ItemStack's identity hash as its `hashCode`, which is inconsistent and will violate Java's contract.

We fix this by implementing a proper `hashCode` implementation based on the item & count.