### PR TITLE
[1.21.3] Relax extensible enum coherence checks for extensible enums without custom entries

### DIFF
--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -264,7 +264,6 @@
   "neoforge.network.data_maps.missing_their": "Cannot connect to server as it has mandatory registry data maps not present on the client: %s",
 
   "neoforge.network.extensible_enums.no_vanilla_server": "This client does not support vanilla servers as it has extended enums used in serverbound networking",
-  "neoforge.network.extensible_enums.enum_set_mismatch": "The set of extensible enums on the client and server do not match. Make sure you are using the same NeoForge version as the server",
   "neoforge.network.extensible_enums.enum_entry_mismatch": "The set of values added to extensible enums on the client and server do not match. Make sure you are using the same mod and NeoForge versions as the server. See the log for more details",
 
   "neoforge.attribute.debug.base": "[Entity: %s | Item: %s]",


### PR DESCRIPTION
This PR relaxes the coherence checks on extensible enums to allow a client/server with an extensible enum without additional entries to connect to a server/client with the respective enum not made extensible. This ensures that a NeoForge version which makes a new enum extensible is network-compatible with the previous NeoForge version as long as no mod adds additional entries to the affected enum. With the current implementation, any additional enum being made extensible and marked as `@NetworkedEnum` would break network compatibility with the previous version, regardless of any mod actually making use of the extensibility.

This PR is the 1.21.3 port of #1559.