### PR TITLE
Add Vanilla runs in NeoForge development environment and give each run its own folder

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevBasePlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevBasePlugin.java
@@ -1,9 +1,12 @@
 package net.neoforged.neodev;
 
 import net.neoforged.minecraftdependencies.MinecraftDependenciesPlugin;
+import net.neoforged.moddevgradle.internal.NeoDevFacade;
 import net.neoforged.nfrtgradle.CreateMinecraftArtifacts;
+import net.neoforged.nfrtgradle.DownloadAssets;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.Sync;
 
 public class NeoDevBasePlugin implements Plugin<Project> {
@@ -12,13 +15,46 @@ public class NeoDevBasePlugin implements Plugin<Project> {
         // These plugins allow us to declare dependencies on Minecraft libraries needed to compile the official sources
         project.getPlugins().apply(MinecraftDependenciesPlugin.class);
 
-        var createSources = NeoDevPlugin.configureMinecraftDecompilation(project);
+        var dependencyFactory = project.getDependencyFactory();
+        var tasks = project.getTasks();
+        var neoDevBuildDir = project.getLayout().getBuildDirectory().dir("neodev");
 
-        project.getTasks().register("setup", Sync.class, task -> {
+        var extension = project.getExtensions().create(NeoDevExtension.NAME, NeoDevExtension.class);
+
+        var createSources = NeoDevPlugin.configureMinecraftDecompilation(project);
+        // Task must run on sync to have MC resources available for IDEA nondelegated builds.
+        NeoDevFacade.runTaskOnProjectSync(project, createSources);
+
+        tasks.register("setup", Sync.class, task -> {
             task.setGroup(NeoDevPlugin.GROUP);
             task.setDescription("Replaces the contents of the base project sources with the unpatched, decompiled Minecraft source code.");
             task.from(project.zipTree(createSources.flatMap(CreateMinecraftArtifacts::getSourcesArtifact)));
             task.into(project.file("src/main/java/"));
         });
+
+        var downloadAssets = tasks.register("downloadAssets", DownloadAssets.class, task -> {
+            task.setGroup(NeoDevPlugin.INTERNAL_GROUP);
+            task.getNeoFormArtifact().set(createSources.flatMap(CreateMinecraftArtifacts::getNeoFormArtifact));
+            task.getAssetPropertiesFile().set(neoDevBuildDir.map(dir -> dir.file("minecraft_assets.properties")));
+        });
+
+        // MC looks for its resources on the classpath.
+        var runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME);
+        runtimeClasspath.getDependencies().add(
+                dependencyFactory.create(
+                        project.files(createSources.flatMap(CreateMinecraftArtifacts::getResourcesArtifact))
+                )
+        );
+        NeoDevFacade.setupRuns(
+                project,
+                neoDevBuildDir,
+                extension.getRuns(),
+                // Pass an empty file collection for the userdev config.
+                // This will cause MDG to generate a dummy config suitable for vanilla.
+                project.files(),
+                modulePath -> {},
+                legacyClasspath -> {},
+                downloadAssets.flatMap(DownloadAssets::getAssetPropertiesFile)
+        );
     }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,8 +19,11 @@ Contributing to NeoForge
 8. Modify the patched Minecraft sources in `projects/neoforge/src/main/java` as needed. The unmodified sources are available in `projects/base/src/main/java` for your reference. Do not modify these.
 9. Test your changes
    - Run the game (Runs are available in the IDE)
-   - Run `gradlew :tests:runGameTestServer` or `Tests: GameTestServer` from IDE
-   - Run `gradlew :tests:runGameTestClient` or `Tests: GameTestClient` from IDE
+     - Runs starting with `base -` run Vanilla without NeoForge or its patches.
+     - Runs starting with `neoforge -` run NeoForge.
+     - Runs starting with `tests -` run NeoForge along with the test mods in the `tests` project.
+   - Run `gradlew :tests:runGameTestServer` or `tests - GameTestServer` from IDE
+   - Run `gradlew :tests:runClient` or `tests - Client` from IDE
    - If possible, write an automated test under the tests project. See [NEOGAMETESTS.md](NEOGAMETESTS.md) for more info.
 10. Run `gradlew genPatches` to generate patch-files from the patched sources
 11. Run `gradlew applyAllFormatting` to automatically format sources

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.debug=false
 #org.gradle.warning.mode=fail
 
 # renovate: net.neoforged:moddev-gradle
-moddevgradle_plugin_version=2.0.46-beta
+moddevgradle_plugin_version=2.0.47-beta
 # renovate: io.codechicken:DiffPatch
 diffpatch_version=2.0.0.35
 

--- a/projects/base/.gitignore
+++ b/projects/base/.gitignore
@@ -1,3 +1,4 @@
 src
 build
 .gradle
+run

--- a/projects/base/build.gradle
+++ b/projects/base/build.gradle
@@ -25,7 +25,7 @@ neoDev {
         server {
             server()
         }
-        // Generated files are in run/generated
+        // Generated files are in run/data/generated
         data {
             data()
             programArgument "--all"

--- a/projects/base/build.gradle
+++ b/projects/base/build.gradle
@@ -16,6 +16,9 @@ dependencies {
 
 neoDev {
     runs {
+        configureEach {
+            gameDirectory = layout.projectDir.dir("run/$name")
+        }
         client {
             client()
         }

--- a/projects/base/build.gradle
+++ b/projects/base/build.gradle
@@ -13,3 +13,19 @@ dependencies {
         endorseStrictVersions()
     }
 }
+
+neoDev {
+    runs {
+        client {
+            client()
+        }
+        server {
+            server()
+        }
+        // Generated files are in run/generated
+        data {
+            data()
+            programArgument "--all"
+        }
+    }
+}

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -138,6 +138,9 @@ dependencies {
 
 neoDev {
     runs {
+        configureEach {
+            gameDirectory = layout.projectDir.dir("run/$name")
+        }
         client {
             client()
         }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -62,6 +62,9 @@ neoDev {
     }
 
     runs {
+        configureEach {
+            gameDirectory = layout.projectDir.dir("run/$name")
+        }
         client {
             client()
         }


### PR DESCRIPTION
Adds client, data and server runs for Vanilla. (In the `base` subproject). This is mostly useful when porting, to step through Vanilla with a debugger even though NeoForge doesn't compile yet.