### PR TITLE
Increase memory used for forked compiler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
-# This is required to provide enough memory for the Minecraft decompilation process.
+# This is required to provide enough memory for recompilation
+# (see also projects/neoforged/build.gradle, where the compile tasks is set to have enough memory when forked)
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for recompilation
 # (see also projects/neoforged/build.gradle, where the compile tasks is set to have enough memory when forked)
-org.gradle.jvmargs=-Xmx3G
+org.gradle.jvmargs=-Xmx2G
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -222,6 +222,11 @@ generateAccessTransformers {
     )
 }
 
+tasks.withType(JavaCompile.class).configureEach {
+    // Increase memory used during compilation, to avoid OutOfMemoryErrors
+    options.forkOptions.memoryMaximumSize = '2g'
+}
+
 tasks.withType(Javadoc.class).configureEach {
     options.tags = [
             'apiNote:a:<em>API Note:</em>',


### PR DESCRIPTION
This PR fixes an out of memory error when compiling with a non-Java 21 JVM running the Gradle Daemon, by specifically setting the maximum memory used by the forked Java compiler process.

When running the Gradle Daemon with a non-J21 JVM, it will fork the Java compiler into a separate process rather than running it in-process with the Daemon. However, that means the compiler process uses the default amount of memory, which is not able to compile all of NeoForge & Minecraft (as it fails with an OutOfMemoryError).

Setting the memory when the compiler is forked ensures that whether the compiler runs in-process with the Daemon or as a forked process, it will always have enough memory to compile all the sources properly.

---

This is an alternative solution to the problem that #1692 also seeks to fix, which is more tailored to the problem by specifically addressing the root cause of the out-of-memory error.

To test, first set the Daemon to use a non-Java 21 JVM (via the `JAVA_HOME` environment variable pointed to a Java 17 JVM, for example), then run `./gradlew clean`, `./gradlew setup` (to prepare the workspace), then `./gradlew assemble --no-build-cache --rerun-tasks`. Without this PR, `:neoforge:compileJava` will fail with a "Java heap space" error; with this PR, the build will succeed.