### PR TITLE
Add `c:obsidians/normal` and `c:obsidians/crying` subtags

### DIFF
--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -53,6 +53,8 @@
   "tag.block.c.hidden_from_recipe_viewers": "Hidden From Recipe Viewers",
   "tag.block.c.netherracks": "Netherracks",
   "tag.block.c.obsidians": "Obsidians",
+  "tag.block.c.obsidians.crying": "Crying Obsidians",
+  "tag.block.c.obsidians.normal": "Normal Obsidians",
   "tag.block.c.ore_bearing_ground.deepslate": "Deepslate Ore Bearing Ground",
   "tag.block.c.ore_bearing_ground.netherrack": "Netherrack Ore Bearing Ground",
   "tag.block.c.ore_bearing_ground.stone": "Stone Ore Bearing Ground",

--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -272,6 +272,8 @@
   "tag.item.c.nuggets.gold": "Gold Nuggets",
   "tag.item.c.nuggets.iron": "Iron Nuggets",
   "tag.item.c.obsidians": "Obsidians",
+  "tag.item.c.obsidians.crying": "Crying Obsidians",
+  "tag.item.c.obsidians.normal": "Normal Obsidians",
   "tag.item.c.ore_bearing_ground.deepslate": "Deepslate Ore Bearing Ground",
   "tag.item.c.ore_bearing_ground.netherrack": "Netherrack Ore Bearing Ground",
   "tag.item.c.ore_bearing_ground.stone": "Stone Ore Bearing Ground",

--- a/src/generated/resources/data/c/tags/block/obsidians.json
+++ b/src/generated/resources/data/c/tags/block/obsidians.json
@@ -1,7 +1,7 @@
 {
   "values": [
-    "minecraft:obsidian",
-    "minecraft:crying_obsidian",
+    "#c:obsidians/normal",
+    "#c:obsidians/crying",
     {
       "id": "#forge:obsidian",
       "required": false

--- a/src/generated/resources/data/c/tags/block/obsidians/crying.json
+++ b/src/generated/resources/data/c/tags/block/obsidians/crying.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:obsidian",
+    "minecraft:crying_obsidian"
+  ]
+}

--- a/src/generated/resources/data/c/tags/block/obsidians/crying.json
+++ b/src/generated/resources/data/c/tags/block/obsidians/crying.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "minecraft:obsidian",
     "minecraft:crying_obsidian"
   ]
 }

--- a/src/generated/resources/data/c/tags/block/obsidians/normal.json
+++ b/src/generated/resources/data/c/tags/block/obsidians/normal.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:obsidian",
+    "minecraft:crying_obsidian"
+  ]
+}

--- a/src/generated/resources/data/c/tags/block/obsidians/normal.json
+++ b/src/generated/resources/data/c/tags/block/obsidians/normal.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "minecraft:obsidian",
-    "minecraft:crying_obsidian"
+    "minecraft:obsidian"
   ]
 }

--- a/src/generated/resources/data/c/tags/item/obsidians.json
+++ b/src/generated/resources/data/c/tags/item/obsidians.json
@@ -1,7 +1,7 @@
 {
   "values": [
-    "minecraft:obsidian",
-    "minecraft:crying_obsidian",
+    "#c:obsidians/normal",
+    "#c:obsidians/crying",
     {
       "id": "#forge:obsidian",
       "required": false

--- a/src/generated/resources/data/c/tags/item/obsidians/crying.json
+++ b/src/generated/resources/data/c/tags/item/obsidians/crying.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:obsidian",
+    "minecraft:crying_obsidian"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/obsidians/crying.json
+++ b/src/generated/resources/data/c/tags/item/obsidians/crying.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "minecraft:obsidian",
     "minecraft:crying_obsidian"
   ]
 }

--- a/src/generated/resources/data/c/tags/item/obsidians/normal.json
+++ b/src/generated/resources/data/c/tags/item/obsidians/normal.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:obsidian",
+    "minecraft:crying_obsidian"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/obsidians/normal.json
+++ b/src/generated/resources/data/c/tags/item/obsidians/normal.json
@@ -1,6 +1,5 @@
 {
   "values": [
-    "minecraft:obsidian",
-    "minecraft:crying_obsidian"
+    "minecraft:obsidian"
   ]
 }

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -117,7 +117,7 @@ public class Tags {
         public static final TagKey<Block> OBSIDIANS = tag("obsidians");
         /**
          * For common obsidian that has no special quirks or behaviors. Ideal for recipe use.
-         * Crying Obsidian, for example, is a light block and harder to obtain and has its own tag instead of being here.
+         * Crying Obsidian, for example, is a light block and harder to obtain. So it gets its own tag instead of being under normal tag.
          */
         public static final TagKey<Block> OBSIDIANS_NORMAL = tag("obsidians/normal");
         public static final TagKey<Block> OBSIDIANS_CRYING = tag("obsidians/crying");
@@ -493,7 +493,7 @@ public class Tags {
         public static final TagKey<Item> OBSIDIANS = tag("obsidians");
         /**
          * For common obsidian that has no special quirks or behaviors. Ideal for recipe use.
-         * Crying Obsidian, for example, is a light block and harder to obtain and has its own tag instead of being here.
+         * Crying Obsidian, for example, is a light block and harder to obtain. So it gets its own tag instead of being under normal tag.
          */
         public static final TagKey<Item> OBSIDIANS_NORMAL = tag("obsidians/normal");
         public static final TagKey<Item> OBSIDIANS_CRYING = tag("obsidians/crying");

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -116,6 +116,12 @@ public class Tags {
         public static final TagKey<Block> NETHERRACKS = tag("netherracks");
         public static final TagKey<Block> OBSIDIANS = tag("obsidians");
         /**
+         * For common obsidian that has no special quirks or behaviors. Ideal for recipe use.
+         * Crying Obsidian, for example, is a light block and harder to obtain and has its own tag instead of being here.
+         */
+        public static final TagKey<Block> OBSIDIANS_NORMAL = tag("obsidians/normal");
+        public static final TagKey<Block> OBSIDIANS_CRYING = tag("obsidians/crying");
+        /**
          * Blocks which are often replaced by deepslate ores, i.e. the ores in the tag {@link #ORES_IN_GROUND_DEEPSLATE}, during world generation
          */
         public static final TagKey<Block> ORE_BEARING_GROUND_DEEPSLATE = tag("ore_bearing_ground/deepslate");
@@ -485,6 +491,12 @@ public class Tags {
         public static final TagKey<Item> NUGGETS_GOLD = tag("nuggets/gold");
         public static final TagKey<Item> NUGGETS_IRON = tag("nuggets/iron");
         public static final TagKey<Item> OBSIDIANS = tag("obsidians");
+        /**
+         * For common obsidian that has no special quirks or behaviors. Ideal for recipe use.
+         * Crying Obsidian, for example, is a light block and harder to obtain and has its own tag instead of being here.
+         */
+        public static final TagKey<Item> OBSIDIANS_NORMAL = tag("obsidians/normal");
+        public static final TagKey<Item> OBSIDIANS_CRYING = tag("obsidians/crying");
         /**
          * Blocks which are often replaced by deepslate ores, i.e. the ores in the tag {@link #ORES_IN_GROUND_DEEPSLATE}, during world generation
          */

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
@@ -80,7 +80,9 @@ public final class NeoForgeBlockTagsProvider extends BlockTagsProvider {
         tag(Tags.Blocks.SKULLS).add(Blocks.SKELETON_SKULL, Blocks.SKELETON_WALL_SKULL, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, Blocks.PLAYER_HEAD, Blocks.PLAYER_WALL_HEAD, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, Blocks.CREEPER_HEAD, Blocks.CREEPER_WALL_HEAD, Blocks.PIGLIN_HEAD, Blocks.PIGLIN_WALL_HEAD, Blocks.DRAGON_HEAD, Blocks.DRAGON_WALL_HEAD);
         tag(Tags.Blocks.HIDDEN_FROM_RECIPE_VIEWERS);
         tag(Tags.Blocks.NETHERRACKS).add(Blocks.NETHERRACK);
-        tag(Tags.Blocks.OBSIDIANS).add(Blocks.OBSIDIAN).add(Blocks.CRYING_OBSIDIAN);
+        tag(Tags.Blocks.OBSIDIANS_NORMAL).add(Blocks.OBSIDIAN).add(Blocks.CRYING_OBSIDIAN);
+        tag(Tags.Blocks.OBSIDIANS_CRYING).add(Blocks.OBSIDIAN).add(Blocks.CRYING_OBSIDIAN);
+        tag(Tags.Blocks.OBSIDIANS).addTags(Tags.Blocks.OBSIDIANS_NORMAL, Tags.Blocks.OBSIDIANS_CRYING);
         tag(Tags.Blocks.ORE_BEARING_GROUND_DEEPSLATE).add(Blocks.DEEPSLATE);
         tag(Tags.Blocks.ORE_BEARING_GROUND_NETHERRACK).add(Blocks.NETHERRACK);
         tag(Tags.Blocks.ORE_BEARING_GROUND_STONE).add(Blocks.STONE);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
@@ -80,8 +80,8 @@ public final class NeoForgeBlockTagsProvider extends BlockTagsProvider {
         tag(Tags.Blocks.SKULLS).add(Blocks.SKELETON_SKULL, Blocks.SKELETON_WALL_SKULL, Blocks.WITHER_SKELETON_SKULL, Blocks.WITHER_SKELETON_WALL_SKULL, Blocks.PLAYER_HEAD, Blocks.PLAYER_WALL_HEAD, Blocks.ZOMBIE_HEAD, Blocks.ZOMBIE_WALL_HEAD, Blocks.CREEPER_HEAD, Blocks.CREEPER_WALL_HEAD, Blocks.PIGLIN_HEAD, Blocks.PIGLIN_WALL_HEAD, Blocks.DRAGON_HEAD, Blocks.DRAGON_WALL_HEAD);
         tag(Tags.Blocks.HIDDEN_FROM_RECIPE_VIEWERS);
         tag(Tags.Blocks.NETHERRACKS).add(Blocks.NETHERRACK);
-        tag(Tags.Blocks.OBSIDIANS_NORMAL).add(Blocks.OBSIDIAN).add(Blocks.CRYING_OBSIDIAN);
-        tag(Tags.Blocks.OBSIDIANS_CRYING).add(Blocks.OBSIDIAN).add(Blocks.CRYING_OBSIDIAN);
+        tag(Tags.Blocks.OBSIDIANS_NORMAL).add(Blocks.OBSIDIAN);
+        tag(Tags.Blocks.OBSIDIANS_CRYING).add(Blocks.CRYING_OBSIDIAN);
         tag(Tags.Blocks.OBSIDIANS).addTags(Tags.Blocks.OBSIDIANS_NORMAL, Tags.Blocks.OBSIDIANS_CRYING);
         tag(Tags.Blocks.ORE_BEARING_GROUND_DEEPSLATE).add(Blocks.DEEPSLATE);
         tag(Tags.Blocks.ORE_BEARING_GROUND_NETHERRACK).add(Blocks.NETHERRACK);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -171,6 +171,8 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
         tag(Tags.Items.NUGGETS_IRON).add(Items.IRON_NUGGET);
         tag(Tags.Items.NUGGETS_GOLD).add(Items.GOLD_NUGGET);
         copy(Tags.Blocks.OBSIDIANS, Tags.Items.OBSIDIANS);
+        copy(Tags.Blocks.OBSIDIANS_NORMAL, Tags.Items.OBSIDIANS_NORMAL);
+        copy(Tags.Blocks.OBSIDIANS_CRYING, Tags.Items.OBSIDIANS_CRYING);
         copy(Tags.Blocks.ORE_BEARING_GROUND_DEEPSLATE, Tags.Items.ORE_BEARING_GROUND_DEEPSLATE);
         copy(Tags.Blocks.ORE_BEARING_GROUND_NETHERRACK, Tags.Items.ORE_BEARING_GROUND_NETHERRACK);
         copy(Tags.Blocks.ORE_BEARING_GROUND_STONE, Tags.Items.ORE_BEARING_GROUND_STONE);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -69,6 +69,8 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Blocks.NEEDS_GOLD_TOOL, "Needs Gold Tools");
         add(Tags.Blocks.NEEDS_NETHERITE_TOOL, "Needs Netherite Tools");
         add(Tags.Blocks.OBSIDIANS, "Obsidians");
+        add(Tags.Blocks.OBSIDIANS_NORMAL, "Normal Obsidians");
+        add(Tags.Blocks.OBSIDIANS_CRYING, "Crying Obsidians");
         add(Tags.Blocks.ORE_BEARING_GROUND_DEEPSLATE, "Deepslate Ore Bearing Ground");
         add(Tags.Blocks.ORE_BEARING_GROUND_NETHERRACK, "Netherrack Ore Bearing Ground");
         add(Tags.Blocks.ORE_BEARING_GROUND_STONE, "Stone Ore Bearing Ground");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -247,6 +247,8 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Items.NUGGETS_IRON, "Iron Nuggets");
         add(Tags.Items.NUGGETS_GOLD, "Gold Nuggets");
         add(Tags.Items.OBSIDIANS, "Obsidians");
+        add(Tags.Items.OBSIDIANS_NORMAL, "Normal Obsidians");
+        add(Tags.Items.OBSIDIANS_CRYING, "Crying Obsidians");
         add(Tags.Items.ORE_BEARING_GROUND_DEEPSLATE, "Deepslate Ore Bearing Ground");
         add(Tags.Items.ORE_BEARING_GROUND_NETHERRACK, "Netherrack Ore Bearing Ground");
         add(Tags.Items.ORE_BEARING_GROUND_STONE, "Stone Ore Bearing Ground");


### PR DESCRIPTION
This PR was a request from some users.

The original change to having Crying Obsidian in the `c:obsidians` tag was required as it is obsidian and excluding it would've been illogical and completely arbitrary. Much like saying brown mushroom shouldn't be in a mushroom tag because it is a light block despite a mushroom. 
 
However, adding subtags is more ideal for narrowing down and clarifying usages. In this case, recipes can target `c:obsidians/normal` and won't have to worry about other mod's special rare obsidians making it inside too. This is the same setup that we do for `c:cobblestones/normal`, `c:cobblestones/mossy`, `c:cobblestones/infested` so we have precedence for using normal for the default regular block.

Closes https://github.com/neoforged/NeoForge/issues/1548
