### PR TITLE
Fix index in `ItemHandlerCopySlot#setStackCopy`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/ItemHandlerCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemHandlerCopySlot.java
@@ -38,7 +38,7 @@ public class ItemHandlerCopySlot extends StackCopySlot {
 
     @Override
     protected void setStackCopy(ItemStack stack) {
-        ((IItemHandlerModifiable) slotItemHandler.getItemHandler()).setStackInSlot(index, stack);
+        ((IItemHandlerModifiable) slotItemHandler.getItemHandler()).setStackInSlot(slotItemHandler.index, stack);
     }
 
     @Override


### PR DESCRIPTION
The current code is using `index`, which is `this.index`, which ends up as `Slot#index`. That is not correct as that index is the index of the slot inside the menu, not inside the item handler. The correct index to use is that of `SlotItemHandler` (the name is the same as the one in the root `Slot`, but the class has access to it as it's protected and we're accessing across the same package)