### PR TITLE
[1.21] Allow requesting entity outline processing for custom renderers outside of entity and blockentity rendering

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -1,9 +1,12 @@
 --- a/net/minecraft/client/renderer/LevelRenderer.java
 +++ b/net/minecraft/client/renderer/LevelRenderer.java
-@@ -233,6 +_,7 @@
+@@ -233,6 +_,10 @@
      private int rainSoundTime;
      private final float[] rainSizeX = new float[1024];
      private final float[] rainSizeZ = new float[1024];
++    /**
++     * Neo: Indicates whether outline effect post-processing was requested for the current frame outside of vanilla codepaths
++     */
 +    private boolean outlineEffectRequested = false;
  
      public LevelRenderer(Minecraft p_234245_, EntityRenderDispatcher p_234246_, BlockEntityRenderDispatcher p_234247_, RenderBuffers p_234248_) {
@@ -239,8 +242,8 @@
 +    }
 +
 +    /**
-+     * Request outline effect post-processing to be enabled for the current frame. Must be called before block entities
-+     * are done rendering, ideally early during the frame
++     * Neo: Request outline effect post-processing to be enabled for the current frame. Must be called before block
++     * entities are done rendering, ideally early during the frame
 +     */
 +    public void requestOutlineEffect() {
 +        this.outlineEffectRequested = true;

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/client/renderer/LevelRenderer.java
 +++ b/net/minecraft/client/renderer/LevelRenderer.java
+@@ -233,6 +_,7 @@
+     private int rainSoundTime;
+     private final float[] rainSizeX = new float[1024];
+     private final float[] rainSizeZ = new float[1024];
++    private boolean outlineEffectRequested = false;
+ 
+     public LevelRenderer(Minecraft p_234245_, EntityRenderDispatcher p_234246_, BlockEntityRenderDispatcher p_234247_, RenderBuffers p_234248_) {
+         this.minecraft = p_234245_;
 @@ -256,6 +_,8 @@
      }
  
@@ -98,7 +106,17 @@
                  this.blockEntityRenderDispatcher.render(blockentity, f, posestack, multibuffersource$buffersource);
                  posestack.popPose();
              }
-@@ -1085,6 +_,7 @@
+@@ -1080,11 +_,17 @@
+         multibuffersource$buffersource.endBatch(Sheets.hangingSignSheet());
+         multibuffersource$buffersource.endBatch(Sheets.chestSheet());
+         this.renderBuffers.outlineBufferSource().endOutlineBatch();
++        // Neo: handle outline effect requests outside glowing entities
++        if (this.outlineEffectRequested) {
++            flag2 |= this.shouldShowEntityOutlines();
++            this.outlineEffectRequested = false;
++        }
+         if (flag2) {
+             this.entityEffect.process(p_348530_.getGameTimeDeltaTicks());
              this.minecraft.getMainRenderTarget().bindWrite(false);
          }
  
@@ -199,7 +217,7 @@
          float f = this.level.effects().getCloudHeight();
          if (!Float.isNaN(f)) {
              float f1 = 12.0F;
-@@ -2488,6 +_,23 @@
+@@ -2488,6 +_,31 @@
          this.viewArea.setDirty(p_109502_, p_109503_, p_109504_, p_109505_);
      }
  
@@ -218,6 +236,14 @@
 +        synchronized (this.globalBlockEntities) {
 +            this.globalBlockEntities.forEach(blockEntityConsumer);
 +        }
++    }
++
++    /**
++     * Request outline effect post-processing to be enabled for the current frame. Must be called before block entities
++     * are done rendering, ideally early during the frame
++     */
++    public void requestOutlineEffect() {
++        this.outlineEffectRequested = true;
 +    }
 +
      public void playJukeboxSong(Holder<JukeboxSong> p_350918_, BlockPos p_350830_) {


### PR DESCRIPTION
This PR adds a way for custom renderers outside of `Entity` and `BlockEntity` rendering to request the entity outline effect post-processing to be enabled. This is particularly useful for custom rendering in applicable `RenderLevelStageEvent` phases (includes all phases which fire before `AFTER_BLOCK_ENTITIES`). This also partially paves the way towards 1.21.2 where the current approach of requesting outline processing for BERs is no longer possible due to the frame graph.