### PR TITLE
[1.21.x] Fix certain percentage attributes being displayed wrong

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'net.neoforged.gradle.platform' version '7.0.170'
+    id 'net.neoforged.gradle.platform' version '7.0.163'
 }
 
 if (rootProject.name.toLowerCase() == "neoforge") {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'net.neoforged.gradle.platform' version '7.0.163'
+    id 'net.neoforged.gradle.platform' version '7.0.170'
 }
 
 if (rootProject.name.toLowerCase() == "neoforge") {

--- a/src/main/java/net/neoforged/neoforge/common/PercentageAttribute.java
+++ b/src/main/java/net/neoforged/neoforge/common/PercentageAttribute.java
@@ -10,6 +10,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation;
 import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minecraft.world.item.TooltipFlag;
+import net.neoforged.neoforge.common.extensions.IAttributeExtension;
 
 /**
  * A Percentage Attribute is one which always displays modifiers as percentages, including for {@link Operation#ADD_VALUE}.
@@ -46,6 +47,10 @@ public class PercentageAttribute extends RangedAttribute {
 
     @Override
     public MutableComponent toValueComponent(Operation op, double value, TooltipFlag flag) {
-        return Component.translatable("neoforge.value.percent", FORMAT.format(value * this.scaleFactor));
+        if (IAttributeExtension.isNullOrAddition(op)) {
+            return Component.translatable("neoforge.value.percent", FORMAT.format(value * this.scaleFactor));
+        }
+
+        return Component.translatable("neoforge.value.percent", FORMAT.format(value * 100));
     }
 }


### PR DESCRIPTION
This PR fixes the implementation of `PercentageAttribute#toValueComponent` when the `scaleFactor` is not equal to `100`. The current implementation will cause non-addition modifiers to be displayed incorrectly unless the scale factor is exactly 100.

For example, the modifier below is a +10% `ADD_MULTIPLIED_TOTAL` modifier, but is incorrectly shown as `+100%` due to the faulty logic. This is a display-only issue, and is not impacting attribute calculations in any form. This will need to be backported to 1.21.1 as well.

![](https://i.imgur.com/OS6Id51.png)