### PR TITLE
Rename isRepairable to isCombineRepairable and make it not reliant on Repairable Data Component

### DIFF
--- a/patches/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -54,7 +54,7 @@
              int l = j + k + i * 5 / 100;
              int i1 = 1;
 -            if (!p_332723_.isDamageableItem()) {
-+            if (!p_332723_.isDamageableItem() || !p_332723_.isRepairable()) {
++            if (!p_332723_.isDamageableItem() || !p_332723_.isCombineRepairable()) {
                  if (p_332723_.getMaxStackSize() < 2 || !ItemStack.matches(p_332723_, p_332686_)) {
                      return ItemStack.EMPTY;
                  }
@@ -62,7 +62,7 @@
              if (itemstack.isDamageableItem()) {
                  itemstack.set(DataComponents.MAX_DAMAGE, i);
                  itemstack.setDamageValue(Math.max(i - l, 0));
-+                if (!p_332686_.isRepairable()) itemstack.setDamageValue(p_332723_.getDamageValue());
++                if (!p_332686_.isCombineRepairable()) itemstack.setDamageValue(p_332723_.getDamageValue());
              }
  
              this.mergeEnchantsFrom(itemstack, p_332686_);

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -18,7 +18,7 @@
      public static final ResourceLocation BASE_ATTACK_DAMAGE_ID = ResourceLocation.withDefaultNamespace("base_attack_damage");
      public static final ResourceLocation BASE_ATTACK_SPEED_ID = ResourceLocation.withDefaultNamespace("base_attack_speed");
      public static final int DEFAULT_MAX_STACK_SIZE = 64;
-@@ -110,7 +_,7 @@
+@@ -110,12 +_,13 @@
          this.components = p_41383_.buildAndValidateComponents(Component.translatable(this.descriptionId), p_41383_.effectiveModel());
          this.craftingRemainingItem = p_41383_.craftingRemainingItem;
          this.requiredFeatures = p_41383_.requiredFeatures;
@@ -27,6 +27,12 @@
              String s = this.getClass().getSimpleName();
              if (!s.endsWith("Item")) {
                  LOGGER.error("Item classes should end with Item and {} doesn't.", s);
+             }
+         }
++        this.canCombineRepair = p_41383_.canCombineRepair;
+     }
+ 
+     @Deprecated
 @@ -127,6 +_,15 @@
          return this.components;
      }
@@ -76,7 +82,7 @@
      public final ItemStack getCraftingRemainder() {
          return this.craftingRemainingItem == null ? ItemStack.EMPTY : new ItemStack(this.craftingRemainingItem);
      }
-@@ -302,7 +_,12 @@
+@@ -302,7 +_,14 @@
      }
  
      public boolean useOnRelease(ItemStack p_41464_) {
@@ -84,9 +90,11 @@
 +        return p_41464_.getItem() == Items.CROSSBOW;
 +    }
 +
++    protected final boolean canCombineRepair;
++
 +    @Override
-+    public boolean isRepairable(ItemStack stack) {
-+        return stack.has(DataComponents.REPAIRABLE) && isDamageable(stack);
++    public boolean isCombineRepairable(ItemStack stack) {
++        return canCombineRepair && isDamageable(stack);
      }
  
      public ItemStack getDefaultInstance() {
@@ -99,6 +107,19 @@
          private static final DependantName<Item, String> BLOCK_DESCRIPTION_ID = p_371954_ -> Util.makeDescriptionId("block", p_371954_.location());
          private static final DependantName<Item, String> ITEM_DESCRIPTION_ID = p_371511_ -> Util.makeDescriptionId("item", p_371511_.location());
          private final DataComponentMap.Builder components = DataComponentMap.builder().addAll(DataComponents.COMMON_ITEM_COMPONENTS);
+@@ -337,6 +_,12 @@
+         private ResourceKey<Item> id;
+         private DependantName<Item, String> descriptionId = ITEM_DESCRIPTION_ID;
+         private DependantName<Item, ResourceLocation> model = ResourceKey::location;
++        private boolean canCombineRepair = true;
++
++        public Item.Properties setNoCombineRepair() {
++            canCombineRepair = false;
++            return this;
++        }
+ 
+         public Item.Properties food(FoodProperties p_41490_) {
+             return this.food(p_41490_, Consumables.DEFAULT_FOOD);
 @@ -437,6 +_,7 @@
          }
  

--- a/patches/net/minecraft/world/item/crafting/RepairItemRecipe.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RepairItemRecipe.java.patch
@@ -6,8 +6,8 @@
              && p_336139_.has(DataComponents.DAMAGE)
 -            && p_335795_.has(DataComponents.DAMAGE);
 +            && p_335795_.has(DataComponents.DAMAGE)
-+            && p_336139_.isRepairable()
-+            && p_335795_.isRepairable();
++            && p_336139_.isCombineRepairable()
++            && p_335795_.isCombineRepairable();
      }
  
      public boolean matches(CraftingInput p_345243_, Level p_44139_) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -129,11 +129,11 @@ public interface IItemExtension {
     }
 
     /**
-     * Called by CraftingManager to determine if an item is reparable.
+     * Called by CraftingManager and Grindstone to determine if an item is repairable by combining two damaged versions together.
      *
-     * @return True if reparable
+     * @return True if reparable by combining
      */
-    boolean isRepairable(ItemStack stack);
+    boolean isCombineRepairable(ItemStack stack);
 
     /**
      * Determines the amount of durability the mending enchantment

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -129,9 +129,9 @@ public interface IItemExtension {
     }
 
     /**
-     * Called by CraftingManager and Grindstone to determine if an item is repairable by combining two damaged versions together.
+     * Determines if an item is repairable by combining, used by Repair recipes and Grindstone.
      *
-     * @return True if reparable by combining
+     * @return True if repairable by combining
      */
     boolean isCombineRepairable(ItemStack stack);
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -317,12 +317,12 @@ public interface IItemStackExtension {
     }
 
     /**
-     * Determines if a item is reparable, used by Repair recipes and Grindstone.
+     * Determines if an item is repairable by combining, used by Repair recipes and Grindstone.
      *
-     * @return True if reparable
+     * @return True if repairable by combining
      */
-    default boolean isRepairable() {
-        return self().getItem().isRepairable(self());
+    default boolean isCombineRepairable() {
+        return self().getItem().isCombineRepairable(self());
     }
 
     /**


### PR DESCRIPTION
Allows bows to be repaired by combining again in crafting screen and in grindstone. The rename is so it is no longer confused with the repairable data component