### PR TITLE
Fix the ability of the build script to use PR builds in installers

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.plugins.BasePluginExtension;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -271,6 +272,7 @@ public class NeoDevPlugin implements Plugin<Project> {
                 genProductionPatches.flatMap(GenerateSourcePatches::getPatchesFolder)
         );
 
+        var installerRepositoryUrls = getInstallerRepositoryUrls(project);
         // Launcher profile = the version.json file used by the Minecraft launcher.
         var createLauncherProfile = tasks.register("createLauncherProfile", CreateLauncherProfile.class, task -> {
             task.setGroup(INTERNAL_GROUP);
@@ -279,17 +281,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.getNeoForgeVersion().set(neoForgeVersion);
             task.getRawNeoFormVersion().set(rawNeoFormVersion);
             task.setLibraries(configurations.launcherProfileClasspath);
-            task.getRepositoryURLs().set(project.provider(() -> {
-                List<URI> repos = new ArrayList<>();
-                for (var repo : project.getRepositories().withType(MavenArtifactRepository.class)) {
-                    var uri = repo.getUrl();
-                    if (!uri.toString().endsWith("/")) {
-                        uri = URI.create(uri + "/");
-                    }
-                    repos.add(uri);
-                }
-                return repos;
-            }));
+            task.getRepositoryURLs().set(installerRepositoryUrls);
             // ${version_name}.jar will be filled out by the launcher. It corresponds to the raw SRG Minecraft client jar.
             task.getIgnoreList().addAll("client-extra", "${version_name}.jar");
             task.setModules(configurations.modulePath);
@@ -308,17 +300,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.addLibraries(configurations.launcherProfileClasspath);
             // We need the NeoForm zip for the SRG mappings.
             task.addLibraries(configurations.neoFormDataOnly);
-            task.getRepositoryURLs().set(project.provider(() -> {
-                List<URI> repos = new ArrayList<>();
-                for (var repo : project.getRepositories().withType(MavenArtifactRepository.class)) {
-                    var uri = repo.getUrl();
-                    if (!uri.toString().endsWith("/")) {
-                        uri = URI.create(uri + "/");
-                    }
-                    repos.add(uri);
-                }
-                return repos;
-            }));
+            task.getRepositoryURLs().set(installerRepositoryUrls);
             task.getUniversalJar().set(universalJar.flatMap(AbstractArchiveTask::getArchiveFile));
             task.getInstallerProfile().set(neoDevBuildDir.map(dir -> dir.file("installer-profile.json")));
 
@@ -465,6 +447,29 @@ public class NeoDevPlugin implements Plugin<Project> {
                 createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawClientJar)
         );
         setupProductionServerTest(project, installerJar);
+    }
+
+    /**
+     * Get the list of Maven repositories that may contain artifacts for the installer.
+     */
+    private static Provider<List<URI>> getInstallerRepositoryUrls(Project project) {
+        return project.provider(() -> {
+            List<URI> repos = new ArrayList<>();
+            var repositories = project.getRepositories();
+            if (repositories.isEmpty()) {
+                // If no project repos are defined, check dependency management on the settings plugin,
+                // which sadly is inaccessible without internals: https://github.com/gradle/gradle/issues/27260
+                repositories = ((GradleInternal) project.getGradle()).getSettings().getDependencyResolutionManagement().getRepositories();
+            }
+            for (var repo : repositories.withType(MavenArtifactRepository.class)) {
+                var uri = repo.getUrl();
+                if (!uri.toString().endsWith("/")) {
+                    uri = URI.create(uri + "/");
+                }
+                repos.add(uri);
+            }
+            return repos;
+        });
     }
 
     private static TaskProvider<TransformSources> configureAccessTransformer(

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -24,7 +24,6 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.plugins.BasePluginExtension;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -38,6 +37,7 @@ import org.gradle.api.tasks.bundling.Zip;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -455,19 +455,20 @@ public class NeoDevPlugin implements Plugin<Project> {
     private static Provider<List<URI>> getInstallerRepositoryUrls(Project project) {
         return project.provider(() -> {
             List<URI> repos = new ArrayList<>();
-            var repositories = project.getRepositories();
-            if (repositories.isEmpty()) {
-                // If no project repos are defined, check dependency management on the settings plugin,
-                // which sadly is inaccessible without internals: https://github.com/gradle/gradle/issues/27260
-                repositories = ((GradleInternal) project.getGradle()).getSettings().getDependencyResolutionManagement().getRepositories();
-            }
-            for (var repo : repositories.withType(MavenArtifactRepository.class)) {
-                var uri = repo.getUrl();
-                if (!uri.toString().endsWith("/")) {
-                    uri = URI.create(uri + "/");
+            var projectRepos = project.getRepositories();
+            if (!projectRepos.isEmpty()) {
+                for (var repo : projectRepos.withType(MavenArtifactRepository.class)) {
+                    repos.add(repo.getUrl());
                 }
-                repos.add(uri);
+            } else {
+                // If no project repos are defined, use the repository list we exposed in settings.gradle via an extension
+                // See the end of settings.gradle for details
+                Collections.addAll(repos, (URI[]) project.getGradle().getExtensions().getByName("repositoryBaseUrls"));
             }
+
+            // Ensure all base urls end with a slash
+            repos.replaceAll(uri -> uri.toString().endsWith("/") ? uri : URI.create(uri + "/"));
+
             return repos;
         });
     }

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryCollector.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryCollector.java
@@ -40,14 +40,6 @@ class LibraryCollector {
         var result = collector.libraries.stream().map(future -> {
             try {
                 return future.get();
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof RuntimeException re) {
-                    throw re;
-                } else if (e.getCause() instanceof IOException re) {
-                    throw new UncheckedIOException(re);
-                } else {
-                    throw new RuntimeException(e);
-                }
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryCollector.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryCollector.java
@@ -6,6 +6,7 @@ import org.gradle.api.logging.Logging;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -21,6 +22,8 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 
@@ -37,11 +40,19 @@ class LibraryCollector {
         var result = collector.libraries.stream().map(future -> {
             try {
                 return future.get();
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof RuntimeException re) {
+                    throw re;
+                } else if (e.getCause() instanceof IOException re) {
+                    throw new UncheckedIOException(re);
+                } else {
+                    throw new RuntimeException(e);
+                }
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         }).toList();
-        LOGGER.info("Collected %d libraries".formatted(result.size()));
+        LOGGER.info("Collected {} libraries", result.size());
         return result;
     }
 
@@ -63,7 +74,9 @@ class LibraryCollector {
 
     private final List<Future<Library>> libraries = new ArrayList<>();
 
-    private final HttpClient httpClient = HttpClient.newBuilder().build();
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
 
     private LibraryCollector(List<URI> repoUrl) {
         this.repositoryUrls = new ArrayList<>(repoUrl);
@@ -86,7 +99,7 @@ class LibraryCollector {
 
         LOGGER.info("Collecting libraries from:");
         for (var repo : repositoryUrls) {
-            LOGGER.info(" - " + repo);
+            LOGGER.info(" - {}", repo);
         }
     }
 
@@ -109,7 +122,7 @@ class LibraryCollector {
                 return httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding())
                         .thenApply(response -> {
                             if (response.statusCode() != 200) {
-                                LOGGER.info("  Got %d for %s".formatted(response.statusCode(), artifactUri));
+                                LOGGER.info("  Got {} for {}", response.statusCode(), artifactUri);
                                 String message = "Could not find %s: %d".formatted(artifactUri, response.statusCode());
                                 // Prepend error message from previous repo if they all fail
                                 if (previousError != null) {
@@ -117,7 +130,7 @@ class LibraryCollector {
                                 }
                                 throw new RuntimeException(message);
                             }
-                            LOGGER.info("  Found %s -> %s".formatted(name, artifactUri));
+                            LOGGER.info("  Found {} -> {}", name, artifactUri);
                             return new Library(
                                     name,
                                     new LibraryDownload(new LibraryArtifact(
@@ -132,6 +145,9 @@ class LibraryCollector {
                 libraryFuture = makeRequest.apply(null);
             } else {
                 libraryFuture = libraryFuture.exceptionallyCompose(error -> {
+                    if (error instanceof CompletionException e) {
+                        return makeRequest.apply(e.getCause().getMessage());
+                    }
                     return makeRequest.apply(error.getMessage());
                 });
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,3 +44,8 @@ include ':coremods'
 // Ensure a unique artifact id within JIJ that does not conflict with net.neoforged:coremods, which is
 // another external dependency.
 project(":coremods").name = "neoforge-coremods"
+
+// Expose the repository base URLs to projects to be able to access them
+// See this Gradle issue for tracking a more permanent solution:
+// https://github.com/gradle/gradle/issues/27260
+gradle.extensions.add("repositoryBaseUrls", dependencyResolutionManagement.repositories.findAll { it instanceof MavenArtifactRepository }.collect { it.url }.toArray(URI[]::new))

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,4 +48,6 @@ project(":coremods").name = "neoforge-coremods"
 // Expose the repository base URLs to projects to be able to access them
 // See this Gradle issue for tracking a more permanent solution:
 // https://github.com/gradle/gradle/issues/27260
-gradle.extensions.add("repositoryBaseUrls", dependencyResolutionManagement.repositories.findAll { it instanceof MavenArtifactRepository }.collect { it.url }.toArray(URI[]::new))
+gradle.settingsEvaluated {
+    gradle.extensions.add("repositoryBaseUrls", dependencyResolutionManagement.repositories.findAll { it instanceof MavenArtifactRepository }.collect { it.url }.toArray(URI[]::new))
+}


### PR DESCRIPTION
Sadly, we currently have no API to access the repositories declared in settings.gradle
When accessing the project repositories, they're just empty, so I opted to use an internal Gradle class here which overall *seems* benign enough. I also linked the corresponding Gradle issue for fixing this missing API at the use location.

Not fixing this complicates the use of PRs in builds since one would have to copy all repository declarations into the neoforge subproject, and then add the PR repository there.