### PR TITLE
[1.20.4] Enable Gradle module metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,6 @@ gradleutils.version {
     }
 }
 
-changelog {
-    from '20.4'
-    disableAutomaticPublicationRegistration()
-}
-
 // Print version, generally useful to know - also appears on CI
 System.out.println("NeoForge version ${gradleutils.version.toString()}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.debug=false
 java_version=17
 
 minecraft_version=1.20.4
-neoform_version=20231207.154220
+neoform_version=20240627.114801
 
 mergetool_version=2.0.0
 accesstransformers_version=10.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -3,7 +3,13 @@ plugins {
     id 'maven-publish'
 }
 
-rootProject.gradleutils.setupSigning(project: project, signAllPublications: true)
+apply plugin: 'net.neoforged.gradleutils'
+gradleutils.setupSigning(project: project, signAllPublications: true)
+
+changelog {
+    from '20.4'
+    disableAutomaticPublicationRegistration()
+}
 
 dynamicProject {
     runtime("${project.minecraft_version}-${project.neoform_version}",
@@ -193,8 +199,6 @@ tasks.withType(Javadoc.class).configureEach {
     options.addStringOption('Xdoclint:all,-missing', '-public')
 }
 
-tasks.withType(GenerateModuleMetadata).configureEach { enabled = false }
-
 configurations {
     forValidation {
         canBeConsumed = true
@@ -216,6 +220,187 @@ artifacts {
     }
 }
 
+AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+// Ensure the two default variants are not published, since they
+// contain Minecraft classes
+javaComponent.withVariantsFromConfiguration(configurations.apiElements) {
+    it.skip()
+}
+javaComponent.withVariantsFromConfiguration(configurations.runtimeElements) {
+    it.skip()
+}
+configurations {
+    modDevBundle {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "data"))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-bundle:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {} // Publish it
+    }
+    modDevConfig {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "data"))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-config:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {} // Publish it
+    }
+    installerJar {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EMBEDDED))
+            // The installer targets JDK 8
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-installer:${project.version}")
+        }
+        // Publish it
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    universalJar {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInteger())
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+        }
+        // Publish it
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    changelog {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "changelog"))
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevApiElements {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom userdevCompileOnly, installerLibraries, moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-dependencies:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevRuntimeElements {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom installerLibraries, moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-dependencies:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevModulePath {
+        canBeResolved = false
+        canBeConsumed = true
+        afterEvaluate {
+            extendsFrom moduleOnly
+        }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-module-path:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+    modDevTestFixtures {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-moddev-test-fixtures:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
+}
+dependencies {
+    modDevBundle("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform'
+        }
+        endorseStrictVersions()
+    }
+    modDevApiElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-dependencies'
+        }
+        endorseStrictVersions()
+    }
+    modDevRuntimeElements("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-dependencies'
+        }
+        endorseStrictVersions()
+    }
+    modDevTestFixtures("net.neoforged.fancymodloader:junit-fml:${project.fancy_mod_loader_version}") {
+        endorseStrictVersions()
+    }
+}
+afterEvaluate {
+    artifacts {
+        modDevBundle(userdevJar) {
+            setClassifier("userdev") // Legacy
+        }
+        modDevConfig(createUserdevJson.output) {
+            builtBy(createUserdevJson)
+            setClassifier("moddev-config")
+        }
+        universalJar(signUniversalJar.output) {
+            builtBy(signUniversalJar)
+            setClassifier("universal")
+        }
+        installerJar(signInstallerJar.output) {
+            builtBy(signInstallerJar)
+            setClassifier("installer")
+        }
+        changelog(createChangelog.outputFile) {
+            builtBy(createChangelog)
+            setClassifier("changelog")
+            setExtension("txt")
+        }
+    }
+}
+
 minecraft {
     modIdentifier 'minecraft'
 }
@@ -227,25 +412,6 @@ publishing {
         version = project.version
 
         from components.java
-
-        artifacts = []
-
-        afterEvaluate {
-            artifact (signUniversalJar.output) {
-                classifier 'universal'
-            }
-            artifact (signInstallerJar.output) {
-                classifier 'installer'
-            }
-            artifact (userdevJar) {
-                classifier 'userdev'
-            }
-            artifact (sourcesJar) {
-                classifier 'sources'
-            }
-        }
-
-        changelog.publish(it)
 
         versionMapping {
             usage('java-api') {
@@ -282,6 +448,6 @@ publishing {
         }
     }
     repositories {
-        maven rootProject.gradleutils.getPublishingMaven()
+        maven gradleutils.getPublishingMaven()
     }
 }

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':neoforge')
+    implementation project(path: ':neoforge', configuration: 'runtimeElements')
 
     compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(path: ':neoforge', configuration: 'runtimeElements')
+    implementation project(':neoforge')
 
     compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -27,7 +27,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation neoforgeProject
+    implementation project(path: ':neoforge', configuration: 'runtimeElements')
     implementation testframeworkProject
 
     implementation "org.junit.jupiter:junit-jupiter-api:${project.jupiter_api_version}"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -27,7 +27,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation project(path: ':neoforge', configuration: 'runtimeElements')
+    implementation neoforgeProject
     implementation testframeworkProject
 
     implementation "org.junit.jupiter:junit-jupiter-api:${project.jupiter_api_version}"


### PR DESCRIPTION
This is a backport of https://github.com/neoforged/NeoForge/pull/959 to 1.20.4, which will enable MDG to be used with this version.