### PR TITLE
Use raw stdout stream for CrashReportExtender

### DIFF
--- a/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
+++ b/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
@@ -17,6 +17,7 @@ import net.minecraft.CrashReport;
 import net.minecraft.CrashReportCategory;
 import net.minecraft.ReportType;
 import net.minecraft.SystemReport;
+import net.minecraft.server.Bootstrap;
 import net.neoforged.fml.CrashReportCallables;
 import net.neoforged.fml.ISystemReportExtender;
 import net.neoforged.fml.ModLoadingIssue;
@@ -83,7 +84,7 @@ public class CrashReportExtender {
         } else {
             logger.fatal("Failed to save crash report");
         }
-        System.out.print(crashReport.getFriendlyReport(ReportType.CRASH));
+        Bootstrap.realStdoutPrintln(crashReport.getFriendlyReport(ReportType.CRASH));
         return file2;
     }
 }


### PR DESCRIPTION
Fixes #1475, see that issue for more context.

I opted to move back to `println`, rather than introducing a `realStdoutPrint`, because it does not seem worth it just to suppress a single newline in a situation where the game is crashing anyway.