### PR TITLE
(1.21.x) feat: Add dropShadow support to drawCenteredString and drawScrollingString

### DIFF
--- a/patches/net/minecraft/client/gui/components/AbstractWidget.java.patch
+++ b/patches/net/minecraft/client/gui/components/AbstractWidget.java.patch
@@ -9,13 +9,19 @@
      private static final double PERIOD_PER_SCROLLED_PIXEL = 0.5;
      private static final double MIN_SCROLL_PERIOD = 3.0;
      protected int width;
-@@ -91,13 +_,19 @@
+@@ -91,13 +_,25 @@
      protected abstract void renderWidget(GuiGraphics p_282139_, int p_268034_, int p_268009_, float p_268085_);
  
      public static void renderScrollingString(
 +            GuiGraphics p_281620_, Font p_282651_, Component p_281467_, int p_283621_, int p_282084_, int p_283398_, int p_281938_, int p_283471_, boolean dropShadow
 +    ) {
 +        renderScrollingString(p_281620_, p_282651_, p_281467_, (p_283621_ + p_283398_) / 2, p_283621_, p_282084_, p_283398_, p_281938_, p_283471_, dropShadow);
++    }
++
++    public static void renderScrollingString(
++            GuiGraphics p_296355_, Font p_295317_, Component p_294875_, int p_294289_, int p_295475_, int p_294243_, int p_296428_, int p_294696_, int p_295687_
++    ){
++        renderScrollingString(p_296355_, p_295317_, p_294875_, p_294289_, p_295475_, p_294243_, p_296428_, p_294696_, p_295687_, true);
 +    }
 +
 +    public static void renderScrollingString(

--- a/patches/net/minecraft/client/gui/components/AbstractWidget.java.patch
+++ b/patches/net/minecraft/client/gui/components/AbstractWidget.java.patch
@@ -9,6 +9,42 @@
      private static final double PERIOD_PER_SCROLLED_PIXEL = 0.5;
      private static final double MIN_SCROLL_PERIOD = 3.0;
      protected int width;
+@@ -91,13 +_,19 @@
+     protected abstract void renderWidget(GuiGraphics p_282139_, int p_268034_, int p_268009_, float p_268085_);
+ 
+     public static void renderScrollingString(
++            GuiGraphics p_281620_, Font p_282651_, Component p_281467_, int p_283621_, int p_282084_, int p_283398_, int p_281938_, int p_283471_, boolean dropShadow
++    ) {
++        renderScrollingString(p_281620_, p_282651_, p_281467_, (p_283621_ + p_283398_) / 2, p_283621_, p_282084_, p_283398_, p_281938_, p_283471_, dropShadow);
++    }
++
++    public static void renderScrollingString(
+         GuiGraphics p_281620_, Font p_282651_, Component p_281467_, int p_283621_, int p_282084_, int p_283398_, int p_281938_, int p_283471_
+     ) {
+-        renderScrollingString(p_281620_, p_282651_, p_281467_, (p_283621_ + p_283398_) / 2, p_283621_, p_282084_, p_283398_, p_281938_, p_283471_);
++        renderScrollingString(p_281620_, p_282651_, p_281467_, (p_283621_ + p_283398_) / 2, p_283621_, p_282084_, p_283398_, p_281938_, p_283471_, true);
+     }
+ 
+     public static void renderScrollingString(
+-        GuiGraphics p_296355_, Font p_295317_, Component p_294875_, int p_294289_, int p_295475_, int p_294243_, int p_296428_, int p_294696_, int p_295687_
++        GuiGraphics p_296355_, Font p_295317_, Component p_294875_, int p_294289_, int p_295475_, int p_294243_, int p_296428_, int p_294696_, int p_295687_, boolean dropShadow
+     ) {
+         int i = p_295317_.width(p_294875_);
+         int j = (p_294243_ + p_294696_ - 9) / 2 + 1;
+@@ -109,11 +_,11 @@
+             double d2 = Math.sin((Math.PI / 2) * Math.cos((Math.PI * 2) * d0 / d1)) / 2.0 + 0.5;
+             double d3 = Mth.lerp(d2, 0.0, (double)l);
+             p_296355_.enableScissor(p_295475_, p_294243_, p_296428_, p_294696_);
+-            p_296355_.drawString(p_295317_, p_294875_, p_295475_ - (int)d3, j, p_295687_);
++            p_296355_.drawString(p_295317_, p_294875_, p_295475_ - (int)d3, j, p_295687_, dropShadow);
+             p_296355_.disableScissor();
+         } else {
+             int i1 = Mth.clamp(p_294289_, p_295475_ + i / 2, p_296428_ - i / 2);
+-            p_296355_.drawCenteredString(p_295317_, p_294875_, i1, j, p_295687_);
++            p_296355_.drawCenteredString(p_295317_, p_294875_, i1, j, p_295687_, dropShadow);
+         }
+     }
+ 
 @@ -123,6 +_,8 @@
          renderScrollingString(p_281857_, p_282790_, this.getMessage(), i, this.getY(), j, this.getY() + this.getHeight(), p_282944_);
      }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension.java
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.FormattedCharSequence;
 
 /**
  * Extension interface for {@link GuiGraphics}.
@@ -142,6 +143,19 @@ public interface IGuiGraphicsExtension {
         }
 
         self().blit(texture, x, y, boundsWidth, boundsHeight, 0.0f, 0.0f, rectWidth, rectHeight, rectWidth, rectHeight);
+    }
+
+    default void drawCenteredString(Font font, String string, int x, int y, int color, boolean dropShadow) {
+        self().drawString(font, string, x - font.width(string) / 2, y, color, dropShadow);
+    }
+
+    default void drawCenteredString(Font font, Component p_282456_, int x, int y, int color, boolean dropShadow) {
+        FormattedCharSequence formattedcharsequence = p_282456_.getVisualOrderText();
+        self().drawString(font, formattedcharsequence, x - font.width(formattedcharsequence) / 2, y, color, dropShadow);
+    }
+
+    default void drawCenteredString(Font font, FormattedCharSequence p_281854_, int x, int y, int color, boolean dropShadow) {
+        self().drawString(font, p_281854_, x - font.width(p_281854_) / 2, y, color, dropShadow);
     }
 
     // TODO: 1.20.2: do we need to fix these or can we just remove them?

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension.java
@@ -40,12 +40,21 @@ public interface IGuiGraphicsExtension {
      * @return the rendered width of the string, never more than {@code maxX - minX}
      */
     default int drawScrollingString(Font font, Component text, int minX, int maxX, int y, int color) {
+        return drawScrollingString(font, text, minX, maxX, y, color, true);
+    }
+
+    /**
+     * Draws a left-aligned string, with a scrolling effect if the string is too long.
+     *
+     * @return the rendered width of the string, never more than {@code maxX - minX}
+     */
+    default int drawScrollingString(Font font, Component text, int minX, int maxX, int y, int color, boolean dropShadow) {
         int maxWidth = maxX - minX;
         int textWidth = font.width(text.getVisualOrderText());
         if (textWidth <= maxWidth) {
             return self().drawString(font, text, minX, y, color);
         } else {
-            AbstractWidget.renderScrollingString(self(), font, text, minX, y, maxX, y + font.lineHeight, color);
+            AbstractWidget.renderScrollingString(self(), font, text, minX, y, maxX, y + font.lineHeight, color, dropShadow);
             return maxWidth;
         }
     }


### PR DESCRIPTION
* Copies the vanilla `drawCenteredString` methods and adds a dropShadow param, as vanilla does not expose it. 
* Adds overloads to supply a dropShadow boolean for renderScrollingString and drawScrollingString