### PR TITLE
[1.21] Implement common networking with config tasks

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -36,12 +36,12 @@
 +        }
 +
 +        if (p_295727_.payload() instanceof net.neoforged.neoforge.network.payload.CommonVersionPayload commonVersionPayload) {
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.checkCommonVersion(this.getConnection(), commonVersionPayload);
++            net.neoforged.neoforge.network.registration.NetworkRegistry.checkCommonVersion(this, commonVersionPayload);
 +            return;
 +        }
 +
 +        if (p_295727_.payload() instanceof net.neoforged.neoforge.network.payload.CommonRegisterPayload commonRegisterPayload) {
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.onCommonRegister(this.getConnection(), commonRegisterPayload);
++            net.neoforged.neoforge.network.registration.NetworkRegistry.onCommonRegister(this, commonRegisterPayload);
 +            return;
 +        }
 +

--- a/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -36,12 +36,12 @@
 +        }
 +
 +        if (p_294276_.payload() instanceof net.neoforged.neoforge.network.payload.CommonVersionPayload commonVersionPayload) {
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.checkCommonVersion(this.getConnection(), commonVersionPayload);
++            net.neoforged.neoforge.network.registration.NetworkRegistry.checkCommonVersion(this, commonVersionPayload);
 +            return;
 +        }
 +
 +        if (p_294276_.payload() instanceof net.neoforged.neoforge.network.payload.CommonRegisterPayload commonRegisterPayload) {
-+            net.neoforged.neoforge.network.registration.NetworkRegistry.onCommonRegister(this.getConnection(), commonRegisterPayload);
++            net.neoforged.neoforge.network.registration.NetworkRegistry.onCommonRegister(this, commonRegisterPayload);
 +            return;
 +        }
 +

--- a/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
@@ -12,10 +12,14 @@ import net.minecraft.server.network.config.SynchronizeRegistriesTask;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.network.configuration.CheckExtensibleEnums;
+import net.neoforged.neoforge.network.configuration.CommonRegisterTask;
+import net.neoforged.neoforge.network.configuration.CommonVersionTask;
 import net.neoforged.neoforge.network.configuration.RegistryDataMapNegotiation;
 import net.neoforged.neoforge.network.configuration.SyncConfig;
 import net.neoforged.neoforge.network.configuration.SyncRegistries;
 import net.neoforged.neoforge.network.event.RegisterConfigurationTasksEvent;
+import net.neoforged.neoforge.network.payload.CommonRegisterPayload;
+import net.neoforged.neoforge.network.payload.CommonVersionPayload;
 import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
@@ -39,12 +43,18 @@ public class ConfigurationInitialization {
 
     @SubscribeEvent
     private static void configureModdedClient(RegisterConfigurationTasksEvent event) {
-        if (event.getListener().hasChannel(ConfigFilePayload.TYPE)) {
-            event.register(new SyncConfig(event.getListener()));
+        ServerConfigurationPacketListener listener = event.getListener();
+        if (listener.hasChannel(CommonVersionPayload.TYPE) && listener.hasChannel(CommonRegisterPayload.TYPE)) {
+            event.register(new CommonVersionTask());
+            event.register(new CommonRegisterTask());
+        }
+
+        if (listener.hasChannel(ConfigFilePayload.TYPE)) {
+            event.register(new SyncConfig(listener));
         }
 
         //These two can always be registered they detect the listener connection type internally and will skip themselves.
-        event.register(new RegistryDataMapNegotiation(event.getListener()));
-        event.register(new CheckExtensibleEnums(event.getListener()));
+        event.register(new RegistryDataMapNegotiation(listener));
+        event.register(new CheckExtensibleEnums(listener));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/configuration/CommonRegisterTask.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/CommonRegisterTask.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.configuration;
+
+import java.util.function.Consumer;
+import net.minecraft.network.ConnectionProtocol;
+import net.minecraft.network.protocol.PacketFlow;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.network.payload.CommonRegisterPayload;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Common Register configuration task. After completion of {@link CommonVersionTask}, sends a {@link CommonRegisterPayload} to the client
+ * containing all known serverbound channels, and awaits a response containing the client's known clientbound channels.
+ */
+@ApiStatus.Internal
+public record CommonRegisterTask() implements ICustomConfigurationTask {
+    public static final Type TYPE = new Type(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "common_register"));
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    public void run(Consumer<CustomPacketPayload> sender) {
+        // There is currently no implementation for a version handshake, and the only existing version is 1, so we only send 1.
+        // Version negotiation will have to be implemented properly if a version 2 is ever added.
+        sender.accept(new CommonRegisterPayload(1, ConnectionProtocol.PLAY, NetworkRegistry.getCommonPlayChannels(PacketFlow.SERVERBOUND)));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/configuration/CommonVersionTask.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/CommonVersionTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.configuration;
+
+import java.util.function.Consumer;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.network.payload.CommonVersionPayload;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Common Version configuration task. Initiated after registry sync to begin the c:register handshake.
+ * The server will start the task, send c:version to the client, and await a reply. Upon reply, we transition to {@link CommonRegisterTask}.
+ */
+@ApiStatus.Internal
+public record CommonVersionTask() implements ICustomConfigurationTask {
+    public static final Type TYPE = new Type(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "common_version"));
+
+    @Override
+    public Type type() {
+        return TYPE;
+    }
+
+    @Override
+    public void run(Consumer<CustomPacketPayload> sender) {
+        sender.accept(new CommonVersionPayload());
+    }
+}


### PR DESCRIPTION
This PR changes the common networking approach to use configuration tasks instead of simply sending the packets during connection init. This aligns with the expectations set by fabric in https://github.com/FabricMC/fabric/pull/3244.

Fixes #1473 