### PR TITLE
Fix statistics for vehicles not working

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -12,6 +12,14 @@
                      this.send(ClientboundMoveVehiclePacket.fromEntity(entity));
                      return;
                  }
+@@ -455,6 +_,7 @@
+                 entity.setOnGroundWithMovement(p_9876_.onGround(), vec3);
+                 entity.doCheckFallDamage(vec3.x, vec3.y, vec3.z, p_9876_.onGround());
+                 this.player.checkMovementStatistics(vec3.x, vec3.y, vec3.z);
++                this.player.checkRidingStatistics(vec3.x, vec3.y, vec3.z); // Neo: check riding stats too as vanilla checks them in rideTick based on the assumption that Entity#rideTick will move the entity, which we break
+                 this.clientVehicleIsFloating = d11 >= -0.03125
+                     && !flag1
+                     && !this.server.isFlightAllowed()
 @@ -467,6 +_,23 @@
          }
      }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -161,6 +161,7 @@ public net.minecraft.server.MinecraftServer$ReloadableResources <init>(Lnet/mine
 public net.minecraft.server.level.ChunkMap getVisibleChunkIfPresent(J)Lnet/minecraft/server/level/ChunkHolder;
 public net.minecraft.server.level.ServerChunkCache level # level
 public net.minecraft.server.level.ServerLevel getEntities()Lnet/minecraft/world/level/entity/LevelEntityGetter; # getEntities
+public net.minecraft.server.level.ServerPlayer checkRidingStatistics(DDD)V # checkRidingStatistics
 public net.minecraft.server.level.ServerPlayer$RespawnPosAngle
 public net.minecraft.server.level.ServerPlayer$RespawnPosAngle <init>(Lnet/minecraft/world/phys/Vec3;F)V
 public net.minecraft.server.packs.FilePackResources <init>(Lnet/minecraft/server/packs/PackLocationInfo;Lnet/minecraft/server/packs/FilePackResources$SharedZipFileAccess;Ljava/lang/String;)V # constructor


### PR DESCRIPTION
This bug has existed for 6 years. Impressive that it took so long to be noticed.
Since we're repositioning the player inside `ServerGamePacketListenerImpl#handleMoveVehicle`, the stat check inside `ServerPlayer#rideTick` will not work as it is based on the assumption that `Entity#rideTick` will reposition the player, which no longer stands true. This PR simply calls `checkRidingStatistics` after `checkMovementStatistics`
Fixes #1582