### PR TITLE
Fix MappedRegistry not throwing exception if duplicate keys/values are registered

### DIFF
--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -22,7 +22,7 @@
      };
      private final Object tagAdditionLock = new Object();
  
-@@ -114,9 +_,17 @@
+@@ -114,15 +_,23 @@
  
      @Override
      public Holder.Reference<T> register(ResourceKey<T> p_256252_, T p_256591_, RegistrationInfo p_326235_) {
@@ -38,8 +38,16 @@
 +            throw new IllegalStateException(String.format(java.util.Locale.ENGLISH, "Invalid id %d - maximum id range of %d exceeded.", i, this.getMaxId()));
 +
          if (this.byLocation.containsKey(p_256252_.location())) {
-             Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
+-            Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
++            throw Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry")); // Neo: properly throw exception when registering duplicate keys
          }
+ 
+         if (this.byValue.containsKey(p_256591_)) {
+-            Util.pauseInIde(new IllegalStateException("Adding duplicate value '" + p_256591_ + "' to registry"));
++            throw Util.pauseInIde(new IllegalStateException("Adding duplicate value '" + p_256591_ + "' to registry")); // Neo: properly throw exception when registering duplicate values
+         }
+ 
+         Holder.Reference<T> reference;
 @@ -135,16 +_,18 @@
              reference.bindKey(p_256252_);
          } else {


### PR DESCRIPTION
Mojang's intent is to throw the exception in `MappedRegistry` when a duplicate key/value is registered, but they forgot to add the `throw` statement, which allows the game to proceed with the registration. It's highly unlikely that this is desirable behavior, since it clobbers old entries & could result in incorrect IDs being computed. This PR adds the missing `throw` statement.

(We can assume this is an oversight since almost every other use of `Util.pauseInIde` is accompanied by a `throw`.)

I have not reported the bug to Mojira since it wouldn't ever affect the unmodded game.