### PR TITLE
New translation format system (sjson variant)

### DIFF
--- a/patches/net/minecraft/client/resources/language/ClientLanguage.java.patch
+++ b/patches/net/minecraft/client/resources/language/ClientLanguage.java.patch
@@ -54,6 +54,19 @@
              } catch (IOException ioexception) {
                  LOGGER.warn("Failed to load translations for {} from pack {}", p_235036_, resource.sourcePackId(), ioexception);
              }
+@@ -60,6 +_,12 @@
+ 
+     @Override
+     public String getOrDefault(String p_118920_, String p_265273_) {
++        return net.neoforged.neoforge.common.text.TemplateStripper.strip(getOrDefaultRaw(p_118920_, p_265273_));
++    }
++
++    @Override
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public String getOrDefaultRaw(String p_118920_, String p_265273_) {
+         return this.storage.getOrDefault(p_118920_, p_265273_);
+     }
+ 
 @@ -76,5 +_,15 @@
      @Override
      public FormattedCharSequence getVisualOrder(FormattedText p_118925_) {

--- a/patches/net/minecraft/locale/Language.java.patch
+++ b/patches/net/minecraft/locale/Language.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/locale/Language.java
 +++ b/net/minecraft/locale/Language.java
-@@ -36,8 +_,10 @@
+@@ -36,11 +_,19 @@
      private static Language loadDefault() {
          Builder<String, String> builder = ImmutableMap.builder();
          BiConsumer<String, String> biconsumer = builder::put;
@@ -13,6 +13,15 @@
          return new Language() {
              @Override
              public String getOrDefault(String p_128127_, String p_265421_) {
++                return net.neoforged.neoforge.common.text.TemplateStripper.strip(getOrDefaultRaw(p_128127_, p_265421_));
++            }
++
++            @Override
++            @org.jetbrains.annotations.ApiStatus.Internal
++            public String getOrDefaultRaw(String p_128127_, String p_265421_) {
+                 return map.getOrDefault(p_128127_, p_265421_);
+             }
+ 
 @@ -64,21 +_,51 @@
                          )
                          .isPresent();
@@ -66,17 +75,28 @@
              String s = UNSUPPORTED_FORMAT_PATTERN.matcher(GsonHelper.convertToString(entry.getValue(), entry.getKey())).replaceAll("%$1s");
              p_128110_.accept(entry.getKey(), s);
          }
-@@ -90,6 +_,13 @@
- 
-     public static void inject(Language p_128115_) {
+@@ -92,11 +_,24 @@
          instance = p_128115_;
-+    }
-+
+     }
+ 
 +    // Neo: All helpers methods below are injected by Neo to ease modder's usage of Language
 +    public Map<String, String> getLanguageData() { return ImmutableMap.of(); }
 +
 +    public @org.jetbrains.annotations.Nullable net.minecraft.network.chat.Component getComponent(String key) {
 +        return null;
++    }
++
+     public String getOrDefault(String p_128111_) {
+         return this.getOrDefault(p_128111_, p_128111_);
      }
  
-     public String getOrDefault(String p_128111_) {
+     public abstract String getOrDefault(String p_265702_, String p_265599_);
++
++    // Neo: Bypass for the formatter
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public String getOrDefaultRaw(String p_265702_, String p_265599_) {
++        return getOrDefault(p_265702_, p_265599_);
++    }
+ 
+     public abstract boolean has(String p_128117_);
+ 

--- a/patches/net/minecraft/network/chat/contents/TranslatableContents.java.patch
+++ b/patches/net/minecraft/network/chat/contents/TranslatableContents.java.patch
@@ -14,10 +14,11 @@
      }
  
      @Override
-@@ -92,6 +_,13 @@
+@@ -92,10 +_,18 @@
          Language language = Language.getInstance();
          if (language != this.decomposedWith) {
              this.decomposedWith = language;
+-            String s = this.fallback != null ? language.getOrDefault(this.key, this.fallback) : language.getOrDefault(this.key);
 +
 +            Component langComponent = language.getComponent(this.key);
 +            if (langComponent != null) {
@@ -25,9 +26,14 @@
 +                return;
 +            }
 +
-             String s = this.fallback != null ? language.getOrDefault(this.key, this.fallback) : language.getOrDefault(this.key);
++            String s = this.fallback != null ? language.getOrDefaultRaw(this.key, this.fallback) : language.getOrDefaultRaw(this.key, this.key);
  
              try {
+                 Builder<FormattedText> builder = ImmutableList.builder();
++                s = net.neoforged.neoforge.common.text.TemplateParser.decomposeTemplate(this, this.args, s, builder::add);
+                 this.decomposeTemplate(s, builder::add);
+                 this.decomposedParts = builder.build();
+             } catch (TranslatableFormatException translatableformatexception) {
 @@ -170,6 +_,12 @@
      public <T> Optional<T> visit(FormattedText.StyledContentConsumer<T> p_237521_, Style p_237522_) {
          this.decompose();

--- a/src/main/java/net/neoforged/neoforge/common/text/TemplateParser.java
+++ b/src/main/java/net/neoforged/neoforge/common/text/TemplateParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.text;
+
+import java.util.function.Consumer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.network.chat.contents.TranslatableFormatException;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class TemplateParser extends TemplateParserBase<FormattedText> {
+    TemplateParser(String template) {
+        super(template);
+    }
+
+    public static String decomposeTemplate(TranslatableContents translatableContents, Object[] args, String template, Consumer<FormattedText> consumer) {
+        if (template.startsWith(TEMPLATE_MARKER_JSON)) {
+            try {
+                new TemplateParser(stripMarker(template)).parseJson(consumer);
+                return "";
+            } catch (ParsingException e) {
+                throw new TranslatableFormatException(translatableContents, e.getMessage());
+            }
+        }
+        return template;
+    }
+
+    @Override
+    protected void consumeComponent(Component component, Consumer<FormattedText> consumer) throws ParsingException {
+        consumer.accept(component);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/text/TemplateParserBase.java
+++ b/src/main/java/net/neoforged/neoforge/common/text/TemplateParserBase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.text;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonSyntaxException;
+import java.util.function.Consumer;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public abstract class TemplateParserBase<T> {
+    protected static final String TEMPLATE_MARKER_JSON = "%j";
+    protected static final Gson GSON = new Gson();
+
+    protected String remaining = "";
+
+    protected TemplateParserBase(String remaining) {
+        this.remaining = remaining;
+    }
+
+    protected static String stripMarker(String template) {
+        return template.replaceFirst(TEMPLATE_MARKER_JSON + ":? *", "");
+    }
+
+    protected void parseJson(Consumer<T> consumer) throws ParsingException {
+        try {
+            consumeComponent(net.minecraft.network.chat.ComponentSerialization.CODEC
+                    .parse(com.mojang.serialization.JsonOps.INSTANCE, GSON.fromJson(remaining, JsonArray.class))
+                    .getOrThrow(msg -> new ParsingException("Error parsing translation for " + remaining + ": " + msg)), consumer);
+            remaining = "";
+        } catch (JsonSyntaxException e) {
+            e.printStackTrace();
+            new ParsingException("Error parsing translation for " + remaining + ": " + e.getMessage());
+        }
+    }
+
+    protected abstract void consumeComponent(Component component, Consumer<T> consumer) throws ParsingException;
+
+    protected static class ParsingException extends RuntimeException {
+        // Note: This should extend Exception, but it is thrown through lambdas which cannot have a "throws" declaration
+        private static final long serialVersionUID = 6142968319664791595L;
+
+        ParsingException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/text/TemplateStripper.java
+++ b/src/main/java/net/neoforged/neoforge/common/text/TemplateStripper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.text;
+
+import java.util.function.Consumer;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class TemplateStripper extends TemplateParserBase<String> {
+    public TemplateStripper(String remaining) {
+        super(remaining);
+    }
+
+    public static String strip(String template) {
+        if (template.startsWith(TEMPLATE_MARKER_JSON)) {
+            try {
+                StringBuilder result = new StringBuilder();
+                new TemplateStripper(stripMarker(template)).parseJson(result::append);
+                return result.toString();
+            } catch (ParsingException e) {
+                // NOP
+            }
+        }
+        return template;
+    }
+
+    @Override
+    protected void consumeComponent(Component component, Consumer<String> consumer) throws ParsingException {
+        consumer.accept(component.getString());
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/text/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/common/text/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.common.text;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -139,51 +139,14 @@
   "neoforge.configuration.uitext.title.common": "%s Common Configuration",
   "neoforge.configuration.uitext.title.startup": "%s Startup Configuration",
 
-  "neoforge.configuration.uitext.notonline": [
-    {
-      "text": "Settings in here are determined by the server and cannot be changed while online.",
-      "color": "red"
-    }
-  ],
-  "neoforge.configuration.uitext.notlan": [
-    {
-      "text": "Settings in here cannot be edited while your game is open to LAN. Please return to the main menu and load the world again.",
-      "color": "red"
-    }
-  ],
-  "neoforge.configuration.uitext.notloaded": [
-    {
-      "text": "Settings in here are only available while a world is loaded.",
-      "color": "red"
-    }
-  ],
-  "neoforge.configuration.uitext.unsupportedelement": [
-    {
-      "text": "This value cannot be edited in the UI. Please contact the mod author about providing a custom UI for it.",
-      "color": "red"
-    }
-  ],
-  "neoforge.configuration.uitext.longstring": [
-    {
-      "text": "This value is too long to be edited in the UI. Please edit it in the config file.",
-      "color": "red"
-    }
-  ],
+  "neoforge.configuration.uitext.notonline": "%j[{\"text\":\"Settings in here are determined by the server and cannot be changed while online.\",\"color\":\"red\"}]",
+  "neoforge.configuration.uitext.notlan": "%j[{\"text\":\"Settings in here cannot be edited while your game is open to LAN. Please return to the main menu and load the world again.\",\"color\":\"red\"}]",
+  "neoforge.configuration.uitext.notloaded": "%j[{\"text\":\"Settings in here are only available while a world is loaded.\",\"color\":\"red\"}]",
+  "neoforge.configuration.uitext.unsupportedelement": "%j[{\"text\":\"This value cannot be edited in the UI. Please contact the mod author about providing a custom UI for it.\",\"color\":\"red\"}]",
+  "neoforge.configuration.uitext.longstring": "%j[{\"text\":\"This value is too long to be edited in the UI. Please edit it in the config file.\",\"color\":\"red\"}]",
   "neoforge.configuration.uitext.section": "%s...",
   "neoforge.configuration.uitext.sectiontext": "Edit",
-  "neoforge.configuration.uitext.breadcrumb": [
-    {
-      "index": 0
-    },
-    {
-      "text": " > ",
-      "color": "gold",
-      "bold": true
-    },
-    {
-      "index": 1
-    }
-  ],
+  "neoforge.configuration.uitext.breadcrumb": "%j[{\"index\": 0},{\"text\": \" > \",\"color\": \"gold\",\"bold\": true},{\"index\": 1}]",
   "neoforge.configuration.uitext.listelement": "%s:",
   "neoforge.configuration.uitext.undo": "Undo",
   "neoforge.configuration.uitext.undo.tooltip": "Reverts changes on this screen only.",
@@ -193,30 +156,8 @@
   "neoforge.configuration.uitext.listelementup": "\u23f6",
   "neoforge.configuration.uitext.listelementdown": "\u23f7",
   "neoforge.configuration.uitext.listelementremove": "\u274c",
-  "neoforge.configuration.uitext.rangetooltip": [
-    {
-      "text": "\n\nRange: ",
-      "color": "gray"
-    },
-    {
-      "index": 0,
-      "color": "gray"
-    }
-  ],
-  "neoforge.configuration.uitext.filenametooltip": [
-    {
-      "text": "File: \"",
-      "color": "gray"
-    },
-    {
-      "index": 0,
-      "color": "gray"
-    },
-    {
-      "text": "\"",
-      "color": "gray"
-    }
-  ],
+  "neoforge.configuration.uitext.rangetooltip": "%j[{\"text\": \"\\n\\nRange: \",\"color\": \"gray\"},{\"index\": 0,\"color\": \"gray\"}]",
+  "neoforge.configuration.uitext.filenametooltip": "%j[{\"text\": \"File: \\\"\",\"color\": \"gray\"},{\"index\": 0,\"color\": \"gray\"},{\"text\": \"\\\"\",\"color\": \"gray\"}]",
   "neoforge.configuration.uitext.common": "Common Options",
   "neoforge.configuration.uitext.client": "Client Options",
   "neoforge.configuration.uitext.server": "Server Options",
@@ -226,13 +167,7 @@
   "neoforge.configuration.uitext.restart.server.title": "World needs to be reloaded",
   "neoforge.configuration.uitext.restart.server.text": "One or more of the configuration option that were changed will only take effect when the world is reloaded.",
   "neoforge.configuration.uitext.restart.return": "Ignore",
-  "neoforge.configuration.uitext.restart.return.tooltip": [
-    {
-      "text": "Your changes will have no effect until you restart!",
-      "color": "red",
-      "bold": true
-    }
-  ],
+  "neoforge.configuration.uitext.restart.return.tooltip": "%j[{\"text\": \"Your changes will have no effect until you restart!\",\"color\": \"red\",\"bold\": true}]",
 
   "neoforge.configuration.title": "NeoForge Configuration",
   "neoforge.configuration.section.neoforge.client.toml": "Client settings",
@@ -256,23 +191,9 @@
   "neoforge.configgui.permissionHandler": "Permission Handler",
   "neoforge.configgui.permissionHandler.tooltip": "The permission handler used by the server. Defaults to neoforge:default_handler if no such handler with that name is registered.",
   "neoforge.configgui.removeErroringBlockEntities": "Remove Erroring Block Entities",
-  "neoforge.configgui.removeErroringBlockEntities.tooltip": [
-    "Set this to true to remove any Entity that throws an error in its update method instead of closing the server and reporting a crash log.\n\n",
-    {
-      "text": "BE WARNED THIS COULD SCREW UP EVERYTHING.\nUSE SPARINGLY.\nWE ARE NOT RESPONSIBLE FOR DAMAGES.",
-      "color": "red",
-      "bold": true
-    }
-  ],
+  "neoforge.configgui.removeErroringBlockEntities.tooltip": "%j[\"Set this to true to remove any Entity that throws an error in its update method instead of closing the server and reporting a crash log.\\n\\n\",{\"text\":\"BE WARNED THIS COULD SCREW UP EVERYTHING.\\nUSE SPARINGLY.\\nWE ARE NOT RESPONSIBLE FOR DAMAGES.\",\"color\":\"red\",\"bold\":true}]",
   "neoforge.configgui.removeErroringEntities": "Remove Erroring Entities",
-  "neoforge.configgui.removeErroringEntities.tooltip": [
-    "Set this to true to remove any BlockEntity that throws an error in its update method instead of closing the server and reporting a crash log.\n\n",
-    {
-      "text": "BE WARNED THIS COULD SCREW UP EVERYTHING.\nUSE SPARINGLY.\nWE ARE NOT RESPONSIBLE FOR DAMAGES.",
-      "color": "red",
-      "bold": true
-    }
-  ],
+  "neoforge.configgui.removeErroringEntities.tooltip": "%j[\"Set this to true to remove any BlockEntity that throws an error in its update method instead of closing the server and reporting a crash log.\\n\\n\",{\"text\":\"BE WARNED THIS COULD SCREW UP EVERYTHING.\\nUSE SPARINGLY.\\nWE ARE NOT RESPONSIBLE FOR DAMAGES.\",\"color\":\"red\",\"bold\":true}]",
   "neoforge.configgui.showLoadWarnings": "Show Load Warnings",
   "neoforge.configgui.showLoadWarnings.tooltip": "When enabled, NeoForge will show any warnings that occurred during loading.",
   "neoforge.configgui.useCombinedDepthStencilAttachment": "Use combined DEPTH_STENCIL Attachment",

--- a/tests/src/main/java/net/neoforged/neoforge/debug/resources/RichTranslationsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/resources/RichTranslationsTest.java
@@ -27,27 +27,67 @@ public class RichTranslationsTest {
     @EmptyTemplate("1x1x1")
     static void richTranslations(final DynamicTest test) {
         test.onGameTest(helper -> {
-            String arg = "Example argument";
-            Component simple = Component.translatable("rich_translations_test.simple_translation", arg);
-            Component simpleRich = Component.translatable("rich_translations_test.simple_rich_translation", arg);
+            final String arg = "Example argument";
+            final Component simple = Component.translatable("rich_translations_test.simple_translation", arg);
+            final Component simpleRich = Component.translatable("rich_translations_test.simple_rich_translation", arg);
 
             helper.assertTrue(simpleRich.getString().equals(simple.getString()), "Rich translation isn't equivalent to simple translation");
 
-            String translation = Language.getInstance().getOrDefault("rich_translations_test.simple_rich_translation");
+            final String translation = Language.getInstance().getOrDefault("rich_translations_test.simple_rich_translation");
             helper.assertTrue(
                     String.format(translation, arg).equals(simpleRich.getString()),
                     "Translatable component isn't equivalent to I18n");
 
-            Component fancy = Component.translatable("rich_translations_test.fancy_rich_translation", arg);
-            MutableBoolean foundRed = new MutableBoolean();
-            MutableBoolean foundBlue = new MutableBoolean();
+            final Component fancy = Component.translatable("rich_translations_test.fancy_rich_translation", arg);
+            final MutableBoolean foundRed = new MutableBoolean();
+            final MutableBoolean foundBlue = new MutableBoolean();
 
             fancy.visit((style, content) -> {
-                if (TextColor.fromLegacyFormat(ChatFormatting.RED).equals(style.getColor()) && content.equals("Ooo, colors!"))
+                if (TextColor.fromLegacyFormat(ChatFormatting.RED).equals(style.getColor()) && content.equals("Ooo, colors!")) {
                     foundRed.setTrue();
+                }
 
-                if (TextColor.fromLegacyFormat(ChatFormatting.BLUE).equals(style.getColor()) && content.equals(arg))
+                if (TextColor.fromLegacyFormat(ChatFormatting.BLUE).equals(style.getColor()) && content.equals(arg)) {
                     foundBlue.setTrue();
+                }
+
+                return Optional.empty();
+            }, Style.EMPTY);
+
+            helper.assertTrue(foundBlue.isTrue() && foundRed.isTrue(), "Rich translation lost colors");
+
+            helper.succeed();
+        });
+    }
+
+    @TestHolder(description = "Tests that rich translations (text json style) work properly", enabledByDefault = true)
+    @GameTest
+    @EmptyTemplate("1x1x1")
+    static void richTranslations3(final DynamicTest test) {
+        test.onGameTest(helper -> {
+            final String arg = "Example argument";
+            final Component simple = Component.translatable("rich_translations_test.simple_translation", arg);
+            final Component simpleRich = Component.translatable("rich_translations_test.simple_rich_translation3", arg);
+
+            helper.assertTrue(simpleRich.getString().equals(simple.getString()), "Rich translation isn't equivalent to simple translation");
+
+            final String translation = Language.getInstance().getOrDefault("rich_translations_test.simple_rich_translation3");
+            helper.assertTrue(
+                    String.format(translation, arg).equals(simpleRich.getString()),
+                    "Translatable component isn't equivalent to I18n");
+
+            final Component fancy = Component.translatable("rich_translations_test.fancy_rich_translation3", arg);
+            final MutableBoolean foundRed = new MutableBoolean();
+            final MutableBoolean foundBlue = new MutableBoolean();
+
+            fancy.visit((style, content) -> {
+                if (TextColor.fromLegacyFormat(ChatFormatting.RED).equals(style.getColor()) && content.equals("Ooo, colors!")) {
+                    foundRed.setTrue();
+                }
+
+                if (TextColor.fromLegacyFormat(ChatFormatting.BLUE).equals(style.getColor()) && content.equals(arg)) {
+                    foundBlue.setTrue();
+                }
 
                 return Optional.empty();
             }, Style.EMPTY);

--- a/tests/src/main/resources/assets/rich_translations_test/lang/en_us.json
+++ b/tests/src/main/resources/assets/rich_translations_test/lang/en_us.json
@@ -4,10 +4,12 @@
         "Simple non-rich translation. ",
         {"index": 0}
     ],
+    "rich_translations_test.simple_rich_translation3": "%j[\"Simple non-rich translation. \",{\"index\": 0}]",
     "rich_translations_test.fancy_rich_translation": [
         "",
         {"text": "Ooo, colors!", "color": "red"},
         " ",
         {"index": 0, "color": "blue"}
-    ]
+    ],
+    "rich_translations_test.fancy_rich_translation3": "%j[\"\",{\"text\": \"Ooo, colors!\", \"color\": \"red\"},\" \",{\"index\": 0, \"color\": \"blue\"}]"
 }


### PR DESCRIPTION
Variant of #1408 that uses textified json, something those non-programmer translators will surely be really happy to translate.

Differences:

- Dropped support for aliases
- Dropped support for proper plurals
- Dropped support for includes
- I have no idea if RGB colors, fonts and keybindings are supported as I have no idea how I would write those in json.
- No Crowdin syntax highlighting support
- Marker is `%j`
- This needs (parts of) 1134 to stay as the parameter handling is reused.

Example:

```json
  "neoforge.configuration.uitext.filenametooltip": "%j[{\"text\": \"File: \\\"\",\"color\": \"gray\"},{\"index\": 0,\"color\": \"gray\"},{\"text\": \"\\\"\",\"color\": \"gray\"}]",
```

---

PS: I intentionally kept the TemplateParserBase class structure allowing this actually to coexist with 1408. So, it's not a mutually exclusive decision. Even adding more formats, like a pure ICU MessageFormat would be possible.

I thought about extending the marker to include a format specifier and allowing custom formats to be registered...but that felt a tiny bit overengineered. But if someone thinks this a good idea, I could make a version with it. (Edit: I had some time on my hand, so I made it: [here](https://github.com/HenryLoenwind/NeoForge/commit/9d4c3ed2b494c832dd051a8e9cdee80992f02926).)