### PR TITLE
Add a display name extension to `KeyMapping`

### DIFF
--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java
 +++ b/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java
+@@ -45,7 +_,7 @@
+                 this.addEntry(new KeyBindsList.CategoryEntry(Component.translatable(s1)));
+             }
+ 
+-            Component component = Component.translatable(keymapping.getName());
++            Component component = keymapping.getDisplayName();
+             int i = p_346132_.font.width(component);
+             if (i > this.maxNameWidth) {
+                 this.maxNameWidth = i;
 @@ -156,6 +_,7 @@
                  )
                  .build();
@@ -8,7 +17,7 @@
                  p_345998_.setKey(p_345998_.getDefaultKey());
                  KeyBindsList.this.resetMappingAndUpdateButtons();
              }).bounds(0, 0, 50, 20).createNarration(p_344899_ -> Component.translatable("narrator.controls.reset", p_345196_)).build();
-@@ -208,7 +_,7 @@
+@@ -208,13 +_,13 @@
              MutableComponent mutablecomponent = Component.empty();
              if (!this.key.isUnbound()) {
                  for (KeyMapping keymapping : KeyBindsList.this.minecraft.options.keyMappings) {
@@ -17,3 +26,10 @@
                          if (this.hasCollision) {
                              mutablecomponent.append(", ");
                          }
+ 
+                         this.hasCollision = true;
+-                        mutablecomponent.append(Component.translatable(keymapping.getName()));
++                        mutablecomponent.append(keymapping.getDisplayName());
+                     }
+                 }
+             }

--- a/src/main/java/net/neoforged/neoforge/client/extensions/IKeyMappingExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/IKeyMappingExtension.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.client.extensions;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.client.settings.IKeyConflictContext;
 import net.neoforged.neoforge.client.settings.KeyModifier;
 
@@ -55,5 +56,13 @@ public interface IKeyMappingExtension {
             }
         }
         return false;
+    }
+
+    /**
+     * {@return the display name of this key mapping}
+     * Defaults to a {@linkplain Component#translatable(String) translatable component} of the {@link KeyMapping#getName() name}.
+     */
+    default Component getDisplayName() {
+        return Component.translatable(self().getName());
     }
 }


### PR DESCRIPTION
This PR adds a `getDisplayName` method to `IKeyMappingExtension`, allowing custom key mapping implementations to show users a name in the keybindings GUI that is not a translatable component of their ID.  
This method can be used, for instance, by generated key mappings that are not statically known at build-time and therefore have no translations for their names. I am working on a mod which allows users to create their own key bundles on-demand to disambiguate keymappings and I need to display the name they gave to the bundle in the bindings UI instead of an untranslated translation key.