### PR TITLE
[1.21.2] Make block outline passes respect render types specified by the model

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -169,14 +169,17 @@
                      p_363901_.popPose();
                  }
              }
-@@ -897,6 +_,7 @@
+@@ -897,8 +_,9 @@
              if (blockhitresult.getType() != HitResult.Type.MISS) {
                  BlockPos blockpos = blockhitresult.getBlockPos();
                  BlockState blockstate = this.level.getBlockState(blockpos);
 +                if (!net.neoforged.neoforge.client.ClientHooks.onDrawHighlight(this, p_363911_, blockhitresult, this.minecraft.getDeltaTracker(), p_361893_, p_362782_, p_361698_))
                  if (!blockstate.isAir() && this.level.getWorldBorder().isWithinBounds(blockpos)) {
-                     boolean flag = ItemBlockRenderTypes.getChunkRenderType(blockstate).sortOnUpload();
+-                    boolean flag = ItemBlockRenderTypes.getChunkRenderType(blockstate).sortOnUpload();
++                    boolean flag = net.neoforged.neoforge.client.ClientHooks.isInTranslucentBlockOutlinePass(this.level, blockpos, blockstate);
                      if (flag != p_361698_) {
+                         return;
+                     }
 @@ -1026,6 +_,7 @@
              compiledshaderprogram.clear();
              VertexBuffer.unbind();

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -1088,4 +1088,13 @@ public class ClientHooks {
         }
         return RECIPE_BOOK_TYPES;
     }
+
+    private static final RandomSource OUTLINE_PASS_RANDOM = RandomSource.create();
+
+    public static boolean isInTranslucentBlockOutlinePass(Level level, BlockPos pos, BlockState state) {
+        BakedModel model = Minecraft.getInstance().getBlockRenderer().getBlockModel(state);
+        OUTLINE_PASS_RANDOM.setSeed(42);
+        ChunkRenderTypeSet renderTypes = model.getRenderTypes(state, OUTLINE_PASS_RANDOM, level.getModelData(pos));
+        return renderTypes.contains(RenderType.TRANSLUCENT) || renderTypes.contains(RenderType.TRIPWIRE);
+    }
 }


### PR DESCRIPTION
This PR makes block outline rendering respect the render types specified by `BakedModel`s when determining whether the outlines should be drawn before or after translucent geometry