### PR TITLE
[1.21.1] Fix WeightedBakedModel not calling getModelData() on the nested model

### DIFF
--- a/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/WeightedBakedModel.java.patch
@@ -34,7 +34,7 @@
      public boolean isGui3d() {
          return this.wrapped.isGui3d();
      }
-@@ -61,8 +_,25 @@
+@@ -61,8 +_,30 @@
      }
  
      @Override
@@ -57,6 +57,11 @@
 +        return WeightedRandom.getWeightedItem(this.list, Math.abs((int)rand.nextLong()) % this.totalWeight)
 +                  .map((p_235065_) -> p_235065_.data().getRenderTypes(state, rand, data))
 +                  .orElse(net.neoforged.neoforge.client.ChunkRenderTypeSet.none());
++    }
++
++    @Override
++    public net.neoforged.neoforge.client.model.data.ModelData getModelData(net.minecraft.world.level.BlockAndTintGetter level, net.minecraft.core.BlockPos pos, BlockState state, net.neoforged.neoforge.client.model.data.ModelData modelData) {
++        return this.wrapped.getModelData(level, pos, state, modelData);
      }
  
      @Override


### PR DESCRIPTION
This PR fixes the `WeightedBakedModel` not calling `IBakedModelExtension#getModelData()` on the wrapped model. The wrapped model used for the delegation is the first in the list of models. This matches the behaviour of the delegations in other methods of this class with the exception being `getRenderTypes()`.

Fixes #1534