### PR TITLE
Do not attempt to format mod description contents

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/main/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -426,7 +426,7 @@ public class ModListScreen extends Screen {
             lines.add(FMLTranslations.parseMessage("fml.menu.mods.info.updateavailable", vercheck.url() == null ? "" : vercheck.url()).replace("\r\n", "\n"));
         lines.add(FMLTranslations.parseMessage("fml.menu.mods.info.license", selectedMod.getOwningFile().getLicense()).replace("\r\n", "\n"));
         lines.add(null);
-        lines.add(FMLTranslations.parseMessageWithFallback("fml.menu.mods.info.description." + selectedMod.getModId(), selectedMod::getDescription));
+        lines.add(FMLTranslations.getPattern("fml.menu.mods.info.description." + selectedMod.getModId(), selectedMod::getDescription));
 
         /* Removed because people bitched that this information was misleading.
         lines.add(null);

--- a/tests/src/main/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/main/resources/META-INF/neoforge.mods.toml
@@ -7,7 +7,7 @@ license="LGPL v2.1"
 
 [[mods]]
     modId="neotests"
-    description="NeoForge tests. Change the language to fr_fr and the description should change too."
+    description="NeoForge's tests. Change the language to fr_fr and the description should change too."
     enumExtensions="META-INF/enumextensions.json"
 [[mods]]
     modId="configui"

--- a/tests/src/main/resources/assets/neotests/lang/fr_fr.json
+++ b/tests/src/main/resources/assets/neotests/lang/fr_fr.json
@@ -1,3 +1,3 @@
 {
-  "fml.menu.mods.info.description.neotests": "Le mod de test de NeoForge oh la la !"
+  "fml.menu.mods.info.description.neotests": "Le mod de test de NeoForge oh la la ! J'aime le français !"
 }


### PR DESCRIPTION
Fixes #1561 by not formatting mod descriptions, and only querying the translation.