### PR TITLE
[1.21.4] Allow modded BE and Entity types to declare that they have NBT data only OPs can set

### DIFF
--- a/patches/net/minecraft/world/entity/EntityType.java.patch
+++ b/patches/net/minecraft/world/entity/EntityType.java.patch
@@ -1,21 +1,22 @@
 --- a/net/minecraft/world/entity/EntityType.java
 +++ b/net/minecraft/world/entity/EntityType.java
-@@ -1070,6 +_,10 @@
+@@ -1070,6 +_,11 @@
      private final float spawnDimensionsScale;
      private final FeatureFlagSet requiredFeatures;
  
 +    private final java.util.function.Predicate<EntityType<?>> trackDeltasSupplier;
 +    private final java.util.function.ToIntFunction<EntityType<?>> trackingRangeSupplier;
 +    private final java.util.function.ToIntFunction<EntityType<?>> updateIntervalSupplier;
++    private final boolean onlyOpCanSetNbt;
 +
      private static <T extends Entity> EntityType<T> register(ResourceKey<EntityType<?>> p_368669_, EntityType.Builder<T> p_368714_) {
          return Registry.register(BuiltInRegistries.ENTITY_TYPE, p_368669_, p_368714_.build(p_368669_));
      }
-@@ -1106,6 +_,28 @@
+@@ -1106,6 +_,29 @@
          Optional<ResourceKey<LootTable>> p_368696_,
          FeatureFlagSet p_273518_
      ) {
-+        this(p_273268_, p_272918_, p_273417_, p_273389_, p_273556_, p_272654_, p_273631_, p_272946_, p_338404_, p_272895_, p_273451_, p_368582_, p_368696_, p_273518_, EntityType::defaultTrackDeltasSupplier, EntityType::defaultTrackingRangeSupplier, EntityType::defaultUpdateIntervalSupplier);
++        this(p_273268_, p_272918_, p_273417_, p_273389_, p_273556_, p_272654_, p_273631_, p_272946_, p_338404_, p_272895_, p_273451_, p_368582_, p_368696_, p_273518_, EntityType::defaultTrackDeltasSupplier, EntityType::defaultTrackingRangeSupplier, EntityType::defaultUpdateIntervalSupplier, false);
 +    }
 +
 +    public EntityType(
@@ -35,18 +36,20 @@
 +        FeatureFlagSet p_273518_,
 +        final java.util.function.Predicate<EntityType<?>> trackDeltasSupplier,
 +        final java.util.function.ToIntFunction<EntityType<?>> trackingRangeSupplier,
-+        final java.util.function.ToIntFunction<EntityType<?>> updateIntervalSupplier
++        final java.util.function.ToIntFunction<EntityType<?>> updateIntervalSupplier,
++        boolean onlyOpCanSetNbt
 +    ) {
          this.factory = p_273268_;
          this.category = p_272918_;
          this.canSpawnFarFromPlayer = p_272654_;
-@@ -1120,6 +_,9 @@
+@@ -1120,6 +_,10 @@
          this.descriptionId = p_368582_;
          this.lootTable = p_368696_;
          this.requiredFeatures = p_273518_;
 +        this.trackDeltasSupplier = trackDeltasSupplier;
 +        this.trackingRangeSupplier = trackingRangeSupplier;
 +        this.updateIntervalSupplier = updateIntervalSupplier;
++        this.onlyOpCanSetNbt = onlyOpCanSetNbt;
      }
  
      @Nullable
@@ -88,7 +91,11 @@
          return this != PLAYER
              && this != LLAMA_SPIT
              && this != WITHER
-@@ -1462,6 +_,8 @@
+@@ -1459,9 +_,12 @@
+     }
+ 
+     public boolean onlyOpCanSetNbt() {
++        if (onlyOpCanSetNbt) return true;
          return OP_ONLY_CUSTOM_DATA.contains(this);
      }
  
@@ -97,18 +104,19 @@
      public static class Builder<T extends Entity> {
          private final EntityType.EntityFactory<T> factory;
          private final MobCategory category;
-@@ -1481,6 +_,10 @@
+@@ -1481,6 +_,11 @@
              );
          private DependantName<EntityType<?>, String> descriptionId = p_367918_ -> Util.makeDescriptionId("entity", p_367918_.location());
  
 +        private java.util.function.Predicate<EntityType<?>> velocityUpdateSupplier = EntityType::defaultTrackDeltasSupplier;
 +        private java.util.function.ToIntFunction<EntityType<?>> trackingRangeSupplier = EntityType::defaultTrackingRangeSupplier;
 +        private java.util.function.ToIntFunction<EntityType<?>> updateIntervalSupplier = EntityType::defaultUpdateIntervalSupplier;
++        private boolean onlyOpCanSetNbt = false;
 +
          private Builder(EntityType.EntityFactory<T> p_20696_, MobCategory p_20697_) {
              this.factory = p_20696_;
              this.category = p_20697_;
-@@ -1593,6 +_,21 @@
+@@ -1593,6 +_,26 @@
              return this;
          }
  
@@ -127,18 +135,24 @@
 +            return this;
 +        }
 +
++        public EntityType.Builder<T> setOnlyOpCanSetNbt(boolean onlyOpCanSetNbt) {
++            this.onlyOpCanSetNbt = onlyOpCanSetNbt;
++            return this;
++        }
++
          public EntityType<T> build(ResourceKey<EntityType<?>> p_368626_) {
              if (this.serialize) {
                  Util.fetchChoiceType(References.ENTITY_TREE, p_368626_.location().toString());
-@@ -1612,7 +_,10 @@
+@@ -1612,7 +_,11 @@
                  this.updateInterval,
                  this.descriptionId.get(p_368626_),
                  this.lootTable.get(p_368626_),
 -                this.requiredFeatures
 +                this.requiredFeatures,
-+                velocityUpdateSupplier,
-+                trackingRangeSupplier,
-+                updateIntervalSupplier
++                this.velocityUpdateSupplier,
++                this.trackingRangeSupplier,
++                this.updateIntervalSupplier,
++                this.onlyOpCanSetNbt
              );
          }
      }

--- a/patches/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -1,35 +1,62 @@
 --- a/net/minecraft/world/level/block/entity/BlockEntityType.java
 +++ b/net/minecraft/world/level/block/entity/BlockEntityType.java
-@@ -230,6 +_,7 @@
+@@ -230,8 +_,11 @@
      public static final BlockEntityType<VaultBlockEntity> VAULT = register("vault", VaultBlockEntity::new, Blocks.VAULT);
      private static final Set<BlockEntityType<?>> OP_ONLY_CUSTOM_DATA = Set.of(COMMAND_BLOCK, LECTERN, SIGN, HANGING_SIGN, MOB_SPAWNER, TRIAL_SPAWNER);
      private final BlockEntityType.BlockEntitySupplier<? extends T> factory;
 +    // Neo: This field will be modified by BlockEntityTypeAddBlocksEvent event. Please use the event to add to this field for vanilla or other mod's BlockEntityTypes.
      private final Set<Block> validBlocks;
      private final Holder.Reference<BlockEntityType<?>> builtInRegistryHolder = BuiltInRegistries.BLOCK_ENTITY_TYPE.createIntrusiveHolder(this);
++    // Neo: Allow modded BE types to declare that they have NBT data only OPs can set
++    private final boolean onlyOpCanSetNbt;
  
-@@ -254,9 +_,24 @@
-         this.validBlocks = p_155260_;
+     @Nullable
+     public static ResourceLocation getKey(BlockEntityType<?> p_58955_) {
+@@ -250,8 +_,25 @@
      }
  
+     public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Set<Block> p_155260_) {
++        this(p_155259_, p_155260_, false);
++    }
++
++    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Set<Block> p_155260_, boolean onlyOpCanSetNbt) {
+         this.factory = p_155259_;
+         this.validBlocks = p_155260_;
++        this.onlyOpCanSetNbt = onlyOpCanSetNbt;
++    }
++
 +    // Neo: Additional constructor for convenience.
 +    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Block... p_155260_) {
-+        this(p_155259_, Set.of(p_155260_));
++        this(p_155259_, false, p_155260_);
++    }
++
++    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, boolean onlyOpCanSetNbt, Block... p_155260_) {
++        this(p_155259_, Set.of(p_155260_), onlyOpCanSetNbt);
 +        if (p_155260_.length == 0) {
 +            throw new IllegalArgumentException("Block entity type instantiated without valid blocks. If this is intentional, pass Set.of() instead of an empty varag.");
 +        }
-+    }
-+
+     }
+ 
      @Nullable
-     public T create(BlockPos p_155265_, BlockState p_155266_) {
+@@ -259,6 +_,13 @@
          return (T)this.factory.create(p_155265_, p_155266_);
-+    }
-+
+     }
+ 
 +    /**
 +     * Neo: Add getter for an immutable view of the set of valid blocks.
 +     */
 +    public Set<Block> getValidBlocks() {
 +        return java.util.Collections.unmodifiableSet(this.validBlocks);
++    }
++
+     public boolean isValid(BlockState p_155263_) {
+         return this.validBlocks.contains(p_155263_.getBlock());
+     }
+@@ -275,6 +_,7 @@
      }
  
-     public boolean isValid(BlockState p_155263_) {
+     public boolean onlyOpCanSetNbt() {
++        if (onlyOpCanSetNbt) return true;
+         return OP_ONLY_CUSTOM_DATA.contains(this);
+     }
+ 

--- a/patches/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -12,7 +12,7 @@
  
      @Nullable
      public static ResourceLocation getKey(BlockEntityType<?> p_58955_) {
-@@ -250,8 +_,25 @@
+@@ -250,8 +_,21 @@
      }
  
      public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Set<Block> p_155260_) {
@@ -26,10 +26,6 @@
 +    }
 +
 +    // Neo: Additional constructor for convenience.
-+    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Block... p_155260_) {
-+        this(p_155259_, false, p_155260_);
-+    }
-+
 +    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, boolean onlyOpCanSetNbt, Block... p_155260_) {
 +        this(p_155259_, Set.of(p_155260_), onlyOpCanSetNbt);
 +        if (p_155260_.length == 0) {

--- a/patches/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -12,7 +12,7 @@
  
      @Nullable
      public static ResourceLocation getKey(BlockEntityType<?> p_58955_) {
-@@ -250,8 +_,21 @@
+@@ -250,8 +_,26 @@
      }
  
      public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Set<Block> p_155260_) {
@@ -23,6 +23,11 @@
          this.factory = p_155259_;
          this.validBlocks = p_155260_;
 +        this.onlyOpCanSetNbt = onlyOpCanSetNbt;
++    }
++
++    // Neo: Additional constructor for convenience.
++    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> p_155259_, Block... p_155260_) {
++        this(p_155259_, false, p_155260_);
 +    }
 +
 +    // Neo: Additional constructor for convenience.


### PR DESCRIPTION
In 1.21.4, `onlyOpsCanSetNbt()` was moved from `BlockEntity` and `Entity` to `BlockEntityType` and `EntityType` respectively and changed to check a hard-coded set.
This PR allows modded BE and Entity types to declare that they have op-only NBT data (such as signs) without having to modify the set. Instead the flag can be provided through the constructor or builder respectively.