### PR TITLE
Bump FML to v5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ neoform_version=20241023.131943
 neoforge_snapshot_next_stable=21.4
 
 mergetool_version=2.0.0
-accesstransformers_version=10.0.1
+accesstransformers_version=11.0.1
 coremods_version=6.0.4
 eventbus_version=8.0.2
 modlauncher_version=11.0.4
@@ -30,7 +30,7 @@ jetbrains_annotations_version=24.0.1
 slf4j_api_version=2.0.7
 apache_maven_artifact_version=3.8.5
 jarjar_version=0.4.1
-fancy_mod_loader_version=4.0.31
+fancy_mod_loader_version=5.0.1
 mojang_logging_version=1.1.1
 log4j_version=2.22.1
 guava_version=31.1.2-jre


### PR DESCRIPTION
Bumps accesstransformers to v11, removing the transitive ANTLR dep.