### PR TITLE
[21.1] Pass along interaction had to ItemStack.onEntitySwing

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -440,7 +440,7 @@
  
      public void swing(InteractionHand p_21012_, boolean p_21013_) {
 +        ItemStack stack = this.getItemInHand(p_21012_);
-+        if (!stack.isEmpty() && stack.onEntitySwing(this)) return;
++        if (!stack.isEmpty() && stack.onEntitySwing(this, p_21012_)) return;
          if (!this.swinging || this.swingTime >= this.getCurrentSwingDuration() / 2 || this.swingTime < 0) {
              this.swingTime = -1;
              this.swinging = true;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -337,7 +337,7 @@ public interface IItemExtension {
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.
-     * @return True to cancel any further processing by {@linkplain LivingEntity}
+     * @return True to cancel any further processing by {@link LivingEntity}
      * @deprecated To be replaced with hand sensitive version in 21.2
      * @see #onEntitySwing(ItemStack, LivingEntity, InteractionHand)
      */
@@ -350,7 +350,7 @@ public interface IItemExtension {
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.
-     * @return True to cancel any further processing by {@linkplain LivingEntity}
+     * @return True to cancel any further processing by {@link LivingEntity}
      */
     default boolean onEntitySwing(ItemStack stack, LivingEntity entity, InteractionHand hand) {
         return onEntitySwing(stack, entity);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -337,10 +337,11 @@ public interface IItemExtension {
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.
-     * @return True to cancel any further processing by EntityLiving
+     * @return True to cancel any further processing by {@linkplain LivingEntity}
      * @deprecated To be replaced with hand sensitive version in 21.2
      * @see #onEntitySwing(ItemStack, LivingEntity, InteractionHand)
      */
+    @Deprecated(forRemoval = true, since = "21.1")
     default boolean onEntitySwing(ItemStack stack, LivingEntity entity) {
         return false;
     }
@@ -349,7 +350,7 @@ public interface IItemExtension {
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.
-     * @return True to cancel any further processing by EntityLiving
+     * @return True to cancel any further processing by {@linkplain LivingEntity}
      */
     default boolean onEntitySwing(ItemStack stack, LivingEntity entity, InteractionHand hand) {
         return onEntitySwing(stack, entity);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -21,6 +21,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
@@ -337,9 +338,21 @@ public interface IItemExtension {
      *
      * @param entity The entity swinging the item.
      * @return True to cancel any further processing by EntityLiving
+     * @deprecated To be replaced with hand sensitive version in 21.2
+     * @see #onEntitySwing(ItemStack, LivingEntity, InteractionHand)
      */
     default boolean onEntitySwing(ItemStack stack, LivingEntity entity) {
         return false;
+    }
+
+    /**
+     * Called when a entity tries to play the 'swing' animation.
+     *
+     * @param entity The entity swinging the item.
+     * @return True to cancel any further processing by EntityLiving
+     */
+    default boolean onEntitySwing(ItemStack stack, LivingEntity entity, InteractionHand hand) {
+        return onEntitySwing(stack, entity);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -218,7 +218,7 @@ public interface IItemStackExtension {
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.
-     * @return True to cancel any further processing by EntityLiving
+     * @return True to cancel any further processing by {@linkplain LivingEntity}
      * @deprecated To be replaced with hand sensitive version in 21.2
      * @see #onEntitySwing(LivingEntity, InteractionHand)
      */
@@ -232,7 +232,7 @@ public interface IItemStackExtension {
      *
      * @param entity The entity swinging the item.
      * @param hand   The hand the item is held in.
-     * @return True to cancel any further processing by EntityLiving
+     * @return True to cancel any further processing by {@linkplain LivingEntity}
      */
     default boolean onEntitySwing(LivingEntity entity, InteractionHand hand) {
         return self().getItem().onEntitySwing(self(), entity, hand);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -12,6 +12,7 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.stats.Stats;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
@@ -218,9 +219,23 @@ public interface IItemStackExtension {
      *
      * @param entity The entity swinging the item.
      * @return True to cancel any further processing by EntityLiving
+     * @deprecated To be replaced with hand sensitive version in 21.2
+     * @see #onEntitySwing(LivingEntity, InteractionHand)
      */
+    @Deprecated(forRemoval = true, since = "21.1")
     default boolean onEntitySwing(LivingEntity entity) {
         return self().getItem().onEntitySwing(self(), entity);
+    }
+
+    /**
+     * Called when a entity tries to play the 'swing' animation.
+     *
+     * @param entity The entity swinging the item.
+     * @param hand   The hand the item is held in.
+     * @return True to cancel any further processing by EntityLiving
+     */
+    default boolean onEntitySwing(LivingEntity entity, InteractionHand hand) {
+        return self().getItem().onEntitySwing(self(), entity, hand);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -218,7 +218,7 @@ public interface IItemStackExtension {
      * Called when a entity tries to play the 'swing' animation.
      *
      * @param entity The entity swinging the item.
-     * @return True to cancel any further processing by {@linkplain LivingEntity}
+     * @return True to cancel any further processing by {@link LivingEntity}
      * @deprecated To be replaced with hand sensitive version in 21.2
      * @see #onEntitySwing(LivingEntity, InteractionHand)
      */
@@ -232,7 +232,7 @@ public interface IItemStackExtension {
      *
      * @param entity The entity swinging the item.
      * @param hand   The hand the item is held in.
-     * @return True to cancel any further processing by {@linkplain LivingEntity}
+     * @return True to cancel any further processing by {@link LivingEntity}
      */
     default boolean onEntitySwing(LivingEntity entity, InteractionHand hand) {
         return self().getItem().onEntitySwing(self(), entity, hand);


### PR DESCRIPTION
The `InteractionHand` is simply passed to `ItemStack.onEntitySwing` - Fixes #1497.

The original method is deprecated and scheduled for removal in version `21.2` (next breaking change window). The new method delegates to the original to avoid breaking existing mods.