### PR TITLE
Namespace the Neoforge Entity Animation JSONs with `neoforge/`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/entity/animation/json/AnimationLoader.java
+++ b/src/main/java/net/neoforged/neoforge/client/entity/animation/json/AnimationLoader.java
@@ -35,7 +35,7 @@ public final class AnimationLoader extends SimpleJsonResourceReloadListener {
     private final List<AnimationHolder> strongHolderReferences = new ArrayList<>();
 
     private AnimationLoader() {
-        super(new Gson(), "animations/entity");
+        super(new Gson(), "neoforge/animations/entity");
     }
 
     /**


### PR DESCRIPTION
[WARNING: BREAKING CHANGE]
This PR aims to fix the big issue introduced in this PR: https://github.com/neoforged/NeoForge/pull/1476

Specifically, that PR adds the ability to support entity animation JSON files put under `animations/entity` folder. Issue is, Geckolib already owned that folder for years. We are now breaking Geckolib and Geckolib is breaking us. We can't stay like this.

So to fix this, we are going to namespace the folder with `neoforge/` so it is `neoforge/animations/entity`. We choose to modloader namespace this instead of picking a new name because after conversing with Fabric, it seems they are not 100% enthusiastic with accepting the entity animation JSON PR if made to them. So with the good chance that this JSON system may not be shared with any loader, we might as well namespace it for now.

Modders can datagen to multiple locations anyway and it is a simple copy/paste if others loaders do end up with their own JSON animation system. We could even just load the json from other modloader folders too if they are the exact same specs. The original PR did not outline modloader cross-compat as a goal in the PR description so we initially reviewed it as a Neoforge-only thing and did not have any discussion with Fabric. So that's why we are still gonna treat this as Neoforge-specific as a consequence of us dropping the ball here.