### PR TITLE
Fix BiomeSpecialEffectsBuilder to copy backgroundMusicVolume

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/world/BiomeSpecialEffectsBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/BiomeSpecialEffectsBuilder.java
@@ -30,6 +30,7 @@ public class BiomeSpecialEffectsBuilder extends BiomeSpecialEffects.Builder {
         baseEffects.getAmbientMoodSettings().ifPresent(builder::ambientMoodSound);
         baseEffects.getAmbientAdditionsSettings().ifPresent(builder::ambientAdditionsSound);
         baseEffects.getBackgroundMusic().ifPresent(builder::backgroundMusic);
+        builder.backgroundMusicVolume = baseEffects.getBackgroundMusicVolume();
         return builder;
     }
 


### PR DESCRIPTION
This PR fixes #1733 by also copying `backgroundMusicVolume` in the copy factory for `BiomeSpecialEffectsBuilder`. Tested by checking that walking into a pale garden biome with background music playing causes the music to slowly fade out, and then fade back in when walking outside of the pale garden biome. See also https://github.com/neoforged/NeoForge/pull/1766#issuecomment-2559770847 for a bit more information.