### PR TITLE
Only factor in tabs with items on Creative Menu pages

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -40,7 +40,7 @@
 +            this.pages.clear();
 +            int tabIndex = 0;
 +            List<CreativeModeTab> currentPage = new java.util.ArrayList<>();
-+            for (CreativeModeTab sortedCreativeModeTab : net.neoforged.neoforge.common.CreativeModeTabRegistry.getSortedCreativeModeTabs()) {
++            for (CreativeModeTab sortedCreativeModeTab : net.neoforged.neoforge.common.CreativeModeTabRegistry.getSortedCreativeModeTabs().stream().filter(CreativeModeTab::hasAnyItems).toList()) {
 +                currentPage.add(sortedCreativeModeTab);
 +                tabIndex++;
 +                if (tabIndex == 10) {


### PR DESCRIPTION
Before the fix (one item-less tab before the last tab that is on 3rd page):
![image](https://github.com/user-attachments/assets/591425a0-4b9a-4369-a0b9-61d3596532fe)
![image](https://github.com/user-attachments/assets/51922253-5515-48c0-bd9a-28e6fd98ad40)

After the fix (item-less tab ignored and third page tab can now fit on second page):
![image](https://github.com/user-attachments/assets/e0ada2e8-534f-4995-a3aa-391554c4d8fe)

Operator tab is completely separate and works perfectly fine. It is not part of the 5 tabs in top left or bottom left. No need any special consideration for it.

Will backport when merged.

Closes https://github.com/neoforged/NeoForge/issues/1565