### PR TITLE
Silence logging for deprecated slimeball tag

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/TagConventionLogWarning.java
+++ b/src/main/java/net/neoforged/neoforge/common/TagConventionLogWarning.java
@@ -334,7 +334,6 @@ public final class TagConventionLogWarning {
             createForgeMapEntry(Registries.ITEM, "seeds/wheat", Tags.Items.SEEDS_WHEAT),
             createForgeMapEntry(Registries.ITEM, "shears", Tags.Items.TOOLS_SHEAR),
             createForgeMapEntry(Registries.ITEM, "slimeballs", Tags.Items.SLIME_BALLS),
-            createMapEntry(Registries.ITEM, "c", "slimeballs", Tags.Items.SLIME_BALLS),
             createForgeMapEntry(Registries.ITEM, "stone", Tags.Items.STONES),
             createForgeMapEntry(Registries.ITEM, "storage_blocks", Tags.Items.STORAGE_BLOCKS),
             createForgeMapEntry(Registries.ITEM, "storage_blocks/amethyst", "storage_blocks/amethyst"),


### PR DESCRIPTION
Error made in: 
https://github.com/neoforged/NeoForge/pull/1417

We already logged when c:slimeballs is present. With that PR above, we re-added that tag which then triggers the logging for NeoForge alone