### PR TITLE
[1.21.x] Move firing point of ChunkEvent$Unload to after chunk save

### DIFF
--- a/patches/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/net/minecraft/server/level/ChunkMap.java.patch
@@ -8,7 +8,7 @@
              return p_140179_;
          }
      }
-@@ -529,8 +_,11 @@
+@@ -529,12 +_,15 @@
              } else {
                  ChunkAccess chunkaccess = p_140183_.getLatestChunk();
                  if (this.pendingUnloads.remove(p_140182_, p_140183_) && chunkaccess != null) {
@@ -16,10 +16,14 @@
 +                    this.chunkTypeCache.remove(chunkaccess.getPos().toLong()); // Neo: Prevent chunk type cache from permanently retaining data for unloaded chunks
                      if (chunkaccess instanceof LevelChunk levelchunk) {
                          levelchunk.setLoaded(false);
-+                        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.ChunkEvent.Unload(chunkaccess));
                      }
  
                      this.save(chunkaccess);
+                     if (chunkaccess instanceof LevelChunk levelchunk1) {
++                        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.ChunkEvent.Unload(levelchunk1));
+                         this.level.unload(levelchunk1);
+                     }
+ 
 @@ -579,6 +_,7 @@
                  Profiler.get().incrementCounter("chunkLoad");
                  if (p_372662_.isPresent()) {

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkDataEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkDataEvent.java
@@ -17,7 +17,7 @@ import net.neoforged.neoforge.common.NeoForge;
 /**
  * ChunkDataEvent is fired when a chunk is about to be loaded from disk or saved to disk.
  */
-public abstract class ChunkDataEvent extends ChunkEvent {
+public abstract class ChunkDataEvent extends ChunkEvent<ChunkAccess> {
     private final SerializableChunkData data;
 
     public ChunkDataEvent(ChunkAccess chunk, SerializableChunkData data) {

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkEvent.java
@@ -9,64 +9,53 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
-import net.neoforged.bus.api.Event;
+import net.minecraft.world.level.chunk.status.ChunkStatusTasks;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * ChunkEvent is fired when an event involving a chunk occurs.<br>
- * If a method utilizes this {@link Event} as its parameter, the method will
- * receive every child event of this class.<br>
- * <br>
- * {@link #chunk} contains the Chunk this event is affecting.<br>
- * <br>
- * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.<br>
- **/
-public abstract class ChunkEvent extends LevelEvent {
-    private final ChunkAccess chunk;
+ * Base class for events involving chunks.
+ * <p>
+ * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.
+ */
+public abstract class ChunkEvent<T extends ChunkAccess> extends LevelEvent {
+    private final T chunk;
 
-    public ChunkEvent(ChunkAccess chunk) {
+    public ChunkEvent(T chunk) {
         super(chunk.getLevel());
         this.chunk = chunk;
     }
 
-    public ChunkEvent(ChunkAccess chunk, LevelAccessor level) {
+    public ChunkEvent(T chunk, LevelAccessor level) {
         super(level);
         this.chunk = chunk;
     }
 
-    public ChunkAccess getChunk() {
+    public T getChunk() {
         return chunk;
     }
 
     /**
-     * ChunkEvent.Load is fired when vanilla Minecraft attempts to load a Chunk into the level.<br>
-     * This event is fired during chunk loading in <br>
-     *
-     * Chunk.onChunkLoad(). <br>
-     * <strong>Note:</strong> This event may be called before the underlying {@link LevelChunk} is promoted to {@link ChunkStatus#FULL}. You will cause chunk loading deadlocks if you don't delay your level interactions.<br>
-     * <br>
-     * This event is not {@link ICancellableEvent}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult} <br>
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
-     **/
-    public static class Load extends ChunkEvent {
+     * This event is fired after Minecraft loads a {@link LevelChunk} into the level, on both the client and server.
+     * <p>
+     * Specifically, this is fired during chunk loading in {@link ChunkStatusTasks#full}, and when the client receives a chunk from the server.
+     * <p>
+     * <b>Note:</b> On the server, this event is fired before the underlying {@link LevelChunk} is promoted to {@link ChunkStatus#FULL}.
+     * Interactions with the {@link LevelChunk#getLevel() level} must be delayed until the next game tick to prevent deadlocking the game.
+     */
+    public static class Load extends ChunkEvent<LevelChunk> {
         private final boolean newChunk;
 
         @ApiStatus.Internal
-        public Load(ChunkAccess chunk, boolean newChunk) {
+        public Load(LevelChunk chunk, boolean newChunk) {
             super(chunk);
             this.newChunk = newChunk;
         }
 
         /**
-         * Check whether the Chunk is newly generated, and being loaded for the first time.
-         *
-         * <p>Will only ever return {@code true} on the {@linkplain net.neoforged.fml.LogicalSide#SERVER logical server}.</p>
-         *
-         * @return whether the Chunk is newly generated
+         * {@return true if this is a newly-generated chunk, instead of one loaded from disk}
+         * 
+         * @apiNote This method only has meaning on the server, since the client does not generate chunks.
          */
         public boolean isNewChunk() {
             return newChunk;
@@ -74,18 +63,12 @@ public abstract class ChunkEvent extends LevelEvent {
     }
 
     /**
-     * ChunkEvent.Unload is fired when vanilla Minecraft attempts to unload a Chunk from the level.<br>
-     * This event is fired during chunk unloading in <br>
-     * Chunk.onChunkUnload(). <br>
-     * <br>
-     * This event is not {@link ICancellableEvent}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult} <br>
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
-     **/
-    public static class Unload extends ChunkEvent {
-        public Unload(ChunkAccess chunk) {
+     * This event is fired when Minecraft unloads a Chunk from the level, just before the side-specific unload method is called.
+     * <p>
+     * On the server, this event is fired after the chunk has been saved, and {@link ChunkDataEvent.Save} has been fired.
+     */
+    public static class Unload extends ChunkEvent<LevelChunk> {
+        public Unload(LevelChunk chunk) {
             super(chunk);
         }
     }


### PR DESCRIPTION
This change moves the firing of `ChunkEvent$Unload` to after the `ChunkMap#save(ChunkAccess)` call, which ensures that `ChunkDataEvent$Save` fires before the unload event.

This fixes the timing of these events to be: chunk load -> data load -> data unload -> chunk unload. It also better unifies with the client pathway, in that the unload event is fired just before the side-specific `unload()` method, instead of at some arbitrary point beforehand.

Finally, this change updates the javadocs of `ChunkEvent` and `Load` / `Unload`, and uses a generic to type `Load` / `Unload` to `LevelChunk` instead of `ChunkAccess` (since the firing of these events is conditional on the chunk being a `LevelChunk` in the first place).

Closes #127