### PR TITLE
Fix index in `ItemHandlerCopySlot#setStackCopy`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/ItemHandlerCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemHandlerCopySlot.java
@@ -38,7 +38,7 @@ public class ItemHandlerCopySlot extends StackCopySlot {
 
     @Override
     protected void setStackCopy(ItemStack stack) {
-        ((IItemHandlerModifiable) slotItemHandler.getItemHandler()).setStackInSlot(index, stack);
+        ((IItemHandlerModifiable) slotItemHandler.getItemHandler()).setStackInSlot(slotItemHandler.index, stack);
     }
 
     @Override

--- a/tests/src/generated/resources/data/neotests_reloadable_reg_data_maps/data_maps/loot_table/effect_grant.json
+++ b/tests/src/generated/resources/data/neotests_reloadable_reg_data_maps/data_maps/loot_table/effect_grant.json
@@ -3,10 +3,6 @@
     "minecraft:blocks/copper_block": {
       "duration": 100,
       "id": "minecraft:nausea",
-      "neoforge:cures": [
-        "milk",
-        "protected_by_totem"
-      ],
       "show_icon": true
     }
   }

--- a/tests/src/generated/resources/data/neotests_reloadable_reg_data_maps/data_maps/loot_table/effect_grant.json
+++ b/tests/src/generated/resources/data/neotests_reloadable_reg_data_maps/data_maps/loot_table/effect_grant.json
@@ -4,8 +4,8 @@
       "duration": 100,
       "id": "minecraft:nausea",
       "neoforge:cures": [
-        "protected_by_totem",
-        "milk"
+        "milk",
+        "protected_by_totem"
       ],
       "show_icon": true
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -317,8 +317,10 @@ public class DataMapTests {
         reg.addProvider(event -> new DataMapProvider(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
             @Override
             protected void gather() {
+                var effect = new MobEffectInstance(MobEffects.CONFUSION, 100);
+                effect.getCures().clear(); // Cures use a hash set (not linked) meaning that their serialization is not deterministic
                 builder(effectGrant)
-                        .add(Blocks.COPPER_BLOCK.getLootTable(), new MobEffectInstance(MobEffects.CONFUSION, 100), false);
+                        .add(Blocks.COPPER_BLOCK.getLootTable(), effect, false);
             }
         });
 


### PR DESCRIPTION
1.21.1 backport of #1804

The current code is using `index`, which is `this.index`, which ends up as `Slot#index`. That is not correct as that index is the index of the slot inside the menu, not inside the item handler. The correct index to use is that of `SlotItemHandler` (the name is the same as the one in the root `Slot`, but the class has access to it as it's protected and we're accessing across the same package)