### PR TITLE
Fix null pointer when stopping chunk pregeneration

### DIFF
--- a/src/main/java/net/neoforged/neoforge/server/command/GenerateCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/GenerateCommand.java
@@ -96,8 +96,10 @@ class GenerateCommand {
             double percent = (double) count / total * 100.0;
             source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.stopped", count, total, percent), true);
 
-            generationBar.close();
-            generationBar = null;
+            if (generationBar != null) {
+                generationBar.close();
+                generationBar = null;
+            }
             activeTask = null;
         } else {
             source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.not_running"), false);


### PR DESCRIPTION
Fix null pointer when using the "/neoforge generate stop" command while the progress bar is disabled or if the command is used from a dedicated server.

Log: https://gist.github.com/gigabit101/df92c91402f4d4010f4cbc494f82b16f