### PR TITLE
Deprecate `BlockItem#removeFromBlockToItemMap` for removal

### DIFF
--- a/patches/net/minecraft/world/item/BlockItem.java.patch
+++ b/patches/net/minecraft/world/item/BlockItem.java.patch
@@ -31,12 +31,14 @@
      @Nullable
      public BlockPlaceContext updatePlacementContext(BlockPlaceContext p_40609_) {
          return p_40609_;
-@@ -193,6 +_,10 @@
+@@ -193,6 +_,12 @@
  
      public void registerBlocks(Map<Block, Item> p_40607_, Item p_40608_) {
          p_40607_.put(this.getBlock(), p_40608_);
 +    }
 +
++    /** @deprecated Neo: To be removed without replacement since registry replacement is not a feature anymore. */
++    @Deprecated(forRemoval = true, since = "1.21.1")
 +    public void removeFromBlockToItemMap(Map<Block, Item> blockToItemMap, Item itemIn) {
 +        blockToItemMap.remove(this.getBlock());
      }

--- a/patches/net/minecraft/world/item/Items.java.patch
+++ b/patches/net/minecraft/world/item/Items.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/Items.java
 +++ b/net/minecraft/world/item/Items.java
-@@ -2092,11 +_,23 @@
+@@ -2092,11 +_,25 @@
      }
  
      public static Item registerBlock(Block p_252092_, Block... p_248886_) {
@@ -17,6 +17,8 @@
 -        for (Block block : p_248886_) {
 -            Item.BY_BLOCK.put(block, blockitem);
 -        }
++            /** @deprecated Neo: To be removed without replacement since registry replacement is not a feature anymore. */
++            @Deprecated(forRemoval = true, since = "1.21.1")
 +            @Override
 +            public void removeFromBlockToItemMap(java.util.Map<Block, Item> map, Item self) {
 +                super.removeFromBlockToItemMap(map, self);

--- a/patches/net/minecraft/world/item/StandingAndWallBlockItem.java.patch
+++ b/patches/net/minecraft/world/item/StandingAndWallBlockItem.java.patch
@@ -1,10 +1,12 @@
 --- a/net/minecraft/world/item/StandingAndWallBlockItem.java
 +++ b/net/minecraft/world/item/StandingAndWallBlockItem.java
-@@ -50,4 +_,9 @@
+@@ -50,4 +_,11 @@
          super.registerBlocks(p_43252_, p_43253_);
          p_43252_.put(this.wallBlock, p_43253_);
      }
 +
++    /** @deprecated Neo: To be removed without replacement since registry replacement is not a feature anymore. */
++    @Deprecated(forRemoval = true, since = "1.21.1")
 +    public void removeFromBlockToItemMap(Map<Block, Item> blockToItemMap, Item itemIn) {
 +        super.removeFromBlockToItemMap(blockToItemMap, itemIn);
 +        blockToItemMap.remove(this.wallBlock);


### PR DESCRIPTION
This PR marks `BlockItem#removeFromBlockToItemMap` as deprecated for removal, which will be done when breaking changes are next allowed. I expect the impact of this removal to be minimal.

This method and its two descendants was added in MinecraftForge/MinecraftForge/pull/5922 when registry replacement was still a supported feature, and when replacing a block also needed any related block items to be removed from the block-to-item map. As we no longer support registry replacement, we no longer need this family of methods.