### PR TITLE
[1.21.1] Allow changing datagen indent width

### DIFF
--- a/patches/net/minecraft/data/DataProvider.java.patch
+++ b/patches/net/minecraft/data/DataProvider.java.patch
@@ -1,11 +1,26 @@
 --- a/net/minecraft/data/DataProvider.java
 +++ b/net/minecraft/data/DataProvider.java
-@@ -24,6 +_,8 @@
+@@ -23,7 +_,14 @@
+ import org.slf4j.Logger;
  
  public interface DataProvider {
++    /**
++     * Neo: Allows changing the indentation width used by {@link #saveStable}.
++     */
++    java.util.concurrent.atomic.AtomicInteger INDENT_WIDTH = new java.util.concurrent.atomic.AtomicInteger(2);
++
      ToIntFunction<String> FIXED_ORDER_FIELDS = Util.make(new Object2IntOpenHashMap<>(), p_236070_ -> {
 +        // Neo: conditions go first
 +        p_236070_.put("neoforge:conditions", -1);
          p_236070_.put("type", 0);
          p_236070_.put("parent", 1);
          p_236070_.defaultReturnValue(2);
+@@ -49,7 +_,7 @@
+ 
+                 try (JsonWriter jsonwriter = new JsonWriter(new OutputStreamWriter(hashingoutputstream, StandardCharsets.UTF_8))) {
+                     jsonwriter.setSerializeNulls(false);
+-                    jsonwriter.setIndent("  ");
++                    jsonwriter.setIndent(" ".repeat(java.lang.Math.max(0, INDENT_WIDTH.get()))); // Neo: Allow changing the indent width without needing to mixin this lambda.
+                     GsonHelper.writeValue(jsonwriter, p_254542_, KEY_COMPARATOR);
+                 }
+ 


### PR DESCRIPTION
Backport of #1687 to 1.21.1. Functionally identical, but the patches were shifted, so this isn't a cherry-pick.