### PR TITLE
Sync server config changes to the connected clients

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -36,6 +36,7 @@ import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.internal.NeoForgeProxy;
+import net.neoforged.neoforge.network.ConfigSync;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.payload.RegistryDataMapSyncPayload;
 import net.neoforged.neoforge.registries.DataMapLoader;
@@ -83,6 +84,7 @@ public class NeoForgeEventHandler {
     @SubscribeEvent
     public void postServerTick(ServerTickEvent.Post event) {
         WorldWorkerManager.tick(false);
+        ConfigSync.syncPendingConfigs(event.getServer());
     }
 
     @SubscribeEvent

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -138,6 +138,7 @@ import net.neoforged.neoforge.fluids.crafting.display.FluidStackSlotDisplay;
 import net.neoforged.neoforge.fluids.crafting.display.FluidTagSlotDisplay;
 import net.neoforged.neoforge.forge.snapshots.ForgeSnapshotsMod;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.network.ConfigSync;
 import net.neoforged.neoforge.network.DualStackUtils;
 import net.neoforged.neoforge.registries.DataPackRegistryEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -566,6 +567,7 @@ public class NeoForgeMod {
         CONDITION_CODECS.register(modEventBus);
         GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
+        ConfigSync.registerEventListeners();
         container.registerConfig(ModConfig.Type.SERVER, NeoForgeServerConfig.SPEC);
         container.registerConfig(ModConfig.Type.COMMON, NeoForgeCommonConfig.SPEC);
         NeoForgeRegistriesSetup.setup(modEventBus);

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.config.ConfigTracker;
 import net.neoforged.fml.config.ModConfig;
@@ -95,7 +96,12 @@ public final class ConfigSync {
             for (var player : server.getPlayerList().getPlayers()) {
                 var toSync = configsToSync.get(player.connection.getConnection());
                 if (toSync == null) {
-                    throw new IllegalStateException("configsToSync should contain an entry for player " + player.getName());
+                    // null for GameTestPlayer. Should not happen for normal players though.
+                    if (player.getClass() == ServerPlayer.class) {
+                        throw new IllegalStateException("configsToSync should contain an entry for player " + player.getName());
+                    } else {
+                        continue;
+                    }
                 }
                 toSync.forEach((fileName, data) -> {
                     PacketDistributor.sendToPlayer(player, new ConfigFilePayload(fileName, data));

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -6,22 +6,46 @@
 package net.neoforged.neoforge.network;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.stream.Collectors;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
+import net.minecraft.server.MinecraftServer;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.config.ConfigTracker;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.config.ModConfigs;
+import net.neoforged.fml.event.config.ModConfigEvent;
+import net.neoforged.neoforge.network.configuration.SyncConfig;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class ConfigSync {
+    private static final Object lock = new Object();
+    /**
+     * Connection -> Config file name -> byte[] of the config serialized to TOML.
+     *
+     * <p>Pending config updates get sent to players in the PLAY phase only,
+     * but start being tracked as soon as the {@link SyncConfig} configuration task runs.
+     * This ensures that all updates during the configuration phase will eventually arrive to the clients.
+     *
+     * <p>Connections get removed when GC'ed thanks to the WeakHashMap.
+     */
+    private static final Map<Connection, Map<String, byte[]>> configsToSync = new WeakHashMap<>();
+
     private ConfigSync() {}
 
-    public static List<ConfigFilePayload> syncConfigs() {
+    public static void syncAllConfigs(ServerConfigurationPacketListener listener) {
+        synchronized (lock) {
+            configsToSync.put(listener.getConnection(), new LinkedHashMap<>());
+        }
+
         final Map<String, byte[]> configData = ModConfigs.getConfigSet(ModConfig.Type.SERVER).stream().collect(Collectors.toMap(ModConfig::getFileName, mc -> {
             try {
                 return Files.readAllBytes(mc.getFullPath());
@@ -30,9 +54,55 @@ public final class ConfigSync {
             }
         }));
 
-        return configData.entrySet().stream()
-                .map(e -> new ConfigFilePayload(e.getKey(), e.getValue()))
-                .toList();
+        for (var entry : configData.entrySet()) {
+            listener.send(new ConfigFilePayload(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    /**
+     * Registers a listener for {@link ModConfigEvent.Reloading} for all mod busses,
+     * that will sync changes to server configs to connected clients.
+     */
+    public static void registerEventListeners() {
+        for (var modContainer : ModList.get().getSortedMods()) {
+            var modBus = modContainer.getEventBus();
+            if (modBus != null) {
+                modBus.addListener(ModConfigEvent.Reloading.class, event -> {
+                    var config = event.getConfig();
+                    if (config.getType() != ModConfig.Type.SERVER) {
+                        return;
+                    }
+                    var loadedConfig = config.getLoadedConfig();
+                    if (loadedConfig == null) {
+                        return;
+                    }
+
+                    // Write config bytes and queue for syncing to all connected players.
+                    // This is harmless client-side, as the configsToSync map is either empty or full of stale connections.
+                    var bytes = loadedConfig.config().configFormat().createWriter().writeToString(loadedConfig.config()).getBytes(StandardCharsets.UTF_8);
+                    synchronized (lock) {
+                        for (var toSync : configsToSync.values()) {
+                            toSync.put(config.getFileName(), bytes);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    public static void syncPendingConfigs(MinecraftServer server) {
+        synchronized (lock) {
+            for (var player : server.getPlayerList().getPlayers()) {
+                var toSync = configsToSync.get(player.connection.getConnection());
+                if (toSync == null) {
+                    throw new IllegalStateException("configsToSync should contain an entry for player " + player.getName());
+                }
+                toSync.forEach((fileName, data) -> {
+                    PacketDistributor.sendToPlayer(player, new ConfigFilePayload(fileName, data));
+                });
+                toSync.clear();
+            }
+        }
     }
 
     public static void receiveSyncedConfig(final byte[] contents, final String fileName) {

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -49,7 +49,7 @@ public class NetworkInitialization {
         final PayloadRegistrar registrar = event.registrar("1") // Update this version if the payload semantics change.
                 .optional();
         registrar
-                .configurationToClient(
+                .commonToClient(
                         ConfigFilePayload.TYPE,
                         ConfigFilePayload.STREAM_CODEC,
                         clientHandler())

--- a/src/main/java/net/neoforged/neoforge/network/configuration/SyncConfig.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/SyncConfig.java
@@ -25,7 +25,7 @@ public record SyncConfig(ServerConfigurationPacketListener listener) implements 
 
     @Override
     public void run(Consumer<CustomPacketPayload> sender) {
-        ConfigSync.syncConfigs().forEach(sender);
+        ConfigSync.syncAllConfigs(listener);
         listener().finishCurrentTask(type());
     }
 


### PR DESCRIPTION
What the title says. All changes to server configs (because of the file watcher or a direct `.set/.save` call) are now synced to connected clients. This is done by listening to `ModConfigEvent.Reloading` for all mod busses, and sending the packet accordingly. The tracking is a bit complex due to threading concerns.