### PR TITLE
Let vanilla try to handle Container interactions before checking for item handlers

### DIFF
--- a/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
@@ -1,11 +1,29 @@
 --- a/net/minecraft/world/level/block/CrafterBlock.java
 +++ b/net/minecraft/world/level/block/CrafterBlock.java
-@@ -214,6 +_,8 @@
+@@ -194,7 +_,8 @@
+         ServerLevel p_335887_, BlockPos p_307620_, CrafterBlockEntity p_307387_, ItemStack p_307296_, BlockState p_307501_, RecipeHolder<?> p_335494_
+     ) {
+         Direction direction = p_307501_.getValue(ORIENTATION).front();
+-        Container container = HopperBlockEntity.getContainerAt(p_335887_, p_307620_.relative(direction));
++        var inventory = HopperBlockEntity.getInventoryAt(p_335887_, p_307620_.relative(direction), direction.getOpposite());
++        Container container = inventory == null ? null : inventory.container();
+         ItemStack itemstack = p_307296_.copy();
+         if (container != null && (container instanceof CrafterBlockEntity || p_307296_.getCount() > container.getMaxStackSize(p_307296_))) {
+             while (!itemstack.isEmpty()) {
+@@ -206,10 +_,14 @@
+ 
+                 itemstack.shrink(1);
+             }
+-        } else if (container != null) {
++        } else if (inventory != null) {
+             while (!itemstack.isEmpty()) {
+                 int i = itemstack.getCount();
+-                itemstack = HopperBlockEntity.addItem(p_307387_, container, itemstack, direction.getOpposite());
++                if (container != null) {
++                    itemstack = HopperBlockEntity.addItem(p_307387_, container, itemstack, direction.getOpposite());
++                } else {
++                    itemstack = net.neoforged.neoforge.items.ItemHandlerHelper.insertItem(inventory.itemHandler(), itemstack, false);
++                }
+                 if (i == itemstack.getCount()) {
                      break;
                  }
-             }
-+        } else {
-+            itemstack = net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertNeighbor(p_335887_, p_307620_, direction, itemstack);
-         }
- 
-         if (!itemstack.isEmpty()) {

--- a/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
@@ -5,7 +5,7 @@
                  }
              }
 +        } else {
-+            itemstack = net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertCrafterOutput(p_335887_, p_307620_, p_307387_, itemstack);
++            itemstack = net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertNeighbor(p_335887_, p_307620_, direction, itemstack);
          }
  
          if (!itemstack.isEmpty()) {

--- a/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/CrafterBlock.java.patch
@@ -5,8 +5,8 @@
      ) {
          Direction direction = p_307501_.getValue(ORIENTATION).front();
 -        Container container = HopperBlockEntity.getContainerAt(p_335887_, p_307620_.relative(direction));
-+        var inventory = HopperBlockEntity.getInventoryAt(p_335887_, p_307620_.relative(direction), direction.getOpposite());
-+        Container container = inventory == null ? null : inventory.container();
++        var containerOrHandler = HopperBlockEntity.getContainerOrHandlerAt(p_335887_, p_307620_.relative(direction), direction.getOpposite());
++        Container container = containerOrHandler.container();
          ItemStack itemstack = p_307296_.copy();
          if (container != null && (container instanceof CrafterBlockEntity || p_307296_.getCount() > container.getMaxStackSize(p_307296_))) {
              while (!itemstack.isEmpty()) {
@@ -15,14 +15,14 @@
                  itemstack.shrink(1);
              }
 -        } else if (container != null) {
-+        } else if (inventory != null) {
++        } else if (!containerOrHandler.isEmpty()) {
              while (!itemstack.isEmpty()) {
                  int i = itemstack.getCount();
 -                itemstack = HopperBlockEntity.addItem(p_307387_, container, itemstack, direction.getOpposite());
 +                if (container != null) {
 +                    itemstack = HopperBlockEntity.addItem(p_307387_, container, itemstack, direction.getOpposite());
 +                } else {
-+                    itemstack = net.neoforged.neoforge.items.ItemHandlerHelper.insertItem(inventory.itemHandler(), itemstack, false);
++                    itemstack = net.neoforged.neoforge.items.ItemHandlerHelper.insertItem(containerOrHandler.itemHandler(), itemstack, false);
 +                }
                  if (i == itemstack.getCount()) {
                      break;

--- a/patches/net/minecraft/world/level/block/DropperBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DropperBlock.java.patch
@@ -1,11 +1,17 @@
 --- a/net/minecraft/world/level/block/DropperBlock.java
 +++ b/net/minecraft/world/level/block/DropperBlock.java
-@@ -56,7 +_,7 @@
-                 p_52944_.levelEvent(1001, p_52945_, 0);
-             } else {
-                 ItemStack itemstack = dispenserblockentity.getItem(i);
--                if (!itemstack.isEmpty()) {
-+                if (!itemstack.isEmpty() && net.neoforged.neoforge.items.VanillaInventoryCodeHooks.dropperInsertHook(p_52944_, p_52945_, dispenserblockentity, i, itemstack)) {
-                     Direction direction = p_52944_.getBlockState(p_52945_).getValue(FACING);
+@@ -61,7 +_,13 @@
                      Container container = HopperBlockEntity.getContainerAt(p_52944_, p_52945_.relative(direction));
                      ItemStack itemstack1;
+                     if (container == null) {
+-                        itemstack1 = DISPENSE_BEHAVIOUR.dispense(blocksource, itemstack);
++                        var leftover = net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertNeighbor(p_52944_, p_52945_, direction, itemstack.copyWithCount(1));
++                        if (leftover.isEmpty()) {
++                            itemstack1 = itemstack.copy();
++                            itemstack1.shrink(1);
++                        } else {
++                            itemstack1 = DISPENSE_BEHAVIOUR.dispense(blocksource, itemstack);
++                        }
+                     } else {
+                         itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, container, itemstack.copyWithCount(1), direction.getOpposite());
+                         if (itemstack1.isEmpty()) {

--- a/patches/net/minecraft/world/level/block/DropperBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DropperBlock.java.patch
@@ -1,17 +1,22 @@
 --- a/net/minecraft/world/level/block/DropperBlock.java
 +++ b/net/minecraft/world/level/block/DropperBlock.java
-@@ -61,7 +_,13 @@
-                     Container container = HopperBlockEntity.getContainerAt(p_52944_, p_52945_.relative(direction));
+@@ -58,12 +_,16 @@
+                 ItemStack itemstack = dispenserblockentity.getItem(i);
+                 if (!itemstack.isEmpty()) {
+                     Direction direction = p_52944_.getBlockState(p_52945_).getValue(FACING);
+-                    Container container = HopperBlockEntity.getContainerAt(p_52944_, p_52945_.relative(direction));
++                    var inventory = HopperBlockEntity.getInventoryAt(p_52944_, p_52945_.relative(direction), direction.getOpposite());
                      ItemStack itemstack1;
-                     if (container == null) {
--                        itemstack1 = DISPENSE_BEHAVIOUR.dispense(blocksource, itemstack);
-+                        var leftover = net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertNeighbor(p_52944_, p_52945_, direction, itemstack.copyWithCount(1));
-+                        if (leftover.isEmpty()) {
-+                            itemstack1 = itemstack.copy();
-+                            itemstack1.shrink(1);
-+                        } else {
-+                            itemstack1 = DISPENSE_BEHAVIOUR.dispense(blocksource, itemstack);
-+                        }
+-                    if (container == null) {
++                    if (inventory == null) {
+                         itemstack1 = DISPENSE_BEHAVIOUR.dispense(blocksource, itemstack);
                      } else {
-                         itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, container, itemstack.copyWithCount(1), direction.getOpposite());
+-                        itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, container, itemstack.copyWithCount(1), direction.getOpposite());
++                        if (inventory.container() != null) {
++                            itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, inventory.container(), itemstack.copyWithCount(1), direction.getOpposite());
++                        } else {
++                            itemstack1 = net.neoforged.neoforge.items.ItemHandlerHelper.insertItem(inventory.itemHandler(), itemstack.copyWithCount(1), false);
++                        }
                          if (itemstack1.isEmpty()) {
+                             itemstack1 = itemstack.copy();
+                             itemstack1.shrink(1);

--- a/patches/net/minecraft/world/level/block/DropperBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DropperBlock.java.patch
@@ -5,17 +5,17 @@
                  if (!itemstack.isEmpty()) {
                      Direction direction = p_52944_.getBlockState(p_52945_).getValue(FACING);
 -                    Container container = HopperBlockEntity.getContainerAt(p_52944_, p_52945_.relative(direction));
-+                    var inventory = HopperBlockEntity.getInventoryAt(p_52944_, p_52945_.relative(direction), direction.getOpposite());
++                    var containerOrHandler = HopperBlockEntity.getContainerOrHandlerAt(p_52944_, p_52945_.relative(direction), direction.getOpposite());
                      ItemStack itemstack1;
 -                    if (container == null) {
-+                    if (inventory == null) {
++                    if (containerOrHandler.isEmpty()) {
                          itemstack1 = DISPENSE_BEHAVIOUR.dispense(blocksource, itemstack);
                      } else {
 -                        itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, container, itemstack.copyWithCount(1), direction.getOpposite());
-+                        if (inventory.container() != null) {
-+                            itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, inventory.container(), itemstack.copyWithCount(1), direction.getOpposite());
++                        if (containerOrHandler.container() != null) {
++                            itemstack1 = HopperBlockEntity.addItem(dispenserblockentity, containerOrHandler.container(), itemstack.copyWithCount(1), direction.getOpposite());
 +                        } else {
-+                            itemstack1 = net.neoforged.neoforge.items.ItemHandlerHelper.insertItem(inventory.itemHandler(), itemstack.copyWithCount(1), false);
++                            itemstack1 = net.neoforged.neoforge.items.ItemHandlerHelper.insertItem(containerOrHandler.itemHandler(), itemstack.copyWithCount(1), false);
 +                        }
                          if (itemstack1.isEmpty()) {
                              itemstack1 = itemstack.copy();

--- a/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -1,22 +1,25 @@
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -137,6 +_,7 @@
-     }
- 
+@@ -139,7 +_,7 @@
      private static boolean ejectItems(Level p_155563_, BlockPos p_155564_, HopperBlockEntity p_326256_) {
-+        if (net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertHook(p_326256_)) return true;
          Container container = getAttachedContainer(p_155563_, p_155564_, p_326256_);
          if (container == null) {
+-            return false;
++            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertHook(p_326256_);
+         } else {
+             Direction direction = p_326256_.facing.getOpposite();
+             if (isFullContainer(container, direction)) {
+@@ -226,6 +_,10 @@
+ 
              return false;
-@@ -214,6 +_,8 @@
-     public static boolean suckInItems(Level p_155553_, Hopper p_155554_) {
-         BlockPos blockpos = BlockPos.containing(p_155554_.getLevelX(), p_155554_.getLevelY() + 1.0, p_155554_.getLevelZ());
-         BlockState blockstate = p_155553_.getBlockState(blockpos);
-+        Boolean ret = net.neoforged.neoforge.items.VanillaInventoryCodeHooks.extractHook(p_155553_, p_155554_);
-+        if (ret != null) return ret;
-         Container container = getSourceContainer(p_155553_, p_155554_, blockpos, blockstate);
-         if (container != null) {
-             Direction direction = Direction.DOWN;
+         } else {
++            if (net.neoforged.neoforge.items.VanillaInventoryCodeHooks.extractHook(p_155553_, p_155554_)) {
++                return true;
++            }
++
+             boolean flag = p_155554_.isGridAligned()
+                 && blockstate.isCollisionShapeFullBlock(p_155553_, blockpos)
+                 && !blockstate.is(BlockTags.DOES_NOT_BLOCK_HOPPERS);
 @@ -470,5 +_,9 @@
      @Override
      protected AbstractContainerMenu createMenu(int p_59312_, Inventory p_59313_) {

--- a/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -6,12 +6,12 @@
      private static boolean ejectItems(Level p_155563_, BlockPos p_155564_, HopperBlockEntity p_326256_) {
 -        Container container = getAttachedContainer(p_155563_, p_155564_, p_326256_);
 -        if (container == null) {
-+        var inventory = getInventoryAt(p_155563_, p_155564_.relative(p_326256_.facing), p_326256_.facing.getOpposite());
-+        if (inventory == null) {
++        var containerOrHandler = getContainerOrHandlerAt(p_155563_, p_155564_.relative(p_326256_.facing), p_326256_.facing.getOpposite());
++        if (containerOrHandler.isEmpty()) {
              return false;
 -        } else {
-+        } else if (inventory.container() != null) {
-+            Container container = inventory.container();
++        } else if (containerOrHandler.container() != null) {
++            Container container = containerOrHandler.container();
              Direction direction = p_326256_.facing.getOpposite();
              if (isFullContainer(container, direction)) {
                  return false;
@@ -20,7 +20,7 @@
                  return false;
              }
 +        } else {
-+            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertHook(p_326256_, inventory.itemHandler());
++            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertHook(p_326256_, containerOrHandler.itemHandler());
          }
      }
  
@@ -30,9 +30,9 @@
          BlockState blockstate = p_155553_.getBlockState(blockpos);
 -        Container container = getSourceContainer(p_155553_, p_155554_, blockpos, blockstate);
 -        if (container != null) {
-+        var inventory = getSourceInventory(p_155553_, p_155554_, blockpos, blockstate);
-+        if (inventory != null && inventory.container() != null) {
-+            Container container = inventory.container();
++        var containerOrHandler = getSourceContainerOrHandler(p_155553_, p_155554_, blockpos, blockstate);
++        if (containerOrHandler.container() != null) {
++            Container container = containerOrHandler.container();
              Direction direction = Direction.DOWN;
  
              for (int i : getSlots(container, direction)) {
@@ -40,8 +40,8 @@
              }
  
              return false;
-+        } else if (inventory != null) {
-+            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.extractHook(p_155554_, inventory.itemHandler());
++        } else if (containerOrHandler.itemHandler() != null) {
++            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.extractHook(p_155554_, containerOrHandler.itemHandler());
          } else {
              boolean flag = p_155554_.isGridAligned()
                  && blockstate.isCollisionShapeFullBlock(p_155553_, blockpos)
@@ -49,29 +49,26 @@
          return p_155590_.getEntitiesOfClass(ItemEntity.class, aabb, EntitySelector.ENTITY_STILL_ALIVE);
      }
  
-+    /** @deprecated Use IItemHandler capability instead. To preserve Container-specific interactions, use {@link #getInventoryAt} and handle both cases. */
++    /** @deprecated Use IItemHandler capability instead. To preserve Container-specific interactions, use {@link #getContainerOrHandlerAt} and handle both cases. */
 +    @Deprecated
      @Nullable
      public static Container getContainerAt(Level p_59391_, BlockPos p_59392_) {
          return getContainerAt(
-@@ -411,6 +_,31 @@
+@@ -411,6 +_,28 @@
          return !list.isEmpty() ? (Container)list.get(p_326325_.random.nextInt(list.size())) : null;
      }
  
-+    @Nullable
-+    private static net.neoforged.neoforge.items.ContainerOrHandler getSourceInventory(Level p_155597_, Hopper p_155598_, BlockPos p_326315_, BlockState p_326093_) {
-+        return getInventoryAt(p_155597_, p_326315_, p_326093_, p_155598_.getLevelX(), p_155598_.getLevelY() + 1.0, p_155598_.getLevelZ(), Direction.DOWN);
++    private static net.neoforged.neoforge.items.ContainerOrHandler getSourceContainerOrHandler(Level p_155597_, Hopper p_155598_, BlockPos p_326315_, BlockState p_326093_) {
++        return getContainerOrHandlerAt(p_155597_, p_326315_, p_326093_, p_155598_.getLevelX(), p_155598_.getLevelY() + 1.0, p_155598_.getLevelZ(), Direction.DOWN);
 +    }
 +
-+    @Nullable
-+    public static net.neoforged.neoforge.items.ContainerOrHandler getInventoryAt(Level level, BlockPos pos, @Nullable Direction side) {
-+        return getInventoryAt(
++    public static net.neoforged.neoforge.items.ContainerOrHandler getContainerOrHandlerAt(Level level, BlockPos pos, @Nullable Direction side) {
++        return getContainerOrHandlerAt(
 +                level, pos, level.getBlockState(pos), (double)pos.getX() + 0.5, (double)pos.getY() + 0.5, (double)pos.getZ() + 0.5, side
 +        );
 +    }
 +
-+    @Nullable
-+    private static net.neoforged.neoforge.items.ContainerOrHandler getInventoryAt(Level level, BlockPos pos, BlockState state, double x, double y, double z, @Nullable Direction side) {
++    private static net.neoforged.neoforge.items.ContainerOrHandler getContainerOrHandlerAt(Level level, BlockPos pos, BlockState state, double x, double y, double z, @Nullable Direction side) {
 +        Container container = getBlockContainer(level, pos, state);
 +        if (container != null) {
 +            return new net.neoforged.neoforge.items.ContainerOrHandler(container, null);
@@ -80,7 +77,7 @@
 +        if (blockItemHandler != null) {
 +            return new net.neoforged.neoforge.items.ContainerOrHandler(null, blockItemHandler);
 +        }
-+        return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.getEntityInventory(level, x, y, z, side);
++        return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.getEntityContainerOrHandler(level, x, y, z, side);
 +    }
 +
      private static boolean canMergeItems(ItemStack p_59345_, ItemStack p_59346_) {

--- a/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/HopperBlockEntity.java.patch
@@ -1,25 +1,91 @@
 --- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -139,7 +_,7 @@
+@@ -137,10 +_,11 @@
+     }
+ 
      private static boolean ejectItems(Level p_155563_, BlockPos p_155564_, HopperBlockEntity p_326256_) {
-         Container container = getAttachedContainer(p_155563_, p_155564_, p_326256_);
-         if (container == null) {
--            return false;
-+            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertHook(p_326256_);
-         } else {
+-        Container container = getAttachedContainer(p_155563_, p_155564_, p_326256_);
+-        if (container == null) {
++        var inventory = getInventoryAt(p_155563_, p_155564_.relative(p_326256_.facing), p_326256_.facing.getOpposite());
++        if (inventory == null) {
+             return false;
+-        } else {
++        } else if (inventory.container() != null) {
++            Container container = inventory.container();
              Direction direction = p_326256_.facing.getOpposite();
              if (isFullContainer(container, direction)) {
-@@ -226,6 +_,10 @@
+                 return false;
+@@ -164,6 +_,8 @@
+ 
+                 return false;
+             }
++        } else {
++            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.insertHook(p_326256_, inventory.itemHandler());
+         }
+     }
+ 
+@@ -214,8 +_,9 @@
+     public static boolean suckInItems(Level p_155553_, Hopper p_155554_) {
+         BlockPos blockpos = BlockPos.containing(p_155554_.getLevelX(), p_155554_.getLevelY() + 1.0, p_155554_.getLevelZ());
+         BlockState blockstate = p_155553_.getBlockState(blockpos);
+-        Container container = getSourceContainer(p_155553_, p_155554_, blockpos, blockstate);
+-        if (container != null) {
++        var inventory = getSourceInventory(p_155553_, p_155554_, blockpos, blockstate);
++        if (inventory != null && inventory.container() != null) {
++            Container container = inventory.container();
+             Direction direction = Direction.DOWN;
+ 
+             for (int i : getSlots(container, direction)) {
+@@ -225,6 +_,8 @@
+             }
  
              return false;
++        } else if (inventory != null) {
++            return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.extractHook(p_155554_, inventory.itemHandler());
          } else {
-+            if (net.neoforged.neoforge.items.VanillaInventoryCodeHooks.extractHook(p_155553_, p_155554_)) {
-+                return true;
-+            }
-+
              boolean flag = p_155554_.isGridAligned()
                  && blockstate.isCollisionShapeFullBlock(p_155553_, blockpos)
-                 && !blockstate.is(BlockTags.DOES_NOT_BLOCK_HOPPERS);
+@@ -368,6 +_,8 @@
+         return p_155590_.getEntitiesOfClass(ItemEntity.class, aabb, EntitySelector.ENTITY_STILL_ALIVE);
+     }
+ 
++    /** @deprecated Use IItemHandler capability instead. To preserve Container-specific interactions, use {@link #getInventoryAt} and handle both cases. */
++    @Deprecated
+     @Nullable
+     public static Container getContainerAt(Level p_59391_, BlockPos p_59392_) {
+         return getContainerAt(
+@@ -411,6 +_,31 @@
+         return !list.isEmpty() ? (Container)list.get(p_326325_.random.nextInt(list.size())) : null;
+     }
+ 
++    @Nullable
++    private static net.neoforged.neoforge.items.ContainerOrHandler getSourceInventory(Level p_155597_, Hopper p_155598_, BlockPos p_326315_, BlockState p_326093_) {
++        return getInventoryAt(p_155597_, p_326315_, p_326093_, p_155598_.getLevelX(), p_155598_.getLevelY() + 1.0, p_155598_.getLevelZ(), Direction.DOWN);
++    }
++
++    @Nullable
++    public static net.neoforged.neoforge.items.ContainerOrHandler getInventoryAt(Level level, BlockPos pos, @Nullable Direction side) {
++        return getInventoryAt(
++                level, pos, level.getBlockState(pos), (double)pos.getX() + 0.5, (double)pos.getY() + 0.5, (double)pos.getZ() + 0.5, side
++        );
++    }
++
++    @Nullable
++    private static net.neoforged.neoforge.items.ContainerOrHandler getInventoryAt(Level level, BlockPos pos, BlockState state, double x, double y, double z, @Nullable Direction side) {
++        Container container = getBlockContainer(level, pos, state);
++        if (container != null) {
++            return new net.neoforged.neoforge.items.ContainerOrHandler(container, null);
++        }
++        var blockItemHandler = level.getCapability(net.neoforged.neoforge.capabilities.Capabilities.ItemHandler.BLOCK, pos, state, null, side);
++        if (blockItemHandler != null) {
++            return new net.neoforged.neoforge.items.ContainerOrHandler(null, blockItemHandler);
++        }
++        return net.neoforged.neoforge.items.VanillaInventoryCodeHooks.getEntityInventory(level, x, y, z, side);
++    }
++
+     private static boolean canMergeItems(ItemStack p_59345_, ItemStack p_59346_) {
+         return p_59345_.getCount() <= p_59345_.getMaxStackSize() && ItemStack.isSameItemSameComponents(p_59345_, p_59346_);
+     }
 @@ -470,5 +_,9 @@
      @Override
      protected AbstractContainerMenu createMenu(int p_59312_, Inventory p_59313_) {

--- a/src/main/java/net/neoforged/neoforge/items/ContainerOrHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ContainerOrHandler.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.items;
+
+import net.minecraft.world.Container;
+import org.jetbrains.annotations.Nullable;
+
+public record ContainerOrHandler(
+        @Nullable Container container,
+        @Nullable IItemHandler itemHandler) {}

--- a/src/main/java/net/neoforged/neoforge/items/ContainerOrHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ContainerOrHandler.java
@@ -10,4 +10,10 @@ import org.jetbrains.annotations.Nullable;
 
 public record ContainerOrHandler(
         @Nullable Container container,
-        @Nullable IItemHandler itemHandler) {}
+        @Nullable IItemHandler itemHandler) {
+    public static final ContainerOrHandler EMPTY = new ContainerOrHandler(null, null);
+
+    public boolean isEmpty() {
+        return container == null && itemHandler == null;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/items/ContainerOrHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ContainerOrHandler.java
@@ -11,6 +11,12 @@ import org.jetbrains.annotations.Nullable;
 public record ContainerOrHandler(
         @Nullable Container container,
         @Nullable IItemHandler itemHandler) {
+    public ContainerOrHandler {
+        if (container != null && itemHandler != null) {
+            throw new IllegalArgumentException("Cannot have both a container and an item handler.");
+        }
+    }
+
     public static final ContainerOrHandler EMPTY = new ContainerOrHandler(null, null);
 
     public boolean isEmpty() {

--- a/src/main/java/net/neoforged/neoforge/items/VanillaHopperItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaHopperItemHandler.java
@@ -32,8 +32,8 @@ public class VanillaHopperItemHandler extends InvWrapper {
                     // This cooldown is always set to 8 in vanilla with one exception:
                     // Hopper -> Hopper transfer sets this cooldown to 7 when this hopper
                     // has not been updated as recently as the one pushing items into it.
-                    // This vanilla behavior is preserved by VanillaInventoryCodeHooks#insertStack,
-                    // the cooldown is set properly by the hopper that is pushing items into this one.
+                    // This vanilla behavior is preserved because we let vanilla handle
+                    // hopper - hopper interactions.
                     hopper.setCooldown(8);
                 }
             }

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -7,13 +7,12 @@ package net.neoforged.neoforge.items;
 
 import java.util.Collections;
 import java.util.List;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.HopperBlock;
 import net.minecraft.world.level.block.entity.Hopper;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
 import net.minecraft.world.phys.AABB;
@@ -25,15 +24,11 @@ import org.jetbrains.annotations.Nullable;
 public class VanillaInventoryCodeHooks {
     /**
      * Copied from TileEntityHopper#captureDroppedItems and added capability support
-     * 
+     *
+     * @param handler target item handler
      * @return {@code true} if we moved an item, {@code false} if we moved no items
      */
-    public static boolean extractHook(Level level, Hopper dest) {
-        var handler = getSourceItemHandler(level, dest);
-        if (handler == null) {
-            return false;
-        }
-
+    public static boolean extractHook(Hopper dest, IItemHandler handler) {
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack extractItem = handler.extractItem(i, 1, true);
             if (!extractItem.isEmpty()) {
@@ -59,12 +54,11 @@ public class VanillaInventoryCodeHooks {
     /**
      * Copied from TileEntityHopper#transferItemsOut and added capability support
      *
+     * @param itemHandler target item handler
      * @return {@code true} if we moved an item, {@code false} if we moved no items
      */
-    public static boolean insertHook(HopperBlockEntity hopper) {
-        Direction hopperFacing = hopper.getBlockState().getValue(HopperBlock.FACING);
-        var itemHandler = getAttachedItemHandler(hopper.getLevel(), hopper.getBlockPos(), hopperFacing);
-        if (itemHandler == null || isFull(itemHandler)) {
+    public static boolean insertHook(HopperBlockEntity hopper, IItemHandler itemHandler) {
+        if (isFull(itemHandler)) {
             return false;
         }
         for (int i = 0; i < hopper.getContainerSize(); ++i) {
@@ -84,17 +78,6 @@ public class VanillaInventoryCodeHooks {
         return false;
     }
 
-    /**
-     * Tries to insert {@code stack} into a neighbor, and returns the remainder.
-     */
-    public static ItemStack insertNeighbor(Level level, BlockPos pos, Direction outputSide, ItemStack stack) {
-        var itemHandler = getAttachedItemHandler(level, pos, outputSide);
-        if (itemHandler == null) {
-            return stack;
-        }
-        return ItemHandlerHelper.insertItem(itemHandler, stack, false);
-    }
-
     private static boolean isFull(IItemHandler itemHandler) {
         for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
             ItemStack stackInSlot = itemHandler.getStackInSlot(slot);
@@ -106,36 +89,21 @@ public class VanillaInventoryCodeHooks {
     }
 
     @Nullable
-    private static IItemHandler getAttachedItemHandler(Level level, BlockPos pos, Direction direction) {
-        return getItemHandlerAt(level, pos.getX() + direction.getStepX() + 0.5, pos.getY() + direction.getStepY() + 0.5, pos.getZ() + direction.getStepZ() + 0.5, direction.getOpposite());
-    }
-
-    @Nullable
-    private static IItemHandler getSourceItemHandler(Level level, Hopper hopper) {
-        return getItemHandlerAt(level, hopper.getLevelX(), hopper.getLevelY() + 1.0, hopper.getLevelZ(), Direction.DOWN);
-    }
-
-    @Nullable
-    private static IItemHandler getItemHandlerAt(Level worldIn, double x, double y, double z, final Direction side) {
-        BlockPos blockpos = BlockPos.containing(x, y, z);
-
-        // Look for block capability first
-        var blockCap = worldIn.getCapability(Capabilities.ItemHandler.BLOCK, blockpos, side);
-        if (blockCap != null)
-            return blockCap;
-
-        // Otherwise fallback to automation entity capability
+    public static ContainerOrHandler getEntityInventory(Level level, double x, double y, double z, @Nullable Direction side) {
         // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
-        List<Entity> list = worldIn.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
+        List<Entity> list = level.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
         if (!list.isEmpty()) {
             Collections.shuffle(list);
             for (Entity entity : list) {
+                if (entity instanceof Container container) {
+                    return new ContainerOrHandler(container, null);
+                }
                 IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
-                if (entityCap != null)
-                    return entityCap;
+                if (entityCap != null) {
+                    return new ContainerOrHandler(null, entityCap);
+                }
             }
         }
-
         return null;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -5,12 +5,10 @@
 
 package net.neoforged.neoforge.items;
 
-import java.util.Collections;
 import java.util.List;
 import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.Hopper;
@@ -89,18 +87,24 @@ public class VanillaInventoryCodeHooks {
     }
 
     public static ContainerOrHandler getEntityContainerOrHandler(Level level, double x, double y, double z, @Nullable Direction side) {
-        // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
-        List<Entity> list = level.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
+        List<Entity> list = level.getEntities(
+                (Entity) null,
+                new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D),
+                entity -> {
+                    // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
+                    if (!entity.isAlive()) {
+                        return false;
+                    }
+                    return entity instanceof Container || entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side) != null;
+                });
         if (!list.isEmpty()) {
-            Collections.shuffle(list);
-            for (Entity entity : list) {
-                if (entity instanceof Container container) {
-                    return new ContainerOrHandler(container, null);
-                }
-                IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
-                if (entityCap != null) {
-                    return new ContainerOrHandler(null, entityCap);
-                }
+            var entity = list.get(level.random.nextInt(list.size()));
+            if (entity instanceof Container container) {
+                return new ContainerOrHandler(container, null);
+            }
+            IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
+            if (entityCap != null) { // Could be null even if it wasn't in the entity predicate above.
+                return new ContainerOrHandler(null, entityCap);
             }
         }
         return ContainerOrHandler.EMPTY;

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -7,183 +7,92 @@ package net.neoforged.neoforge.items;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.FrontAndTop;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntitySelector;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.DropperBlock;
 import net.minecraft.world.level.block.HopperBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.CrafterBlockEntity;
-import net.minecraft.world.level.block.entity.DispenserBlockEntity;
 import net.minecraft.world.level.block.entity.Hopper;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.capabilities.Capabilities;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+@ApiStatus.Internal
 public class VanillaInventoryCodeHooks {
     /**
      * Copied from TileEntityHopper#captureDroppedItems and added capability support
      * 
-     * @return Null if we did nothing {no IItemHandler}, True if we moved an item, False if we moved no items
+     * @return {@code true} if we moved an item, {@code false} if we moved no items
      */
-    @Nullable
-    public static Boolean extractHook(Level level, Hopper dest) {
-        return getSourceItemHandler(level, dest)
-                .map(itemHandlerResult -> {
-                    IItemHandler handler = itemHandlerResult.getKey();
-
-                    for (int i = 0; i < handler.getSlots(); i++) {
-                        ItemStack extractItem = handler.extractItem(i, 1, true);
-                        if (!extractItem.isEmpty()) {
-                            for (int j = 0; j < dest.getContainerSize(); j++) {
-                                ItemStack destStack = dest.getItem(j);
-                                if (dest.canPlaceItem(j, extractItem) && (destStack.isEmpty() || destStack.getCount() < destStack.getMaxStackSize() && destStack.getCount() < dest.getMaxStackSize() && ItemStack.isSameItemSameComponents(extractItem, destStack))) {
-                                    extractItem = handler.extractItem(i, 1, false);
-                                    if (destStack.isEmpty())
-                                        dest.setItem(j, extractItem);
-                                    else {
-                                        destStack.grow(1);
-                                        dest.setItem(j, destStack);
-                                    }
-                                    dest.setChanged();
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-
-                    return false;
-                })
-                .orElse(null); // TODO bad null
-    }
-
-    /**
-     * Copied from BlockDropper#dispense and added capability support
-     */
-    public static boolean dropperInsertHook(Level level, BlockPos pos, DispenserBlockEntity dropper, int slot, ItemStack stack) {
-        Direction facing = level.getBlockState(pos).getValue(DropperBlock.FACING);
-        return getAttachedItemHandler(level, pos, facing)
-                .map(destinationResult -> {
-                    IItemHandler itemHandler = destinationResult.getKey();
-                    Object destination = destinationResult.getValue();
-                    ItemStack dispensedStack = stack.copy().split(1);
-                    ItemStack remainder = putStackInInventoryAllSlots(dropper, destination, itemHandler, dispensedStack);
-
-                    if (remainder.isEmpty()) {
-                        remainder = stack.copy();
-                        remainder.shrink(1);
-                    } else {
-                        remainder = stack.copy();
-                    }
-
-                    dropper.setItem(slot, remainder);
-                    return false;
-                })
-                .orElse(true);
-    }
-
-    /**
-     * Copied from TileEntityHopper#transferItemsOut and added capability support
-     */
-    public static boolean insertHook(HopperBlockEntity hopper) {
-        Direction hopperFacing = hopper.getBlockState().getValue(HopperBlock.FACING);
-        return getAttachedItemHandler(hopper.getLevel(), hopper.getBlockPos(), hopperFacing)
-                .map(destinationResult -> {
-                    IItemHandler itemHandler = destinationResult.getKey();
-                    Object destination = destinationResult.getValue();
-                    if (isFull(itemHandler)) {
-                        return false;
-                    } else {
-                        for (int i = 0; i < hopper.getContainerSize(); ++i) {
-                            if (!hopper.getItem(i).isEmpty()) {
-                                ItemStack originalSlotContents = hopper.getItem(i).copy();
-                                ItemStack insertStack = hopper.removeItem(i, 1);
-                                ItemStack remainder = putStackInInventoryAllSlots(hopper, destination, itemHandler, insertStack);
-
-                                if (remainder.isEmpty()) {
-                                    return true;
-                                }
-
-                                hopper.setItem(i, originalSlotContents);
-                            }
-                        }
-
-                        return false;
-                    }
-                })
-                .orElse(false);
-    }
-
-    /**
-     * Added capability support for the Crafter dispensing the result
-     */
-    public static ItemStack insertCrafterOutput(Level level, BlockPos pos, CrafterBlockEntity crafterBlockEntity, ItemStack stack) {
-        FrontAndTop frontAndTop = level.getBlockState(pos).getValue(BlockStateProperties.ORIENTATION);
-        return getAttachedItemHandler(level, pos, frontAndTop.front())
-                .map(destinationResult -> {
-                    IItemHandler itemHandler = destinationResult.getKey();
-                    Object destination = destinationResult.getValue();
-                    ItemStack remainder = putStackInInventoryAllSlots(crafterBlockEntity, destination, itemHandler, stack);
-                    return remainder;
-                })
-                .orElse(stack);
-    }
-
-    private static ItemStack putStackInInventoryAllSlots(BlockEntity source, Object destination, IItemHandler destInventory, ItemStack stack) {
-        for (int slot = 0; slot < destInventory.getSlots() && !stack.isEmpty(); slot++) {
-            stack = insertStack(source, destination, destInventory, stack, slot);
+    public static boolean extractHook(Level level, Hopper dest) {
+        var handler = getSourceItemHandler(level, dest);
+        if (handler == null) {
+            return false;
         }
-        return stack;
-    }
 
-    /**
-     * Copied from TileEntityHopper#insertStack and added capability support
-     */
-    private static ItemStack insertStack(BlockEntity source, Object destination, IItemHandler destInventory, ItemStack stack, int slot) {
-        ItemStack itemstack = destInventory.getStackInSlot(slot);
-
-        if (destInventory.insertItem(slot, stack, true).isEmpty()) {
-            boolean insertedItem = false;
-            boolean inventoryWasEmpty = isEmpty(destInventory);
-
-            if (itemstack.isEmpty()) {
-                destInventory.insertItem(slot, stack, false);
-                stack = ItemStack.EMPTY;
-                insertedItem = true;
-            } else if (ItemStack.isSameItemSameComponents(itemstack, stack)) {
-                int originalSize = stack.getCount();
-                stack = destInventory.insertItem(slot, stack, false);
-                insertedItem = originalSize < stack.getCount();
-            }
-
-            if (insertedItem) {
-                if (inventoryWasEmpty && destination instanceof HopperBlockEntity) {
-                    HopperBlockEntity destinationHopper = (HopperBlockEntity) destination;
-
-                    if (!destinationHopper.isOnCustomCooldown()) {
-                        int k = 0;
-                        if (source instanceof HopperBlockEntity) {
-                            if (destinationHopper.getLastUpdateTime() >= ((HopperBlockEntity) source).getLastUpdateTime()) {
-                                k = 1;
-                            }
+        for (int i = 0; i < handler.getSlots(); i++) {
+            ItemStack extractItem = handler.extractItem(i, 1, true);
+            if (!extractItem.isEmpty()) {
+                for (int j = 0; j < dest.getContainerSize(); j++) {
+                    ItemStack destStack = dest.getItem(j);
+                    if (dest.canPlaceItem(j, extractItem) && (destStack.isEmpty() || destStack.getCount() < destStack.getMaxStackSize() && destStack.getCount() < dest.getMaxStackSize() && ItemStack.isSameItemSameComponents(extractItem, destStack))) {
+                        extractItem = handler.extractItem(i, 1, false);
+                        if (destStack.isEmpty())
+                            dest.setItem(j, extractItem);
+                        else {
+                            destStack.grow(1);
+                            dest.setItem(j, destStack);
                         }
-                        destinationHopper.setCooldown(8 - k);
+                        dest.setChanged();
+                        return true;
                     }
                 }
             }
         }
+        return false;
+    }
 
-        return stack;
+    /**
+     * Copied from TileEntityHopper#transferItemsOut and added capability support
+     *
+     * @return {@code true} if we moved an item, {@code false} if we moved no items
+     */
+    public static boolean insertHook(HopperBlockEntity hopper) {
+        Direction hopperFacing = hopper.getBlockState().getValue(HopperBlock.FACING);
+        var itemHandler = getAttachedItemHandler(hopper.getLevel(), hopper.getBlockPos(), hopperFacing);
+        if (itemHandler == null || isFull(itemHandler)) {
+            return false;
+        }
+        for (int i = 0; i < hopper.getContainerSize(); ++i) {
+            if (!hopper.getItem(i).isEmpty()) {
+                ItemStack originalSlotContents = hopper.getItem(i).copy();
+                ItemStack insertStack = hopper.removeItem(i, 1);
+                ItemStack remainder = ItemHandlerHelper.insertItem(itemHandler, insertStack, false);
+
+                if (remainder.isEmpty()) {
+                    return true;
+                }
+
+                hopper.setItem(i, originalSlotContents);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to insert {@code stack} into a neighbor, and returns the remainder.
+     */
+    public static ItemStack insertNeighbor(Level level, BlockPos pos, Direction outputSide, ItemStack stack) {
+        var itemHandler = getAttachedItemHandler(level, pos, outputSide);
+        if (itemHandler == null) {
+            return stack;
+        }
+        return ItemHandlerHelper.insertItem(itemHandler, stack, false);
     }
 
     private static boolean isFull(IItemHandler itemHandler) {
@@ -196,33 +105,24 @@ public class VanillaInventoryCodeHooks {
         return true;
     }
 
-    private static boolean isEmpty(IItemHandler itemHandler) {
-        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
-            ItemStack stackInSlot = itemHandler.getStackInSlot(slot);
-            if (stackInSlot.getCount() > 0) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static Optional<Pair<IItemHandler, Object>> getAttachedItemHandler(Level level, BlockPos pos, Direction direction) {
+    @Nullable
+    private static IItemHandler getAttachedItemHandler(Level level, BlockPos pos, Direction direction) {
         return getItemHandlerAt(level, pos.getX() + direction.getStepX() + 0.5, pos.getY() + direction.getStepY() + 0.5, pos.getZ() + direction.getStepZ() + 0.5, direction.getOpposite());
     }
 
-    private static Optional<Pair<IItemHandler, Object>> getSourceItemHandler(Level level, Hopper hopper) {
+    @Nullable
+    private static IItemHandler getSourceItemHandler(Level level, Hopper hopper) {
         return getItemHandlerAt(level, hopper.getLevelX(), hopper.getLevelY() + 1.0, hopper.getLevelZ(), Direction.DOWN);
     }
 
-    private static Optional<Pair<IItemHandler, Object>> getItemHandlerAt(Level worldIn, double x, double y, double z, final Direction side) {
+    @Nullable
+    private static IItemHandler getItemHandlerAt(Level worldIn, double x, double y, double z, final Direction side) {
         BlockPos blockpos = BlockPos.containing(x, y, z);
-        BlockState state = worldIn.getBlockState(blockpos);
-        BlockEntity blockEntity = state.hasBlockEntity() ? worldIn.getBlockEntity(blockpos) : null;
 
         // Look for block capability first
-        var blockCap = worldIn.getCapability(Capabilities.ItemHandler.BLOCK, blockpos, state, blockEntity, side);
+        var blockCap = worldIn.getCapability(Capabilities.ItemHandler.BLOCK, blockpos, side);
         if (blockCap != null)
-            return Optional.of(ImmutablePair.of(blockCap, blockEntity));
+            return blockCap;
 
         // Otherwise fallback to automation entity capability
         // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
@@ -232,10 +132,10 @@ public class VanillaInventoryCodeHooks {
             for (Entity entity : list) {
                 IItemHandler entityCap = entity.getCapability(Capabilities.ItemHandler.ENTITY_AUTOMATION, side);
                 if (entityCap != null)
-                    return Optional.of(ImmutablePair.of(entityCap, entity));
+                    return entityCap;
             }
         }
 
-        return Optional.empty();
+        return null;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 @ApiStatus.Internal
 public class VanillaInventoryCodeHooks {
     /**
-     * Copied from TileEntityHopper#captureDroppedItems and added capability support
+     * Tries to extract items from an item handler and insert them in the hopper.
      *
      * @param handler target item handler
      * @return {@code true} if we moved an item, {@code false} if we moved no items
@@ -52,7 +52,7 @@ public class VanillaInventoryCodeHooks {
     }
 
     /**
-     * Copied from TileEntityHopper#transferItemsOut and added capability support
+     * Tries to insert a hopper's items into an item handler.
      *
      * @param itemHandler target item handler
      * @return {@code true} if we moved an item, {@code false} if we moved no items

--- a/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/items/VanillaInventoryCodeHooks.java
@@ -88,8 +88,7 @@ public class VanillaInventoryCodeHooks {
         return true;
     }
 
-    @Nullable
-    public static ContainerOrHandler getEntityInventory(Level level, double x, double y, double z, @Nullable Direction side) {
+    public static ContainerOrHandler getEntityContainerOrHandler(Level level, double x, double y, double z, @Nullable Direction side) {
         // Note: the isAlive check matches what vanilla does for hoppers in EntitySelector.CONTAINER_ENTITY_SELECTOR
         List<Entity> list = level.getEntities((Entity) null, new AABB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), EntitySelector.ENTITY_STILL_ALIVE);
         if (!list.isEmpty()) {
@@ -104,6 +103,6 @@ public class VanillaInventoryCodeHooks {
                 }
             }
         }
-        return null;
+        return ContainerOrHandler.EMPTY;
     }
 }


### PR DESCRIPTION
Move our `IItemHandler` interaction hooks after vanilla checks for `Container` interactions. This gives vanilla control over interactions with `Container`s. Fixes #1750. Fixes #1770. (Did not test the latter but I assume it gets fixed).
As a side effect, this greatly simplifies our hooks since we don't need to handle vanilla edge cases such as hopper - hopper interactions having special interactions when it comes to cooldowns.

## Breaking change
Modders need to be careful that their `Container`s will be interacted with as `Container`s before an item handler is even attempted to be found. I'd suggest not implementing `Container` directly on block entities to avoid this problem. Nevertheless, this counts as a breaking change.

## Lookup order
From highest priority to lowest priority: `Container block > IItemHandler block > Container entity > IItemHandler entity`.