### PR TITLE
Fix rare NPE in CapabilityListenerHolder

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityListenerHolder.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityListenerHolder.java
@@ -93,6 +93,8 @@ public class CapabilityListenerHolder {
                 continue;
 
             var set = chunkHolder.get(ref.pos.asLong());
+            if (set == null)
+                continue;
             // We might remove a different garbage-collected reference,
             // or we might remove nothing if the reference was already removed.
             // Because the hash codes will match, that is fine.


### PR DESCRIPTION
Fixes #1467. Thanks to shartte for finding the cause of the issue.

It's possible that the set is null because of previous cleanup. Same reason why there are the other null checks.