### PR TITLE
Add a helper for constructing singleton ModelData instances

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/data/ModelData.java
@@ -70,6 +70,18 @@ public final class ModelData {
         return new Builder(null);
     }
 
+    /**
+     * Helper to create a {@link ModelData} instance for a single property-value pair, without the verbosity
+     * and runtime overhead of creating a builder object.
+     */
+    public static <T> ModelData of(ModelProperty<T> property, T value) {
+        Preconditions.checkState(property.test(value), "The provided value is invalid for this property.");
+        // Must use one of the two map types from the builder to avoid megamorphic calls to Map.get() later
+        Reference2ReferenceArrayMap<ModelProperty<?>, Object> map = new Reference2ReferenceArrayMap<>(1);
+        map.put(property, value);
+        return new ModelData(map);
+    }
+
     public static final class Builder {
         /**
          * Hash maps are slower than array maps for *extremely* small maps (empty maps or singletons are the most

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
@@ -165,7 +165,7 @@ public class FullPotsAccessorDemo {
 
         public DioriteFlowerPotBlockEntity(BlockPos pos, BlockState state) {
             super(DIORITE_POT_BLOCK_ENTITY.get(), pos, state);
-            modelData = ModelData.builder().with(PLANT_PROPERTY, plant).build();
+            modelData = ModelData.of(PLANT_PROPERTY, plant);
         }
 
         public void setPlant(Block plant) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
@@ -133,11 +133,11 @@ public class MegaModelTest {
 
             @Override
             public ModelData getModelData() {
-                return ModelData.builder().with(TestData.PROPERTY, new TestData(new Transformation(
+                return ModelData.of(TestData.PROPERTY, new TestData(new Transformation(
                         new Vector3f(0, y * 0.2f, 0),
                         new Quaternionf(1f, 1f, 1f, 1f),
                         Transformation.identity().getScale(),
-                        new Quaternionf(1f, 1f, 1f, 1f)))).build();
+                        new Quaternionf(1f, 1f, 1f, 1f))));
             }
         }
     }


### PR DESCRIPTION
I commonly find myself wanting to construct a fresh `ModelData` instance with a single property. This helper makes the syntax slightly more concise (`ModelData.of(k, v)` rather than `ModelData.builder().with(k, v).build()`) and avoids the allocation of a `ModelData.Builder` object.