### PR TITLE
[1.21.4] Add event fired at the start of the framegraph setup

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -1,5 +1,15 @@
 --- a/net/minecraft/client/renderer/LevelRenderer.java
 +++ b/net/minecraft/client/renderer/LevelRenderer.java
+@@ -473,6 +_,9 @@
+             this.targets.entityOutline = framegraphbuilder.importExternal("entity_outline", this.entityOutlineTarget);
+         }
+ 
++        var setupEvent = net.neoforged.neoforge.client.ClientHooks.fireFrameGraphSetup(framegraphbuilder, this.targets, rendertargetdescriptor, frustum, p_109604_, p_254120_, p_323920_, p_348530_, profilerfiller);
++        flag2 |= setupEvent.isOutlineProcessingEnabled();
++
+         FramePass framepass = framegraphbuilder.addPass("clear");
+         this.targets.main = framepass.readsAndWrites(this.targets.main);
+         framepass.executes(() -> {
 @@ -480,7 +_,7 @@
              RenderSystem.clear(16640);
          });

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.client;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
+import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
@@ -65,6 +66,7 @@ import net.minecraft.client.renderer.FogParameters;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.LevelTargetBundle;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.ShaderDefines;
@@ -106,6 +108,7 @@ import net.minecraft.server.packs.resources.ReloadableResourceManager;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.profiling.Profiler;
+import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
@@ -144,6 +147,7 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
 import net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.FrameGraphSetupEvent;
 import net.neoforged.neoforge.client.event.GatherEffectScreenTooltipsEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
 import net.neoforged.neoforge.client.event.ModelEvent;
@@ -1099,5 +1103,15 @@ public class ClientHooks {
         vanillaAtlases = new HashMap<>(vanillaAtlases);
         ModLoader.postEvent(new RegisterMaterialAtlasesEvent(vanillaAtlases));
         return Map.copyOf(vanillaAtlases);
+    }
+
+    @ApiStatus.Internal
+    public static FrameGraphSetupEvent.Pre fireFrameGraphSetupPre(FrameGraphBuilder builder, LevelTargetBundle targets, Frustum frustum, Camera camera, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, DeltaTracker deltaTracker, ProfilerFiller profiler) {
+        return NeoForge.EVENT_BUS.post(new FrameGraphSetupEvent.Pre(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler));
+    }
+
+    @ApiStatus.Internal
+    public static FrameGraphSetupEvent.Post fireFrameGraphSetupPost(FrameGraphBuilder builder, LevelTargetBundle targets, Frustum frustum, Camera camera, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, DeltaTracker deltaTracker, ProfilerFiller profiler) {
+        return NeoForge.EVENT_BUS.post(new FrameGraphSetupEvent.Post(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.platform.Window;
+import com.mojang.blaze3d.resource.RenderTargetDescriptor;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -1106,12 +1107,7 @@ public class ClientHooks {
     }
 
     @ApiStatus.Internal
-    public static FrameGraphSetupEvent.Pre fireFrameGraphSetupPre(FrameGraphBuilder builder, LevelTargetBundle targets, Frustum frustum, Camera camera, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, DeltaTracker deltaTracker, ProfilerFiller profiler) {
-        return NeoForge.EVENT_BUS.post(new FrameGraphSetupEvent.Pre(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler));
-    }
-
-    @ApiStatus.Internal
-    public static FrameGraphSetupEvent.Post fireFrameGraphSetupPost(FrameGraphBuilder builder, LevelTargetBundle targets, Frustum frustum, Camera camera, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, DeltaTracker deltaTracker, ProfilerFiller profiler) {
-        return NeoForge.EVENT_BUS.post(new FrameGraphSetupEvent.Post(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler));
+    public static FrameGraphSetupEvent fireFrameGraphSetup(FrameGraphBuilder builder, LevelTargetBundle targets, RenderTargetDescriptor renderTargetDescriptor, Frustum frustum, Camera camera, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, DeltaTracker deltaTracker, ProfilerFiller profiler) {
+        return NeoForge.EVENT_BUS.post(new FrameGraphSetupEvent(builder, targets, renderTargetDescriptor, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/event/FrameGraphSetupEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/FrameGraphSetupEvent.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
+import net.minecraft.client.Camera;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.renderer.LevelTargetBundle;
+import net.minecraft.client.renderer.culling.Frustum;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+import org.joml.Matrix4f;
+
+/**
+ * Fired when the {@linkplain FrameGraphBuilder frame graph} is set up at the start of level rendering.
+ * <p>
+ * These events are not {@linkplain ICancellableEvent cancellable}.
+ * <p>
+ * These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.
+ */
+public abstract sealed class FrameGraphSetupEvent extends Event {
+    protected final FrameGraphBuilder builder;
+    private final LevelTargetBundle targets;
+    private final Frustum frustum;
+    private final Camera camera;
+    private final Matrix4f modelViewMatrix;
+    private final Matrix4f projectionMatrix;
+    private final DeltaTracker deltaTracker;
+    private final ProfilerFiller profiler;
+
+    protected FrameGraphSetupEvent(
+            FrameGraphBuilder builder,
+            LevelTargetBundle targets,
+            Frustum frustum,
+            Camera camera,
+            Matrix4f modelViewMatrix,
+            Matrix4f projectionMatrix,
+            DeltaTracker deltaTracker,
+            ProfilerFiller profiler) {
+        this.builder = builder;
+        this.targets = targets;
+        this.frustum = frustum;
+        this.camera = camera;
+        this.modelViewMatrix = modelViewMatrix;
+        this.projectionMatrix = projectionMatrix;
+        this.deltaTracker = deltaTracker;
+        this.profiler = profiler;
+    }
+
+    /**
+     * {@return the {@link FrameGraphBuilder} used to set up the frame graph}
+     */
+    public FrameGraphBuilder getFrameGrapBuilder() {
+        return builder;
+    }
+
+    /**
+     * {@return the render targets used during level rendering}
+     */
+    public LevelTargetBundle getTargetBundle() {
+        return targets;
+    }
+
+    /**
+     * {@return the culling frustum}
+     */
+    public Frustum getFrustum() {
+        return frustum;
+    }
+
+    /**
+     * {@return the active {@link Camera}}
+     */
+    public Camera getCamera() {
+        return camera;
+    }
+
+    /**
+     * {@return the model view matrix}
+     */
+    public Matrix4f getModelViewMatrix() {
+        return modelViewMatrix;
+    }
+
+    /**
+     * {@return the projection matrix}
+     */
+    public Matrix4f getProjectionMatrix() {
+        return projectionMatrix;
+    }
+
+    /**
+     * {@return the {@link DeltaTracker}}
+     */
+    public DeltaTracker getDeltaTracker() {
+        return deltaTracker;
+    }
+
+    /**
+     * {@return the active {@linkplain ProfilerFiller profiler}}
+     */
+    public ProfilerFiller getProfiler() {
+        return profiler;
+    }
+
+    /**
+     * Fired at the start of frame graph setup, right after the "clear" pass is added
+     */
+    public static final class Pre extends FrameGraphSetupEvent {
+        private boolean enableOutline;
+
+        @ApiStatus.Internal
+        public Pre(
+                FrameGraphBuilder builder,
+                LevelTargetBundle targets,
+                Frustum frustum,
+                Camera camera,
+                Matrix4f modelViewMatrix,
+                Matrix4f projectionMatrix,
+                DeltaTracker deltaTracker,
+                ProfilerFiller profiler) {
+            super(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler);
+        }
+
+        /**
+         * Enables the entity outline post-processing shader regardless of any entities having active outlines
+         */
+        public void enableOutlineProcessing() {
+            this.enableOutline = true;
+        }
+
+        /**
+         * {@return whether the entity outline post-processing shader will be enabled regardless of entities using it}
+         */
+        public boolean isOutlineProcessingEnabled() {
+            return enableOutline;
+        }
+    }
+
+    /**
+     * Fired at the end of frame graph setup, right before the frame graph is executed
+     */
+    public static final class Post extends FrameGraphSetupEvent {
+        @ApiStatus.Internal
+        public Post(
+                FrameGraphBuilder builder,
+                LevelTargetBundle targets,
+                Frustum frustum,
+                Camera camera,
+                Matrix4f modelViewMatrix,
+                Matrix4f projectionMatrix,
+                DeltaTracker deltaTracker,
+                ProfilerFiller profiler) {
+            super(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler);
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/event/FrameGraphSetupEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/FrameGraphSetupEvent.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.framegraph.FrameGraphBuilder;
+import com.mojang.blaze3d.resource.RenderTargetDescriptor;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.LevelTargetBundle;
@@ -19,26 +20,31 @@ import org.jetbrains.annotations.ApiStatus;
 import org.joml.Matrix4f;
 
 /**
- * Fired when the {@linkplain FrameGraphBuilder frame graph} is set up at the start of level rendering.
+ * Fired when the {@linkplain FrameGraphBuilder frame graph} is set up at the start of level rendering, right before
+ * the vanilla frame passes are set up.
  * <p>
- * These events are not {@linkplain ICancellableEvent cancellable}.
+ * This event is not {@linkplain ICancellableEvent cancellable}.
  * <p>
- * These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.
  */
-public abstract sealed class FrameGraphSetupEvent extends Event {
-    protected final FrameGraphBuilder builder;
+public final class FrameGraphSetupEvent extends Event {
+    private final FrameGraphBuilder builder;
     private final LevelTargetBundle targets;
+    private final RenderTargetDescriptor renderTargetDescriptor;
     private final Frustum frustum;
     private final Camera camera;
     private final Matrix4f modelViewMatrix;
     private final Matrix4f projectionMatrix;
     private final DeltaTracker deltaTracker;
     private final ProfilerFiller profiler;
+    private boolean enableOutline;
 
-    protected FrameGraphSetupEvent(
+    @ApiStatus.Internal
+    public FrameGraphSetupEvent(
             FrameGraphBuilder builder,
             LevelTargetBundle targets,
+            RenderTargetDescriptor renderTargetDescriptor,
             Frustum frustum,
             Camera camera,
             Matrix4f modelViewMatrix,
@@ -47,6 +53,7 @@ public abstract sealed class FrameGraphSetupEvent extends Event {
             ProfilerFiller profiler) {
         this.builder = builder;
         this.targets = targets;
+        this.renderTargetDescriptor = renderTargetDescriptor;
         this.frustum = frustum;
         this.camera = camera;
         this.modelViewMatrix = modelViewMatrix;
@@ -67,6 +74,13 @@ public abstract sealed class FrameGraphSetupEvent extends Event {
      */
     public LevelTargetBundle getTargetBundle() {
         return targets;
+    }
+
+    /**
+     * {@return the render target descriptor to use for creating full-screen render targets}
+     */
+    public RenderTargetDescriptor getRenderTargetDescriptor() {
+        return renderTargetDescriptor;
     }
 
     /**
@@ -112,54 +126,16 @@ public abstract sealed class FrameGraphSetupEvent extends Event {
     }
 
     /**
-     * Fired at the start of frame graph setup, right after the "clear" pass is added
+     * Enables the entity outline post-processing shader regardless of any entities having active outlines
      */
-    public static final class Pre extends FrameGraphSetupEvent {
-        private boolean enableOutline;
-
-        @ApiStatus.Internal
-        public Pre(
-                FrameGraphBuilder builder,
-                LevelTargetBundle targets,
-                Frustum frustum,
-                Camera camera,
-                Matrix4f modelViewMatrix,
-                Matrix4f projectionMatrix,
-                DeltaTracker deltaTracker,
-                ProfilerFiller profiler) {
-            super(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler);
-        }
-
-        /**
-         * Enables the entity outline post-processing shader regardless of any entities having active outlines
-         */
-        public void enableOutlineProcessing() {
-            this.enableOutline = true;
-        }
-
-        /**
-         * {@return whether the entity outline post-processing shader will be enabled regardless of entities using it}
-         */
-        public boolean isOutlineProcessingEnabled() {
-            return enableOutline;
-        }
+    public void enableOutlineProcessing() {
+        this.enableOutline = true;
     }
 
     /**
-     * Fired at the end of frame graph setup, right before the frame graph is executed
+     * {@return whether the entity outline post-processing shader will be enabled regardless of entities using it}
      */
-    public static final class Post extends FrameGraphSetupEvent {
-        @ApiStatus.Internal
-        public Post(
-                FrameGraphBuilder builder,
-                LevelTargetBundle targets,
-                Frustum frustum,
-                Camera camera,
-                Matrix4f modelViewMatrix,
-                Matrix4f projectionMatrix,
-                DeltaTracker deltaTracker,
-                ProfilerFiller profiler) {
-            super(builder, targets, frustum, camera, modelViewMatrix, projectionMatrix, deltaTracker, profiler);
-        }
+    public boolean isOutlineProcessingEnabled() {
+        return enableOutline;
     }
 }


### PR DESCRIPTION
This PR adds events during the framegraph setup at the start of level rendering. These allow adding custom passes to the graph and enabling entity outline post-processing without any entities in view having active outlines.
The pre event is fired right after the "clear" pass is set up and the post event is fired right before the graph is executed.

Opening as a draft for now because I'm not totally sure whether the split into pre and post is actually useful or whether the pre event primarily for the outline stuff and people using mixins to precisely inject custom passes between vanilla passes is more suitable.