### PR TITLE
Make self-test more robust against ticking multiple times.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/util/SelfTest.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/SelfTest.java
@@ -39,8 +39,10 @@ public final class SelfTest {
                 if (Minecraft.getInstance().getOverlay() instanceof LoadingOverlay) {
                     return;
                 }
-                writeSelfTestReport(clientSelfTestDestination);
-                Minecraft.getInstance().stop();
+                if (Minecraft.getInstance().isRunning()) {
+                    writeSelfTestReport(clientSelfTestDestination);
+                    Minecraft.getInstance().stop();
+                }
             });
         }
     }
@@ -53,8 +55,10 @@ public final class SelfTest {
                 System.exit(1);
             }
             NeoForge.EVENT_BUS.addListener((ServerTickEvent.Pre e) -> {
-                writeSelfTestReport(serverSelfTestDestination);
-                e.getServer().halt(false);
+                if (e.getServer().isRunning()) {
+                    writeSelfTestReport(serverSelfTestDestination);
+                    e.getServer().halt(false);
+                }
             });
         }
     }
@@ -66,11 +70,10 @@ public final class SelfTest {
     private static void writeSelfTestReport(String path) {
         try {
             Files.createFile(Paths.get(path));
+            LOGGER.info("Wrote self-test report to '{}'", path);
         } catch (IOException e) {
             LOGGER.error("Failed to write self-test to '{}'", path, e);
             System.exit(1);
         }
-
-        LOGGER.info("Write self-test report to '{}'", path);
     }
 }


### PR DESCRIPTION
Should fix this:

```

[21:52:16] [Render thread/INFO] [ne.ne.ne.co.ut.SelfTest/]: Write self-test report to '/home/runner/work/NeoForge/NeoForge/projects/neoforge/build/tmp/testProductionClient/client_self_test.txt'
[21:52:16] [Render thread/ERROR] [ne.ne.ne.co.ut.SelfTest/]: Failed to write self-test to '/home/runner/work/NeoForge/NeoForge/projects/neoforge/build/tmp/testProductionClient/client_self_test.txt'
java.nio.file.FileAlreadyExistsException: /home/runner/work/NeoForge/NeoForge/projects/neoforge/build/tmp/testProductionClient/client_self_test.txt
```