### PR TITLE
[1.21.3] Fix for data map serialization

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/data/DataMapProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/DataMapProvider.java
@@ -63,7 +63,7 @@ public abstract class DataMapProvider implements DataProvider {
         return lookupProvider.thenCompose(provider -> {
             gather(provider);
 
-            final DynamicOps<JsonElement> dynamicOps = RegistryOps.create(JsonOps.INSTANCE, provider);
+            final DynamicOps<JsonElement> dynamicOps = provider.createSerializationContext(JsonOps.INSTANCE);
 
             return CompletableFuture.allOf(this.builders.entrySet().stream().map(entry -> {
                 DataMapType<?, ?> type = entry.getKey();

--- a/src/main/java/net/neoforged/neoforge/common/data/DataMapProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/DataMapProvider.java
@@ -25,7 +25,6 @@ import net.minecraft.core.Registry;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
-import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;


### PR DESCRIPTION
Closes #1644 

Reason for this change is that `RegistryOps.create` wraps `HolderLookup.Provider`s in a `HolderLookupAdapter`, which creates a new `RegistryInfoLookup` and sets the `owner` field to the registry itself (same object instance as the `getter` field), rather than whatever it was during datagen, thereby creating a disconnect between holders (which are bound to the real owner) and the registry lookup (which is now the wrong owner). However, `RegistrySetBuilder` uses its own anonymous `HolderLookup.Provider` which overrides `createSerializationContext` to return a `RegistryOps` with a `RegistryInfoLookup` which would obtain the correct owner for the given registry based on how it was built during `RegistrySetBuilder#buildProviderWithContext`.