### PR TITLE
[1.21.x] Fix perf slowdown caused by AnyHolderSet#contains

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
@@ -80,7 +80,8 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
 
     @Override
     public boolean contains(Holder<T> holder) {
-        return holder.unwrapKey().map(key -> this.registryLookup.listElementIds().anyMatch(key::equals)).orElse(false);
+        ResourceKey<T> key = holder.getKey();
+        return key != null && this.registryLookup().get(key).isPresent();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a substantial performance issue caused by `AnyHolderSet#contains` by changing the implementation to a `.get(key)` call against the underlying `RegistryLookup`.

The prior implementation relied on iterating through every resource key in the registry and executing `ResourceKey::equals`. While `::equals` is fast (due to it being a reference equality check), iterating entire registries is not.  

![](https://i.imgur.com/UDZQhph.png)