### PR TITLE
Make Biome and Structure Modifiers not crash when attempted to be re-applied

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/ModifiableBiomeInfo.java
@@ -66,15 +66,13 @@ public class ModifiableBiomeInfo {
     }
 
     /**
-     * Internal forge method; the game will crash if mods invoke this.
+     * Internal NeoForge method. Will do nothing if this modifier had already been applied.
      * Creates and caches the modified biome info.
      * 
      * @param biome          named biome with original data.
      * @param biomeModifiers biome modifiers to apply.
      *
      * @return whether the biome's network-synced data was modified
-     * 
-     * @throws IllegalStateException if invoked more than once.
      */
     @ApiStatus.Internal
     public boolean applyBiomeModifiers(final Holder<Biome> biome, final List<BiomeModifier> biomeModifiers, RegistryAccess registryAccess) {

--- a/src/main/java/net/neoforged/neoforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/ModifiableBiomeInfo.java
@@ -10,7 +10,6 @@ import com.mojang.logging.LogUtils;
 import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.JsonOps;
 import java.util.List;
-import java.util.Locale;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.RegistryOps;

--- a/src/main/java/net/neoforged/neoforge/common/world/ModifiableBiomeInfo.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/ModifiableBiomeInfo.java
@@ -80,7 +80,7 @@ public class ModifiableBiomeInfo {
     @ApiStatus.Internal
     public boolean applyBiomeModifiers(final Holder<Biome> biome, final List<BiomeModifier> biomeModifiers, RegistryAccess registryAccess) {
         if (this.modifiedBiomeInfo != null)
-            throw new IllegalStateException(String.format(Locale.ENGLISH, "Biome %s already modified", biome));
+            return true;
 
         BiomeInfo original = this.getOriginalBiomeInfo();
         final BiomeInfo.Builder builder = BiomeInfo.Builder.copyOf(original);

--- a/src/main/java/net/neoforged/neoforge/common/world/ModifiableStructureInfo.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/ModifiableStructureInfo.java
@@ -66,7 +66,7 @@ public class ModifiableStructureInfo {
     @ApiStatus.Internal
     public void applyStructureModifiers(final Holder<Structure> structure, final List<StructureModifier> structureModifiers) {
         if (this.modifiedStructureInfo != null)
-            throw new IllegalStateException(String.format(Locale.ENGLISH, "Structure %s already modified", structure));
+            return;
 
         StructureInfo original = this.getOriginalStructureInfo();
         final StructureInfo.Builder builder = StructureInfo.Builder.copyOf(original);

--- a/src/main/java/net/neoforged/neoforge/common/world/ModifiableStructureInfo.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/ModifiableStructureInfo.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.common.world;
 
 import java.util.List;
-import java.util.Locale;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.Structure.StructureSettings;

--- a/src/main/java/net/neoforged/neoforge/common/world/ModifiableStructureInfo.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/ModifiableStructureInfo.java
@@ -54,13 +54,11 @@ public class ModifiableStructureInfo {
     }
 
     /**
-     * Internal neoforge method; the game will crash if mods invoke this.
+     * Internal NeoForge method. Will do nothing if this modifier had already been applied.
      * Creates and caches the modified structure info.
      * 
      * @param structure          named structure with original data.
      * @param structureModifiers structure modifiers to apply.
-     * 
-     * @throws IllegalStateException if invoked more than once.
      */
     @ApiStatus.Internal
     public void applyStructureModifiers(final Holder<Structure> structure, final List<StructureModifier> structureModifiers) {


### PR DESCRIPTION
Basically, the modifiers already know if a biome or structure was modified and ideally should just no-op instead. It doesn't make sense to throw an exception when the exception isn't really helping anyone or preventing any error. Even Commoble, when asked, said there wasn't any strong reason for the exception either
![image](https://github.com/user-attachments/assets/0b9a388d-2a70-4ceb-9346-3e0f1b1e3a4b)

So let's just remove the exception and the modifier do nothing if object was already modified. Basically cleanup. Might allow for more niche use case for the modifiers but they have other issues to deal with on their own when recycling registries. Just NeoForge should be one less roadblock

Closes https://github.com/neoforged/NeoForge/issues/431