### PR TITLE
[1.21.3] Render Minecraft logo as builtin mods `logoFile`

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -494,3 +494,6 @@ public net.minecraft.world.item.enchantment.Enchantment locationContext(Lnet/min
 public net.minecraft.world.item.enchantment.Enchantment entityContext(Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;)Lnet/minecraft/world/level/storage/loot/LootContext;
 public net.minecraft.world.item.enchantment.Enchantment blockHitContext(Lnet/minecraft/server/level/ServerLevel;ILnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/level/block/state/BlockState;)Lnet/minecraft/world/level/storage/loot/LootContext;
 public net.minecraft.world.item.enchantment.Enchantment applyEffects(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/LootContext;Ljava/util/function/Consumer;)V
+# Made public for mc logo render in mods list
+public net.minecraft.client.gui.components.LogoRenderer LOGO_TEXTURE_WIDTH
+public net.minecraft.client.gui.components.LogoRenderer LOGO_TEXTURE_HEIGHT


### PR DESCRIPTION
Redirects mod container `logoFile` generation/rendering to simply render the built in vanilla logo png file when viewing the built in Minecraft mod info.

Fixes #1616 depends on #1615

### Before
![image](https://github.com/user-attachments/assets/caa48d09-faa9-4106-b8e4-99ea57357b8e)

### After
![image](https://github.com/user-attachments/assets/cd497872-4560-46c3-8930-4ed6a0650ca2)
