### PR TITLE
Add `hangingSignBlock` method to `BlockStateProvider`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/generators/BlockStateProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/BlockStateProvider.java
@@ -29,6 +29,7 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ButtonBlock;
+import net.minecraft.world.level.block.CeilingHangingSignBlock;
 import net.minecraft.world.level.block.CrossCollisionBlock;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceBlock;
@@ -42,6 +43,7 @@ import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.block.StandingSignBlock;
 import net.minecraft.world.level.block.TrapDoorBlock;
 import net.minecraft.world.level.block.WallBlock;
+import net.minecraft.world.level.block.WallHangingSignBlock;
 import net.minecraft.world.level.block.WallSignBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.AttachFace;
@@ -479,6 +481,16 @@ public abstract class BlockStateProvider implements DataProvider {
     public void signBlock(StandingSignBlock signBlock, WallSignBlock wallSignBlock, ModelFile sign) {
         simpleBlock(signBlock, sign);
         simpleBlock(wallSignBlock, sign);
+    }
+
+    public void hangingSignBlock(CeilingHangingSignBlock hangingSignBlock, WallHangingSignBlock wallHangingSignBlock, ResourceLocation texture) {
+        ModelFile hangingSign = models().sign(name(hangingSignBlock), texture);
+        hangingSignBlock(hangingSignBlock, wallHangingSignBlock, hangingSign);
+    }
+
+    public void hangingSignBlock(CeilingHangingSignBlock hangingSignBlock, WallHangingSignBlock wallHangingSignBlock, ModelFile hangingSign) {
+        simpleBlock(hangingSignBlock, hangingSign);
+        simpleBlock(wallHangingSignBlock, hangingSign);
     }
 
     public void fourWayBlock(CrossCollisionBlock block, ModelFile post, ModelFile side) {

--- a/tests/src/generated/resources/assets/data_gen_test/models/block/acacia_hanging_sign.json
+++ b/tests/src/generated/resources/assets/data_gen_test/models/block/acacia_hanging_sign.json
@@ -1,0 +1,5 @@
+{
+  "textures": {
+    "particle": "minecraft:block/stripped_acacia_log"
+  }
+}

--- a/tests/src/generated/resources/assets/minecraft/blockstates/acacia_hanging_sign.json
+++ b/tests/src/generated/resources/assets/minecraft/blockstates/acacia_hanging_sign.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "data_gen_test:block/acacia_hanging_sign"
+    }
+  }
+}

--- a/tests/src/generated/resources/assets/minecraft/blockstates/acacia_wall_hanging_sign.json
+++ b/tests/src/generated/resources/assets/minecraft/blockstates/acacia_wall_hanging_sign.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "data_gen_test:block/acacia_hanging_sign"
+    }
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
@@ -86,6 +86,7 @@ import net.minecraft.world.level.block.BarrelBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ButtonBlock;
+import net.minecraft.world.level.block.CeilingHangingSignBlock;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.FurnaceBlock;
@@ -96,6 +97,7 @@ import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.block.StandingSignBlock;
 import net.minecraft.world.level.block.TrapDoorBlock;
+import net.minecraft.world.level.block.WallHangingSignBlock;
 import net.minecraft.world.level.block.WallSignBlock;
 import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import net.minecraft.world.level.dimension.DimensionType;
@@ -742,6 +744,7 @@ public class DataGeneratorTest {
             pressurePlateBlock((PressurePlateBlock) Blocks.ACACIA_PRESSURE_PLATE, blockTexture(Blocks.ACACIA_PLANKS));
 
             signBlock((StandingSignBlock) Blocks.ACACIA_SIGN, (WallSignBlock) Blocks.ACACIA_WALL_SIGN, blockTexture(Blocks.ACACIA_PLANKS));
+            hangingSignBlock((CeilingHangingSignBlock) Blocks.ACACIA_HANGING_SIGN, (WallHangingSignBlock) Blocks.ACACIA_WALL_HANGING_SIGN, blockTexture(Blocks.STRIPPED_ACACIA_LOG));
 
             simpleBlock(Blocks.TORCH, models().torch("torch", mcLoc("block/torch")));
             horizontalBlock(Blocks.WALL_TORCH, models().torchWall("wall_torch", mcLoc("block/torch")), 90);


### PR DESCRIPTION
The method BlockStateProvider.signBlock does not support usages for data generating HangingSignBlocks.
This PR just adds a pair of methods in the same fashion as BlockStateProvider.signBlock that allow you to create the files from either a ResourceLocation or a ModelFile

Recreated because my Github had a small minor meltdown when trying to make the Registry Access PR too

Original PR: https://github.com/neoforged/NeoForge/pull/1511