### PR TITLE
Stop listening for advancements when a fake player is unloaded

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayerFactory.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayerFactory.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.common.util;
 import com.google.common.collect.Maps;
 import com.mojang.authlib.GameProfile;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import net.minecraft.server.level.ServerLevel;
 
@@ -35,6 +36,13 @@ public class FakePlayerFactory {
     }
 
     public static void unloadLevel(ServerLevel level) {
-        fakePlayers.entrySet().removeIf(entry -> entry.getValue().level() == level);
+        Set.copyOf(fakePlayers.keySet()).forEach(key -> {
+            if (key.level == level) {
+                var player = fakePlayers.remove(key);
+                if (player != null) {
+                    player.getAdvancements().stopListening();
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
Advancement criteria hold players in a map key that's only cleared when `PlayerAdvancements#stopListening` is called. Fixes #1487