### PR TITLE
Stop FileWatcher default instance on dedicated server exit

### DIFF
--- a/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -44,7 +44,7 @@
              return true;
          }
      }
-@@ -277,6 +_,10 @@
+@@ -277,6 +_,13 @@
          if (this.queryThreadGs4 != null) {
              this.queryThreadGs4.stop();
          }
@@ -52,6 +52,9 @@
 +            this.dediLanPinger.interrupt();
 +            this.dediLanPinger = null;
 +        }
++
++        // Neo: Forcibly stop the FileWatcher default instance, to prevent it from blocking normal JVM exit; see #1626
++        com.electronwill.nightconfig.core.file.FileWatcher.defaultInstance().stop();
      }
  
      @Override


### PR DESCRIPTION
This PR fixes #1626 by stopping the default `FileWatcher` instance when the dedicated server instance exits (from `DedicatedServer#onServerExit()`).

This prevents the `FileWatcher` instance from blocking the JVM from exiting normally, as the instance keeps alive a non-daemon thread (and the JVM waits on all non-daemon threads to exit).

This is meant to be a temporary bugfix, until a bugfix is landed in NightConfig that marks the pool thread it creates as a daemon thread. (Follow the linked issue for more details.)

Tested by following the listed reproduction steps in the issue (which is important, since the FileWatcher has to be triggered once for the erring pool thread to be made), and observing that the JVM does exit soon after the server is stopped through `/stop`.

---

Out of the 'normal' runs, the dedicated server is affected. The client and the game test server exit the JVM using `System.exit`, as seen in `Minecraft#destroy` and `GameTestServer#onServerExit` respectively. The datagenerator, both client and server, does not load the configs, as seen in `CommonModLoader#begin`.

The JUnit server _might_ be affected, but I am unsure if it is truly affected, since it may be that JUnit itself does a `System.exit` at the end of testing to handle the exit codes itself. I'm leaning towards the possibility that it is unaffected due to the special considerations of JUnit.