### PR TITLE
[1.21.3] Add condition to validate feature flags enabled state

### DIFF
--- a/patches/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/net/minecraft/server/ReloadableServerResources.java.patch
@@ -6,7 +6,7 @@
          this.functionLibrary = new ServerFunctionLibrary(p_206859_, this.commands.getDispatcher());
 +        // Neo: Store registries and create context object
 +        this.registryLookup = p_361583_;
-+        this.context = new net.neoforged.neoforge.common.conditions.ConditionContext(this.postponedTags);
++        this.context = new net.neoforged.neoforge.common.conditions.ConditionContext(this.postponedTags, p_250695_);
      }
  
      public ServerFunctionLibrary getFunctionLibrary() {

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -87,6 +87,7 @@ import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEn
 import net.neoforged.neoforge.common.advancements.critereon.SnowBootsEntityPredicate;
 import net.neoforged.neoforge.common.conditions.AndCondition;
 import net.neoforged.neoforge.common.conditions.FalseCondition;
+import net.neoforged.neoforge.common.conditions.FlagCondition;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.common.conditions.ItemExistsCondition;
 import net.neoforged.neoforge.common.conditions.ModLoadedCondition;
@@ -385,6 +386,7 @@ public class NeoForgeMod {
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<OrCondition>> OR_CONDITION = CONDITION_CODECS.register("or", () -> OrCondition.CODEC);
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<TagEmptyCondition>> TAG_EMPTY_CONDITION = CONDITION_CODECS.register("tag_empty", () -> TagEmptyCondition.CODEC);
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<TrueCondition>> TRUE_CONDITION = CONDITION_CODECS.register("true", () -> TrueCondition.CODEC);
+    public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<FlagCondition>> FEATURE_FLAG_CONDITION = CONDITION_CODECS.register("feature_flags", () -> FlagCondition.CODEC);
 
     private static final DeferredRegister<MapCodec<? extends EntitySubPredicate>> ENTITY_PREDICATE_CODECS = DeferredRegister.create(Registries.ENTITY_SUB_PREDICATE_TYPE, NeoForgeVersion.MOD_ID);
     public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<PiglinNeutralArmorEntityPredicate>> PIGLIN_NEUTRAL_ARMOR_PREDICATE = ENTITY_PREDICATE_CODECS.register("piglin_neutral_armor", () -> PiglinNeutralArmorEntityPredicate.CODEC);

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionContext.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionContext.java
@@ -13,6 +13,8 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.flag.FeatureFlags;
+import org.jetbrains.annotations.ApiStatus;
 
 public class ConditionContext implements ICondition.IContext {
     private final Map<ResourceKey<? extends Registry<?>>, HolderLookup.RegistryLookup<?>> pendingTags;
@@ -25,6 +27,13 @@ public class ConditionContext implements ICondition.IContext {
         for (var tags : pendingTags) {
             this.pendingTags.put(tags.key(), tags.lookup());
         }
+    }
+
+    // Use FeatureFlagSet sensitive constructor
+    @ApiStatus.ScheduledForRemoval(inVersion = "1.21.4")
+    @Deprecated(forRemoval = true, since = "1.21.3")
+    public ConditionContext(List<Registry.PendingTags<?>> pendingTags) {
+        this(pendingTags, FeatureFlags.VANILLA_SET);
     }
 
     public void clear() {

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionContext.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionContext.java
@@ -12,12 +12,16 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.flag.FeatureFlagSet;
 
 public class ConditionContext implements ICondition.IContext {
     private final Map<ResourceKey<? extends Registry<?>>, HolderLookup.RegistryLookup<?>> pendingTags;
+    private final FeatureFlagSet enabledFeatures;
 
-    public ConditionContext(List<Registry.PendingTags<?>> pendingTags) {
+    public ConditionContext(List<Registry.PendingTags<?>> pendingTags, FeatureFlagSet enabledFeatures) {
         this.pendingTags = new IdentityHashMap<>();
+        this.enabledFeatures = enabledFeatures;
+
         for (var tags : pendingTags) {
             this.pendingTags.put(tags.key(), tags.lookup());
         }
@@ -32,5 +36,10 @@ public class ConditionContext implements ICondition.IContext {
     public <T> boolean isTagLoaded(TagKey<T> key) {
         var lookup = pendingTags.get(key.registry());
         return lookup != null && lookup.get((TagKey) key).isPresent();
+    }
+
+    @Override
+    public FeatureFlagSet enabledFeatures() {
+        return enabledFeatures;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/conditions/FlagCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/FlagCondition.java
@@ -16,29 +16,29 @@ import net.minecraft.world.flag.FeatureFlags;
  * Condition checking for the enabled state of a given {@link FeatureFlagSet}.
  * <p>
  * {@code requiredFeatures} - {@link FeatureFlagSet} containing all {@link FeatureFlag feature flags} to be validated.
- * {@code checkEnabled} - Validates that all given {@link FeatureFlag feature flags} are enabled when {@code true} or disabled when {@code false}.
+ * {@code expectedResult} - Validates that all given {@link FeatureFlag feature flags} are enabled when {@code true} or disabled when {@code false}.
  *
  * @apiNote Mainly to be used when flagged content is not contained within the same feature pack which also enables said {@link FeatureFlag feature flags}.
  */
 public final class FlagCondition implements ICondition {
     public static final MapCodec<FlagCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             FeatureFlags.CODEC.fieldOf("flags").forGetter(condition -> condition.requiredFeatures),
-            Codec.BOOL.lenientOptionalFieldOf("check_enabled", true).forGetter(condition -> condition.checkEnabled)).apply(instance, FlagCondition::new));
+            Codec.BOOL.lenientOptionalFieldOf("check_enabled", true).forGetter(condition -> condition.expectedResult)).apply(instance, FlagCondition::new));
 
     private final FeatureFlagSet requiredFeatures;
-    private final boolean checkEnabled;
+    private final boolean expectedResult;
 
-    private FlagCondition(FeatureFlagSet requiredFeatures, boolean checkEnabled) {
+    private FlagCondition(FeatureFlagSet requiredFeatures, boolean expectedResult) {
         this.requiredFeatures = requiredFeatures;
-        this.checkEnabled = checkEnabled;
+        this.expectedResult = expectedResult;
     }
 
     @Override
     public boolean test(IContext context) {
         var flagsEnabled = requiredFeatures.isSubsetOf(context.enabledFeatures());
-        // true if: 'checkEnabled' is true nd all given flags are enabled
+        // true if: 'expectedResult' is true nd all given flags are enabled
         // false if: `enabledEnabled' is false and all given flags are disabled
-        return flagsEnabled == checkEnabled;
+        return flagsEnabled == expectedResult;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/conditions/FlagCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/FlagCondition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.conditions;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.world.flag.FeatureFlag;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.flag.FeatureFlags;
+
+/**
+ * Condition checking for the enabled state of a given {@link FeatureFlagSet}.
+ * <p>
+ * {@code requiredFeatures} - {@link FeatureFlagSet} containing all {@link FeatureFlag feature flags} to be validated.
+ * {@code checkEnabled} - Validates that all given {@link FeatureFlag feature flags} are enabled when {@code true} or disabled when {@code false}.
+ *
+ * @apiNote Mainly to be used when flagged content is not contained within the same feature pack which also enables said {@link FeatureFlag feature flags}.
+ */
+public final class FlagCondition implements ICondition {
+    public static final MapCodec<FlagCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            FeatureFlags.CODEC.fieldOf("flags").forGetter(condition -> condition.requiredFeatures),
+            Codec.BOOL.lenientOptionalFieldOf("check_enabled", true).forGetter(condition -> condition.checkEnabled)).apply(instance, FlagCondition::new));
+
+    private final FeatureFlagSet requiredFeatures;
+    private final boolean checkEnabled;
+
+    private FlagCondition(FeatureFlagSet requiredFeatures, boolean checkEnabled) {
+        this.requiredFeatures = requiredFeatures;
+        this.checkEnabled = checkEnabled;
+    }
+
+    @Override
+    public boolean test(IContext context) {
+        var flagsEnabled = requiredFeatures.isSubsetOf(context.enabledFeatures());
+        // true if: 'checkEnabled' is true nd all given flags are enabled
+        // false if: `enabledEnabled' is false and all given flags are disabled
+        return flagsEnabled == checkEnabled;
+    }
+
+    @Override
+    public MapCodec<? extends ICondition> codec() {
+        return CODEC;
+    }
+
+    public static ICondition isEnabled(FeatureFlagSet requiredFeatures) {
+        return new FlagCondition(requiredFeatures, true);
+    }
+
+    public static ICondition isEnabled(FeatureFlag requiredFlag) {
+        return isEnabled(FeatureFlagSet.of(requiredFlag));
+    }
+
+    public static ICondition isEnabled(FeatureFlag requiredFlag, FeatureFlag... requiredFlags) {
+        return isEnabled(FeatureFlagSet.of(requiredFlag, requiredFlags));
+    }
+
+    public static ICondition isDisabled(FeatureFlagSet requiredFeatures) {
+        return new FlagCondition(requiredFeatures, false);
+    }
+
+    public static ICondition isDisabled(FeatureFlag requiredFlag) {
+        return isDisabled(FeatureFlagSet.of(requiredFlag));
+    }
+
+    public static ICondition isDisabled(FeatureFlag requiredFlag, FeatureFlag... requiredFlags) {
+        return isDisabled(FeatureFlagSet.of(requiredFlag, requiredFlags));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/conditions/FlagCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/FlagCondition.java
@@ -23,7 +23,7 @@ import net.minecraft.world.flag.FeatureFlags;
 public final class FlagCondition implements ICondition {
     public static final MapCodec<FlagCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             FeatureFlags.CODEC.fieldOf("flags").forGetter(condition -> condition.requiredFeatures),
-            Codec.BOOL.lenientOptionalFieldOf("check_enabled", true).forGetter(condition -> condition.expectedResult)).apply(instance, FlagCondition::new));
+            Codec.BOOL.lenientOptionalFieldOf("expected_result", true).forGetter(condition -> condition.expectedResult)).apply(instance, FlagCondition::new));
 
     private final FeatureFlagSet requiredFeatures;
     private final boolean expectedResult;

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
@@ -81,28 +81,12 @@ public interface ICondition {
             public <T> boolean isTagLoaded(TagKey<T> key) {
                 return false;
             }
-
-            @Override
-            public FeatureFlagSet enabledFeatures() {
-                // returning the vanilla set causes everything to result in everything being disabled
-                // return FeatureFlags.VANILLA_SET;
-
-                // lookup the active enabledFeatures from the current server
-                // if no server exists, delegating back to 'VANILLA_SET' should be fine (should rarely ever happen)
-                var server = ServerLifecycleHooks.getCurrentServer();
-                return server == null ? FeatureFlags.VANILLA_SET : server.getWorldData().enabledFeatures();
-            }
         };
 
         IContext TAGS_INVALID = new IContext() {
             @Override
             public <T> boolean isTagLoaded(TagKey<T> key) {
                 throw new UnsupportedOperationException("Usage of tag-based conditions is not permitted in this context!");
-            }
-
-            @Override
-            public FeatureFlagSet enabledFeatures() {
-                throw new UnsupportedOperationException("Usage of flag-based conditions is not permitted in this context!");
             }
         };
 
@@ -111,6 +95,14 @@ public interface ICondition {
          */
         <T> boolean isTagLoaded(TagKey<T> key);
 
-        FeatureFlagSet enabledFeatures();
+        default FeatureFlagSet enabledFeatures() {
+            // returning the vanilla set causes reports false positives for flags outside of vanilla
+            // return FeatureFlags.VANILLA_SET;
+
+            // lookup the active enabledFeatures from the current server
+            // if no server exists, delegating back to 'VANILLA_SET' should be fine (should rarely ever happen)
+            var server = ServerLifecycleHooks.getCurrentServer();
+            return server == null ? FeatureFlags.VANILLA_SET : server.getWorldData().enabledFeatures();
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
@@ -19,7 +19,10 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.Unit;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.flag.FeatureFlags;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 public interface ICondition {
     Codec<ICondition> CODEC = NeoForgeRegistries.CONDITION_SERIALIZERS.byNameCodec()
@@ -78,6 +81,17 @@ public interface ICondition {
             public <T> boolean isTagLoaded(TagKey<T> key) {
                 return false;
             }
+
+            @Override
+            public FeatureFlagSet enabledFeatures() {
+                // returning the vanilla set causes everything to result in everything being disabled
+                // return FeatureFlags.VANILLA_SET;
+
+                // lookup the active enabledFeatures from the current server
+                // if no server exists, delegating back to 'VANILLA_SET' should be fine (should rarely ever happen)
+                var server = ServerLifecycleHooks.getCurrentServer();
+                return server == null ? FeatureFlags.VANILLA_SET : server.getWorldData().enabledFeatures();
+            }
         };
 
         IContext TAGS_INVALID = new IContext() {
@@ -85,11 +99,18 @@ public interface ICondition {
             public <T> boolean isTagLoaded(TagKey<T> key) {
                 throw new UnsupportedOperationException("Usage of tag-based conditions is not permitted in this context!");
             }
+
+            @Override
+            public FeatureFlagSet enabledFeatures() {
+                throw new UnsupportedOperationException("Usage of flag-based conditions is not permitted in this context!");
+            }
         };
 
         /**
          * Returns {@code true} if the requested tag is available.
          */
         <T> boolean isTagLoaded(TagKey<T> key);
+
+        FeatureFlagSet enabledFeatures();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/conditions/IConditionBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/IConditionBuilder.java
@@ -7,6 +7,8 @@ package net.neoforged.neoforge.common.conditions;
 
 import java.util.List;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.flag.FeatureFlag;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.item.Item;
 
 public interface IConditionBuilder {
@@ -40,5 +42,29 @@ public interface IConditionBuilder {
 
     default ICondition tagEmpty(TagKey<Item> tag) {
         return new TagEmptyCondition(tag.location());
+    }
+
+    default ICondition isFeatureEnabled(FeatureFlagSet requiredFeatures) {
+        return FlagCondition.isEnabled(requiredFeatures);
+    }
+
+    default ICondition isFeatureEnabled(FeatureFlag requiredFlag) {
+        return FlagCondition.isEnabled(requiredFlag);
+    }
+
+    default ICondition isFeatureEnabled(FeatureFlag requiredFlag, FeatureFlag... requiredFlags) {
+        return FlagCondition.isEnabled(requiredFlag, requiredFlags);
+    }
+
+    default ICondition isFeatureDisabled(FeatureFlagSet requiredFeatures) {
+        return FlagCondition.isDisabled(requiredFeatures);
+    }
+
+    default ICondition isFeatureDisabled(FeatureFlag requiredFlag) {
+        return FlagCondition.isDisabled(requiredFlag);
+    }
+
+    default ICondition isFeatureDisabled(FeatureFlag requiredFlag, FeatureFlag... requiredFlags) {
+        return FlagCondition.isDisabled(requiredFlag, requiredFlags);
     }
 }

--- a/tests/src/generated/resources/data/neotests_test_flag_condition/advancement/recipes/misc/diamonds_from_dirt.json
+++ b/tests/src/generated/resources/data/neotests_test_flag_condition/advancement/recipes/misc/diamonds_from_dirt.json
@@ -1,0 +1,40 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:feature_flags",
+      "flags": [
+        "custom_feature_flags_pack_test:test_flag"
+      ]
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_dirt": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#minecraft:dirt"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_test_flag_condition:diamonds_from_dirt"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_dirt"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_test_flag_condition:diamonds_from_dirt"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_test_flag_condition/advancement/recipes/misc/dirt_from_diamonds.json
+++ b/tests/src/generated/resources/data/neotests_test_flag_condition/advancement/recipes/misc/dirt_from_diamonds.json
@@ -2,7 +2,7 @@
   "neoforge:conditions": [
     {
       "type": "neoforge:feature_flags",
-      "check_enabled": false,
+      "expected_result": false,
       "flags": [
         "custom_feature_flags_pack_test:test_flag"
       ]

--- a/tests/src/generated/resources/data/neotests_test_flag_condition/advancement/recipes/misc/dirt_from_diamonds.json
+++ b/tests/src/generated/resources/data/neotests_test_flag_condition/advancement/recipes/misc/dirt_from_diamonds.json
@@ -1,0 +1,41 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:feature_flags",
+      "check_enabled": false,
+      "flags": [
+        "custom_feature_flags_pack_test:test_flag"
+      ]
+    }
+  ],
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_diamond": {
+      "conditions": {
+        "items": [
+          {
+            "items": "#c:gems/diamond"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "neotests_test_flag_condition:dirt_from_diamonds"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_diamond"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "neotests_test_flag_condition:dirt_from_diamonds"
+    ]
+  }
+}

--- a/tests/src/generated/resources/data/neotests_test_flag_condition/recipe/diamonds_from_dirt.json
+++ b/tests/src/generated/resources/data/neotests_test_flag_condition/recipe/diamonds_from_dirt.json
@@ -1,0 +1,19 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:feature_flags",
+      "flags": [
+        "custom_feature_flags_pack_test:test_flag"
+      ]
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "#minecraft:dirt"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:diamond"
+  }
+}

--- a/tests/src/generated/resources/data/neotests_test_flag_condition/recipe/dirt_from_diamonds.json
+++ b/tests/src/generated/resources/data/neotests_test_flag_condition/recipe/dirt_from_diamonds.json
@@ -2,7 +2,7 @@
   "neoforge:conditions": [
     {
       "type": "neoforge:feature_flags",
-      "check_enabled": false,
+      "expected_result": false,
       "flags": [
         "custom_feature_flags_pack_test:test_flag"
       ]

--- a/tests/src/generated/resources/data/neotests_test_flag_condition/recipe/dirt_from_diamonds.json
+++ b/tests/src/generated/resources/data/neotests_test_flag_condition/recipe/dirt_from_diamonds.json
@@ -1,0 +1,20 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:feature_flags",
+      "check_enabled": false,
+      "flags": [
+        "custom_feature_flags_pack_test:test_flag"
+      ]
+    }
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "#c:gems/diamond"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:dirt"
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/CustomFeatureFlagsTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/CustomFeatureFlagsTests.java
@@ -6,10 +6,12 @@
 package net.neoforged.neoforge.debug.data;
 
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.Pack;
@@ -21,6 +23,7 @@ import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.conditions.FlagCondition;
 import net.neoforged.neoforge.event.AddPackFindersEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
@@ -98,22 +101,34 @@ public class CustomFeatureFlagsTests {
         });
     }
 
-    @TestHolder(description = "Tests that elements can be toggled via conditions using the flag condition")
+    @TestHolder(description = "Tests that elements can be toggled via conditions using the flag condition", enabledByDefault = true)
     static void testFlagCondition(DynamicTest test, RegistrationHelper reg) {
+        // custom flag are provided by our other flag tests
+        // and enabled via our `custom featureflag test pack`
+        var flagName = ResourceLocation.fromNamespaceAndPath("custom_feature_flags_pack_test", "test_flag");
+        var flag = FeatureFlags.REGISTRY.getFlag(flagName);
+
+        var modId = reg.modId();
+        var enabledRecipeName = ResourceKey.create(Registries.RECIPE, ResourceLocation.fromNamespaceAndPath(modId, "diamonds_from_dirt"));
+        var disabledRecipeName = ResourceKey.create(Registries.RECIPE, ResourceLocation.fromNamespaceAndPath(modId, "dirt_from_diamonds"));
+
         reg.addProvider(event -> new RecipeProvider.Runner(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
             @Override
             protected RecipeProvider createRecipeProvider(HolderLookup.Provider registries, RecipeOutput output) {
                 return new RecipeProvider(registries, output) {
                     @Override
                     protected void buildRecipes() {
-                        // custom flag provided by our tests
-                        // and enabled via our `custom featureflag test pack`
-                        var flag = FeatureFlags.REGISTRY.getFlag(ResourceLocation.fromNamespaceAndPath("custom_feature_flags_pack_test", "test_flag"));
-
+                        // recipe available when above flag is enabled
                         shapeless(RecipeCategory.MISC, Items.DIAMOND)
                                 .requires(ItemTags.DIRT)
                                 .unlockedBy("has_dirt", has(ItemTags.DIRT))
-                                .save(output.withConditions(FlagCondition.isEnabled(flag)), reg.modId() + ":diamonds_from_dirt");
+                                .save(output.withConditions(FlagCondition.isEnabled(flag)), enabledRecipeName);
+
+                        // recipe available when above flag is disabled
+                        shapeless(RecipeCategory.MISC, Items.DIRT)
+                                .requires(Tags.Items.GEMS_DIAMOND)
+                                .unlockedBy("has_diamond", has(Tags.Items.GEMS_DIAMOND))
+                                .save(output.withConditions(FlagCondition.isDisabled(flag)), disabledRecipeName);
                     }
                 };
             }
@@ -122,6 +137,32 @@ public class CustomFeatureFlagsTests {
             public String getName() {
                 return "conditional_flag_recipes";
             }
+        });
+
+        test.eventListeners().forge().addListener((ServerStartedEvent event) -> {
+            var server = event.getServer();
+            var isFlagEnabled = server.getWorldData().enabledFeatures().contains(flag);
+            var recipeMap = server.getRecipeManager().recipeMap();
+            var hasEnabledRecipe = recipeMap.byKey(enabledRecipeName) != null;
+            var hasDisabledRecipe = recipeMap.byKey(disabledRecipeName) != null;
+
+            if (isFlagEnabled) {
+                if (!hasEnabledRecipe) {
+                    test.fail("Missing recipe '" + enabledRecipeName.location() + "', This should be enabled due to our flag '" + flagName + "' being enabled");
+                }
+                if (hasDisabledRecipe) {
+                    test.fail("Found recipe '" + disabledRecipeName.location() + "', This should be disabled due to our flag '" + flagName + "' being disabled");
+                }
+            } else {
+                if (hasEnabledRecipe) {
+                    test.fail("Found recipe '" + enabledRecipeName.location() + "', This should be disabled due to our flag '" + flagName + "' being enabled");
+                }
+                if (!hasDisabledRecipe) {
+                    test.fail("Missing recipe '" + disabledRecipeName.location() + "', This should be enabled due to our flag '" + flagName + "' being disabled");
+                }
+            }
+
+            test.pass();
         });
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/CustomFeatureFlagsTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/CustomFeatureFlagsTests.java
@@ -5,22 +5,30 @@
 
 package net.neoforged.neoforge.debug.data;
 
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.flag.FeatureFlag;
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.conditions.FlagCondition;
 import net.neoforged.neoforge.event.AddPackFindersEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.registration.RegistrationHelper;
 
 @ForEachTest(groups = "data.feature_flags")
 public class CustomFeatureFlagsTests {
@@ -86,6 +94,33 @@ public class CustomFeatureFlagsTests {
                 test.fail("Item with disabled custom flag in extended mask range was unexpectedly enabled");
             } else {
                 test.pass();
+            }
+        });
+    }
+
+    @TestHolder(description = "Tests that elements can be toggled via conditions using the flag condition")
+    static void testFlagCondition(DynamicTest test, RegistrationHelper reg) {
+        reg.addProvider(event -> new RecipeProvider.Runner(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
+            @Override
+            protected RecipeProvider createRecipeProvider(HolderLookup.Provider registries, RecipeOutput output) {
+                return new RecipeProvider(registries, output) {
+                    @Override
+                    protected void buildRecipes() {
+                        // custom flag provided by our tests
+                        // and enabled via our `custom featureflag test pack`
+                        var flag = FeatureFlags.REGISTRY.getFlag(ResourceLocation.fromNamespaceAndPath("custom_feature_flags_pack_test", "test_flag"));
+
+                        shapeless(RecipeCategory.MISC, Items.DIAMOND)
+                                .requires(ItemTags.DIRT)
+                                .unlockedBy("has_dirt", has(ItemTags.DIRT))
+                                .save(output.withConditions(FlagCondition.isEnabled(flag)), reg.modId() + ":diamonds_from_dirt");
+                    }
+                };
+            }
+
+            @Override
+            public String getName() {
+                return "conditional_flag_recipes";
             }
         });
     }


### PR DESCRIPTION
Modders who maintain multi-jar mods, that being mods whose feature set is split across multiple jars, may want a single flag in their common jar which toggles features across all of their mod jars. Due to the nature of how feature packs work and are enabled, this is not possible.

While you can have multiple packs which all enable the same flag, they will all display as individual selections in the "experiments" screen, when the intention is to have 1 toggle for all these packs.

To work around that, modders can make use of the newly added condition in this PR, which takes in a set of feature flags and whether to validate for them being enabled or disabled to conditionally load their desired elements without needing to be in the same feature pack.