### PR TITLE
Guard against item BakedModels using incorrect RenderTypes

### DIFF
--- a/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
@@ -9,15 +9,14 @@
          }
      }
  
-@@ -116,6 +_,15 @@
+@@ -116,6 +_,14 @@
          }
  
          public void setupBlockModel(BakedModel p_386829_, RenderType p_387529_) {
-+            // Neo: Guard against models using the wrong render type, in particular chunk render types.
-+            if (p_387529_.format != com.mojang.blaze3d.vertex.DefaultVertexFormat.NEW_ENTITY) {
++            // Neo: Guard against models using chunk render types.
++            if (RenderType.chunkBufferLayers().contains(p_387529_)) {
 +                throw new IllegalArgumentException("""
 +                        Attempting to render an item BakedModel with an invalid RenderType: %s.
-+                        Only the NEW_ENTITY vertex format is supported.
 +                        Chunk render types are not supported, and the equivalent render types from the Sheets class should be used.
 +                        Model: %s.
 +                        """.formatted(p_387529_, p_386829_));

--- a/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
@@ -20,7 +20,7 @@
 +                        Only the NEW_ENTITY vertex format is supported.
 +                        Chunk render types are not supported, and the equivalent render types from the Sheets class should be used.
 +                        Model: %s.
-+                        """.formatted(p_386829_, p_386829_));
++                        """.formatted(p_387529_, p_386829_));
 +            }
              this.model = p_386829_;
              this.renderType = p_387529_;

--- a/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
@@ -9,6 +9,22 @@
          }
      }
  
+@@ -116,6 +_,15 @@
+         }
+ 
+         public void setupBlockModel(BakedModel p_386829_, RenderType p_387529_) {
++            // Neo: Guard against models using the wrong render type, in particular chunk render types.
++            if (p_387529_.format != com.mojang.blaze3d.vertex.DefaultVertexFormat.NEW_ENTITY) {
++                throw new IllegalArgumentException("""
++                        Attempting to render an item BakedModel with an invalid RenderType: %s.
++                        Only the NEW_ENTITY vertex format is supported.
++                        Chunk render types are not supported, and the equivalent render types from the Sheets class should be used.
++                        Model: %s.
++                        """.formatted(p_386829_, p_386829_));
++            }
+             this.model = p_386829_;
+             this.renderType = p_387529_;
+         }
 @@ -149,6 +_,9 @@
  
          void render(PoseStack p_387607_, MultiBufferSource p_386763_, int p_387589_, int p_388775_) {

--- a/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemStackRenderState.java.patch
@@ -14,7 +14,7 @@
  
          public void setupBlockModel(BakedModel p_386829_, RenderType p_387529_) {
 +            // Neo: Guard against models using chunk render types.
-+            if (RenderType.chunkBufferLayers().contains(p_387529_)) {
++            if (p_387529_.getChunkLayerId() != -1) {
 +                throw new IllegalArgumentException("""
 +                        Attempting to render an item BakedModel with an invalid RenderType: %s.
 +                        Chunk render types are not supported, and the equivalent render types from the Sheets class should be used.


### PR DESCRIPTION
Should we backport this to 1.21.1? This might break some models, but using the wrong RenderType can lead to subtle correctness or performance issues.