### PR TITLE
Fix Biome network codec not ignoring field redirects

### DIFF
--- a/patches/net/minecraft/world/level/biome/Biome.java.patch
+++ b/patches/net/minecraft/world/level/biome/Biome.java.patch
@@ -11,6 +11,17 @@
                      BiomeGenerationSettings.CODEC.forGetter(p_220548_ -> p_220548_.generationSettings),
                      MobSpawnSettings.CODEC.forGetter(p_220546_ -> p_220546_.mobSettings)
                  )
+@@ -45,8 +_,8 @@
+     );
+     public static final Codec<Biome> NETWORK_CODEC = RecordCodecBuilder.create(
+         p_220540_ -> p_220540_.group(
+-                    Biome.ClimateSettings.CODEC.forGetter(p_220542_ -> p_220542_.climateSettings),
+-                    BiomeSpecialEffects.CODEC.fieldOf("effects").forGetter(p_220538_ -> p_220538_.specialEffects)
++                    Biome.ClimateSettings.CODEC.forGetter(p_220542_ -> p_220542_.modifiableBiomeInfo().getOriginalBiomeInfo().climateSettings()), // Neo: Patch codec to ignore field redirect coremods.
++                    BiomeSpecialEffects.CODEC.fieldOf("effects").forGetter(p_220538_ -> p_220538_.modifiableBiomeInfo().getOriginalBiomeInfo().effects()) // Neo: Patch codec to ignore field redirect coremods.
+                 )
+                 .apply(p_220540_, (p_220535_, p_220536_) -> new Biome(p_220535_, p_220536_, BiomeGenerationSettings.EMPTY, MobSpawnSettings.EMPTY))
+     );
 @@ -61,9 +_,11 @@
      )
      public static final PerlinSimplexNoise BIOME_INFO_NOISE = new PerlinSimplexNoise(new WorldgenRandom(new LegacyRandomSource(2345L)), ImmutableList.of(0));


### PR DESCRIPTION
This PR adds the corresponding biome info patch to `Biome`'s network codec, not just the regular codec. Previously it seems some data was not being synced to the client correctly; this change fixes #1733.