### PR TITLE
[1.21.1] Adjust `DeferredRegister$DataComponents` constructor to accept registry key

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -178,9 +178,9 @@ public class DeferredRegister<T> {
      * @see #create(ResourceKey, String)
      * @see #create(ResourceLocation, String)
      * @see #createItems(String)
-     * @deprecated Use the overload with the {@link ResourceKey} parameter
+     * @deprecated Use {@link DeferredRegister#createDataComponents(ResourceKey, String)}
      */
-    @Deprecated(since = "21.1", forRemoval = true)
+    @Deprecated(since = "1.21.1", forRemoval = true)
     public static DataComponents createDataComponents(String modid) {
         return new DataComponents(modid);
     }
@@ -619,8 +619,8 @@ public class DeferredRegister<T> {
             super(registryKey, namespace);
         }
 
-        /** @deprecated Use the overload with the {@link ResourceKey} parameter */
-        @Deprecated(since = "21.1", forRemoval = true)
+        /** @deprecated Use {@link DataComponents#DataComponents(ResourceKey, String)} */
+        @Deprecated(since = "1.21.1", forRemoval = true)
         protected DataComponents(String namespace) {
             super(Registries.DATA_COMPONENT_TYPE, namespace);
         }

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -170,6 +170,21 @@ public class DeferredRegister<T> {
         return new DataComponents(registryKey, modid);
     }
 
+    /**
+     * Factory for a specialized DeferredRegister for {@link DataComponentType DataComponentTypes}.
+     *
+     * @param modid The namespace for all objects registered to this DeferredRegister
+     * @see #create(Registry, String)
+     * @see #create(ResourceKey, String)
+     * @see #create(ResourceLocation, String)
+     * @see #createItems(String)
+     * @deprecated Use the overload with the {@link ResourceKey} parameter
+     */
+    @Deprecated(since = "21.1", forRemoval = true)
+    public static DataComponents createDataComponents(String modid) {
+        return new DataComponents(modid);
+    }
+
     private final ResourceKey<? extends Registry<T>> registryKey;
     private final String namespace;
     private final Map<DeferredHolder<T, ? extends T>, Supplier<? extends T>> entries = new LinkedHashMap<>();
@@ -602,6 +617,12 @@ public class DeferredRegister<T> {
     public static class DataComponents extends DeferredRegister<DataComponentType<?>> {
         protected DataComponents(ResourceKey<Registry<DataComponentType<?>>> registryKey, String namespace) {
             super(registryKey, namespace);
+        }
+
+        /** @deprecated Use the overload with the {@link ResourceKey} parameter */
+        @Deprecated(since = "21.1", forRemoval = true)
+        protected DataComponents(String namespace) {
+            super(Registries.DATA_COMPONENT_TYPE, namespace);
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -159,14 +159,15 @@ public class DeferredRegister<T> {
     /**
      * Factory for a specialized DeferredRegister for {@link DataComponentType DataComponentTypes}.
      *
-     * @param modid The namespace for all objects registered to this DeferredRegister
+     * @param registryKey The key for the data component type registry
+     * @param modid       The namespace for all objects registered to this DeferredRegister
      * @see #create(Registry, String)
      * @see #create(ResourceKey, String)
      * @see #create(ResourceLocation, String)
      * @see #createItems(String)
      */
-    public static DataComponents createDataComponents(String modid) {
-        return new DataComponents(modid);
+    public static DataComponents createDataComponents(ResourceKey<Registry<DataComponentType<?>>> registryKey, String modid) {
+        return new DataComponents(registryKey, modid);
     }
 
     private final ResourceKey<? extends Registry<T>> registryKey;
@@ -599,8 +600,8 @@ public class DeferredRegister<T> {
      * Specialized DeferredRegister for {@link DataComponentType DataComponentTypes}.
      */
     public static class DataComponents extends DeferredRegister<DataComponentType<?>> {
-        protected DataComponents(String namespace) {
-            super(Registries.DATA_COMPONENT_TYPE, namespace);
+        protected DataComponents(ResourceKey<Registry<DataComponentType<?>>> registryKey, String namespace) {
+            super(registryKey, namespace);
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -178,7 +178,7 @@ public class DeferredRegister<T> {
      * @see #create(ResourceKey, String)
      * @see #create(ResourceLocation, String)
      * @see #createItems(String)
-     * @deprecated Use {@link DeferredRegister#createDataComponents(ResourceKey, String)}
+     * @deprecated Scheduled for removal in 1.21.2; use {@link DeferredRegister#createDataComponents(ResourceKey, String)}
      */
     @Deprecated(since = "1.21.1", forRemoval = true)
     public static DataComponents createDataComponents(String modid) {
@@ -619,7 +619,7 @@ public class DeferredRegister<T> {
             super(registryKey, namespace);
         }
 
-        /** @deprecated Use {@link DataComponents#DataComponents(ResourceKey, String)} */
+        /** @deprecated Scheduled for removal in 1.21.2; use {@link DataComponents#DataComponents(ResourceKey, String)} */
         @Deprecated(since = "1.21.1", forRemoval = true)
         protected DataComponents(String namespace) {
             super(Registries.DATA_COMPONENT_TYPE, namespace);

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -178,7 +178,7 @@ public class DeferredRegister<T> {
      * @see #create(ResourceKey, String)
      * @see #create(ResourceLocation, String)
      * @see #createItems(String)
-     * @deprecated Scheduled for removal in 1.21.2; use {@link DeferredRegister#createDataComponents(ResourceKey, String)}
+     * @deprecated Scheduled for removal in 1.21.2; use {@link DeferredRegister#createDataComponents(ResourceKey, String)} with {@link Registries#DATA_COMPONENT_TYPE} instead
      */
     @Deprecated(since = "1.21.1", forRemoval = true)
     public static DataComponents createDataComponents(String modid) {

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -159,7 +159,7 @@ public class DeferredRegister<T> {
     /**
      * Factory for a specialized DeferredRegister for {@link DataComponentType DataComponentTypes}.
      *
-     * @param registryKey The key for the data component type registry
+     * @param registryKey The key for the data component type registry, like {@link Registries#DATA_COMPONENT_TYPE} for item data components
      * @param modid       The namespace for all objects registered to this DeferredRegister
      * @see #create(Registry, String)
      * @see #create(ResourceKey, String)

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredRegistryTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredRegistryTest.java
@@ -41,7 +41,7 @@ public class DeferredRegistryTest {
     private static final Logger LOGGER = LogManager.getLogger();
 
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
-    private static final DeferredRegister.DataComponents COMPONENTS = DeferredRegister.createDataComponents(MODID);
+    private static final DeferredRegister.DataComponents COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
     private static final ResourceKey<Registry<Custom>> CUSTOM_REGISTRY_KEY = ResourceKey.createRegistryKey(ResourceLocation.fromNamespaceAndPath(MODID, "test_registry"));
     private static final DeferredRegister<Custom> CUSTOMS = DeferredRegister.create(CUSTOM_REGISTRY_KEY, MODID);


### PR DESCRIPTION
Allows it to be used for other data component registries, like the enchantment effect registry and future registries. Targets the next BC window due to breaking changes