### PR TITLE
[1.21.4] Add event for registering custom special block model renderers

### DIFF
--- a/patches/net/minecraft/client/renderer/special/SpecialModelRenderers.java.patch
+++ b/patches/net/minecraft/client/renderer/special/SpecialModelRenderers.java.patch
@@ -9,3 +9,12 @@
      }
  
      public static Map<Block, SpecialModelRenderer<?>> createBlockRenderers(EntityModelSet p_387779_) {
+@@ -179,6 +_,8 @@
+             map.put(Blocks.CHEST, GIFT_CHEST);
+             map.put(Blocks.TRAPPED_CHEST, GIFT_CHEST);
+         }
++
++        net.neoforged.fml.ModLoader.postEvent(new net.neoforged.neoforge.client.event.RegisterSpecialBlockModelRendererEvent(map));
+ 
+         Builder<Block, SpecialModelRenderer<?>> builder = ImmutableMap.builder();
+         map.forEach((p_386808_, p_388898_) -> {

--- a/src/main/java/net/neoforged/neoforge/client/event/RegisterSpecialBlockModelRendererEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RegisterSpecialBlockModelRendererEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import java.util.Map;
+import net.minecraft.client.renderer.special.SpecialModelRenderer;
+import net.minecraft.world.level.block.Block;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.fml.event.IModBusEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Event fired when special block model renderers are created.
+ * <p>
+ * This event is fired on a worker thread during model loading. It is used to register custom special block model
+ * renderers which handle dynamic rendering when the associated block is rendered in a non-placed context such
+ * as in a minecart, a display entity or the Enderman's hands.
+ * <p>
+ * This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.
+ */
+public class RegisterSpecialBlockModelRendererEvent extends Event implements IModBusEvent {
+    private final Map<Block, SpecialModelRenderer.Unbaked> renderers;
+
+    @ApiStatus.Internal
+    public RegisterSpecialBlockModelRendererEvent(Map<Block, SpecialModelRenderer.Unbaked> renderers) {
+        this.renderers = renderers;
+    }
+
+    public void register(Block block, SpecialModelRenderer.Unbaked unbakedRenderer) {
+        SpecialModelRenderer.Unbaked prev = this.renderers.putIfAbsent(block, unbakedRenderer);
+        if (prev != null) {
+            throw new IllegalStateException("Duplicate block model renderer registration for " + block);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an event for attaching custom `SpecialModelRenderer`s to blocks which render a part of or their entire model in a BER (i.e. blocks like chests, signs, skulls, shulker boxes, banners and beds). These `SpecialModelRenderer`s are used via `BlockRenderDispatcher#renderSingleBlock()` when such a block is rendered in a minecart, as a display entity, on the back of a mushroom cow, in the iron golem's hand or in the enderman's hands.