### PR TITLE
Add `removeOptional` methods to `ITagAppenderExtension`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IIntrinsicHolderTagAppenderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IIntrinsicHolderTagAppenderExtension.java
@@ -73,6 +73,12 @@ public interface IIntrinsicHolderTagAppenderExtension<T> extends ITagAppenderExt
     }
 
     @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> removeOptional(final ResourceLocation location) {
+        ITagAppenderExtension.super.removeOptional(location);
+        return self();
+    }
+
+    @Override
     default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(final ResourceKey<T> resourceKey) {
         ITagAppenderExtension.super.remove(resourceKey);
         return self();
@@ -86,6 +92,12 @@ public interface IIntrinsicHolderTagAppenderExtension<T> extends ITagAppenderExt
     }
 
     @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> removeOptional(final ResourceKey<T> resourceKey) {
+        ITagAppenderExtension.super.removeOptional(resourceKey);
+        return self();
+    }
+
+    @Override
     default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(TagKey<T> tag) {
         ITagAppenderExtension.super.remove(tag);
         return self();
@@ -95,6 +107,18 @@ public interface IIntrinsicHolderTagAppenderExtension<T> extends ITagAppenderExt
     @SuppressWarnings("unchecked")
     default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> remove(TagKey<T> first, TagKey<T>... tags) {
         ITagAppenderExtension.super.remove(first, tags);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> removeOptionalTag(ResourceLocation location) {
+        ITagAppenderExtension.super.removeOptionalTag(location);
+        return self();
+    }
+
+    @Override
+    default IntrinsicHolderTagsProvider.IntrinsicTagAppender<T> removeOptionalTag(TagKey<T> tag) {
+        ITagAppenderExtension.super.removeOptionalTag(tag);
         return self();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagAppenderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagAppenderExtension.java
@@ -59,6 +59,19 @@ public interface ITagAppenderExtension<T> {
     }
 
     /**
+     * Optionally adds a single element's ID to the tag json's remove list. If the added ID is not present, it will be
+     * ignored and the containing tag will continue to be loaded as normal. Callable during datageneration.
+     *
+     * @param location The ID of the element to remove
+     * @return The builder for chaining
+     */
+    default TagsProvider.TagAppender<T> removeOptional(final ResourceLocation location) {
+        TagsProvider.TagAppender<T> builder = self();
+        builder.getInternalBuilder().removeOptionalElement(location);
+        return builder;
+    }
+
+    /**
      * Adds multiple elements' IDs to the tag json's remove list. Callable during datageneration.
      * 
      * @param locations The IDs of the elements to remove
@@ -80,6 +93,18 @@ public interface ITagAppenderExtension<T> {
      */
     default TagsProvider.TagAppender<T> remove(final ResourceKey<T> resourceKey) {
         this.remove(resourceKey.location());
+        return self();
+    }
+
+    /**
+     * Optionally adds a resource key to the tag json's remove list. If the added key is not present, it will be
+     * ignored and the containing tag will continue to be loaded as normal. Callable during datageneration.
+     *
+     * @param resourceKey The resource key of the element to remove
+     * @return The appender for chaining
+     */
+    default TagsProvider.TagAppender<T> removeOptional(final ResourceKey<T> resourceKey) {
+        this.removeOptional(resourceKey.location());
         return self();
     }
 
@@ -107,6 +132,31 @@ public interface ITagAppenderExtension<T> {
     default TagsProvider.TagAppender<T> remove(TagKey<T> tag) {
         TagsProvider.TagAppender<T> builder = self();
         builder.getInternalBuilder().removeTag(tag.location());
+        return builder;
+    }
+
+    /**
+     * Optionally adds a tag to the tag json's remove list. If the added tag is not present, it will be
+     * ignored and the containing tag will continue to be loaded as normal. Callable during datageneration.
+     *
+     * @param tag The ID of the tag to remove
+     * @return The builder for chaining
+     */
+    default TagsProvider.TagAppender<T> removeOptionalTag(TagKey<T> tag) {
+        this.removeOptionalTag(tag.location());
+        return self();
+    }
+
+    /**
+     * Optionally adds a tag to the tag json's remove list. If the added tag is not present, it will be
+     * ignored and the containing tag will continue to be loaded as normal. Callable during datageneration.
+     *
+     * @param location The ID of the tag to remove
+     * @return The builder for chaining
+     */
+    default TagsProvider.TagAppender<T> removeOptionalTag(ResourceLocation location) {
+        TagsProvider.TagAppender<T> builder = self();
+        builder.getInternalBuilder().removeOptionalTag(location);
         return builder;
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ITagBuilderExtension.java
@@ -52,6 +52,16 @@ public interface ITagBuilderExtension {
     }
 
     /**
+     * Adds an optional single-element entry to the remove list.
+     *
+     * @param elementID The ID of the element to add to the remove list
+     * @return The builder for chaining purposes
+     */
+    default TagBuilder removeOptionalElement(final ResourceLocation elementID) {
+        return this.getRawBuilder().remove(TagEntry.optionalElement(elementID));
+    }
+
+    /**
      * Adds a tag to the remove list.
      * 
      * @param tagID  The ID of the tag to add to the remove list
@@ -72,5 +82,15 @@ public interface ITagBuilderExtension {
      */
     default TagBuilder removeTag(final ResourceLocation tagID) {
         return this.getRawBuilder().remove(TagEntry.tag(tagID));
+    }
+
+    /**
+     * Adds an optional tag to the remove list.
+     *
+     * @param tagID The ID of the tag to add to the remove list
+     * @return The builder for chaining purposes
+     */
+    default TagBuilder removeOptionalTag(final ResourceLocation tagID) {
+        return this.getRawBuilder().remove(TagEntry.optionalTag(tagID));
     }
 }

--- a/tests/src/generated/resources/data/minecraft/tags/block/test_tag.json
+++ b/tests/src/generated/resources/data/minecraft/tags/block/test_tag.json
@@ -8,7 +8,27 @@
     "minecraft:polished_andesite",
     "#minecraft:beehives",
     "#minecraft:banners",
-    "#minecraft:beds"
+    "#minecraft:beds",
+    {
+      "id": "minecraft:granite",
+      "required": false
+    },
+    {
+      "id": "minecraft:diorite",
+      "required": false
+    },
+    {
+      "id": "minecraft:dacite",
+      "required": false
+    },
+    {
+      "id": "#minecraft:snow",
+      "required": false
+    },
+    {
+      "id": "#minecraft:igneous_rocks",
+      "required": false
+    }
   ],
   "values": []
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
@@ -46,7 +46,12 @@ public class RemoveTagDatagenTest {
                         .remove(key(Blocks.ANVIL))
                         .remove(key(Blocks.BASALT), key(Blocks.POLISHED_ANDESITE))
                         .remove(BlockTags.BEEHIVES)
-                        .remove(BlockTags.BANNERS, BlockTags.BEDS);
+                        .remove(BlockTags.BANNERS, BlockTags.BEDS)
+                        .removeOptional(key(Blocks.GRANITE))
+                        .removeOptional(key(Blocks.DIORITE))
+                        .removeOptional(ResourceLocation.withDefaultNamespace("dacite"))
+                        .removeOptionalTag(BlockTags.SNOW)
+                        .removeOptionalTag(ResourceLocation.withDefaultNamespace("igneous_rocks"));
             }
         };
 


### PR DESCRIPTION
This PR adds some extra methods to NeoForge's `ITagAppenderExtension` interface to allow for optionally removing entries from a tag during data generation, i.e. including an entry in the `remove` list where `required` is set to `false`. This is in order to mirror the methods already included in vanilla Minecraft for optionally _adding_ entries for which the IDs may not be present at runtime, proceeding with loading the rest of the tag as normal and without throwing any errors should these IDs indeed not be present.