### PR TITLE
Update NeoGradle to 7.0.171

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'net.neoforged.gradle.platform' version '7.0.163'
+    id 'net.neoforged.gradle.platform' version '7.0.171'
 }
 
 if (rootProject.name.toLowerCase() == "neoforge") {


### PR DESCRIPTION
This PR updates NeoGradle from 7.0.163 to 7.0.171.

More notable changes include Eclipse IDE compatibility fixes, interface injection support, and addition of DSL for configuring tools used by the installer/userdev runtime. See https://github.com/neoforged/NeoGradle/compare/878a92a90bf4d5d6da7deef01b3e4a9cd734d6c1...3a8ca288e8c3d028bcd812d10e7e008a2490573e for all commits included in the update.