### PR TITLE
Optimised ItemDecorationHandler for the default case

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
+++ b/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
@@ -20,13 +20,16 @@ import net.neoforged.neoforge.client.event.RegisterItemDecorationsEvent;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-public final class ItemDecoratorHandler {
+public class ItemDecoratorHandler {
     private final List<IItemDecorator> itemDecorators;
     private final GlStateBackup stateBackup = new GlStateBackup();
 
     private static Map<Item, ItemDecoratorHandler> DECORATOR_LOOKUP = ImmutableMap.of();
 
-    private static final ItemDecoratorHandler EMPTY = new ItemDecoratorHandler();
+    private static final ItemDecoratorHandler EMPTY = new ItemDecoratorHandler() {
+        public void render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
+        }
+    };
 
     private ItemDecoratorHandler() {
         this.itemDecorators = ImmutableList.of();


### PR DESCRIPTION
In 99+% of cases, there is no registered IItemDecorator, so shaving off a couple of ns when rendering a GUI ItemStack makes sense in my opinion. Especially when it can be done so cheaply.

BTW: Carrying around a GlStateBackup for each item with a decorator instead of a ThreadLocal one seems overkill and wasteful, but it probably is inconsequential given the low number of items with decorators. Unless there are mods that decorate all items? Then it'd be worth changing. (But in that case, a way to register one decorator for all items would be even more sensible.)