### PR TITLE
Add Crying Obsidian to `c:obsidians` tag

### DIFF
--- a/src/generated/resources/data/c/tags/block/obsidians.json
+++ b/src/generated/resources/data/c/tags/block/obsidians.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "minecraft:obsidian",
+    "minecraft:crying_obsidian",
     {
       "id": "#forge:obsidian",
       "required": false

--- a/src/generated/resources/data/c/tags/item/obsidians.json
+++ b/src/generated/resources/data/c/tags/item/obsidians.json
@@ -1,6 +1,7 @@
 {
   "values": [
     "minecraft:obsidian",
+    "minecraft:crying_obsidian",
     {
       "id": "#forge:obsidian",
       "required": false

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
@@ -80,7 +80,7 @@ public final class NeoForgeBlockTagsProvider extends BlockTagsProvider {
         tag(Tags.Blocks.SKULLS).add(Blocks.SKELETON_SKULL, Blocks.SKELETON_WALL_SKULL, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, Blocks.PLAYER_HEAD, Blocks.PLAYER_WALL_HEAD, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, Blocks.CREEPER_HEAD, Blocks.CREEPER_WALL_HEAD, Blocks.PIGLIN_HEAD, Blocks.PIGLIN_WALL_HEAD, Blocks.DRAGON_HEAD, Blocks.DRAGON_WALL_HEAD);
         tag(Tags.Blocks.HIDDEN_FROM_RECIPE_VIEWERS);
         tag(Tags.Blocks.NETHERRACKS).add(Blocks.NETHERRACK);
-        tag(Tags.Blocks.OBSIDIANS).add(Blocks.OBSIDIAN);
+        tag(Tags.Blocks.OBSIDIANS).add(Blocks.OBSIDIAN).add(Blocks.CRYING_OBSIDIAN);
         tag(Tags.Blocks.ORE_BEARING_GROUND_DEEPSLATE).add(Blocks.DEEPSLATE);
         tag(Tags.Blocks.ORE_BEARING_GROUND_NETHERRACK).add(Blocks.NETHERRACK);
         tag(Tags.Blocks.ORE_BEARING_GROUND_STONE).add(Blocks.STONE);


### PR DESCRIPTION
Really old tag that was ported from `forge:obsidian` back int he day. Forge never added Crying Obsidian which was an oversight when that new block was added. 

The tag is not on Fabric yet but got a PR here to see if we can sync it. If not, that's alright.
https://github.com/FabricMC/fabric/pull/4088

Closes https://github.com/neoforged/NeoForge/issues/1535