### PR TITLE
Fill deprecated Slimeballtag with entry again

### DIFF
--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -313,6 +313,7 @@
   "tag.item.c.seeds.wheat": "Wheat Seeds",
   "tag.item.c.shulker_boxes": "Shulker Boxes",
   "tag.item.c.slime_balls": "Slimeballs",
+  "tag.item.c.slimeballs": "Slimeballs",
   "tag.item.c.stones": "Stones",
   "tag.item.c.storage_blocks": "Storage Blocks",
   "tag.item.c.storage_blocks.bone_meal": "Bone Meal Storage Blocks",

--- a/src/generated/resources/data/c/tags/item/slimeballs.json
+++ b/src/generated/resources/data/c/tags/item/slimeballs.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:slime_ball"
+  ]
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -204,6 +204,7 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
         tag(Tags.Items.SEEDS_MELON).add(Items.MELON_SEEDS);
         tag(Tags.Items.SEEDS_PUMPKIN).add(Items.PUMPKIN_SEEDS);
         tag(Tags.Items.SEEDS_WHEAT).add(Items.WHEAT_SEEDS);
+        tag(Tags.Items.SLIMEBALLS).add(Items.SLIME_BALL); // Deprecated
         tag(Tags.Items.SLIME_BALLS).add(Items.SLIME_BALL).addOptionalTag(Tags.Items.SLIMEBALLS);
         tag(Tags.Items.SHULKER_BOXES)
                 .add(Items.SHULKER_BOX).add(Items.WHITE_SHULKER_BOX).add(Items.ORANGE_SHULKER_BOX)

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -285,6 +285,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Items.SEEDS_WHEAT, "Wheat Seeds");
         add(Tags.Items.SHULKER_BOXES, "Shulker Boxes");
         add(Tags.Items.SLIME_BALLS, "Slimeballs");
+        add(Tags.Items.SLIMEBALLS, "Slimeballs");
         add(Tags.Items.STONES, "Stones");
         add(Tags.Items.STORAGE_BLOCKS, "Storage Blocks");
         add(Tags.Items.STORAGE_BLOCKS_BONE_MEAL, "Bone Meal Storage Blocks");


### PR DESCRIPTION
Undoes accidental behavioral breaking change. Still, move to the other `c:slime_balls` tag instead