### PR TITLE
[1.21.3] Fix composite and separate transforms models not baking generated item models correctly

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/CompositeModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/CompositeModel.java
@@ -80,7 +80,7 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
             if (!context.isComponentVisible(name, true))
                 continue;
             var model = entry.getValue();
-            bakedPartsBuilder.put(name, model.bake(baker, spriteGetter, modelState));
+            bakedPartsBuilder.put(name, baker.bakeUncached(model, modelState, spriteGetter));
         }
         var bakedParts = bakedPartsBuilder.build();
 

--- a/src/main/java/net/neoforged/neoforge/client/model/SeparateTransformsModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/SeparateTransformsModel.java
@@ -56,8 +56,8 @@ public class SeparateTransformsModel implements IUnbakedGeometry<SeparateTransfo
         BakedModel baked = new Baked(
                 context.useAmbientOcclusion(), context.isGui3d(), context.useBlockLight(),
                 spriteGetter.apply(context.getMaterial("particle")),
-                baseModel.bake(baker, spriteGetter, modelState),
-                ImmutableMap.copyOf(Maps.transformValues(perspectives, value -> value.bake(baker, spriteGetter, modelState))));
+                baker.bakeUncached(baseModel, modelState, spriteGetter),
+                ImmutableMap.copyOf(Maps.transformValues(perspectives, value -> baker.bakeUncached(value, modelState, spriteGetter))));
         if (!overrides.isEmpty()) {
             baked = new ItemModel.BakedModelWithOverrides(baked, new BakedOverrides(baker, overrides, spriteGetter));
         }


### PR DESCRIPTION
This PR fixes generated item models wrapped in composite models and separate transforms models not getting baked correctly and ending up empty. This is caused by the generated item model special casing being gone from `BlockModel#bake()` due to the flattening of `UnbakedGeometryHelper.bake()`.

Fixes #1666