### PR TITLE
Add a way to animate armor models in HumanoidArmorLayer

### DIFF
--- a/patches/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
@@ -1,6 +1,28 @@
 --- a/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java
 +++ b/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java
-@@ -66,22 +_,28 @@
+@@ -54,34 +_,47 @@
+         float p_117104_,
+         float p_117105_
+     ) {
+-        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.CHEST, p_117098_, this.getArmorModel(EquipmentSlot.CHEST));
+-        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.LEGS, p_117098_, this.getArmorModel(EquipmentSlot.LEGS));
+-        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.FEET, p_117098_, this.getArmorModel(EquipmentSlot.FEET));
+-        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.HEAD, p_117098_, this.getArmorModel(EquipmentSlot.HEAD));
++        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.CHEST, p_117098_, this.getArmorModel(EquipmentSlot.CHEST), p_117100_, p_117101_, p_117102_, p_117103_, p_117104_, p_117105_);
++        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.LEGS, p_117098_, this.getArmorModel(EquipmentSlot.LEGS), p_117100_, p_117101_, p_117102_, p_117103_, p_117104_, p_117105_);
++        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.FEET, p_117098_, this.getArmorModel(EquipmentSlot.FEET), p_117100_, p_117101_, p_117102_, p_117103_, p_117104_, p_117105_);
++        this.renderArmorPiece(p_117096_, p_117097_, p_117099_, EquipmentSlot.HEAD, p_117098_, this.getArmorModel(EquipmentSlot.HEAD), p_117100_, p_117101_, p_117102_, p_117103_, p_117104_, p_117105_);
+     }
+ 
++    /** @deprecated Neo: use {@link #renderArmorPiece(PoseStack, MultiBufferSource, LivingEntity, EquipmentSlot, int, HumanoidModel, float, float, float, float, float, float)} instead. */
++    @Deprecated
+     private void renderArmorPiece(PoseStack p_117119_, MultiBufferSource p_117120_, T p_117121_, EquipmentSlot p_117122_, int p_117123_, A p_117124_) {
++        this.renderArmorPiece(p_117119_, p_117120_, p_117121_, p_117122_, p_117123_, p_117124_, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F);
++    }
++
++    private void renderArmorPiece(PoseStack p_117119_, MultiBufferSource p_117120_, T p_117121_, EquipmentSlot p_117122_, int p_117123_, A p_117124_, float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw, float headPitch) {
+         ItemStack itemstack = p_117121_.getItemBySlot(p_117122_);
+         if (itemstack.getItem() instanceof ArmorItem armoritem) {
              if (armoritem.getEquipmentSlot() == p_117122_) {
                  this.getParentModel().copyPropertiesTo(p_117124_);
                  this.setPartVisibility(p_117124_, p_117122_);
@@ -13,6 +35,7 @@
 -                    int j = armormaterial$layer.dyeable() ? i : -1;
 -                    this.renderModel(p_117119_, p_117120_, p_117123_, p_117124_, j, armormaterial$layer.texture(flag));
 +                net.neoforged.neoforge.client.extensions.common.IClientItemExtensions extensions = net.neoforged.neoforge.client.extensions.common.IClientItemExtensions.of(itemstack);
++                extensions.setupModelAnimations(p_117121_, itemstack, p_117122_, p_117124_, limbSwing, limbSwingAmount, partialTick, ageInTicks, netHeadYaw, headPitch);
 +                int fallbackColor = extensions.getDefaultDyeColor(itemstack);
 +                for (int layerIdx = 0; layerIdx < armormaterial.layers().size(); layerIdx++) {
 +                    ArmorMaterial.Layer armormaterial$layer = armormaterial.layers().get(layerIdx);

--- a/patches/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/layers/HumanoidArmorLayer.java.patch
@@ -35,7 +35,7 @@
 -                    int j = armormaterial$layer.dyeable() ? i : -1;
 -                    this.renderModel(p_117119_, p_117120_, p_117123_, p_117124_, j, armormaterial$layer.texture(flag));
 +                net.neoforged.neoforge.client.extensions.common.IClientItemExtensions extensions = net.neoforged.neoforge.client.extensions.common.IClientItemExtensions.of(itemstack);
-+                extensions.setupModelAnimations(p_117121_, itemstack, p_117122_, p_117124_, limbSwing, limbSwingAmount, partialTick, ageInTicks, netHeadYaw, headPitch);
++                extensions.setupModelAnimations(p_117121_, itemstack, p_117122_, model, limbSwing, limbSwingAmount, partialTick, ageInTicks, netHeadYaw, headPitch);
 +                int fallbackColor = extensions.getDefaultDyeColor(itemstack);
 +                for (int layerIdx = 0; layerIdx < armormaterial.layers().size(); layerIdx++) {
 +                    ArmorMaterial.Layer armormaterial$layer = armormaterial.layers().get(layerIdx);

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -128,6 +128,22 @@ public interface IClientItemExtensions {
     }
 
     /**
+     * Called when an armor piece is about to be rendered, allowing parts of the model to be animation or changed.
+     *
+     * @param itemStack       The item stack
+     * @param livingEntity    The entity weariing the armor
+     * @param equipmentSlot   The slot the armor is being worn in
+     * @param model           The Armor model being rendered
+     * @param limbSwing       The swing position of the entity's walk animation
+     * @param limbSwingAmount The swing speed of the entity's walk animation
+     * @param partialTick     The partial tick time
+     * @param ageInTicks      The total age of the entity, with partialTick already applied
+     * @param netHeadYaw      The yaw (Y rotation) of the entity's head
+     * @param headPitch       The pitch (X rotation) of the entity's head
+     */
+    default void setupModelAnimations(LivingEntity livingEntity, ItemStack itemStack, EquipmentSlot equipmentSlot, HumanoidModel<?> model, float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw, float headPitch) {}
+
+    /**
      * Called when the client starts rendering the HUD, and is wearing this item in the helmet slot.
      * <p>
      * This is where pumpkins would render their overlay.

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -130,10 +130,10 @@ public interface IClientItemExtensions {
     /**
      * Called when an armor piece is about to be rendered, allowing parts of the model to be animated or changed.
      *
-     * @param itemStack       The item stack
-     * @param livingEntity    The entity weariing the armor
-     * @param equipmentSlot   The slot the armor is being worn in
-     * @param model           The Armor model being rendered
+     * @param itemStack       The item stack being worn
+     * @param livingEntity    The entity wearing the armor
+     * @param equipmentSlot   The slot the armor stack is being worn in
+     * @param model           The armor model being rendered
      * @param limbSwing       The swing position of the entity's walk animation
      * @param limbSwingAmount The swing speed of the entity's walk animation
      * @param partialTick     The partial tick time

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -141,7 +141,7 @@ public interface IClientItemExtensions {
      * @param netHeadYaw      The yaw (Y rotation) of the entity's head
      * @param headPitch       The pitch (X rotation) of the entity's head
      */
-    default void setupModelAnimations(LivingEntity livingEntity, ItemStack itemStack, EquipmentSlot equipmentSlot, HumanoidModel<?> model, float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw, float headPitch) {}
+    default void setupModelAnimations(LivingEntity livingEntity, ItemStack itemStack, EquipmentSlot equipmentSlot, Model model, float limbSwing, float limbSwingAmount, float partialTick, float ageInTicks, float netHeadYaw, float headPitch) {}
 
     /**
      * Called when the client starts rendering the HUD, and is wearing this item in the helmet slot.

--- a/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -128,7 +128,7 @@ public interface IClientItemExtensions {
     }
 
     /**
-     * Called when an armor piece is about to be rendered, allowing parts of the model to be animation or changed.
+     * Called when an armor piece is about to be rendered, allowing parts of the model to be animated or changed.
      *
      * @param itemStack       The item stack
      * @param livingEntity    The entity weariing the armor


### PR DESCRIPTION
Hello again!

I have a custom armor model that I'm rendering via `HumanoidArmorLayer`, as it should be. The armor model has some extra bits that I would like to animate to sway, similar to how the player's arms do. There's one small issue though: `HumanoidArmorLayer` doesn't call `setupAnim` or `prepareMobModel` anywhere, making it impossible to do so. I don't really want to handle this through a custom layer as everything else works perfectly, so I drafted up this PR to fix my issue. 

This PR adds a new method to `IClientItemExtensions` that allows for calling animation methods in the armor model if desired. This is called right before the model is rendered, meaning you can manipulate parts of the model (moving or rotating) as you so desire. 

Please let me know if anything needs changing or if my documentation needs updating. I'll fix it as soon as I can. Thanks for looking over this!