### PR TITLE
Fix #1077 Fix up ScreenEvent.BackgroundRendered

### DIFF
--- a/patches/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/Screen.java.patch
@@ -50,14 +50,14 @@
      }
  
      @Override
-@@ -353,6 +_,7 @@
+@@ -383,6 +_,7 @@
  
-         this.renderBlurredBackground();
-         this.renderMenuBackground(p_283688_);
-+        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ScreenEvent.BackgroundRendered(this, p_283688_));
+     public void renderTransparentBackground(GuiGraphics p_294586_) {
+         p_294586_.fillGradient(0, 0, this.width, this.height, -1072689136, -804253680);
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ScreenEvent.BackgroundRendered(this, p_294586_));
      }
  
-     protected void renderBlurredBackground() {
+     public boolean isPauseScreen() {
 @@ -458,6 +_,10 @@
      public void onFilesDrop(List<Path> p_96591_) {
      }

--- a/src/main/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -228,17 +228,15 @@ public abstract class ScreenEvent extends Event {
     }
 
     /**
-     * Fired directly after the background of the screen is drawn. (Only when the screen calls {@link Screen#renderBackground})
-     * Can be used for drawing above the background but below the tooltips.
+     * Fired directly after the transparent background behind the screen is drawn.
+     * (Only when the screen calls {@link Screen#renderTransparentBackground})
+     * Can be used for drawing next to the screen and below the tooltips.
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
      * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
-     * 
-     * @deprecated Planned on being removed in 1.21.1 due to extreme maintenance burden to make this event fire consistently for most screens.
      */
-    @Deprecated(forRemoval = true, since = "21.0")
     public static class BackgroundRendered extends ScreenEvent {
         private final GuiGraphics guiGraphics;
 


### PR DESCRIPTION
# Context

In #1077 I advocated for removing this event as no longer necessary, but it turns out this event is still needed after all, for a single very specific case.

![image](https://github.com/user-attachments/assets/0e11a798-ff1b-48ec-a6b8-25475c4da629)

Tooltips and item energy bars both render using `RenderType.GUI_OVERLAY` which has forced `setDepthTestState(NO_DEPTH_TEST)`.
So the only way to order them correctly is to have the items draw before the tooltip using this event:

![image](https://github.com/user-attachments/assets/84d5b46c-da0d-4c6c-8461-1f34a4338d98)

# Solution notes

There is a better place to fire this event so that it doesn't need many patches: right after the transparent background is drawn. Every normal in-game GUI makes the call to draw that transparent background before their own background.

Technically this is a breaking change, but an extremely minor one. Also, the event was pretty broken before anyway.