### PR TITLE
Skip GL state manipulation in ItemDecoratorHandler when there are no decorators

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
+++ b/src/main/java/net/neoforged/neoforge/client/ItemDecoratorHandler.java
@@ -50,6 +50,10 @@ public final class ItemDecoratorHandler {
     }
 
     public void render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
+        if (itemDecorators.isEmpty()) {
+            return;
+        }
+
         RenderSystem.backupGlState(stateBackup);
 
         resetRenderState();


### PR DESCRIPTION
Alternative solution to #1482, that will accomplish the same goal (and is updated for 1.21.4). The GL state backup/restore is now skipped if there are no item decorators for an item. I did not profile this, as it's pretty obvious it cannot worsen performance.