### PR TITLE
Throw only when passed clientside level

### DIFF
--- a/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
+++ b/src/main/java/net/neoforged/neoforge/network/PacketDistributor.java
@@ -87,22 +87,24 @@ public final class PacketDistributor {
      * Send the given payload(s) to all players tracking the given entity
      */
     public static void sendToPlayersTrackingEntity(Entity entity, CustomPacketPayload payload, CustomPacketPayload... payloads) {
-        if (entity.level().getChunkSource() instanceof ServerChunkCache chunkCache) {
-            chunkCache.broadcast(entity, makeClientboundPacket(payload, payloads));
-        } else {
+        if (entity.level().isClientSide()) {
             throw new IllegalStateException("Cannot send clientbound payloads on the client");
+        } else if (entity.level().getChunkSource() instanceof ServerChunkCache chunkCache) {
+            chunkCache.broadcast(entity, makeClientboundPacket(payload, payloads));
         }
+        // Silently ignore custom Level implementations which may not return ServerChunkCache.
     }
 
     /**
      * Send the given payload(s) to all players tracking the given entity and the entity itself if it is a player
      */
     public static void sendToPlayersTrackingEntityAndSelf(Entity entity, CustomPacketPayload payload, CustomPacketPayload... payloads) {
-        if (entity.level().getChunkSource() instanceof ServerChunkCache chunkCache) {
-            chunkCache.broadcastAndSend(entity, makeClientboundPacket(payload, payloads));
-        } else {
+        if (entity.level().isClientSide()) {
             throw new IllegalStateException("Cannot send clientbound payloads on the client");
+        } else if (entity.level().getChunkSource() instanceof ServerChunkCache chunkCache) {
+            chunkCache.broadcastAndSend(entity, makeClientboundPacket(payload, payloads));
         }
+        // Silently ignore custom Level implementations which may not return ServerChunkCache.
     }
 
     /**


### PR DESCRIPTION
Modders can implement fake levels that are server side with a chunk cache. We were throwing on these when our exception specifically stated client side issue. So the exception was untrue. The fix is restrict our check to make sure the thrown exception is correct

Closes https://github.com/neoforged/NeoForge/issues/1669