### PR TITLE
[1.21.1] Recipe prioritization for NeoForge ingredients over vanilla ingredients.

### DIFF
--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -1,8 +1,11 @@
 --- a/net/minecraft/world/item/crafting/RecipeManager.java
 +++ b/net/minecraft/world/item/crafting/RecipeManager.java
-@@ -50,16 +_,22 @@
+@@ -49,23 +_,38 @@
+     protected void apply(Map<ResourceLocation, JsonElement> p_44037_, ResourceManager p_44038_, ProfilerFiller p_44039_) {
          this.hasErrors = false;
          Builder<RecipeType<?>, RecipeHolder<?>> builder = ImmutableMultimap.builder();
++        Builder<RecipeType<?>, RecipeHolder<?>> overrides = ImmutableMultimap.builder(); // Neo: Stores recipes mapped to the IDs of the recipe they override.
++        com.google.common.collect.LinkedListMultimap<RecipeType<?>, RecipeHolder<?>> finalBuilder = com.google.common.collect.LinkedListMultimap.create(); // Neo: Final version of "builder" that becomes "byType".
          com.google.common.collect.ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> builder1 = ImmutableMap.builder();
 -        RegistryOps<JsonElement> registryops = this.registries.createSerializationContext(JsonOps.INSTANCE);
 +        RegistryOps<JsonElement> registryops = this.makeConditionalOps(); // Neo: add condition context
@@ -17,7 +20,12 @@
 +                decoded.ifPresentOrElse(r -> {
 +                Recipe<?> recipe = r.carrier();
                  RecipeHolder<?> recipeholder = new RecipeHolder<>(resourcelocation, recipe);
-                 builder.put(recipe.getType(), recipeholder);
+-                builder.put(recipe.getType(), recipeholder);
++                if (recipeholder.value().getIngredients().stream().anyMatch((ingredient) -> ingredient.getCustomIngredient() != null)) {
++                    overrides.put(recipe.getType(), recipeholder);
++                } else {
++                    builder.put(recipe.getType(), recipeholder);
++                }
                  builder1.put(resourcelocation, recipeholder);
 +                }, () -> {
 +                    LOGGER.debug("Skipping loading recipe {} as its conditions were not met", resourcelocation);
@@ -25,3 +33,13 @@
              } catch (IllegalArgumentException | JsonParseException jsonparseexception) {
                  LOGGER.error("Parsing error loading recipe {}", resourcelocation, jsonparseexception);
              }
+         }
+ 
+-        this.byType = builder.build();
++        finalBuilder.putAll(overrides.build());
++        finalBuilder.putAll(builder.build());
++
++        this.byType = ImmutableMultimap.copyOf(finalBuilder);
+         this.byName = builder1.build();
+         LOGGER.info("Loaded {} recipes", this.byType.size());
+     }

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -21,7 +21,7 @@
 +                Recipe<?> recipe = r.carrier();
                  RecipeHolder<?> recipeholder = new RecipeHolder<>(resourcelocation, recipe);
 -                builder.put(recipe.getType(), recipeholder);
-+                if (recipeholder.value().getIngredients().stream().anyMatch((ingredient) -> ingredient.getCustomIngredient() != null)) {
++                if (recipeholder.value().getIngredients().stream().anyMatch((ingredient) -> ingredient.getCustomIngredient() != null && ingredient.getCustomIngredient().isNestedAndPriority())) {
 +                    overrides.put(recipe.getType(), recipeholder);
 +                } else {
 +                    builder.put(recipe.getType(), recipeholder);

--- a/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/DifferenceIngredient.java
@@ -37,6 +37,11 @@ public record DifferenceIngredient(Ingredient base, Ingredient subtracted) imple
     }
 
     @Override
+    public boolean isNestedAndPriority() {
+        return true;
+    }
+
+    @Override
     public IngredientType<?> getType() {
         return NeoForgeMod.DIFFERENCE_INGREDIENT_TYPE.get();
     }

--- a/src/main/java/net/neoforged/neoforge/common/crafting/ICustomIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/ICustomIngredient.java
@@ -60,6 +60,13 @@ public interface ICustomIngredient {
     boolean isSimple();
 
     /**
+     * @return Whether this ingredient has nesting of other basic ingredients that it should take priority over.
+     */
+    default boolean isNestedAndPriority() {
+        return false;
+    }
+
+    /**
      * {@return the type of this ingredient}
      *
      * <p>The type must be registered to {@link NeoForgeRegistries#INGREDIENT_TYPES}.

--- a/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
@@ -71,6 +71,11 @@ public record IntersectionIngredient(List<Ingredient> children) implements ICust
     }
 
     @Override
+    public boolean isNestedAndPriority() {
+        return true;
+    }
+
+    @Override
     public IngredientType<?> getType() {
         return NeoForgeMod.INTERSECTION_INGREDIENT_TYPE.get();
     }

--- a/tests/src/generated/resources/data/minecraft/advancement/recipes/misc/cherry_redstone.json
+++ b/tests/src/generated/resources/data/minecraft/advancement/recipes/misc/cherry_redstone.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_cherry_planks": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:cherry_planks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:cherry_redstone"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_cherry_planks"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:cherry_redstone"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/minecraft/recipe/cherry_redstone.json
+++ b/tests/src/generated/resources/data/minecraft/recipe/cherry_redstone.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "group": "bed",
+  "key": {
+    "#": {
+      "tag": "minecraft:wool"
+    },
+    "X": {
+      "type": "neoforge:intersection",
+      "children": [
+        {
+          "item": "minecraft:cherry_planks"
+        },
+        {
+          "tag": "minecraft:planks"
+        }
+      ]
+    }
+  },
+  "pattern": [
+    "###",
+    "XXX"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:redstone_block"
+  }
+}


### PR DESCRIPTION
_Alternative version to #1141_

This PR changes `RecipeManager` to check if a recipe has an `ICustomIngredient`. If it does, then the custom ingredient recipe will be prioritized over recipes without custom ingredients through the ordering of the recipe map.

This allows a modder to utilize NeoForge's custom ingredient types like `IntersectionIngredient` to solve conflicts between their mod and vanilla, as opposed to only having the ability to fix conflicts in the mod itself or between other mods with deliberate communication and compatibility.

One example of this would be when a modder may be trying to make a Chest for a specific wood type. In Vanilla, crafting Chests uses the `#planks` tag, so all wood types are normally going to give the default Chest block. With custom ingredient prioritization, a modder could get around this by using an `IntersectionIngredient` to get the intersection input of the specific wood but no other wood types from the planks tag.