### PR TITLE
Do not fail tag datagen when removing IDs not present at runtime

### DIFF
--- a/patches/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/TagsProvider.java.patch
@@ -64,7 +64,7 @@
 -                                    List<TagEntry> list1 = list.stream().filter(p_274771_ -> !p_274771_.verifyIfPresent(predicate, predicate1)).toList();
 +                                    List<TagEntry> list1 = java.util.stream.Stream.concat(list.stream(), tagbuilder.getRemoveEntries())
 +                                              .filter((p_274771_) -> !p_274771_.verifyIfPresent(predicate, predicate1))
-+                                              .filter(this::missing)
++                                              .filter(entry -> tagbuilder.getRemoveEntries().noneMatch(entry::equals) && this.missing(entry))
 +                                              .toList();
                                      if (!list1.isEmpty()) {
                                          throw new IllegalArgumentException(

--- a/patches/net/minecraft/data/tags/TagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/TagsProvider.java.patch
@@ -62,9 +62,9 @@
                                      TagBuilder tagbuilder = p_323138_.getValue();
                                      List<TagEntry> list = tagbuilder.build();
 -                                    List<TagEntry> list1 = list.stream().filter(p_274771_ -> !p_274771_.verifyIfPresent(predicate, predicate1)).toList();
-+                                    List<TagEntry> list1 = java.util.stream.Stream.concat(list.stream(), tagbuilder.getRemoveEntries())
++                                    List<TagEntry> list1 = list.stream()
 +                                              .filter((p_274771_) -> !p_274771_.verifyIfPresent(predicate, predicate1))
-+                                              .filter(entry -> tagbuilder.getRemoveEntries().noneMatch(entry::equals) && this.missing(entry))
++                                              .filter(this::missing)
 +                                              .toList();
                                      if (!list1.isEmpty()) {
                                          throw new IllegalArgumentException(

--- a/tests/src/generated/resources/data/minecraft/tags/block/test_tag.json
+++ b/tests/src/generated/resources/data/minecraft/tags/block/test_tag.json
@@ -8,7 +8,8 @@
     "minecraft:polished_andesite",
     "#minecraft:beehives",
     "#minecraft:banners",
-    "#minecraft:beds"
+    "#minecraft:beds",
+    "minecraft:dacite"
   ],
   "values": []
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
@@ -46,7 +46,9 @@ public class RemoveTagDatagenTest {
                         .remove(key(Blocks.ANVIL))
                         .remove(key(Blocks.BASALT), key(Blocks.POLISHED_ANDESITE))
                         .remove(BlockTags.BEEHIVES)
-                        .remove(BlockTags.BANNERS, BlockTags.BEDS);
+                        .remove(BlockTags.BANNERS, BlockTags.BEDS)
+                        // test removing optional IDs not present at run-time
+                        .remove(ResourceLocation.withDefaultNamespace("dacite"));
             }
         };
 


### PR DESCRIPTION
Continuing on from the discussion on (the now seemingly redundant PR) #1794, this PR allows Tag data generation in 1.21.1 to proceed as normal in the event that the `ITagAppenderExtension::remove` methods are used with IDs which may not exist at runtime, bypassing the `ExistingFileHelper` checks for such IDs should they be marked as removal entries.