### PR TITLE
Fix NeoForge fluid ingredient types not being registered

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -535,6 +535,7 @@ public class NeoForgeMod {
         ITEM_SUB_PREDICATES.register(modEventBus);
         SLOT_DISPLAY_TYPES.register(modEventBus);
         INGREDIENT_TYPES.register(modEventBus);
+        FLUID_INGREDIENT_TYPES.register(modEventBus);
         CONDITION_CODECS.register(modEventBus);
         GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredientCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/FluidIngredientCodecs.java
@@ -24,7 +24,9 @@ public class FluidIngredientCodecs {
     static Codec<FluidIngredient> codec() {
         return Codec.xor(
                 NeoForgeRegistries.FLUID_INGREDIENT_TYPES.byNameCodec().<FluidIngredient>dispatch("neoforge:ingredient_type", FluidIngredient::getType, FluidIngredientType::codec),
-                SimpleFluidIngredient.CODEC).xmap(either -> either.map(i -> i, i -> i), ingredient -> switch (ingredient) {
+                // Use lazy: SimpleFluidIngredient.CODEC is initialized after FluidIngredient.CODEC which lives in a superclass.
+                Codec.lazyInitialized(() -> SimpleFluidIngredient.CODEC))
+                .xmap(either -> either.map(i -> i, i -> i), ingredient -> switch (ingredient) {
                     case SimpleFluidIngredient simple -> Either.right(simple);
                     default -> Either.left(ingredient);
                 });


### PR DESCRIPTION
Fixes #1780.

- Added the missing DR register call.
- This exposed a bug in how the codec is constructed, so I added a `Codec.lazyInitialized` call to fix it.
- I also added a simple round-trip test, and reactivated a test that was missing a `@Test` annotation.