### PR TITLE
[1.21.1] Remove getters and setters from Level.java.patch

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientLevel.java.patch
@@ -109,7 +109,7 @@
              this.difficulty = p_104852_;
          }
  
-@@ -1069,14 +_,75 @@
+@@ -1069,14 +_,74 @@
              if (p_171712_ instanceof AbstractClientPlayer) {
                  ClientLevel.this.players.add((AbstractClientPlayer)p_171712_);
              }
@@ -163,25 +163,24 @@
 +
 +    // Neo: Variable day time code
 +
-+    private float dayTimeFraction = 0.0f;
-+    private float dayTimePerTick = -1.0f;
++    public float dayTimeFraction = 0.0f;
++    public float dayTimePerTick = -1.0f;
 +
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    public void setDayTimeFraction(float dayTimeFraction) {
-+        this.dayTimeFraction = dayTimeFraction;
-+    }
-+
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    public float getDayTimeFraction() {
-+        return dayTimeFraction;
-+    }
-+
++    /**
++     * @deprecated Read from the field instead
++     */
++    @Deprecated(forRemoval = true, since = "1.21.1")
 +    public float getDayTimePerTick() {
 +        return dayTimePerTick;
 +    }
 +
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    public void setDayTimePerTick(float dayTimePerTick) {
-+        this.dayTimePerTick = dayTimePerTick;
++    protected long advanceDaytime() {
++        if (dayTimePerTick < 0) {
++            return 1L; // avoid doing math (and rounding errors) if no speed has been set
++        }
++        float dayTimeStep = dayTimeFraction + dayTimePerTick;
++        long result = (long)dayTimeStep;
++        dayTimeFraction = dayTimeStep - result;
++        return result;
      }
  }

--- a/patches/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/net/minecraft/server/level/ServerLevel.java.patch
@@ -214,7 +214,7 @@
                      ServerLevel.this.dragonParts.put(enderdragonpart.getId(), enderdragonpart);
                  }
              }
-@@ -1733,24 +_,106 @@
+@@ -1733,24 +_,115 @@
                  if (ServerLevel.this.isUpdatingNavigations) {
                      String s = "onTrackingStart called during navigation iteration";
                      Util.logAndPauseIfInIde(
@@ -243,7 +243,7 @@
          public void onSectionChange(Entity p_215086_) {
              p_215086_.updateDynamicGameEventListener(DynamicGameEventListener::move);
          }
-     }
++    }
 +
 +    @Override
 +    public java.util.Collection<net.neoforged.neoforge.entity.PartEntity<?>> getPartEntities() {
@@ -295,6 +295,7 @@
 +     * Returns the current ratio between game ticks and clock ticks. If this value is negative, no
 +     * speed has been set and those two are coupled 1:1 (i.e. vanilla mode).
 +     */
++    @Override
 +    public float getDayTimePerTick() {
 +        return serverLevelData.getDayTimePerTick();
 +    }
@@ -315,7 +316,6 @@
 +     * While this still technically works when vanilla clients are connected, those will desync and
 +     * experience a time jump once per second.
 +     */
-+    @Override
 +    public void setDayTimePerTick(float dayTimePerTick) {
 +        if (dayTimePerTick != getDayTimePerTick() && dayTimePerTick != 0f) {
 +            serverLevelData.setDayTimePerTick(dayTimePerTick);
@@ -323,4 +323,13 @@
 +        }
 +    }
 +
++    protected long advanceDaytime() {
++        if (serverLevelData.getDayTimePerTick() < 0) {
++            return 1L; // avoid doing math (and rounding errors) if no speed has been set
++        }
++        float dayTimeStep = serverLevelData.getDayTimeFraction() + serverLevelData.getDayTimePerTick();
++        long result = (long)dayTimeStep;
++        serverLevelData.setDayTimeFraction(dayTimeStep - result);
++        return result;
+     }
  }

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -48,13 +48,21 @@
                  this.stopSleepInBed(false, true);
              }
          } else if (this.sleepCounter > 0) {
-@@ -291,7 +_,11 @@
+@@ -291,7 +_,19 @@
              }
  
              if (!this.isSleeping()) {
 -                this.awardStat(Stats.TIME_SINCE_REST);
++                float dayTimeFraction;
++
++                if (level().isClientSide) {
++                    dayTimeFraction = ((net.minecraft.client.multiplayer.ClientLevel) level()).dayTimeFraction;
++                } else {
++                    dayTimeFraction = ((ServerLevel) level()).getDayTimeFraction();
++                }
++
 +                // Neo: Advance TIME_SINCE_REST if (a) vanilla daytime handling in effect, or (b) days are shorter, or (c) dayTime has ticked, or (d) dayTime advances are off and we need to ignore day length
-+                if (level().getDayTimeFraction() < 0 || level().getDayTimeFraction() >= 1 || lastDayTimeTick != level().getDayTime() || !level().getGameRules().getRule(GameRules.RULE_DAYLIGHT).get()) {
++                if (dayTimeFraction < 0 || dayTimeFraction >= 1 || lastDayTimeTick != level().getDayTime() || !level().getGameRules().getRule(GameRules.RULE_DAYLIGHT).get()) {
 +                    lastDayTimeTick = level().getDayTime();
 +                    this.awardStat(Stats.TIME_SINCE_REST);
 +                }

--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -238,42 +238,16 @@
      public final boolean isDebug() {
          return this.isDebug;
      }
-@@ -1118,5 +_,38 @@
-         public String getSerializedName() {
+@@ -1119,4 +_,12 @@
              return this.id;
          }
-+    }
+     }
 +
 +    // Neo: Variable day time code
-+
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    public abstract void setDayTimeFraction(float dayTimeFraction);
-+
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    public abstract float getDayTimeFraction();
 +
 +    /**
 +     * Returns the current ratio between game ticks and clock ticks. If this value is negative, no
 +     * speed has been set and those two are coupled 1:1 (i.e. vanilla mode).
 +     */
 +    public abstract float getDayTimePerTick();
-+
-+    /**
-+     * DO NOT CALL.
-+     * <p>
-+     * Use {@link net.minecraft.server.level.ServerLevel#setDayTimePerTick(float)} instead.
-+     */
-+    public abstract void setDayTimePerTick(float dayTimePerTick);
-+
-+    // advances the fractional daytime, returns the integer part of it
-+    @org.jetbrains.annotations.ApiStatus.Internal
-+    protected long advanceDaytime() {
-+        if (getDayTimePerTick() < 0) {
-+            return 1L; // avoid doing math (and rounding errors) if no speed has been set
-+        }
-+        float dayTimeStep = getDayTimeFraction() + getDayTimePerTick();
-+        long result = (long)dayTimeStep;
-+        setDayTimeFraction(dayTimeStep - result);
-+        return result;
-     }
  }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -155,7 +155,7 @@ public final class ClientPayloadHandler {
         level.setGameTime(payload.gameTime());
         level.setDayTime(payload.dayTime());
         level.getGameRules().getRule(GameRules.RULE_DAYLIGHT).set(payload.gameRule(), null);
-        level.setDayTimeFraction(payload.dayTimeFraction());
-        level.setDayTimePerTick(payload.dayTimePerTick());
+        level.dayTimeFraction = payload.dayTimeFraction();
+        level.dayTimePerTick = payload.dayTimePerTick();
     }
 }


### PR DESCRIPTION
- These getters and setters are not needed, and just make extending Level in a multiloader mod annoying.