### PR TITLE
[1.21.3] Fix custom maps not syncing

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -23,6 +23,15 @@
              if (this.tickCount % 20 == 0) {
                  CriteriaTriggers.LOCATION.trigger(this);
              }
+@@ -781,7 +_,7 @@
+ 
+     private void synchronizeSpecialItemUpdates(ItemStack p_372884_) {
+         MapId mapid = p_372884_.get(DataComponents.MAP_ID);
+-        MapItemSavedData mapitemsaveddata = MapItem.getSavedData(mapid, this.level());
++        MapItemSavedData mapitemsaveddata = MapItem.getSavedData(p_372884_, this.level());
+         if (mapitemsaveddata != null) {
+             Packet<?> packet = mapitemsaveddata.getUpdatePacket(mapid, this);
+             if (packet != null) {
 @@ -850,6 +_,7 @@
      @Override
      public void die(DamageSource p_9035_) {


### PR DESCRIPTION
Hi!
Since Mojang changed maps (yet again... sigh), the way maps sync was changed a bit. This PR just adds a patch to use the neo method to get map data so custom map data can be used again. 