### PR TITLE
[1.21] Fix PayloadRegistrar constructor not copying the handler thread

### DIFF
--- a/src/main/java/net/neoforged/neoforge/network/registration/PayloadRegistrar.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/PayloadRegistrar.java
@@ -35,6 +35,7 @@ public class PayloadRegistrar {
     private PayloadRegistrar(PayloadRegistrar source) {
         this.version = source.version;
         this.optional = source.optional;
+        this.thread = source.thread;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the `PayloadRegistrar` copy constructor not copying over the configured `HandlerThread`, which causes it to reset to the main thread when the registrar's version is changed or it is marked as optional.