### PR TITLE
[1.21.4] Fix a couple model and model loader issues

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/BlockModel.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/BlockModel.java.patch
@@ -19,13 +19,14 @@
          .create();
      private final List<BlockElement> elements;
      @Nullable
-@@ -49,7 +_,14 @@
+@@ -49,7 +_,15 @@
      private UnbakedModel parent;
      @Nullable
      private final ResourceLocation parentLocation;
 +    @Nullable
-+    private final com.mojang.math.Transformation transformation;
++    private final com.mojang.math.Transformation rootTransform;
 +    private final net.neoforged.neoforge.client.RenderTypeGroup renderTypeGroup;
++    private final java.util.Map<String, Boolean> partVisibility;
  
 +    /**
 +     * @deprecated Neo: use {@link net.neoforged.neoforge.client.model.UnbakedModelParser#parse(Reader)} instead
@@ -34,11 +35,11 @@
      public static BlockModel fromStream(Reader p_111462_) {
          return GsonHelper.fromJson(GSON, p_111462_, BlockModel.class);
      }
-@@ -62,12 +_,27 @@
+@@ -62,12 +_,29 @@
          @Nullable UnbakedModel.GuiLight p_387948_,
          @Nullable ItemTransforms p_273480_
      ) {
-+        this(p_273263_, p_272668_, p_386899_, p_272676_, p_387948_, p_273480_, null, net.neoforged.neoforge.client.RenderTypeGroup.EMPTY);
++        this(p_273263_, p_272668_, p_386899_, p_272676_, p_387948_, p_273480_, null, net.neoforged.neoforge.client.RenderTypeGroup.EMPTY, java.util.Map.of());
 +    }
 +
 +    public BlockModel(
@@ -48,8 +49,9 @@
 +            @Nullable Boolean p_272676_,
 +            @Nullable UnbakedModel.GuiLight p_387948_,
 +            @Nullable ItemTransforms p_273480_,
-+            @Nullable com.mojang.math.Transformation transformation,
-+            net.neoforged.neoforge.client.RenderTypeGroup renderTypeGroup
++            @Nullable com.mojang.math.Transformation rootTransform,
++            net.neoforged.neoforge.client.RenderTypeGroup renderTypeGroup,
++            java.util.Map<String, Boolean> partVisibility
 +    ) {
          this.elements = p_272668_;
          this.hasAmbientOcclusion = p_272676_;
@@ -57,8 +59,9 @@
          this.textureSlots = p_386899_;
          this.parentLocation = p_273263_;
          this.transforms = p_273480_;
-+        this.transformation = transformation;
++        this.rootTransform = rootTransform;
 +        this.renderTypeGroup = renderTypeGroup;
++        this.partVisibility = partVisibility;
      }
  
      @Nullable
@@ -78,42 +81,31 @@
      }
  
      @Nullable
-@@ -125,6 +_,16 @@
+@@ -125,6 +_,13 @@
          return this.parentLocation;
      }
  
 +    @Override
 +    public void fillAdditionalProperties(net.minecraft.util.context.ContextMap.Builder propertiesBuilder) {
-+        if (this.transformation != null) {
-+            propertiesBuilder.withParameter(net.neoforged.neoforge.client.model.NeoForgeModelProperties.TRANSFORM, this.transformation);
-+        }
-+        if (!this.renderTypeGroup.isEmpty()) {
-+            propertiesBuilder.withParameter(net.neoforged.neoforge.client.model.NeoForgeModelProperties.RENDER_TYPE, this.renderTypeGroup);
-+        }
++        net.neoforged.neoforge.client.model.NeoForgeModelProperties.fillRootTransformProperty(propertiesBuilder, this.rootTransform);
++        net.neoforged.neoforge.client.model.NeoForgeModelProperties.fillRenderTypeProperty(propertiesBuilder, this.renderTypeGroup);
++        net.neoforged.neoforge.client.model.NeoForgeModelProperties.fillPartVisibilityProperty(propertiesBuilder, this.partVisibility);
 +    }
 +
      @OnlyIn(Dist.CLIENT)
      public static class Deserializer implements JsonDeserializer<BlockModel> {
          public BlockModel deserialize(JsonElement p_111498_, Type p_111499_, JsonDeserializationContext p_111500_) throws JsonParseException {
-@@ -145,7 +_,20 @@
+@@ -145,7 +_,12 @@
              }
  
              ResourceLocation resourcelocation = s.isEmpty() ? null : ResourceLocation.parse(s);
 -            return new BlockModel(resourcelocation, list, textureslots$data, obool, unbakedmodel$guilight, itemtransforms);
 +
-+            com.mojang.math.Transformation rootTransform = null;
-+            if (jsonobject.has("transform")) {
-+                JsonElement transform = jsonobject.get("transform");
-+                rootTransform = p_111500_.deserialize(transform, com.mojang.math.Transformation.class);
-+            }
++            var rootTransform = net.neoforged.neoforge.client.model.NeoForgeModelProperties.deserializeRootTransform(jsonobject, p_111500_);
++            var renderTypeGroup = net.neoforged.neoforge.client.model.NeoForgeModelProperties.deserializeRenderType(jsonobject);
++            var partVisibility = net.neoforged.neoforge.client.model.NeoForgeModelProperties.deserializePartVisibility(jsonobject);
 +
-+            var renderTypeGroup = net.neoforged.neoforge.client.RenderTypeGroup.EMPTY;
-+            if (jsonobject.has("render_type")) {
-+                var renderTypeHintName = GsonHelper.getAsString(jsonobject, "render_type");
-+                renderTypeGroup = net.neoforged.neoforge.client.NamedRenderTypeManager.get(ResourceLocation.parse(renderTypeHintName));
-+            }
-+
-+            return new BlockModel(resourcelocation, list, textureslots$data, obool, unbakedmodel$guilight, itemtransforms, rootTransform, renderTypeGroup);
++            return new BlockModel(resourcelocation, list, textureslots$data, obool, unbakedmodel$guilight, itemtransforms, rootTransform, renderTypeGroup, partVisibility);
          }
  
          private TextureSlots.Data getTextureMap(JsonObject p_111510_) {

--- a/patches/net/minecraft/client/renderer/item/BlockModelWrapper.java.patch
+++ b/patches/net/minecraft/client/renderer/item/BlockModelWrapper.java.patch
@@ -37,7 +37,7 @@
 +            int[] aint = itemstackrenderstate$layerrenderstate.prepareTintLayers(tints.length);
 +            System.arraycopy(tints, 0, aint, 0, tints.length);
 +
-+            itemstackrenderstate$layerrenderstate.setupBlockModel(this.model, pass.getRenderType(p_386443_));
++            itemstackrenderstate$layerrenderstate.setupBlockModel(pass, pass.getRenderType(p_386443_));
 +        });
      }
  

--- a/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client.model;
 
 import net.minecraft.client.renderer.block.model.ItemTransforms;

--- a/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.block.model.TextureSlots;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelState;
 import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.util.context.ContextMap;
 import org.jetbrains.annotations.Nullable;
@@ -19,6 +21,11 @@ import org.jetbrains.annotations.Nullable;
  * than the vanilla elements spec.
  */
 public abstract class AbstractUnbakedModel implements ExtendedUnbakedModel {
+    /**
+     * Holds the standard top-level model parameters except elements.
+     * {@link UnbakedModel#bake(TextureSlots, ModelBaker, ModelState, boolean, boolean, ItemTransforms, ContextMap)}
+     * must always use the values given as parameters instead of accessing this parameter directly.
+     */
     protected final StandardModelParameters parameters;
     private UnbakedModel parent;
 

--- a/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
@@ -1,0 +1,70 @@
+package net.neoforged.neoforge.client.model;
+
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.block.model.TextureSlots;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.util.context.ContextMap;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Base unbaked model for custom models which support the standard top-level model parameters
+ * added by vanilla and NeoForge except elements but create the quads from something other
+ * than the vanilla elements spec.
+ */
+public abstract class AbstractUnbakedModel implements ExtendedUnbakedModel {
+    protected final StandardModelParameters parameters;
+    private UnbakedModel parent;
+
+    protected AbstractUnbakedModel(StandardModelParameters parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public void resolveDependencies(Resolver resolver) {
+        if (this.parameters.parent() != null) {
+            this.parent = resolver.resolve(this.parameters.parent());
+        }
+    }
+
+    @Nullable
+    @Override
+    public Boolean getAmbientOcclusion() {
+        return this.parameters.ambientOcclusion();
+    }
+
+    @Nullable
+    @Override
+    public GuiLight getGuiLight() {
+        return this.parameters.guiLight();
+    }
+
+    @Nullable
+    @Override
+    public ItemTransforms getTransforms() {
+        return this.parameters.itemTransforms();
+    }
+
+    @Override
+    public TextureSlots.Data getTextureSlots() {
+        return this.parameters.textures();
+    }
+
+    @Nullable
+    @Override
+    public UnbakedModel getParent() {
+        return this.parent;
+    }
+
+    @Override
+    public void fillAdditionalProperties(ContextMap.Builder propertiesBuilder) {
+        if (this.parameters.rootTransform() != null) {
+            propertiesBuilder.withParameter(NeoForgeModelProperties.TRANSFORM, this.parameters.rootTransform());
+        }
+        if (!this.parameters.renderTypeGroup().isEmpty()) {
+            propertiesBuilder.withParameter(NeoForgeModelProperties.RENDER_TYPE, this.parameters.renderTypeGroup());
+        }
+        if (!this.parameters.partVisibility().isEmpty()) {
+            propertiesBuilder.withParameter(NeoForgeModelProperties.PART_VISIBILITY, this.parameters.partVisibility());
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
@@ -22,7 +22,8 @@ public abstract class AbstractUnbakedModel implements ExtendedUnbakedModel {
     /**
      * Holds the standard top-level model parameters except elements.
      * {@link UnbakedModel#bake(TextureSlots, ModelBaker, ModelState, boolean, boolean, ItemTransforms, ContextMap)}
-     * must always use the values given as parameters instead of accessing this parameter directly.
+     * must always use the values given as parameters instead of accessing this parameter directly in order to
+     * take values collected along the model's parent chain into account.
      */
     protected final StandardModelParameters parameters;
     private UnbakedModel parent;

--- a/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
@@ -5,8 +5,6 @@
 
 package net.neoforged.neoforge.client.model;
 
-import java.util.HashMap;
-import java.util.Map;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.block.model.TextureSlots;
 import net.minecraft.client.resources.model.ModelBaker;
@@ -71,22 +69,8 @@ public abstract class AbstractUnbakedModel implements ExtendedUnbakedModel {
 
     @Override
     public void fillAdditionalProperties(ContextMap.Builder propertiesBuilder) {
-        if (this.parameters.rootTransform() != null) {
-            propertiesBuilder.withParameter(NeoForgeModelProperties.TRANSFORM, this.parameters.rootTransform());
-        }
-        if (!this.parameters.renderTypeGroup().isEmpty()) {
-            propertiesBuilder.withParameter(NeoForgeModelProperties.RENDER_TYPE, this.parameters.renderTypeGroup());
-        }
-        if (!this.parameters.partVisibility().isEmpty()) {
-            Map<String, Boolean> visibility = propertiesBuilder.getOptionalParameter(NeoForgeModelProperties.PART_VISIBILITY);
-            if (visibility != null) {
-                visibility = new HashMap<>(visibility);
-                visibility.putAll(this.parameters.partVisibility());
-                visibility = Map.copyOf(visibility);
-            } else {
-                visibility = this.parameters.partVisibility();
-            }
-            propertiesBuilder.withParameter(NeoForgeModelProperties.PART_VISIBILITY, visibility);
-        }
+        NeoForgeModelProperties.fillRootTransformProperty(propertiesBuilder, this.parameters.rootTransform());
+        NeoForgeModelProperties.fillRenderTypeProperty(propertiesBuilder, this.parameters.renderTypeGroup());
+        NeoForgeModelProperties.fillPartVisibilityProperty(propertiesBuilder, this.parameters.partVisibility());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/AbstractUnbakedModel.java
@@ -5,6 +5,8 @@
 
 package net.neoforged.neoforge.client.model;
 
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.block.model.TextureSlots;
 import net.minecraft.client.resources.model.UnbakedModel;
@@ -69,7 +71,15 @@ public abstract class AbstractUnbakedModel implements ExtendedUnbakedModel {
             propertiesBuilder.withParameter(NeoForgeModelProperties.RENDER_TYPE, this.parameters.renderTypeGroup());
         }
         if (!this.parameters.partVisibility().isEmpty()) {
-            propertiesBuilder.withParameter(NeoForgeModelProperties.PART_VISIBILITY, this.parameters.partVisibility());
+            Map<String, Boolean> visibility = propertiesBuilder.getOptionalParameter(NeoForgeModelProperties.PART_VISIBILITY);
+            if (visibility != null) {
+                visibility = new HashMap<>(visibility);
+                visibility.putAll(this.parameters.partVisibility());
+                visibility = Map.copyOf(visibility);
+            } else {
+                visibility = this.parameters.partVisibility();
+            }
+            propertiesBuilder.withParameter(NeoForgeModelProperties.PART_VISIBILITY, visibility);
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/NeoForgeModelProperties.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/NeoForgeModelProperties.java
@@ -5,12 +5,21 @@
 
 package net.neoforged.neoforge.client.model;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.math.Transformation;
+import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
 import net.minecraft.util.context.ContextKey;
+import net.minecraft.util.context.ContextMap;
+import net.neoforged.neoforge.client.NamedRenderTypeManager;
 import net.neoforged.neoforge.client.RenderTypeGroup;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Properties that NeoForge adds for {@link BlockModel}s and {@link UnbakedModel}s.
@@ -32,4 +41,77 @@ public final class NeoForgeModelProperties {
      * Part visibilities. For models with named parts (i.e. OBJ and composite), this can be specified under the {@code visibility} JSON key
      */
     public static final ContextKey<Map<String, Boolean>> PART_VISIBILITY = ContextKey.vanilla("part_visibility");
+
+    /**
+     * {@return a {@link Transformation} if the {@code transform} key is present, otherwise {@code null}}
+     */
+    @Nullable
+    public static Transformation deserializeRootTransform(JsonObject jsonObject, JsonDeserializationContext context) {
+        if (jsonObject.has("transform")) {
+            JsonElement transform = jsonObject.get("transform");
+            return context.deserialize(transform, Transformation.class);
+        }
+        return null;
+    }
+
+    /**
+     * {@return a {@link RenderTypeGroup} if the {@code render_type} key is present, otherwise {@link RenderTypeGroup#EMPTY}}
+     */
+    public static RenderTypeGroup deserializeRenderType(JsonObject jsonObject) {
+        if (jsonObject.has("render_type")) {
+            String renderTypeHintName = GsonHelper.getAsString(jsonObject, "render_type");
+            return NamedRenderTypeManager.get(ResourceLocation.parse(renderTypeHintName));
+        }
+        return RenderTypeGroup.EMPTY;
+    }
+
+    /**
+     * {@return a map of part visibilities if the {@code visibility} key is present, otherwise an empty map}
+     */
+    public static Map<String, Boolean> deserializePartVisibility(JsonObject jsonObject) {
+        Map<String, Boolean> partVisibility = new HashMap<>();
+        if (jsonObject.has("visibility")) {
+            JsonObject visibility = GsonHelper.getAsJsonObject(jsonObject, "visibility");
+            for (Map.Entry<String, JsonElement> part : visibility.entrySet()) {
+                partVisibility.put(part.getKey(), part.getValue().getAsBoolean());
+            }
+        }
+        return Map.copyOf(partVisibility);
+    }
+
+    /**
+     * Puts the given {@linkplain Transformation root transform} into the given builder if present, overwriting any value specified in a parent model
+     */
+    public static void fillRootTransformProperty(ContextMap.Builder propertiesBuilder, @Nullable Transformation rootTransform) {
+        if (rootTransform != null) {
+            propertiesBuilder.withParameter(NeoForgeModelProperties.TRANSFORM, rootTransform);
+        }
+    }
+
+    /**
+     * Puts the given {@link RenderTypeGroup} into the given builder if present, overwriting any value specified in a parent model
+     */
+    public static void fillRenderTypeProperty(ContextMap.Builder propertiesBuilder, RenderTypeGroup renderTypeGroup) {
+        if (!renderTypeGroup.isEmpty()) {
+            propertiesBuilder.withParameter(NeoForgeModelProperties.RENDER_TYPE, renderTypeGroup);
+        }
+    }
+
+    /**
+     * Puts the given part visibility into the given builder if present, merging the with values from parent models
+     * on a per-key basis and overwriting existing keys
+     */
+    public static void fillPartVisibilityProperty(ContextMap.Builder propertiesBuilder, Map<String, Boolean> partVisibility) {
+        if (!partVisibility.isEmpty()) {
+            Map<String, Boolean> visibility = propertiesBuilder.getOptionalParameter(NeoForgeModelProperties.PART_VISIBILITY);
+            if (visibility != null) {
+                visibility = new HashMap<>(visibility);
+                visibility.putAll(partVisibility);
+            } else {
+                visibility = partVisibility;
+            }
+            visibility = Map.copyOf(visibility);
+            propertiesBuilder.withParameter(NeoForgeModelProperties.PART_VISIBILITY, visibility);
+        }
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/NeoForgeModelProperties.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/NeoForgeModelProperties.java
@@ -6,12 +6,11 @@
 package net.neoforged.neoforge.client.model;
 
 import com.mojang.math.Transformation;
+import java.util.Map;
 import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.util.context.ContextKey;
 import net.neoforged.neoforge.client.RenderTypeGroup;
-
-import java.util.Map;
 
 /**
  * Properties that NeoForge adds for {@link BlockModel}s and {@link UnbakedModel}s.

--- a/src/main/java/net/neoforged/neoforge/client/model/NeoForgeModelProperties.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/NeoForgeModelProperties.java
@@ -11,6 +11,8 @@ import net.minecraft.client.resources.model.UnbakedModel;
 import net.minecraft.util.context.ContextKey;
 import net.neoforged.neoforge.client.RenderTypeGroup;
 
+import java.util.Map;
+
 /**
  * Properties that NeoForge adds for {@link BlockModel}s and {@link UnbakedModel}s.
  */
@@ -26,4 +28,9 @@ public final class NeoForgeModelProperties {
      * Render type to use. For block models, this can be specified under the {@code render_type} JSON key.
      */
     public static final ContextKey<RenderTypeGroup> RENDER_TYPE = ContextKey.vanilla("render_type");
+
+    /**
+     * Part visibilities. For models with named parts (i.e. OBJ and composite), this can be specified under the {@code visibility} JSON key
+     */
+    public static final ContextKey<Map<String, Boolean>> PART_VISIBILITY = ContextKey.vanilla("part_visibility");
 }

--- a/src/main/java/net/neoforged/neoforge/client/model/StandardModelParameters.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/StandardModelParameters.java
@@ -1,9 +1,16 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client.model;
 
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mojang.math.Transformation;
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.block.model.TextureSlots;
 import net.minecraft.client.renderer.texture.TextureAtlas;
@@ -12,9 +19,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.neoforged.neoforge.client.RenderTypeGroup;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Wrapper around all standard top-level model parameters added by vanilla and NeoForge except elements.
@@ -31,7 +35,6 @@ public record StandardModelParameters(
         @Nullable Transformation rootTransform,
         RenderTypeGroup renderTypeGroup,
         Map<String, Boolean> partVisibility) {
-
     public static StandardModelParameters parse(JsonObject jsonObject, JsonDeserializationContext context) {
         String parentName = GsonHelper.getAsString(jsonObject, "parent", "");
         ResourceLocation parent = parentName.isEmpty() ? null : ResourceLocation.parse(parentName);

--- a/src/main/java/net/neoforged/neoforge/client/model/StandardModelParameters.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/StandardModelParameters.java
@@ -6,10 +6,8 @@
 package net.neoforged.neoforge.client.model;
 
 import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mojang.math.Transformation;
-import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.client.renderer.block.model.TextureSlots;
@@ -61,26 +59,9 @@ public record StandardModelParameters(
             guiLight = UnbakedModel.GuiLight.getByName(GsonHelper.getAsString(jsonObject, "gui_light"));
         }
 
-        Transformation rootTransform = null;
-        if (jsonObject.has("transform")) {
-            JsonElement transform = jsonObject.get("transform");
-            rootTransform = context.deserialize(transform, Transformation.class);
-        }
-
-        RenderTypeGroup renderTypeGroup = RenderTypeGroup.EMPTY;
-        if (jsonObject.has("render_type")) {
-            var renderTypeHintName = GsonHelper.getAsString(jsonObject, "render_type");
-            renderTypeGroup = net.neoforged.neoforge.client.NamedRenderTypeManager.get(ResourceLocation.parse(renderTypeHintName));
-        }
-
-        Map<String, Boolean> partVisibility = new HashMap<>();
-        if (jsonObject.has("visibility")) {
-            JsonObject visibility = GsonHelper.getAsJsonObject(jsonObject, "visibility");
-            for (Map.Entry<String, JsonElement> part : visibility.entrySet()) {
-                partVisibility.put(part.getKey(), part.getValue().getAsBoolean());
-            }
-        }
-        partVisibility = Map.copyOf(partVisibility);
+        Transformation rootTransform = NeoForgeModelProperties.deserializeRootTransform(jsonObject, context);
+        RenderTypeGroup renderTypeGroup = NeoForgeModelProperties.deserializeRenderType(jsonObject);
+        Map<String, Boolean> partVisibility = NeoForgeModelProperties.deserializePartVisibility(jsonObject);
 
         return new StandardModelParameters(parent, textures, itemTransforms, ambientOcclusion, guiLight, rootTransform, renderTypeGroup, partVisibility);
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/StandardModelParameters.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/StandardModelParameters.java
@@ -1,0 +1,84 @@
+package net.neoforged.neoforge.client.model;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.math.Transformation;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.block.model.TextureSlots;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.neoforged.neoforge.client.RenderTypeGroup;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Wrapper around all standard top-level model parameters added by vanilla and NeoForge except elements.
+ * <p>
+ * For use in custom model loaders which want to respect these properties but create the quads from
+ * something other than the vanilla elements spec.
+ */
+public record StandardModelParameters(
+        @Nullable ResourceLocation parent,
+        TextureSlots.Data textures,
+        @Nullable ItemTransforms itemTransforms,
+        @Nullable Boolean ambientOcclusion,
+        @Nullable UnbakedModel.GuiLight guiLight,
+        @Nullable Transformation rootTransform,
+        RenderTypeGroup renderTypeGroup,
+        Map<String, Boolean> partVisibility) {
+
+    public static StandardModelParameters parse(JsonObject jsonObject, JsonDeserializationContext context) {
+        String parentName = GsonHelper.getAsString(jsonObject, "parent", "");
+        ResourceLocation parent = parentName.isEmpty() ? null : ResourceLocation.parse(parentName);
+
+        TextureSlots.Data textures = TextureSlots.Data.EMPTY;
+        if (jsonObject.has("textures")) {
+            JsonObject jsonobject = GsonHelper.getAsJsonObject(jsonObject, "textures");
+            textures = TextureSlots.parseTextureMap(jsonobject, TextureAtlas.LOCATION_BLOCKS);
+        }
+
+        ItemTransforms itemTransforms = null;
+        if (jsonObject.has("display")) {
+            JsonObject jsonobject1 = GsonHelper.getAsJsonObject(jsonObject, "display");
+            itemTransforms = context.deserialize(jsonobject1, ItemTransforms.class);
+        }
+
+        Boolean ambientOcclusion = null;
+        if (jsonObject.has("ambientocclusion")) {
+            ambientOcclusion = GsonHelper.getAsBoolean(jsonObject, "ambientocclusion");
+        }
+
+        UnbakedModel.GuiLight guiLight = null;
+        if (jsonObject.has("gui_light")) {
+            guiLight = UnbakedModel.GuiLight.getByName(GsonHelper.getAsString(jsonObject, "gui_light"));
+        }
+
+        Transformation rootTransform = null;
+        if (jsonObject.has("transform")) {
+            JsonElement transform = jsonObject.get("transform");
+            rootTransform = context.deserialize(transform, Transformation.class);
+        }
+
+        RenderTypeGroup renderTypeGroup = RenderTypeGroup.EMPTY;
+        if (jsonObject.has("render_type")) {
+            var renderTypeHintName = GsonHelper.getAsString(jsonObject, "render_type");
+            renderTypeGroup = net.neoforged.neoforge.client.NamedRenderTypeManager.get(ResourceLocation.parse(renderTypeHintName));
+        }
+
+        Map<String, Boolean> partVisibility = new HashMap<>();
+        if (jsonObject.has("visibility")) {
+            JsonObject visibility = GsonHelper.getAsJsonObject(jsonObject, "visibility");
+            for (Map.Entry<String, JsonElement> part : visibility.entrySet()) {
+                partVisibility.put(part.getKey(), part.getValue().getAsBoolean());
+            }
+        }
+        partVisibility = Map.copyOf(partVisibility);
+
+        return new StandardModelParameters(parent, textures, itemTransforms, ambientOcclusion, guiLight, rootTransform, renderTypeGroup, partVisibility);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/CompositeModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/CompositeModelBuilder.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.client.model.generators.CustomLoaderBuilder;
 import net.neoforged.neoforge.client.model.generators.ModelBuilder;
+import net.neoforged.neoforge.client.model.generators.ModelFile;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 public class CompositeModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuilder<T> {
@@ -23,17 +24,17 @@ public class CompositeModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         return new CompositeModelBuilder<>(parent, existingFileHelper);
     }
 
-    private final Map<String, T> childModels = new LinkedHashMap<>();
+    private final Map<String, ResourceLocation> childModels = new LinkedHashMap<>();
     private final List<String> itemRenderOrder = new ArrayList<>();
 
     protected CompositeModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
         super(ResourceLocation.fromNamespaceAndPath("neoforge", "composite"), parent, existingFileHelper, false);
     }
 
-    public CompositeModelBuilder<T> child(String name, T modelBuilder) {
+    public CompositeModelBuilder<T> child(String name, ModelFile model) {
         Preconditions.checkNotNull(name, "name must not be null");
-        Preconditions.checkNotNull(modelBuilder, "modelBuilder must not be null");
-        childModels.put(name, modelBuilder);
+        Preconditions.checkNotNull(model, "model must not be null");
+        childModels.put(name, model.getLocation());
         itemRenderOrder.add(name);
         return this;
     }
@@ -54,8 +55,8 @@ public class CompositeModelBuilder<T extends ModelBuilder<T>> extends CustomLoad
         json = super.toJson(json);
 
         JsonObject children = new JsonObject();
-        for (Map.Entry<String, T> entry : childModels.entrySet()) {
-            children.add(entry.getKey(), entry.getValue().toJson());
+        for (Map.Entry<String, ResourceLocation> entry : childModels.entrySet()) {
+            children.addProperty(entry.getKey(), entry.getValue().toString());
         }
         json.add("children", children);
 

--- a/src/main/java/net/neoforged/neoforge/client/model/obj/ObjLoader.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/obj/ObjLoader.java
@@ -7,20 +7,17 @@ package net.neoforged.neoforge.client.model.obj;
 
 import com.google.common.collect.Maps;
 import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.mojang.math.Transformation;
 import java.io.FileNotFoundException;
-import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.model.BlockModel;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraft.util.GsonHelper;
+import net.neoforged.neoforge.client.model.StandardModelParameters;
 import net.neoforged.neoforge.client.model.UnbakedModelLoader;
 
 /**
@@ -55,22 +52,9 @@ public class ObjLoader implements UnbakedModelLoader<ObjModel>, ResourceManagerR
         boolean flipV = GsonHelper.getAsBoolean(jsonObject, "flip_v", false);
         boolean emissiveAmbient = GsonHelper.getAsBoolean(jsonObject, "emissive_ambient", true);
         String mtlOverride = GsonHelper.getAsString(jsonObject, "mtl_override", null);
+        StandardModelParameters parameters = StandardModelParameters.parse(jsonObject, jsonDeserializationContext);
 
-        final Map<String, Boolean> partVisibility = new HashMap<>();
-        if (jsonObject.has("visibility")) {
-            JsonObject visibility = GsonHelper.getAsJsonObject(jsonObject, "visibility");
-            for (Map.Entry<String, JsonElement> part : visibility.entrySet()) {
-                partVisibility.put(part.getKey(), part.getValue().getAsBoolean());
-            }
-        }
-
-        Transformation transformation = Transformation.identity();
-        if (jsonObject.has("transform")) {
-            JsonElement transform = jsonObject.get("transform");
-            transformation = BlockModel.GSON.fromJson(transform, Transformation.class);
-        }
-
-        return loadModel(new ObjModel.ModelSettings(ResourceLocation.parse(modelLocation), automaticCulling, shadeQuads, flipV, emissiveAmbient, mtlOverride, partVisibility, transformation));
+        return loadModel(new ObjModel.ModelSettings(ResourceLocation.parse(modelLocation), automaticCulling, shadeQuads, flipV, emissiveAmbient, mtlOverride, parameters));
     }
 
     public ObjModel loadModel(ObjModel.ModelSettings settings) {

--- a/src/main/java/net/neoforged/neoforge/client/model/obj/ObjTokenizer.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/obj/ObjTokenizer.java
@@ -28,8 +28,7 @@ public class ObjTokenizer implements AutoCloseable {
         this.lineReader = new BufferedReader(new InputStreamReader(inputStream, Charsets.UTF_8));
     }
 
-    @Nullable
-    public String[] readAndSplitLine(boolean ignoreEmptyLines) throws IOException {
+    public String @Nullable[] readAndSplitLine(boolean ignoreEmptyLines) throws IOException {
         //noinspection LoopConditionNotUpdatedInsideLoop
         do {
             String currentLine = lineReader.readLine();

--- a/src/main/java/net/neoforged/neoforge/client/model/obj/ObjTokenizer.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/obj/ObjTokenizer.java
@@ -28,7 +28,7 @@ public class ObjTokenizer implements AutoCloseable {
         this.lineReader = new BufferedReader(new InputStreamReader(inputStream, Charsets.UTF_8));
     }
 
-    public String @Nullable[] readAndSplitLine(boolean ignoreEmptyLines) throws IOException {
+    public String @Nullable [] readAndSplitLine(boolean ignoreEmptyLines) throws IOException {
         //noinspection LoopConditionNotUpdatedInsideLoop
         do {
             String currentLine = lineReader.readLine();


### PR DESCRIPTION
This PR fixes a couple issues with models and model loaders:
- Fix `BlockModelWrapper` using the root model instead of the "pass" models
- Fix OBJ and composite models ignoring all top-level properties (textures, item transforms, etc.)
- Fix composite model builder generating the old format