### PR TITLE
[1.21] Allow looking up a Dimensions translated name

### DIFF
--- a/patches/net/minecraft/server/commands/ForceLoadCommand.java.patch
+++ b/patches/net/minecraft/server/commands/ForceLoadCommand.java.patch
@@ -1,0 +1,64 @@
+--- a/net/minecraft/server/commands/ForceLoadCommand.java
++++ b/net/minecraft/server/commands/ForceLoadCommand.java
+@@ -106,13 +_,13 @@
+         if (flag) {
+             p_137683_.sendSuccess(
+                 () -> Component.translatable(
+-                        "commands.forceload.query.success", Component.translationArg(chunkpos), Component.translationArg(resourcekey.location())
++                        "commands.forceload.query.success", Component.translationArg(chunkpos), serverlevel.getDescription() // Neo: Use dimension translation, if one exists
+                     ),
+                 false
+             );
+             return 1;
+         } else {
+-            throw ERROR_NOT_TICKING.create(chunkpos, resourcekey.location());
++            throw ERROR_NOT_TICKING.create(chunkpos, serverlevel.getDescription()); // Neo: Use dimension translation, if one exists
+         }
+     }
+ 
+@@ -125,15 +_,15 @@
+             String s = Joiner.on(", ").join(longset.stream().sorted().map(ChunkPos::new).map(ChunkPos::toString).iterator());
+             if (i == 1) {
+                 p_137681_.sendSuccess(
+-                    () -> Component.translatable("commands.forceload.list.single", Component.translationArg(resourcekey.location()), s), false
++                    () -> Component.translatable("commands.forceload.list.single", serverlevel.getDescription(), s), false // Neo: Use dimension translation, if one exists
+                 );
+             } else {
+                 p_137681_.sendSuccess(
+-                    () -> Component.translatable("commands.forceload.list.multiple", i, Component.translationArg(resourcekey.location()), s), false
++                    () -> Component.translatable("commands.forceload.list.multiple", i, serverlevel.getDescription(), s), false // Neo: Use dimension translation, if one exists
+                 );
+             }
+         } else {
+-            p_137681_.sendFailure(Component.translatable("commands.forceload.added.none", Component.translationArg(resourcekey.location())));
++            p_137681_.sendFailure(Component.translatable("commands.forceload.added.none", serverlevel.getDescription())); // Neo: Use dimension translation, if one exists
+         }
+ 
+         return i;
+@@ -144,7 +_,7 @@
+         ResourceKey<Level> resourcekey = serverlevel.dimension();
+         LongSet longset = serverlevel.getForcedChunks();
+         longset.forEach(p_137675_ -> serverlevel.setChunkForced(ChunkPos.getX(p_137675_), ChunkPos.getZ(p_137675_), false));
+-        p_137696_.sendSuccess(() -> Component.translatable("commands.forceload.removed.all", Component.translationArg(resourcekey.location())), true);
++        p_137696_.sendSuccess(() -> Component.translatable("commands.forceload.removed.all", serverlevel.getDescription()), true); // Neo: Use dimension translation, if one exists
+         return 0;
+     }
+ 
+@@ -189,7 +_,7 @@
+                             () -> Component.translatable(
+                                     "commands.forceload." + (p_137689_ ? "added" : "removed") + ".single",
+                                     Component.translationArg(chunkpos2),
+-                                    Component.translationArg(resourcekey.location())
++                                    serverlevel.getDescription() // Neo: Use dimension translation, if one exists
+                                 ),
+                             true
+                         );
+@@ -200,7 +_,7 @@
+                             () -> Component.translatable(
+                                     "commands.forceload." + (p_137689_ ? "added" : "removed") + ".multiple",
+                                     i3,
+-                                    Component.translationArg(resourcekey.location()),
++                                    Component.translationArg(serverlevel.getDescription()), // Neo: Use dimension translation, if one exists
+                                     Component.translationArg(chunkpos3),
+                                     Component.translationArg(chunkpos1)
+                                 ),

--- a/patches/net/minecraft/server/commands/SetSpawnCommand.java.patch
+++ b/patches/net/minecraft/server/commands/SetSpawnCommand.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/commands/SetSpawnCommand.java
++++ b/net/minecraft/server/commands/SetSpawnCommand.java
+@@ -80,7 +_,7 @@
+                         p_138652_.getY(),
+                         p_138652_.getZ(),
+                         p_138653_,
+-                        s,
++                        p_138650_.getLevel().getDescription(), // Neo: Use dimension translation, if one exists
+                         p_138651_.iterator().next().getDisplayName()
+                     ),
+                 true

--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -1,4 +1,7 @@
 {
+  "dimension.minecraft.overworld": "Overworld",
+  "dimension.minecraft.the_end": "The End",
+  "dimension.minecraft.the_nether": "The Nether",
   "tag.block.c.barrels": "Barrels",
   "tag.block.c.barrels.wooden": "Wooden Barrels",
   "tag.block.c.bookshelves": "Bookshelves",

--- a/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
@@ -14,12 +14,16 @@ import java.util.function.Supplier;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.common.extensions.ILevelExtension;
 import net.neoforged.neoforge.common.Tags;
 
 public abstract class LanguageProvider implements DataProvider {
@@ -120,5 +124,9 @@ public abstract class LanguageProvider implements DataProvider {
     public void add(String key, String value) {
         if (data.put(key, value) != null)
             throw new IllegalStateException("Duplicate translation key " + key);
+    }
+
+    public void add(ResourceKey<Level> dimension, String value) {
+        add(dimension.location().toLanguageKey(ILevelExtension.TRANSLATION_PREFIX), value);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
@@ -126,7 +126,7 @@ public abstract class LanguageProvider implements DataProvider {
             throw new IllegalStateException("Duplicate translation key " + key);
     }
 
-    public void add(ResourceKey<Level> dimension, String value) {
+    public void addDimension(ResourceKey<Level> dimension, String value) {
         add(dimension.location().toLanguageKey(ILevelExtension.TRANSLATION_PREFIX), value);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
@@ -15,7 +15,6 @@ import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.EntityType;
@@ -23,8 +22,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.neoforged.neoforge.common.extensions.ILevelExtension;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.extensions.ILevelExtension;
 
 public abstract class LanguageProvider implements DataProvider {
     private final Map<String, String> data = new TreeMap<>();

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -23,9 +23,9 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
     @Override
     protected void addTranslations() {
         // Vanilla Dimensions
-        add(Level.OVERWORLD, "Overworld");
-        add(Level.NETHER, "The Nether");
-        add(Level.END, "The End");
+        addDimension(Level.OVERWORLD, "Overworld");
+        addDimension(Level.NETHER, "The Nether");
+        addDimension(Level.END, "The End");
 
         // Blocks
         add(Tags.Blocks.BARRELS, "Barrels");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -10,6 +10,7 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.LanguageProvider;
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +22,11 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
 
     @Override
     protected void addTranslations() {
+        // Vanilla Dimensions
+        add(Level.OVERWORLD, "Overworld");
+        add(Level.NETHER, "The Nether");
+        add(Level.END, "The End");
+
         // Blocks
         add(Tags.Blocks.BARRELS, "Barrels");
         add(Tags.Blocks.BARRELS_WOODEN, "Wooden Barrels");

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -20,6 +20,14 @@ import net.neoforged.neoforge.entity.PartEntity;
 import org.jetbrains.annotations.Nullable;
 
 public interface ILevelExtension {
+    /**
+     * Prefix used for all dimension based translations
+     * <p>
+     * All dimension translations must start with this prefix,
+     * followed by the registry namespace and prefix.
+     * <p>
+     * {@code dimension.<namespace>.<path>}
+     */
     String TRANSLATION_PREFIX = "dimension";
 
     private Level self() {
@@ -138,10 +146,25 @@ public interface ILevelExtension {
      */
     default void invalidateCapabilities(ChunkPos pos) {}
 
+    /**
+     * Returns the translation key for this dimension.
+     * <p>
+     * Used when looking up the matching translation.
+     *
+     * @return Translation key used to lookup translation for this dimension.
+     * @see #TRANSLATION_PREFIX
+     */
     default String getDescriptionKey() {
         return self().dimension().location().toLanguageKey(TRANSLATION_PREFIX);
     }
 
+    /**
+     * Returns Component which looks up the matching value for {@linkplain #getDescriptionKey()},
+     * falling back to the registry name if no translation exists.
+     *
+     * @return Translated name or registry name if none exists.
+     * @see #getDescriptionKey()
+     */
     default Component getDescription() {
         return Component.translatableWithFallback(getDescriptionKey(), self().dimension().location().toString());
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -24,7 +24,7 @@ public interface ILevelExtension {
      * Prefix used for all dimension based translations
      * <p>
      * All dimension translations must start with this prefix,
-     * followed by the registry namespace and prefix.
+     * followed by the registry namespace and path.
      * <p>
      * {@code dimension.<namespace>.<path>}
      */

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILevelExtension.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.common.extensions;
 import java.util.Collection;
 import java.util.Collections;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
@@ -19,6 +20,8 @@ import net.neoforged.neoforge.entity.PartEntity;
 import org.jetbrains.annotations.Nullable;
 
 public interface ILevelExtension {
+    String TRANSLATION_PREFIX = "dimension";
+
     private Level self() {
         return (Level) this;
     }
@@ -134,4 +137,12 @@ public interface ILevelExtension {
      * but it is safe to call on any {@link Level}, without the need for an {@code instanceof} check.
      */
     default void invalidateCapabilities(ChunkPos pos) {}
+
+    default String getDescriptionKey() {
+        return self().dimension().location().toLanguageKey(TRANSLATION_PREFIX);
+    }
+
+    default Component getDescription() {
+        return Component.translatableWithFallback(getDescriptionKey(), self().dimension().location().toString());
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/server/command/DimensionsCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/DimensionsCommand.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.Registry;
@@ -34,7 +33,19 @@ class DimensionsCommand {
                     }
 
                     types.keySet().stream().sorted().forEach(key -> {
-                        ctx.getSource().sendSuccess(() -> Component.literal(key + ": " + types.get(key).stream().map(Component::getString).sorted().collect(Collectors.joining(", "))), false);
+                        ctx.getSource().sendSuccess(() -> {
+                            var component = Component.literal(key + ": ");
+                            var components = types.get(key);
+
+                            for (int i = 0; i < components.size(); i++) {
+                                component.append(components.get(i));
+
+                                if (i + 1 < components.size())
+                                    component.append(", ");
+                            }
+
+                            return component;
+                        }, false);
                     });
                     return 0;
                 });

--- a/src/main/java/net/neoforged/neoforge/server/command/DimensionsCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/DimensionsCommand.java
@@ -28,13 +28,13 @@ class DimensionsCommand {
                     ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.dimensions.list"), true);
                     final Registry<DimensionType> reg = ctx.getSource().registryAccess().registryOrThrow(Registries.DIMENSION_TYPE);
 
-                    Map<ResourceLocation, List<ResourceLocation>> types = new HashMap<>();
+                    Map<ResourceLocation, List<Component>> types = new HashMap<>();
                     for (ServerLevel dim : ctx.getSource().getServer().getAllLevels()) {
-                        types.computeIfAbsent(reg.getKey(dim.dimensionType()), k -> new ArrayList<>()).add(dim.dimension().location());
+                        types.computeIfAbsent(reg.getKey(dim.dimensionType()), k -> new ArrayList<>()).add(dim.getDescription());
                     }
 
                     types.keySet().stream().sorted().forEach(key -> {
-                        ctx.getSource().sendSuccess(() -> Component.literal(key + ": " + types.get(key).stream().map(ResourceLocation::toString).sorted().collect(Collectors.joining(", "))), false);
+                        ctx.getSource().sendSuccess(() -> Component.literal(key + ": " + types.get(key).stream().map(Component::getString).sorted().collect(Collectors.joining(", "))), false);
                     });
                     return 0;
                 });

--- a/src/main/java/net/neoforged/neoforge/server/command/TPSCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TPSCommand.java
@@ -49,7 +49,7 @@ class TPSCommand {
         final Registry<DimensionType> reg = cs.registryAccess().registryOrThrow(Registries.DIMENSION_TYPE);
         double worldTickTime = mean(times) * 1.0E-6D;
         double worldTPS = TimeUtil.MILLISECONDS_PER_SECOND / Math.max(worldTickTime, dim.tickRateManager().millisecondsPerTick());
-        cs.sendSuccess(() -> Component.translatable("commands.neoforge.tps.summary.named", dim.dimension().location().toString(), reg.getKey(dim.dimensionType()).toString(), TIME_FORMATTER.format(worldTickTime), TIME_FORMATTER.format(worldTPS)), false);
+        cs.sendSuccess(() -> Component.translatable("commands.neoforge.tps.summary.named", dim.getDescription(), reg.getKey(dim.dimensionType()).toString(), TIME_FORMATTER.format(worldTickTime), TIME_FORMATTER.format(worldTPS)), false);
 
         return 1;
     }

--- a/src/main/java/net/neoforged/neoforge/server/command/TimeSpeedCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TimeSpeedCommand.java
@@ -43,8 +43,8 @@ class TimeSpeedCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static String levelName(CommandSourceStack source) {
-        return source.getLevel().dimension().location().toLanguageKey();
+    private static Component levelName(CommandSourceStack source) {
+        return source.getLevel().getDescription();
     }
 
     private static float minutes(final float speed) {


### PR DESCRIPTION
This PR introduces a couple of new methods to `Level`, allowing for the lookup of the translation key and translated component for a given dimension. If no translation currently exists, the translated component falls back to the registry name.

The format for these translations is `dimension.<namespace>.<path>`. For example, the overworld would be `dimension.minecraft.overworld`.

Additionally, a new method has been added to `LanguageProvider` to facilitate data generation of translations for dimensions. This method takes in the dimension’s registry key and translated name.