### PR TITLE
Remove hard coding on `AbstractSkeleton.canFireProjectileWeapon`

### DIFF
--- a/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -24,3 +24,12 @@
          double d0 = p_32141_.getX() - this.getX();
          double d1 = p_32141_.getY(0.3333333333333333) - abstractarrow.getY();
          double d2 = p_32141_.getZ() - this.getZ();
+@@ -200,7 +_,7 @@
+ 
+     @Override
+     public boolean canFireProjectileWeapon(ProjectileWeaponItem p_32144_) {
+-        return p_32144_ == Items.BOW;
++        return p_32144_.getDefaultInstance().is(net.neoforged.neoforge.common.Tags.Items.SKELETON_USABLE_BOWS);
+     }
+ 
+     @Override

--- a/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -29,7 +29,7 @@
      @Override
      public boolean canFireProjectileWeapon(ProjectileWeaponItem p_32144_) {
 -        return p_32144_ == Items.BOW;
-+        return p_32144_.getDefaultInstance().is(net.neoforged.neoforge.common.Tags.Items.SKELETON_USABLE_BOWS);
++        return p_32144_.builtInRegistryHolder().is(net.neoforged.neoforge.common.Tags.Items.SKELETON_USABLE_BOWS);
      }
  
      @Override

--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -362,6 +362,7 @@
   "tag.item.c.tools.spear": "Spears",
   "tag.item.c.villager_job_sites": "Villager Job Sites",
   "tag.item.neoforge.enchanting_fuels": "Enchanting Fuels",
+  "tag.item.neoforge.skeleton_usable_bows": "Skeleton Usable Bows",
   "tag.worldgen.biome.c.hidden_from_locator_selection": "Hidden From Locator's Selection",
   "tag.worldgen.biome.c.is_aquatic": "Aquatic",
   "tag.worldgen.biome.c.is_aquatic_icy": "Aquatic Icy",

--- a/src/generated/resources/data/neoforge/tags/item/skeleton_usable_bows.json
+++ b/src/generated/resources/data/neoforge/tags/item/skeleton_usable_bows.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:bow"
+  ]
+}

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -271,6 +271,11 @@ public class Tags {
          * This tag defaults to {@link net.minecraft.world.item.Items#LAPIS_LAZULI} when not present in any datapacks, including forge client on vanilla server
          */
         public static final TagKey<Item> ENCHANTING_FUELS = neoforgeTag("enchanting_fuels");
+        /**
+         * Controls what bows can be used by {@link net.minecraft.world.entity.monster.AbstractSkeleton}
+         * This tag defaults to {@link net.minecraft.world.item.Items#BOW} when not present in any datapacks, including forge client on vanilla server
+         */
+        public static final TagKey<Item> SKELETON_USABLE_BOWS = neoforgeTag("skeleton_usable_bows");
 
         // `c` tags for common conventions
         public static final TagKey<Item> BARRELS = tag("barrels");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -222,6 +222,7 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
         tag(Tags.Items.SEEDS_MELON).add(Items.MELON_SEEDS);
         tag(Tags.Items.SEEDS_PUMPKIN).add(Items.PUMPKIN_SEEDS);
         tag(Tags.Items.SEEDS_WHEAT).add(Items.WHEAT_SEEDS);
+        tag(Tags.Items.SKELETON_USABLE_BOWS).add(Items.BOW);
         tag(Tags.Items.SLIMEBALLS).add(Items.SLIME_BALL); // Deprecated
         tag(Tags.Items.SLIME_BALLS).add(Items.SLIME_BALL).addOptionalTag(Tags.Items.SLIMEBALLS);
         tag(Tags.Items.SHULKER_BOXES)

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -300,6 +300,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Items.SEEDS_MELON, "Melon Seeds");
         add(Tags.Items.SEEDS_PUMPKIN, "Pumpkin Seeds");
         add(Tags.Items.SEEDS_WHEAT, "Wheat Seeds");
+        add(Tags.Items.SKELETON_USABLE_BOWS, "Skeleton Usable Bows");
         add(Tags.Items.SHULKER_BOXES, "Shulker Boxes");
         add(Tags.Items.SLIME_BALLS, "Slimeballs");
         add(Tags.Items.SLIMEBALLS, "Slimeballs");


### PR DESCRIPTION
A [suggestion](https://discord.com/channels/313125603924639766/852298000042164244/1293932229860524102) from Commoble to remove the hard coding on `AbstractSkeleton.canFireProjectileWeapon` and bind it to a Neoforge functionality tag

Currently only contains `minecraft:bow` within the tag as that is all the vanilla skeleton checks for, added some javadoc to it but maybe specification that it should be items that extend `BowItem` is required as Crossbow Logic won't work with skeletons

Also open to better naming suggestions if that's a thought