### PR TITLE
Add ${version_name}.jar to the prod client ignoreList, fixes crashes with some launchers

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -252,7 +252,8 @@ public class NeoDevPlugin implements Plugin<Project> {
                 }
                 return repos;
             }));
-            task.getIgnoreList().addAll("client-extra", "neoforge-");
+            // ${version_name}.jar will be filled out by the launcher. It corresponds to the raw SRG Minecraft client jar.
+            task.getIgnoreList().addAll("client-extra", "${version_name}.jar");
             task.setModules(configurations.modulePath);
             task.getLauncherProfile().set(neoDevBuildDir.map(dir -> dir.file("launcher-profile.json")));
         });

--- a/buildSrc/src/main/java/net/neoforged/neodev/e2e/RunProductionClient.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/e2e/RunProductionClient.java
@@ -230,6 +230,7 @@ public abstract class RunProductionClient extends JavaExec {
         var gameJar = installDir.resolve("versions").resolve(versionId).resolve(versionId + ".jar");
         copyIfNeeded(getOriginalClientJar().get().getAsFile().toPath(), gameJar);
         classpathItems.add(gameJar.toAbsolutePath().toString());
+        placeholders.put("version_name", versionId);
 
         var classpath = String.join(File.pathSeparator, classpathItems);
         placeholders.putIfAbsent("classpath", classpath);


### PR DESCRIPTION
The goal is to ignore the raw MC jar that launchers put on the classpath. Add back this entry which got accidentally removed in #1485. Removes `neoforge-` which is superseded by this entry.