### PR TITLE
Deprecate DummySavedData for removal and remove associated patches

### DIFF
--- a/patches/net/minecraft/world/level/storage/DimensionDataStorage.java.patch
+++ b/patches/net/minecraft/world/level/storage/DimensionDataStorage.java.patch
@@ -1,19 +1,6 @@
 --- a/net/minecraft/world/level/storage/DimensionDataStorage.java
 +++ b/net/minecraft/world/level/storage/DimensionDataStorage.java
-@@ -54,16 +_,20 @@
-     @Nullable
-     public <T extends SavedData> T get(SavedData.Factory<T> p_295091_, String p_164860_) {
-         SavedData saveddata = this.cache.get(p_164860_);
-+        if (saveddata == net.neoforged.neoforge.common.util.DummySavedData.DUMMY) return null;
-         if (saveddata == null && !this.cache.containsKey(p_164860_)) {
-             saveddata = this.readSavedData(p_295091_.deserializer(), p_295091_.type(), p_164860_);
-             this.cache.put(p_164860_, saveddata);
-+        } else if (saveddata == null) {
-+            this.cache.put(p_164860_, net.neoforged.neoforge.common.util.DummySavedData.DUMMY);
-+            return null;
-         }
- 
-         return (T)saveddata;
+@@ -63,7 +_,7 @@
      }
  
      @Nullable

--- a/src/main/java/net/neoforged/neoforge/common/util/DummySavedData.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/DummySavedData.java
@@ -5,11 +5,10 @@
 
 package net.neoforged.neoforge.common.util;
 
+import java.io.File;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.saveddata.SavedData;
-
-import java.io.File;
 
 public class DummySavedData extends SavedData {
     public static final DummySavedData DUMMY = new DummySavedData();

--- a/src/main/java/net/neoforged/neoforge/common/util/DummySavedData.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/DummySavedData.java
@@ -9,6 +9,8 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.saveddata.SavedData;
 
+import java.io.File;
+
 public class DummySavedData extends SavedData {
     public static final DummySavedData DUMMY = new DummySavedData();
 
@@ -20,5 +22,11 @@ public class DummySavedData extends SavedData {
     public CompoundTag save(final CompoundTag compound, HolderLookup.Provider provider) {
         // NOOP
         return null;
+    }
+
+    @Override
+    public void save(final File file, final HolderLookup.Provider provider) {
+        // Do nothing, because we don't want to overwrite the saved data
+        // that may already be here.
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/DummySavedData.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/DummySavedData.java
@@ -10,6 +10,12 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.saveddata.SavedData;
 
+/**
+ * A no-op {@link SavedData} implementation which does not store data.
+ * 
+ * @deprecated This type often causes more data corruption than is worth.
+ */
+@Deprecated(since = "1.21.1", forRemoval = true)
 public class DummySavedData extends SavedData {
     public static final DummySavedData DUMMY = new DummySavedData();
 


### PR DESCRIPTION
There is a potential race condition/edge case during crashes on startup which may cause data to be overwritten:
- DimensionDataStorage#get is called
  - We patch this method to save a "dummy" instance in the cache when readSavedData returns null
- An error happens elsewhere, not necessarily directly related to saving/loading
- DimensionDataStorage#readSavedData returns null
  - This could be due to an exception, thread interrupt, etc - who knows!
  - By design, on an exception it returns null and swallows the error (it is, at the very least, logged)
- The dummy instance is saved into the cache
- DimensionDataStorage#save is called because the server is crashing
  - This iterates over the members of the cache and saves them
- DummySavedData#save is called
  - This **overwrites** any data that was previously in the file!

So, to fix this we simply override the DummySavedData to not even attempt to write to the file. While this *does* mean that a corrupt file will fail to load every time on server startup and not get cleared, data will never be lost in this potential scenario.