### PR TITLE
[1.21.x] Fix Eclipse generic inference failure in testframework

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlocks.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlocks.java
@@ -51,7 +51,7 @@ public class DeferredBlocks extends DeferredRegister.Blocks {
     }
 
     public <B extends Block, E extends BlockEntity> DeferredBlockBuilder<B> registerBlockWithBEType(String name, BiFunction<BlockBehaviour.Properties, Supplier<BlockEntityType<E>>, ? extends B> func, TriFunction<BlockEntityType<?>, BlockPos, BlockState, E> beType, BlockBehaviour.Properties props) {
-        final var be = registrationHelper.registrar(Registries.BLOCK_ENTITY_TYPE).register(name, () -> new BlockEntityType<>(
+        final Supplier<BlockEntityType<E>> be = registrationHelper.registrar(Registries.BLOCK_ENTITY_TYPE).register(name, () -> new BlockEntityType<>(
                 (pos, state) -> beType.apply(BuiltInRegistries.BLOCK_ENTITY_TYPE.getValue(ResourceLocation.fromNamespaceAndPath(getNamespace(), name)), pos, state),
                 BuiltInRegistries.BLOCK.getValue(ResourceLocation.fromNamespaceAndPath(getNamespace(), name))));
         return registerBlock(name, properties -> func.apply(properties, be), props);


### PR DESCRIPTION
A new usage of `var` in `DeferredBlocks.java` makes ECJ fail to compile the file, due to a generic inference failure in the type of the `be` variable that causes the signature of `func.apply` to be invalid (it resolves to a wildcard instead of `E`).

This change explicitly types `be` to resolve the inference failure.