### PR TITLE
Sync code in onDestroyedByPushReaction to original

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -249,7 +249,7 @@ public interface IBlockExtension {
      * @param fluid         The current fluid state at current position
      */
     default void onDestroyedByPushReaction(BlockState state, Level level, BlockPos pos, Direction pushDirection, FluidState fluid) {
-        level.setBlock(pos, Blocks.AIR.defaultBlockState(), level.isClientSide ? 11 : 3);
+        level.setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_KNOWN_SHAPE | Block.UPDATE_CLIENTS);
         level.gameEvent(GameEvent.BLOCK_DESTROY, pos, GameEvent.Context.of(state));
     }
 


### PR DESCRIPTION
This PR fixes #1699 by synchronizing the code in `IBlockExtension#onDestroyedByPushReaction` to the original code from `PistonBaseBlock` (which was moved to the extension method).

Particularly, the flags passed to `Level#setBlock` is now a constant `18`, which is the combination of `Block#UPDATE_KNOWN_SHAPE` and `Block#UPDATE_CLIENTS`.

Tested with the same reproduction steps in the linked issue, and the fix works as the sign does not pop off on piston push.