### PR TITLE
[1.21.3] Fix `ToolMaterial` and `ArmorMaterial` causing crashes when unique tags are used

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -65,7 +65,10 @@ public class GameData {
 
     public static void freezeData() {
         LOGGER.debug(REGISTRIES, "Freezing registries");
-        BuiltInRegistries.REGISTRY.stream().filter(r -> r instanceof MappedRegistry).forEach(r -> ((MappedRegistry<?>) r).freeze());
+        BuiltInRegistries.REGISTRY.stream().filter(r -> r instanceof MappedRegistry).forEach(r -> {
+            ((MappedRegistry<?>) r).bindAllTagsToEmpty();
+            ((MappedRegistry<?>) r).freeze();
+        });
 
         RegistryManager.takeFrozenSnapshot();
 

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -66,6 +66,7 @@ public class GameData {
     public static void freezeData() {
         LOGGER.debug(REGISTRIES, "Freezing registries");
         BuiltInRegistries.REGISTRY.stream().filter(r -> r instanceof MappedRegistry).forEach(r -> {
+            // HolderSet.Named may be used for registry objects, vanilla binds these tags so freeze won't throw for unbound tags
             ((MappedRegistry<?>) r).bindAllTagsToEmpty();
             ((MappedRegistry<?>) r).freeze();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -17,6 +17,8 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityType;
@@ -33,7 +35,9 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.MobBucketItem;
+import net.minecraft.world.item.PickaxeItem;
 import net.minecraft.world.item.Rarity;
+import net.minecraft.world.item.ToolMaterial;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.equipment.ArmorMaterials;
 import net.minecraft.world.item.equipment.ArmorType;
@@ -193,5 +197,11 @@ public class ItemTests {
                 .thenExecute(pig -> pig.setHealth(pig.getMaxHealth()))
                 .thenWaitUntil(() -> helper.assertEntityPresent(EntityType.PIG, 1, 1, 1))
                 .thenSucceed());
+    }
+
+    @TestHolder(description = "Adds a stone-pickaxe-like item that cannot mine bamboo blocks and is repaired with beds. Tests that registries can correctly handle named holder set references.")
+    static void toolItem(final DynamicTest test, final RegistrationHelper reg) {
+        var material = new ToolMaterial(BlockTags.BAMBOO_BLOCKS, 160, 5.0F, 0.5F, 10, ItemTags.BEDS);
+        reg.items().registerItem("neo_pickaxe", properties -> new PickaxeItem(material, 1.0F, -2.8F, properties));
     }
 }


### PR DESCRIPTION
Closes #1631 

The fix for this issue was to call `MappedRegistry#bindAllTagsToEmpty` before refreezing registries. Vanilla calls this when they freeze registries, allowing them to use named `HolderSet`s in registry objects before they're available in-game (such as in `ToolMaterial`s and `ArmorMaterial`s). If this is not called, then tags are left unbound and `freeze` throws an exception. Vanilla's tags remained bound when NeoForge unfroze registries, however any new tags used were not bound on refreeze.