### PR TITLE
Fix incorrect ParticleEngine render patch

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/client/renderer/LevelRenderer.java
 +++ b/net/minecraft/client/renderer/LevelRenderer.java
+@@ -47,6 +_,7 @@
+ import net.minecraft.client.PrioritizeChunkUpdates;
+ import net.minecraft.client.multiplayer.ClientLevel;
+ import net.minecraft.client.particle.Particle;
++import net.minecraft.client.particle.ParticleRenderType;
+ import net.minecraft.client.player.LocalPlayer;
+ import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
+ import net.minecraft.client.renderer.chunk.RenderRegionCache;
 @@ -480,7 +_,7 @@
              RenderSystem.clear(16640);
          });
@@ -81,10 +89,12 @@
          FramePass framepass = p_363357_.addPass("particles");
          if (this.targets.particles != null) {
              this.targets.particles = framepass.readsAndWrites(this.targets.particles);
-@@ -679,6 +_,7 @@
+@@ -678,7 +_,8 @@
+                 resourcehandle1.get().copyDepthFrom(resourcehandle.get());
              }
  
-             this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource());
+-            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource());
++            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource(), frustum, resourcehandle1 == null ? ParticleRenderType::translucent : type -> true); // Neo: only render translucent particles here in Fast/Fancy
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, null, modelViewMatrix, projectionMatrix, this.ticks, p_365299_, getFrustum());
          });
      }

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/client/renderer/LevelRenderer.java
 +++ b/net/minecraft/client/renderer/LevelRenderer.java
-@@ -47,6 +_,7 @@
- import net.minecraft.client.PrioritizeChunkUpdates;
- import net.minecraft.client.multiplayer.ClientLevel;
- import net.minecraft.client.particle.Particle;
-+import net.minecraft.client.particle.ParticleRenderType;
- import net.minecraft.client.player.LocalPlayer;
- import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
- import net.minecraft.client.renderer.chunk.RenderRegionCache;
 @@ -480,7 +_,7 @@
              RenderSystem.clear(16640);
          });
@@ -94,7 +86,7 @@
              }
  
 -            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource());
-+            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource(), frustum, resourcehandle1 == null ? ParticleRenderType::translucent : type -> true); // Neo: only render translucent particles here in Fast/Fancy
++            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource(), frustum, resourcehandle1 == null ? type -> type.translucent() : type -> true);
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, null, modelViewMatrix, projectionMatrix, this.ticks, p_365299_, getFrustum());
          });
      }

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -86,7 +86,7 @@
              }
  
 -            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource());
-+            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource(), frustum, resourcehandle1 == null ? type -> type.translucent() : type -> true);
++            this.minecraft.particleEngine.render(p_365299_, p_364282_, this.renderBuffers.bufferSource(), frustum, resourcehandle1 == null ? type -> type.translucent() : type -> true); // Neo: only render translucent particles here in Fast/Fancy
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_PARTICLES, this, null, modelViewMatrix, projectionMatrix, this.ticks, p_365299_, getFrustum());
          });
      }


### PR DESCRIPTION
Fixes solid particles being drawn twice, and without a Frustum check.