### PR TITLE
Properly resolve the parent in composite models

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/UnbakedCompositeModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/UnbakedCompositeModel.java
@@ -100,6 +100,7 @@ public class UnbakedCompositeModel extends AbstractUnbakedModel {
 
     @Override
     public void resolveDependencies(Resolver resolver) {
+        super.resolveDependencies(resolver);
         for (Either<ResourceLocation, UnbakedModel> child : children.values()) {
             child.ifLeft(resolver::resolve).ifRight(model -> model.resolveDependencies(resolver));
         }


### PR DESCRIPTION
It looks like there's a small bug where composite models don't resolve their parents properly, leading to missing texture references when baking. This change corrects that.

Before:
![image](https://github.com/user-attachments/assets/4ea19f0a-94ff-4ed1-b040-b321576c1e81)

After:
![image](https://github.com/user-attachments/assets/09b11885-cf01-4a32-8793-e111414e6bf0)
