### PR TITLE
Remove now-unused BakedModel return from applyTransform

### DIFF
--- a/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
@@ -14,7 +14,7 @@
          void render(PoseStack p_387607_, MultiBufferSource p_386763_, int p_387589_, int p_388775_) {
              p_387607_.pushPose();
 +            if (model != null)
-+                net.neoforged.neoforge.client.ClientHooks.handleCameraTransforms(p_387607_, model, displayContext, ItemStackRenderState.this.isLeftHand);
++                model.applyTransform(displayContext, p_387607_, ItemStackRenderState.this.isLeftHand);
 +            else
              this.transform().apply(ItemStackRenderState.this.isLeftHand, p_387607_);
              p_387607_.translate(-0.5F, -0.5F, -0.5F);

--- a/patches/net/minecraft/client/resources/model/DelegateBakedModel.java.patch
+++ b/patches/net/minecraft/client/resources/model/DelegateBakedModel.java.patch
@@ -49,8 +49,8 @@
 +    }
 +
 +    @Override
-+    public BakedModel applyTransform(net.minecraft.world.item.ItemDisplayContext transformType, com.mojang.blaze3d.vertex.PoseStack poseStack, boolean applyLeftHandTransform) {
-+        return this.parent.applyTransform(transformType, poseStack, applyLeftHandTransform);
++    public void applyTransform(net.minecraft.world.item.ItemDisplayContext transformType, com.mojang.blaze3d.vertex.PoseStack poseStack, boolean applyLeftHandTransform) {
++        this.parent.applyTransform(transformType, poseStack, applyLeftHandTransform);
 +    }
 +
 +    @Override

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -114,7 +114,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.RecipeBookType;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
-import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.GameType;
@@ -460,11 +459,6 @@ public class ClientHooks {
 
     public static void onModelBake(ModelManager modelManager, ModelBakery.BakingResult bakingResult, ModelBakery modelBakery) {
         ModLoader.postEvent(new ModelEvent.BakingCompleted(modelManager, bakingResult, modelBakery));
-    }
-
-    public static BakedModel handleCameraTransforms(PoseStack poseStack, @Nullable BakedModel model, ItemDisplayContext cameraTransformType, boolean applyLeftHandTransform) {
-        model = model.applyTransform(cameraTransformType, poseStack, applyLeftHandTransform);
-        return model;
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IBakedModelExtension.java
@@ -63,9 +63,8 @@ public interface IBakedModelExtension {
      * Applies a transform for the given {@link ItemTransforms.TransformType} and {@code applyLeftHandTransform}, and
      * returns the model to be rendered.
      */
-    default BakedModel applyTransform(ItemDisplayContext transformType, PoseStack poseStack, boolean applyLeftHandTransform) {
+    default void applyTransform(ItemDisplayContext transformType, PoseStack poseStack, boolean applyLeftHandTransform) {
         self().getTransforms().getTransform(transformType).apply(applyLeftHandTransform, poseStack);
-        return self();
     }
 
     default ModelData getModelData(BlockAndTintGetter level, BlockPos pos, BlockState state, ModelData modelData) {


### PR DESCRIPTION
Selecting among multiple models based on the `ItemDisplayContext` can be done through `ItemModel`s now.