### PR TITLE
Release bed POI if villager child spawn is blocked

### DIFF
--- a/patches/net/minecraft/world/entity/ai/behavior/VillagerMakeLove.java.patch
+++ b/patches/net/minecraft/world/entity/ai/behavior/VillagerMakeLove.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/behavior/VillagerMakeLove.java
++++ b/net/minecraft/world/entity/ai/behavior/VillagerMakeLove.java
+@@ -112,6 +_,8 @@
+             villager.setAge(-24000);
+             villager.moveTo(p_24657_.getX(), p_24657_.getY(), p_24657_.getZ(), 0.0F, 0.0F);
+             p_24656_.addFreshEntityWithPassengers(villager);
++            // Neo: If villager is blocked from spawning (e.g., FinalizeSpawnEvent), then breed should be unsuccessful
++            if (!villager.isAddedToLevel()) return Optional.empty();
+             p_24656_.broadcastEntityEvent(villager, (byte)12);
+             return Optional.of(villager);
+         }


### PR DESCRIPTION
This PR fixes #1606 by ensuring the bed POI is released if the villager child is blocked from spawning in the world, such as being spawn-cancelled through `FinalizeSpawnEvent`, by returning an empty optional from `VillagerMakeLove#breed` to mimic an unsuccessful breeding event. See the linked issue for more details.

Tested by following the instructions in the linked issue, with the following code inserted in the constructor of `FinalizeSpawnEvent` to mimic the mod (and using hotswap to change the `true` to `false` as the arbitrary condition specified in the reproduction steps):
```java
        if (entity instanceof Villager && spawnType == EntitySpawnReason.BREEDING) {
            System.out.println("Captured finalized spawn event for bred villager");

            if (true) {
                this.setSpawnCancelled(true);
                System.out.println("Cancelled spawn");
            } else {
                System.out.println("Allowed spawn to go through");
            }
        }
```