### PR TITLE
[1.21.3] Expose RecipeManager#recipes

### DIFF
--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/item/crafting/RecipeManager.java
++++ b/net/minecraft/world/item/crafting/RecipeManager.java
+@@ -260,6 +_,10 @@
+                 : Optional.empty();
+     }
+ 
++    public RecipeMap recipeMap() {
++        return this.recipes;
++    }
++
+     public interface CachedCheck<I extends RecipeInput, T extends Recipe<I>> {
+         Optional<RecipeHolder<T>> getRecipeFor(I p_344938_, ServerLevel p_379487_);
+     }

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -1,9 +1,10 @@
 --- a/net/minecraft/world/item/crafting/RecipeManager.java
 +++ b/net/minecraft/world/item/crafting/RecipeManager.java
-@@ -260,6 +_,10 @@
+@@ -260,6 +_,11 @@
                  : Optional.empty();
      }
  
++    // Neo: expose recipe map
 +    public RecipeMap recipeMap() {
 +        return this.recipes;
 +    }


### PR DESCRIPTION
Exposes the `RecipeMap` as a getter via `RecipeManager#recipeMap`. This done over an AT as the field is mutable and should not be modified.

`RecipeMap` contains methods to get the recipes of a given type (`byKey`) and to return a stream of all recipes that match (`getRecipesFor`). Depending on the recipe consumer, they may reasonably want to return all recipes that could potentially match the input, or simply all recipes for that given type. The most `RecipeManager` can do at the moment on its own is return all holders, regardless of type.