### PR TITLE
Enhance readability of mod loading crash reports

### DIFF
--- a/patches/net/minecraft/CrashReportCategory.java.patch
+++ b/patches/net/minecraft/CrashReportCategory.java.patch
@@ -13,7 +13,7 @@
              return this.stackTrace.length;
          }
      }
-@@ -165,16 +_,16 @@
+@@ -165,16 +_,22 @@
  
          if (this.stackTrace != null && this.stackTrace.length > 0) {
              p_128169_.append("\nStacktrace:");
@@ -30,8 +30,14 @@
          return this.stackTrace;
 +    }
 +
++    /** @deprecated Neo: Use {@link #setStackTrace(StackTraceElement[])} instead. */
++    @Deprecated(forRemoval = true, since = "1.21.1")
 +    public void applyStackTrace(Throwable t) {
-+        this.stackTrace = t.getStackTrace();
++        setStackTrace(t.getStackTrace());
++    }
++
++    public void setStackTrace(StackTraceElement[] stackTrace) {
++        this.stackTrace = stackTrace;
      }
  
      public static void populateBlockDetails(CrashReportCategory p_178951_, LevelHeightAccessor p_178952_, BlockPos p_178953_, @Nullable BlockState p_178954_) {

--- a/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
+++ b/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
@@ -61,7 +61,7 @@ public class CrashReportExtender {
         final CrashReport crashReport = CrashReport.forThrowable(new ModLoadingCrashException("Mod loading has failed"), "Mod loading failures have occurred; consult the issue messages for more details");
         for (var issue : issues) {
             final Optional<IModInfo> modInfo = Optional.ofNullable(issue.affectedMod());
-            final CrashReportCategory category = crashReport.addCategory(modInfo.map(iModInfo -> "Mod: " + iModInfo.getModId()).orElse("Mod loading issue"));
+            final CrashReportCategory category = crashReport.addCategory(modInfo.map(iModInfo -> "Mod loading issue for: " + iModInfo.getModId()).orElse("Mod loading issue"));
             Throwable cause = issue.cause();
             int depth = 0;
             while (cause != null && cause.getCause() != null && cause.getCause() != cause) {

--- a/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
+++ b/src/main/java/net/neoforged/neoforge/logging/CrashReportExtender.java
@@ -60,7 +60,7 @@ public class CrashReportExtender {
         final CrashReport crashReport = CrashReport.forThrowable(new ModLoadingCrashException("Mod loading has failed"), "Mod loading failures have occurred; consult the issue messages for more details");
         for (var issue : issues) {
             final Optional<IModInfo> modInfo = Optional.ofNullable(issue.affectedMod());
-            final CrashReportCategory category = crashReport.addCategory(modInfo.map(iModInfo -> "MOD " + iModInfo.getModId()).orElse("NO MOD INFO AVAILABLE"));
+            final CrashReportCategory category = crashReport.addCategory(modInfo.map(iModInfo -> "Mod: " + iModInfo.getModId()).orElse("Mod loading issue"));
             Throwable cause = issue.cause();
             int depth = 0;
             while (cause != null && cause.getCause() != null && cause.getCause() != cause) {
@@ -73,15 +73,15 @@ public class CrashReportExtender {
                 category.setStackTrace(cause.getStackTrace());
             else
                 category.setStackTrace(BLANK_STACK_TRACE);
-            category.setDetail("Mod File", () -> modInfo.map(IModInfo::getOwningFile).map(t -> t.getFile().getFilePath().toUri().getPath()).orElse("NO FILE INFO"));
+            category.setDetail("Mod file", () -> modInfo.map(IModInfo::getOwningFile).map(t -> t.getFile().getFilePath().toUri().getPath()).orElse("<No mod information provided>"));
             category.setDetail("Failure message", () -> issue.translationKey().replace("\n", "\n\t\t"));
             for (int i = 0; i < issue.translationArgs().size(); i++) {
                 var arg = issue.translationArgs().get(i);
                 category.setDetail("Failure message arg " + (i + 1), () -> arg.toString().replace("\n", "\n\t\t"));
             }
-            category.setDetail("Mod Version", () -> modInfo.map(IModInfo::getVersion).map(Object::toString).orElse("NO MOD INFO AVAILABLE"));
-            category.setDetail("Mod Issue URL", () -> modInfo.map(IModInfo::getOwningFile).map(IModFileInfo.class::cast).flatMap(mfi -> mfi.getConfig().<String>getConfigElement("issueTrackerURL")).orElse("NOT PROVIDED"));
-            category.setDetail("Exception message", Objects.toString(cause, "MISSING EXCEPTION MESSAGE"));
+            category.setDetail("Mod version", () -> modInfo.map(IModInfo::getVersion).map(Object::toString).orElse("<No mod information provided>"));
+            category.setDetail("Mod issues URL", () -> modInfo.map(IModInfo::getOwningFile).map(IModFileInfo.class::cast).flatMap(mfi -> mfi.getConfig().<String>getConfigElement("issueTrackerURL")).orElse("<No issues URL found>"));
+            category.setDetail("Exception message", Objects.toString(cause, "<No associated exception found>"));
         }
         final File file1 = new File(topLevelDir, "crash-reports");
         final File file2 = new File(file1, "crash-" + (new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss")).format(new Date()) + "-fml.txt");


### PR DESCRIPTION
This PR enhances the readability of mod loading crash reports (as dumped by `CrashReportExtender#dumpModLoadingCrashReport`) by doing the following set of cleanups:

- The 'root' exception of the crash report, which is a mere dummy that has no bearing on the actual contents of the report since the issues are added as categories ("issue-category", for the sake of discussion), was changed to have no stacktrace.
- The stacktrace in each issue-category will now only appear if the loading issue itself contains a stacktrace.
- The detail messages and title of the issue-categories were changed to remove the use of all-caps and be more sentence-like in form. To avoid confusion with actual information from the loading issue, the placeholders are surrounded in angle brackets `<like so>`.
- The failure message is now translated (into English, since crash reports are unlocalized) from the original translation key to an actual human-readable message. The previous behavior (of using the translation key as-is and the translation arguments) are kept as a fallback if translation should fail due to some kind of exception.

For comparison, here are two crash reports, one made without this PR's changes and one made with this PR's changes:

- [crash-before-pr.txt](https://github.com/user-attachments/files/16715806/crash-before-pr.txt)
- [crash-after-pr.txt](https://github.com/user-attachments/files/16715807/crash-after-pr.txt)

For a quick visual demonstration, here's the two reports side-by-side (left being the old, right being the new), with the first 78 lines visible: (Notice how the System Details is actually visible in the new crash report.)

![Screenshot of the two crash reports visible side-by-side](https://github.com/user-attachments/assets/3564e155-a2dc-4663-8b6c-56678bd138d7)

> The following was the code inserted into `ClientModLoader#completeModLoading` to induce the creation of those crash reports:
```java
error = new ModLoadingException(List.of(
                ModLoadingIssue.error("Something terrible happened.").withAffectedMod(ModList.get().getModContainerById("minecraft").get().getModInfo()),
                ModLoadingIssue.error("fml.modloadingissue.discouragedmod", "beep", "boop", "", "reason", "test"),
                ModLoadingIssue.warning("An issue with an exception")
                        .withCause(new Exception("Dummy exception"))));
```