### PR TITLE
Stop FileWatcher default instance on dedicated server exit

### DIFF
--- a/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -44,7 +44,7 @@
              return true;
          }
      }
-@@ -277,6 +_,10 @@
+@@ -277,6 +_,13 @@
          if (this.queryThreadGs4 != null) {
              this.queryThreadGs4.stop();
          }
@@ -52,6 +52,9 @@
 +            this.dediLanPinger.interrupt();
 +            this.dediLanPinger = null;
 +        }
++
++        // Neo: Forcibly stop the FileWatcher default instance, to prevent it from blocking normal JVM exit; see #1626
++        com.electronwill.nightconfig.core.file.FileWatcher.defaultInstance().stop();
      }
  
      @Override


### PR DESCRIPTION
This PR is a backport of #1757 to 1.21.3, which #1626 by stopping the default `FileWatcher` instance when the dedicated server instance exits (from `DedicatedServer#onServerExit()`). See that PR for more details on the fix.