### PR TITLE
Fix chunk force ticking

### DIFF
--- a/patches/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/net/minecraft/server/level/ChunkMap.java.patch
@@ -59,7 +59,7 @@
 +            ChunkHolder holder = this.visibleChunkMap.get(entry.getLongKey());
 +            if (holder != null && !entry.getValue().isEmpty()) {
 +                var chunk = holder.getTickingChunk();
-+                if (chunk != null && !list.contains(chunk)) {
++                if (chunk != null) {
 +                    list.add(chunk);
 +                }
 +            }

--- a/patches/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/net/minecraft/server/level/ChunkMap.java.patch
@@ -48,6 +48,27 @@
          p_294215_.connection.chunkSender.dropChunk(p_294215_, p_294758_);
      }
  
+@@ -955,6 +_,20 @@
+         }
+     }
+ 
++    void collectForceTickingChunks(List<LevelChunk> list) {
++        var itr = distanceManager.forcedTickets.long2ObjectEntrySet().fastIterator();
++        while (itr.hasNext()) {
++            var entry = itr.next();
++            ChunkHolder holder = this.visibleChunkMap.get(entry.getLongKey());
++            if (holder != null && !entry.getValue().isEmpty()) {
++                var chunk = holder.getTickingChunk();
++                if (chunk != null && !list.contains(chunk)) {
++                    list.add(chunk);
++                }
++            }
++        }
++    }
++
+     boolean anyPlayerCloseEnoughForSpawning(ChunkPos p_183880_) {
+         return !this.distanceManager.hasPlayersNearby(p_183880_.toLong()) ? false : this.anyPlayerCloseEnoughForSpawningInternal(p_183880_);
+     }
 @@ -1059,6 +_,7 @@
                  this.playerMap.unIgnorePlayer(p_140185_);
              }

--- a/patches/net/minecraft/server/level/DistanceManager.java.patch
+++ b/patches/net/minecraft/server/level/DistanceManager.java.patch
@@ -4,7 +4,7 @@
      final Executor mainThreadExecutor;
      private long ticketTickCounter;
      private int simulationDistance = 10;
-+    private final Long2ObjectOpenHashMap<SortedArraySet<Ticket<?>>> forcedTickets = new Long2ObjectOpenHashMap<>();
++    final Long2ObjectOpenHashMap<SortedArraySet<Ticket<?>>> forcedTickets = new Long2ObjectOpenHashMap<>();
  
      protected DistanceManager(Executor p_140774_, Executor p_140775_) {
          TaskScheduler<Runnable> taskscheduler = TaskScheduler.wrapExecutor("player ticket throttler", p_140775_);
@@ -13,8 +13,8 @@
              this.ticketTracker.update(p_140785_, p_140786_.getTicketLevel(), true);
          }
 +        if (p_140786_.isForceTicks()) {
-+             SortedArraySet<Ticket<?>> tickets = forcedTickets.computeIfAbsent(p_140785_, e -> SortedArraySet.create(4));
-+             tickets.addOrGet(ticket);
++            SortedArraySet<Ticket<?>> tickets = forcedTickets.computeIfAbsent(p_140785_, e -> SortedArraySet.create(4));
++            tickets.addOrGet(ticket);
 +        }
      }
  
@@ -25,10 +25,10 @@
          this.ticketTracker.update(p_140819_, getTicketLevelAt(sortedarrayset), false);
 +
 +        if (p_140820_.isForceTicks()) {
-+             SortedArraySet<Ticket<?>> tickets = forcedTickets.get(p_140819_);
-+             if (tickets != null) {
-+                  tickets.remove(p_140820_);
-+             }
++            SortedArraySet<Ticket<?>> tickets = forcedTickets.get(p_140819_);
++            if (tickets != null) {
++                tickets.remove(p_140820_);
++            }
 +        }
      }
  
@@ -63,8 +63,8 @@
 +    }
 +
 +    public boolean shouldForceTicks(long chunkPos) {
-+         SortedArraySet<Ticket<?>> tickets = forcedTickets.get(chunkPos);
-+         return tickets != null && !tickets.isEmpty();
++        SortedArraySet<Ticket<?>> tickets = forcedTickets.get(chunkPos);
++        return tickets != null && !tickets.isEmpty();
      }
  
      private void dumpTickets(String p_143208_) {

--- a/patches/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -28,15 +28,14 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
-@@ -384,7 +_,7 @@
-     private void collectTickingChunks(List<LevelChunk> p_363421_) {
-         this.chunkMap.forEachSpawnCandidateChunk(p_381767_ -> {
-             LevelChunk levelchunk = p_381767_.getTickingChunk();
--            if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_381767_.getPos())) {
-+            if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_381767_.getPos()) || this.distanceManager.shouldForceTicks(p_381767_.getPos().toLong())) {
+@@ -388,6 +_,7 @@
                  p_363421_.add(levelchunk);
              }
          });
++        chunkMap.collectForceTickingChunks(p_363421_);
+     }
+ 
+     private void tickChunks(ProfilerFiller p_364065_, long p_361343_, List<LevelChunk> p_360873_) {
 @@ -480,11 +_,17 @@
      }
  

--- a/patches/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/patches/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -28,7 +28,12 @@
                  ChunkAccess chunkaccess1 = chunkholder.getChunkIfPresent(ChunkStatus.FULL);
                  if (chunkaccess1 != null) {
                      this.storeInCache(i, chunkaccess1, ChunkStatus.FULL);
-@@ -388,6 +_,7 @@
+@@ -384,10 +_,11 @@
+     private void collectTickingChunks(List<LevelChunk> p_363421_) {
+         this.chunkMap.forEachSpawnCandidateChunk(p_381767_ -> {
+             LevelChunk levelchunk = p_381767_.getTickingChunk();
+-            if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_381767_.getPos())) {
++            if (levelchunk != null && this.level.isNaturalSpawningAllowed(p_381767_.getPos()) && !this.distanceManager.shouldForceTicks(p_381767_.getPos().toLong())) { // Neo: we add force ticked chunks in the list below
                  p_363421_.add(levelchunk);
              }
          });


### PR DESCRIPTION
In 1.21.2, Mojang changed the previous chunk ticking code. Instead of iterating all known chunks and checking if each one should be ticked, it now uses a chunk manager that's constantly based on the location of players.

This means that our previous code which simply adds a check on the ticking candidates is no longer feasible, as chunks situated far out from players will not even be considered candidates to begin with. The new method adds each force ticked chunk to the list of final candidates manually, checking if the chunk is already in the list.

Fixes #1702