### PR TITLE
[1.21.x] Fix ECJ compile error in ClientEventTests.java

### DIFF
--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
@@ -15,12 +15,14 @@ import net.minecraft.client.renderer.entity.AbstractHoglinRenderer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.client.renderer.entity.player.PlayerRenderer;
+import net.minecraft.client.renderer.entity.state.HoglinRenderState;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.SectionPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.context.ContextKey;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.monster.hoglin.HoglinBase;
@@ -150,7 +152,8 @@ public class ClientEventTests {
                 renderState.setRenderData(numRenderAttachmentKey, entity.getData(testAttachment));
             });
             // Test other type parameters for safety
-            event.registerEntityModifier(new TypeToken<AbstractHoglinRenderer<?>>() {}, (entity, renderState) -> {});
+            // This call requires explicit typing to satisfy ECJ. Without it, the wildcard on AbstractHoglinRenderer is invalid.
+            event.<Entity, HoglinRenderState>registerEntityModifier(new TypeToken<AbstractHoglinRenderer<?>>() {}, (entity, renderState) -> {});
             event.registerEntityModifier(new TypeToken<MobRenderer<Mob, LivingEntityRenderState, ?>>() {}, (entity, renderState) -> {});
             try {
                 class TestBrokenHoglinRendererTypeToken<T extends Mob & HoglinBase> extends TypeToken<AbstractHoglinRenderer<T>> {}


### PR DESCRIPTION
ECJ fails to compile the line `event.registerEntityModifier(new TypeToken<AbstractHoglinRenderer<?>>() {}, (entity, renderState) -> {});` which was introduced by #1650 

The produced error message is 
```
The method registerEntityModifier(TypeToken<? extends EntityRenderer<? extends E,? extends S>>, BiConsumer<E,S>) in the type RegisterRenderStateModifiersEvent is not applicable for the arguments (new TypeToken<AbstractHoglinRenderer<?>>(){}, BiConsumer<E,S>)
```

Which appears to be an inability for eclipse to infer `E` and `S` from the generic bounds of `AbstractHoglinRenderer<T extends Mob & HoglinBase>`.

Attempting to elevate the method call into a helper function satisfies both compilers, but will cause the test to fail since the inferred `T` does not satisfy `RegisterRenderStateModifiersEvent#ensureParametersMatchBounds`:
```java
    private static <T extends Mob & HoglinBase> void anotherEcjHack(RegisterRenderStateModifiersEvent event){
        event.registerEntityModifier(new TypeToken<AbstractHoglinRenderer<T>>() {}, (entity, renderState) -> {});
    }
```

Explicitly typing the call works, though only when the type bounds are `<Entity, HoglinRenderState>`. I suspect `<Mob, HoglinRenderState>` would be closer to "correct", but trying to pass `Mob` causes javac to fail (though ECJ accepts it).