### PR TITLE
[1.21.1] Add holder overloads and presence check for client extensions registration

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent.java
@@ -5,6 +5,8 @@
 
 package net.neoforged.neoforge.client.extensions.common;
 
+import java.util.Arrays;
+import net.minecraft.core.Holder;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -34,10 +36,40 @@ public final class RegisterClientExtensionsEvent extends Event implements IModBu
     }
 
     /**
+     * Register the given {@link IClientBlockExtensions} for the given {@link Block}s
+     */
+    @SafeVarargs
+    public final void registerBlock(IClientBlockExtensions extensions, Holder<Block>... blocks) {
+        registerBlock(extensions, Arrays.stream(blocks).map(Holder::value).toArray(Block[]::new));
+    }
+
+    /**
+     * {@return whether a {@link IClientBlockExtensions} has been registered for the given {@link Block}}
+     */
+    public boolean isBlockRegistered(Block block) {
+        return ClientExtensionsManager.BLOCK_EXTENSIONS.containsKey(block);
+    }
+
+    /**
      * Register the given {@link IClientItemExtensions} for the given {@link Item}s
      */
     public void registerItem(IClientItemExtensions extensions, Item... items) {
         ClientExtensionsManager.register(extensions, ClientExtensionsManager.ITEM_EXTENSIONS, items);
+    }
+
+    /**
+     * Register the given {@link IClientItemExtensions} for the given {@link Item}s
+     */
+    @SafeVarargs
+    public final void registerItem(IClientItemExtensions extensions, Holder<Item>... items) {
+        registerItem(extensions, Arrays.stream(items).map(Holder::value).toArray(Item[]::new));
+    }
+
+    /**
+     * {@return whether a {@link IClientItemExtensions} has been registered for the given {@link Item}}
+     */
+    public boolean isItemRegistered(Item item) {
+        return ClientExtensionsManager.ITEM_EXTENSIONS.containsKey(item);
     }
 
     /**
@@ -48,9 +80,39 @@ public final class RegisterClientExtensionsEvent extends Event implements IModBu
     }
 
     /**
+     * Register the given {@link IClientMobEffectExtensions} for the given {@link MobEffect}s
+     */
+    @SafeVarargs
+    public final void registerMobEffect(IClientMobEffectExtensions extensions, Holder<MobEffect>... mobEffects) {
+        registerMobEffect(extensions, Arrays.stream(mobEffects).map(Holder::value).toArray(MobEffect[]::new));
+    }
+
+    /**
+     * {@return whether a {@link IClientMobEffectExtensions} has been registered for the given {@link MobEffect}}
+     */
+    public boolean isMobEffectRegistered(MobEffect mobEffect) {
+        return ClientExtensionsManager.MOB_EFFECT_EXTENSIONS.containsKey(mobEffect);
+    }
+
+    /**
      * Register the given {@link IClientFluidTypeExtensions} for the given {@link FluidType}s
      */
     public void registerFluidType(IClientFluidTypeExtensions extensions, FluidType... fluidTypes) {
         ClientExtensionsManager.register(extensions, ClientExtensionsManager.FLUID_TYPE_EXTENSIONS, fluidTypes);
+    }
+
+    /**
+     * Register the given {@link IClientFluidTypeExtensions} for the given {@link FluidType}s
+     */
+    @SafeVarargs
+    public final void registerFluidType(IClientFluidTypeExtensions extensions, Holder<FluidType>... fluidTypes) {
+        registerFluidType(extensions, Arrays.stream(fluidTypes).map(Holder::value).toArray(FluidType[]::new));
+    }
+
+    /**
+     * {@return whether a {@link IClientFluidTypeExtensions} has been registered for the given {@link FluidType}}
+     */
+    public boolean isFluidTypeRegistered(FluidType fluidType) {
+        return ClientExtensionsManager.FLUID_TYPE_EXTENSIONS.containsKey(fluidType);
     }
 }


### PR DESCRIPTION
This PR adds overloads for registering client extensions with `Holder`s instead of resolved registered objects and methods to check whether a client extension has already been registered for a given object. The latter is useful when one mod provides a base implementation of a block/item/etc. and needs to ensure that all instances of that base class and deriving classes have a certain client extension registered for them while optionally allowing mods to provide their own client extension if necessary. One example of this is the Diagonal Fences integration in FramedBlocks: Diagonal Fences needs to ensure that a client extension is registered for all blocks extending from its diagonal block classes to reduce the breaking particle spam caused by the higher-resolution collision box. FramedBlocks needs to be able to provide its own client extension as it needs even further control over breaking particle spawning. With the current implementation, scenarios like these lead to a crash as duplicate registration of client extensions is prohibited. The added methods can be used to solve this by having Diagonal Fences use a lower priority listener and only registering a client extension if none is present yet.