### PR TITLE
Patch `Ingredient#isEmpty` for custom ingredients

### DIFF
--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -27,7 +27,7 @@
  
      private Ingredient(HolderSet<Item> p_365027_) {
          p_365027_.unwrap().ifRight(p_360057_ -> {
-@@ -45,30 +_,98 @@
+@@ -45,30 +_,96 @@
          this.values = p_365027_;
      }
  
@@ -43,16 +43,14 @@
      @Deprecated
      public Stream<Holder<Item>> items() {
 +        if (this.customIngredient != null) {
-+            updateCustomIngredientValues();
-+            return this.customIngredientValues.stream();
++            return updateCustomIngredientValues().stream();
 +        }
          return this.values.stream();
      }
  
      public boolean isEmpty() {
 +        if (this.customIngredient != null) {
-+            updateCustomIngredientValues();
-+            return customIngredientValues.isEmpty();
++            return updateCustomIngredientValues().isEmpty();
 +        }
          return this.values.size() == 0;
      }
@@ -66,8 +64,7 @@
  
      public boolean acceptsItem(Holder<Item> p_389400_) {
 +        if (this.customIngredient != null) {
-+            updateCustomIngredientValues();
-+            return this.customIngredientValues.contains(p_389400_);
++            return updateCustomIngredientValues().contains(p_389400_);
 +        }
          return this.values.contains(p_389400_);
      }
@@ -120,10 +117,11 @@
 +        return this.customIngredient != null;
 +    }
 +
-+    private void updateCustomIngredientValues() {
++    private List<Holder<Item>> updateCustomIngredientValues() {
 +        if (this.customIngredientValues == null) {
 +            this.customIngredientValues = this.customIngredient.items().toList();
 +        }
++        return this.customIngredientValues;
      }
  
      public static Ingredient of(ItemLike p_364285_) {

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -43,9 +43,7 @@
      @Deprecated
      public Stream<Holder<Item>> items() {
 +        if (this.customIngredient != null) {
-+            if (this.customIngredientValues == null) {
-+                this.customIngredientValues = this.customIngredient.items().toList();
-+            }
++            updateCustomIngredientValues();
 +            return this.customIngredientValues.stream();
 +        }
          return this.values.stream();
@@ -53,9 +51,7 @@
  
      public boolean isEmpty() {
 +        if (this.customIngredient != null) {
-+            if (this.customIngredientValues == null) {
-+                this.customIngredientValues = this.customIngredient.items().toList();
-+            }
++            updateCustomIngredientValues();
 +            return customIngredientValues.isEmpty();
 +        }
          return this.values.size() == 0;
@@ -70,9 +66,7 @@
  
      public boolean acceptsItem(Holder<Item> p_389400_) {
 +        if (this.customIngredient != null) {
-+            if (this.customIngredientValues == null) {
-+                this.customIngredientValues = this.customIngredient.items().toList();
-+            }
++            updateCustomIngredientValues();
 +            return this.customIngredientValues.contains(p_389400_);
 +        }
          return this.values.contains(p_389400_);
@@ -124,6 +118,12 @@
 +
 +    public boolean isCustom() {
 +        return this.customIngredient != null;
++    }
++
++    private void updateCustomIngredientValues() {
++        if (this.customIngredientValues == null) {
++            this.customIngredientValues = this.customIngredient.items().toList();
++        }
      }
  
      public static Ingredient of(ItemLike p_364285_) {

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -27,7 +27,7 @@
  
      private Ingredient(HolderSet<Item> p_365027_) {
          p_365027_.unwrap().ifRight(p_360057_ -> {
-@@ -45,12 +_,23 @@
+@@ -45,30 +_,98 @@
          this.values = p_365027_;
      }
  
@@ -51,7 +51,14 @@
          return this.values.stream();
      }
  
-@@ -59,16 +_,67 @@
+     public boolean isEmpty() {
++        if (this.customIngredient != null) {
++            if (this.customIngredientValues == null) {
++                this.customIngredientValues = this.customIngredient.items().toList();
++            }
++            return customIngredientValues.isEmpty();
++        }
+         return this.values.size() == 0;
      }
  
      public boolean test(ItemStack p_43914_) {


### PR DESCRIPTION
Seems like we forgot to patch this new method to use the custom ingredient item list.
Fixes #1726