### PR TITLE
Add chorus fruit to `c:foods/fruit` tag

### DIFF
--- a/src/generated/resources/data/c/tags/item/foods/fruit.json
+++ b/src/generated/resources/data/c/tags/item/foods/fruit.json
@@ -3,6 +3,7 @@
     "minecraft:apple",
     "minecraft:golden_apple",
     "minecraft:enchanted_golden_apple",
+    "minecraft:chorus_fruit",
     "minecraft:melon_slice",
     {
       "id": "#c:foods/fruits",

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -101,7 +101,7 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
         copy(Tags.Blocks.FENCES_NETHER_BRICK, Tags.Items.FENCES_NETHER_BRICK);
         copy(Tags.Blocks.FENCES_WOODEN, Tags.Items.FENCES_WOODEN);
         tag(Tags.Items.FERTILIZERS).add(Items.BONE_MEAL);
-        tag(Tags.Items.FOODS_FRUIT).add(Items.APPLE, Items.GOLDEN_APPLE, Items.ENCHANTED_GOLDEN_APPLE).add(Items.MELON_SLICE);
+        tag(Tags.Items.FOODS_FRUIT).add(Items.APPLE, Items.GOLDEN_APPLE, Items.ENCHANTED_GOLDEN_APPLE, Items.CHORUS_FRUIT, Items.MELON_SLICE);
         tag(Tags.Items.FOODS_VEGETABLE).add(Items.CARROT, Items.GOLDEN_CARROT, Items.POTATO, Items.BEETROOT);
         tag(Tags.Items.FOODS_BERRY).add(Items.SWEET_BERRIES, Items.GLOW_BERRIES);
         tag(Tags.Items.FOODS_BREAD).add(Items.BREAD);


### PR DESCRIPTION
Chorus Fruit is an edible fruit. Therefore, should go in fruits tag

If you have a recipe that should take in fruits but not chorus fruits, use a difference ingredient to exclude chorus fruits. See `net.neoforged.neoforge.common.crafting.DifferenceIngredient` for more details.

Fabric PR: https://github.com/FabricMC/fabric/pull/4021

Closes https://github.com/neoforged/NeoForge/issues/1437