### PR TITLE
Fix GrindstoneEvent.OnPlaceItem patch

### DIFF
--- a/patches/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -40,15 +40,15 @@
                  int l = 0;
                  l += this.getExperienceFromItem(GrindstoneMenu.this.repairSlots.getItem(0));
                  l += this.getExperienceFromItem(GrindstoneMenu.this.repairSlots.getItem(1));
-@@ -131,6 +_,8 @@
+@@ -125,6 +_,8 @@
+     }
  
-     private ItemStack computeResult(ItemStack p_332654_, ItemStack p_332736_) {
-         boolean flag = !p_332654_.isEmpty() || !p_332736_.isEmpty();
-+        this.xp = net.neoforged.neoforge.common.CommonHooks.onGrindstoneChange(p_332654_, p_332736_, this.resultSlots, -1);
-+        if (this.xp != Integer.MIN_VALUE) return ItemStack.EMPTY; // Porting 1.20.5 check if this is correct
-         if (!flag) {
-             return ItemStack.EMPTY;
-         } else if (p_332654_.getCount() <= 1 && p_332736_.getCount() <= 1) {
+     private void createResult() {
++        this.xp = net.neoforged.neoforge.common.CommonHooks.onGrindstoneChange(this.repairSlots.getItem(0), this.repairSlots.getItem(1), this.resultSlots, -1);
++        if (this.xp == Integer.MIN_VALUE)
+         this.resultSlots.setItem(0, this.computeResult(this.repairSlots.getItem(0), this.repairSlots.getItem(1)));
+         this.broadcastChanges();
+     }
 @@ -155,7 +_,7 @@
              int k = p_332686_.getMaxDamage() - p_332686_.getDamageValue();
              int l = j + k + i * 5 / 100;


### PR DESCRIPTION
Got misplaced in an update. The hook needs to stop all of vanilla processing, including the part that overwrites the output slot.
