### PR TITLE
Add back original constructor for `TagsProvider.TagAppender`

### DIFF
--- a/patches/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/TagsProvider.java.patch
@@ -115,19 +115,16 @@
 -    public static class TagAppender<T> {
 +    public static class TagAppender<T> implements net.neoforged.neoforge.common.extensions.ITagAppenderExtension<T> {
          private final TagBuilder builder;
--
--        protected TagAppender(TagBuilder p_256426_) {
--            this.builder = p_256426_;
-+        private final String modId;
-+
-+        // Neo: Add constructor overload with mod ID parameter, for logging
-+        protected TagAppender(TagBuilder p_236454_, String modId) {
-+            this.builder = p_236454_;
-+            this.modId = modId;
+ 
+         protected TagAppender(TagBuilder p_256426_) {
++            this(p_256426_, "<unknown>");
 +        }
 +
-+        protected TagAppender(TagBuilder p_236454_) {
-+            this(p_236454_, "<unknown>");
++        private final String modId;
++        // Neo: Add constructor overload with mod ID parameter, for logging
++        protected TagAppender(TagBuilder p_256426_, String modId) {
+             this.builder = p_256426_;
++            this.modId = modId;
          }
  
          public final TagsProvider.TagAppender<T> add(ResourceKey<T> p_256138_) {

--- a/patches/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/TagsProvider.java.patch
@@ -108,7 +108,7 @@
          return this.builders.computeIfAbsent(p_236452_.location(), p_236442_ -> TagBuilder.create());
      }
  
-@@ -127,11 +_,18 @@
+@@ -127,11 +_,19 @@
          });
      }
  
@@ -121,7 +121,8 @@
 +        }
 +
 +        private final String modId;
-+        // Neo: Add constructor overload with mod ID parameter, for logging
++        /** @deprecated Neo: The additional mod ID parameter is unused; use the one-parameter constructor instead. */
++        @Deprecated(forRemoval = true, since = "1.21.1")
 +        protected TagAppender(TagBuilder p_256426_, String modId) {
              this.builder = p_256426_;
 +            this.modId = modId;

--- a/patches/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/TagsProvider.java.patch
@@ -108,20 +108,26 @@
          return this.builders.computeIfAbsent(p_236452_.location(), p_236442_ -> TagBuilder.create());
      }
  
-@@ -127,11 +_,13 @@
+@@ -127,11 +_,18 @@
          });
      }
  
 -    public static class TagAppender<T> {
 +    public static class TagAppender<T> implements net.neoforged.neoforge.common.extensions.ITagAppenderExtension<T> {
          private final TagBuilder builder;
-+        private final String modId;
- 
+-
 -        protected TagAppender(TagBuilder p_256426_) {
 -            this.builder = p_256426_;
++        private final String modId;
++
++        // Neo: Add constructor overload with mod ID parameter, for logging
 +        protected TagAppender(TagBuilder p_236454_, String modId) {
 +            this.builder = p_236454_;
 +            this.modId = modId;
++        }
++
++        protected TagAppender(TagBuilder p_236454_) {
++            this(p_236454_, "<unknown>");
          }
  
          public final TagsProvider.TagAppender<T> add(ResourceKey<T> p_256138_) {

--- a/patches/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/TagsProvider.java.patch
@@ -129,7 +129,7 @@
          }
  
          public final TagsProvider.TagAppender<T> add(ResourceKey<T> p_256138_) {
-@@ -169,6 +_,19 @@
+@@ -169,6 +_,22 @@
          public TagsProvider.TagAppender<T> addOptionalTag(ResourceLocation p_176842_) {
              this.builder.addOptionalTag(p_176842_);
              return this;
@@ -140,10 +140,13 @@
 +             return this;
 +        }
 +
++        // TODO: In 1.21.2, mark this as @ApiStatus.Internal
 +        public TagBuilder getInternalBuilder() {
 +             return builder;
 +        }
 +
++        /** @deprecated Neo: Avoid using this method to get the mod ID, as this method will be removed in 1.21.2. */
++        @Deprecated(forRemoval = true, since = "1.21.1")
 +        public String getModID() {
 +             return modId;
          }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagAppenderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagAppenderExtension.java
@@ -54,7 +54,7 @@ public interface ITagAppenderExtension<T> {
      */
     default TagsProvider.TagAppender<T> remove(final ResourceLocation location) {
         TagsProvider.TagAppender<T> builder = self();
-        builder.getInternalBuilder().removeElement(location, builder.getModID());
+        builder.getInternalBuilder().removeElement(location);
         return builder;
     }
 
@@ -106,7 +106,7 @@ public interface ITagAppenderExtension<T> {
      */
     default TagsProvider.TagAppender<T> remove(TagKey<T> tag) {
         TagsProvider.TagAppender<T> builder = self();
-        builder.getInternalBuilder().removeTag(tag.location(), builder.getModID());
+        builder.getInternalBuilder().removeTag(tag.location());
         return builder;
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
@@ -10,7 +10,7 @@ import net.minecraft.tags.TagBuilder;
 import net.minecraft.tags.TagEntry;
 
 public interface ITagBuilderExtension {
-    // TODO: In 1.21.1, rename this to self() and mark as private
+    // TODO: In 1.21.2, rename this to self() and mark as private
     default TagBuilder getRawBuilder() {
         return (TagBuilder) this;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
@@ -67,7 +67,7 @@ public interface ITagBuilderExtension {
     /**
      * Adds a tag to the remove list.
      *
-     * @param tagID  The ID of the tag to add to the remove list
+     * @param tagID The ID of the tag to add to the remove list
      * @return The builder for chaining purposes
      */
     default TagBuilder removeTag(final ResourceLocation tagID) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
@@ -10,6 +10,7 @@ import net.minecraft.tags.TagBuilder;
 import net.minecraft.tags.TagEntry;
 
 public interface ITagBuilderExtension {
+    // TODO: In 1.21.1, rename this to self() and mark as private
     default TagBuilder getRawBuilder() {
         return (TagBuilder) this;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
@@ -20,7 +20,9 @@ public interface ITagBuilderExtension {
      * @param tagEntry The tag entry to add to the remove list
      * @param source   The source of the caller for logging purposes (generally a modid)
      * @return The builder for chaining purposes
+     * @deprecated Use {@link TagBuilder#remove(TagEntry)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.21.1")
     default TagBuilder remove(final TagEntry tagEntry, final String source) {
         return this.getRawBuilder().remove(tagEntry);
     }
@@ -31,9 +33,21 @@ public interface ITagBuilderExtension {
      * @param elementID The ID of the element to add to the remove list
      * @param source    The source of the caller for logging purposes (generally a modid)
      * @return The builder for chaining purposes
+     * @deprecated Use {@link #removeElement(ResourceLocation)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.21.1")
     default TagBuilder removeElement(final ResourceLocation elementID, final String source) {
         return this.remove(TagEntry.element(elementID), source);
+    }
+
+    /**
+     * Adds a single-element entry to the remove list.
+     *
+     * @param elementID The ID of the element to add to the remove list
+     * @return The builder for chaining purposes
+     */
+    default TagBuilder removeElement(final ResourceLocation elementID) {
+        return this.getRawBuilder().remove(TagEntry.element(elementID));
     }
 
     /**
@@ -42,8 +56,20 @@ public interface ITagBuilderExtension {
      * @param tagID  The ID of the tag to add to the remove list
      * @param source The source of the caller for logging purposes (generally a modid)
      * @return The builder for chaining purposes
+     * @deprecated Use {@link #removeElement(ResourceLocation)} instead.
      */
+    @Deprecated(forRemoval = true, since = "1.21.1")
     default TagBuilder removeTag(final ResourceLocation tagID, final String source) {
         return this.remove(TagEntry.tag(tagID), source);
+    }
+
+    /**
+     * Adds a tag to the remove list.
+     *
+     * @param tagID  The ID of the tag to add to the remove list
+     * @return The builder for chaining purposes
+     */
+    default TagBuilder removeTag(final ResourceLocation tagID) {
+        return this.getRawBuilder().remove(TagEntry.tag(tagID));
     }
 }


### PR DESCRIPTION
This PR fixes #831 by restoring the original one-parameter constructor for `TagsProvider.TagAppender`. (Neo)Forge patched the existing constructor to add a mod ID argument which, as the linked issue notes, is currently unused but is purported to be for logging.

Because we cannot remove it for now due to our compatibility policy, and I'm unsure whether we want to keep it for potential reimplementation or remove it entirely, I've left the patched constructor untouched. If wanted, I can (terminally) deprecate that constructor.