### PR TITLE
[1.21] Fix IShearable

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -452,7 +452,7 @@
      }
  
      public void checkDespawn() {
-@@ -3449,6 +_,126 @@
+@@ -3449,6 +_,128 @@
  
      public boolean mayInteract(Level p_146843_, BlockPos p_146844_) {
          return true;
@@ -466,11 +466,13 @@
 +    @Nullable
 +    private java.util.Collection<ItemEntity> captureDrops = null;
 +
++    @Nullable
 +    @Override
 +    public java.util.Collection<ItemEntity> captureDrops() {
 +        return captureDrops;
 +    }
 +
++    @Nullable
 +    @Override
 +    public java.util.Collection<ItemEntity> captureDrops(@Nullable java.util.Collection<ItemEntity> value) {
 +        java.util.Collection<ItemEntity> ret = captureDrops;

--- a/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
+++ b/patches/net/minecraft/world/entity/animal/MushroomCow.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/MushroomCow.java
 +++ b/net/minecraft/world/entity/animal/MushroomCow.java
+@@ -108,7 +_,7 @@
+ 
+             this.playSound(soundevent, 1.0F, 1.0F);
+             return InteractionResult.sidedSuccess(this.level().isClientSide);
+-        } else if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
++        } else if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { // Neo: Shear logic is handled by IShearable
+             this.shear(SoundSource.PLAYERS);
+             this.gameEvent(GameEvent.SHEAR, p_28941_);
+             if (!this.level().isClientSide) {
 @@ -165,8 +_,10 @@
      public void shear(SoundSource p_28924_) {
          this.level().playSound(null, this, SoundEvents.MOOSHROOM_SHEAR, p_28924_, 1.0F, 1.0F);
@@ -11,7 +20,7 @@
                  ((ServerLevel)this.level()).sendParticles(ParticleTypes.EXPLOSION, this.getX(), this.getY(0.5), this.getZ(), 1, 0.0, 0.0, 0.0, 0.0);
                  this.discard();
                  cow.moveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
-@@ -185,10 +_,9 @@
+@@ -185,10 +_,13 @@
                  this.level().addFreshEntity(cow);
  
                  for (int i = 0; i < 5; i++) {
@@ -19,9 +28,13 @@
 -                        .addFreshEntity(
 -                            new ItemEntity(this.level(), this.getX(), this.getY(1.0), this.getZ(), new ItemStack(this.getVariant().blockState.getBlock()))
 -                        );
-+                    //Neo: Change from addFreshEntity to spawnAtLocation to ensure captureDrops can capture this, we also need to unset the default pickup delay from the item
-+                    ItemEntity item = spawnAtLocation(new ItemStack(this.getVariant().blockState.getBlock()), getBbHeight());
-+                    if (item != null) item.setNoPickUpDelay();
++                    // Neo: Change from addFreshEntity to spawnAtLocation to ensure captureDrops can capture this, we also need to unset the default pickup delay from the item
++                    // Vanilla uses this.getY(1.0) for the y-level, which is this.getY() + this.getBbHeight() * 1.0, so we pass the BB height as the Y-offset.
++                    ItemEntity item = spawnAtLocation(new ItemStack(this.getVariant().blockState.getBlock()), this.getBbHeight());
++                    if (item != null) {
++                        // addFreshEntity does not incur a pickup delay, while spawnAtLocation sets the default pickup delay.
++                        item.setNoPickUpDelay();
++                    }
                  }
              }
          }

--- a/patches/net/minecraft/world/entity/animal/Sheep.java.patch
+++ b/patches/net/minecraft/world/entity/animal/Sheep.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/Sheep.java
++++ b/net/minecraft/world/entity/animal/Sheep.java
+@@ -212,7 +_,7 @@
+     @Override
+     public InteractionResult mobInteract(Player p_29853_, InteractionHand p_29854_) {
+         ItemStack itemstack = p_29853_.getItemInHand(p_29854_);
+-        if (itemstack.is(Items.SHEARS)) {
++        if (false && itemstack.is(Items.SHEARS)) { // Neo: Shear logic is handled by IShearable
+             if (!this.level().isClientSide && this.readyForShearing()) {
+                 this.shear(SoundSource.PLAYERS);
+                 this.gameEvent(GameEvent.SHEAR, p_29853_);

--- a/patches/net/minecraft/world/entity/animal/SnowGolem.java.patch
+++ b/patches/net/minecraft/world/entity/animal/SnowGolem.java.patch
@@ -9,3 +9,12 @@
                  return;
              }
  
+@@ -127,7 +_,7 @@
+     @Override
+     protected InteractionResult mobInteract(Player p_29920_, InteractionHand p_29921_) {
+         ItemStack itemstack = p_29920_.getItemInHand(p_29921_);
+-        if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
++        if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { // Neo: Shear logic is handled by IShearable
+             this.shear(SoundSource.PLAYERS);
+             this.gameEvent(GameEvent.SHEAR, p_29920_);
+             if (!this.level().isClientSide) {

--- a/patches/net/minecraft/world/entity/monster/Bogged.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Bogged.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/Bogged.java
++++ b/net/minecraft/world/entity/monster/Bogged.java
+@@ -74,7 +_,7 @@
+     @Override
+     protected InteractionResult mobInteract(Player p_330736_, InteractionHand p_331786_) {
+         ItemStack itemstack = p_330736_.getItemInHand(p_331786_);
+-        if (itemstack.is(Items.SHEARS) && this.readyForShearing()) {
++        if (false && itemstack.is(Items.SHEARS) && this.readyForShearing()) { // Neo: Shear logic is handled by IShearable
+             this.shear(SoundSource.PLAYERS);
+             this.gameEvent(GameEvent.SHEAR, p_330736_);
+             if (!this.level().isClientSide) {

--- a/patches/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/net/minecraft/world/item/ShearsItem.java.patch
@@ -1,20 +1,38 @@
 --- a/net/minecraft/world/item/ShearsItem.java
 +++ b/net/minecraft/world/item/ShearsItem.java
-@@ -55,19 +_,39 @@
+@@ -54,20 +_,57 @@
+             || p_43080_.is(BlockTags.WOOL);
      }
  
-     @Override
++    /**
++     * Neo: Migrate shear behavior into {@link ShearsItem#interactLivingEntity} to call into IShearable instead of relying on {@link net.minecraft.world.entity.Mob#mobInteract}
++     * <p>
++     * To preserve vanilla behavior, this method retains the original flow shared by the various mobInteract overrides.
++     */
++    @Override
 +    public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity entity, net.minecraft.world.InteractionHand hand) {
 +        if (entity instanceof net.neoforged.neoforge.common.IShearable target) {
-+            if (entity.level().isClientSide) return InteractionResult.CONSUME;
 +            BlockPos pos = entity.blockPosition();
++            boolean isClient = entity.level().isClientSide();
++            // Check isShearable on both sides (mirrors vanilla readyForShearing())
 +            if (target.isShearable(player, stack, entity.level(), pos)) {
-+                target.onSheared(player, stack, entity.level(), pos)
-+                      .forEach(drop -> target.spawnShearedDrop(entity.level(), pos, drop));
++                // Call onSheared on both sides (mirrors vanilla shear())
++                List<ItemStack> drops = target.onSheared(player, stack, entity.level(), pos);
++                // Spawn drops on the server side using spawnShearedDrop to retain vanilla mob-specific behavior
++                if (!isClient) {
++                    for(ItemStack drop : drops) {
++                        target.spawnShearedDrop(entity.level(), pos, drop);
++                    }
++                }
++                // Call GameEvent.SHEAR on both sides
 +                entity.gameEvent(GameEvent.SHEAR, player);
-+                stack.hurtAndBreak(1, player, hand == net.minecraft.world.InteractionHand.MAIN_HAND ? net.minecraft.world.entity.EquipmentSlot.MAINHAND : net.minecraft.world.entity.EquipmentSlot.OFFHAND);
++                // Damage the shear item stack by 1 on the server side
++                if (!isClient) {
++                    stack.hurtAndBreak(1, player, LivingEntity.getSlotForHand(hand));
++                }
++                // Return sided success if the entity was shearable
++                return InteractionResult.sidedSuccess(isClient);
 +            }
-+            return InteractionResult.SUCCESS;
 +        }
 +        return InteractionResult.PASS;
 +    }
@@ -24,7 +42,7 @@
 +        return net.neoforged.neoforge.common.ItemAbilities.DEFAULT_SHEARS_ACTIONS.contains(itemAbility);
 +    }
 +
-+    @Override
+     @Override
      public InteractionResult useOn(UseOnContext p_186371_) {
          Level level = p_186371_.getLevel();
          BlockPos blockpos = p_186371_.getClickedPos();


### PR DESCRIPTION
This PR fixes the `IShearable` interface, which is currently a hot mess.  There are more changes to be made (relating to `Block` support [or lack thereof]), but those require a BC.  In any case, the changes made by this PR are as follows:

1. Re-adds the patches to `Mob#mobInteract` in implementers of `Shearable` (which are `Sheep` / `MushroomCow` / `Bogged` / `SnowGolem`). These were present in 1.20.1 and prior.
  a. These allow `IShearable` to be invoked for vanilla entities, which was the primary driver of this change. Without this, if you extend one of these classes and override `IShearble#onSheared`, your override will be ignored.
  b. This functionality is also required to support mixins to `IShearable#onSheared`, which allows contextual additions to shear behaviors (i.e. the Shear enchantments from Apotheosis).
2. Fixes the shear logic in `ShearsItem#interactLivingEntity` to match the usage pattern of vanilla.
  a. Prior to this change, clicking an entity which returned false to `isShearable` would still swing the hand, and the `onSheared` method was not being called on the client (which is stipulated by its contract).
3. Fixes some vanilla default values in `IShearable#spawnShearedDrop` which were using incorrect y-offsets.
4. Improves the documentation for `IShearable` and related patch locations.
5. Adds missing nullability annotations to `Entity#captureDrops`.