### PR TITLE
[1.20.6] Enable Gradle module metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,6 @@ if (isPreReleaseVersion) {
         }
     }
 
-    changelog {
-        from '20.6'
-        disableAutomaticPublicationRegistration()
-    }
-
     project.version = gradleutils.version.toString()
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.debug=false
 java_version=21
 
 minecraft_version=1.20.6
-neoform_version=20240429.153634
+neoform_version=20240627.102356
 # on snapshot versions, used to prefix the version
 neoforge_snapshot_next_stable=21.0
 

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -8,7 +8,14 @@ plugins {
     id 'net.neoforged.jarcompatibilitychecker' version '0.1.10'
 }
 
-rootProject.gradleutils.setupSigning(project: project, signAllPublications: true)
+apply plugin: 'net.neoforged.gradleutils'
+
+gradleutils.setupSigning(project: project, signAllPublications: true)
+
+changelog {
+    from '20.6'
+    disableAutomaticPublicationRegistration()
+}
 
 dynamicProject {
     runtime("${project.minecraft_version}-${project.neoform_version}",
@@ -231,8 +238,6 @@ tasks.withType(Javadoc.class).configureEach {
     options.addStringOption('Xdoclint:all,-missing', '-public')
 }
 
-tasks.withType(GenerateModuleMetadata).configureEach { enabled = false }
-
 configurations {
     forValidation {
         canBeConsumed = true
@@ -254,6 +259,193 @@ artifacts {
     }
 }
 
+AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+// Ensure the two default variants are not published, since they
+// contain Minecraft classes
+javaComponent.withVariantsFromConfiguration(configurations.apiElements) {
+    it.skip()
+}
+javaComponent.withVariantsFromConfiguration(configurations.runtimeElements) {
+    it.skip()
+}
+
+configurations {
+    modDevBundle {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "data"))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-bundle:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {} // Publish it
+    }
+    modDevConfig {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "data"))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-config:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {} // Publish it
+    }
+    installerJar {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EMBEDDED))
+            // The installer targets JDK 8
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-installer:${project.version}")
+        }
+        // Publish it
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    universalJar {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInteger())
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+        }
+        // Publish it
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    changelog {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "changelog"))
+        }
+        // Publish it, but only for release versions
+        if (!rootProject.isPreReleaseVersion) {
+            javaComponent.addVariantsFromConfiguration(it) {}
+        }
+    }
+    modDevApiElements {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom userdevCompileOnly, installerLibraries, moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-dependencies:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevRuntimeElements {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom installerLibraries, moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-dependencies:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevModulePath {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-module-path:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevTestFixtures {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-test-fixtures:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+}
+
+dependencies {
+    modDevBundle("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform'
+        }
+        endorseStrictVersions()
+    }
+    modDevApiElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-dependencies'
+        }
+        endorseStrictVersions()
+    }
+    modDevRuntimeElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-dependencies'
+        }
+        endorseStrictVersions()
+    }
+    modDevTestFixtures("net.neoforged.fancymodloader:junit-fml:${project.fancy_mod_loader_version}") {
+        endorseStrictVersions()
+    }
+}
+
+afterEvaluate {
+    artifacts {
+        modDevBundle(userdevJar) {
+            setClassifier("userdev") // Legacy
+        }
+        modDevConfig(createUserdevJson.output) {
+            builtBy(createUserdevJson)
+            setClassifier("moddev-config")
+        }
+        universalJar(signUniversalJar.output) {
+            builtBy(signUniversalJar)
+            setClassifier("universal")
+        }
+        installerJar(signInstallerJar.output) {
+            builtBy(signInstallerJar)
+            setClassifier("installer")
+        }
+        changelog(createChangelog.outputFile) {
+            builtBy(createChangelog)
+            setClassifier("changelog")
+            setExtension("txt")
+        }
+    }
+}
+
 publishing {
     publications.create('NeoForge', MavenPublication) {
         groupId = project.group
@@ -261,28 +453,6 @@ publishing {
         version = project.version
 
         from components.java
-
-        artifacts = []
-
-        afterEvaluate {
-            artifact (signUniversalJar.output) {
-                classifier 'universal'
-            }
-            artifact (signInstallerJar.output) {
-                classifier 'installer'
-            }
-            artifact (userdevJar) {
-                classifier 'userdev'
-            }
-            artifact (sourcesJar) {
-                classifier 'sources'
-            }
-        }
-
-        if (!rootProject.isPreReleaseVersion) {
-            // Only publish a changelog for releases
-            changelog.publish(it)
-        }
 
         versionMapping {
             usage('java-api') {
@@ -319,6 +489,6 @@ publishing {
         }
     }
     repositories {
-        maven rootProject.gradleutils.getPublishingMaven()
+        maven gradleutils.getPublishingMaven()
     }
 }

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':neoforge')
+    implementation project(path: ':neoforge', configuration: 'runtimeElements')
 
     compileOnly(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
     compileOnly "org.junit.jupiter:junit-jupiter-params"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    implementation(neoforgeProject)
+    implementation project(path: ':neoforge', configuration: 'runtimeElements')
     implementation(testframeworkProject)
 
     junitImplementation(platform("org.junit:junit-bom:${project.jupiter_api_version}"))


### PR DESCRIPTION
This is a backport of #959 to 1.20.6, which will enable MDG to be used with this version.