### PR TITLE
Fix custom bows being unusable by monsters extending `AbstractSkeleton`

### DIFF
--- a/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/net/minecraft/world/entity/monster/AbstractSkeleton.java.patch
@@ -1,14 +1,16 @@
 --- a/net/minecraft/world/entity/monster/AbstractSkeleton.java
 +++ b/net/minecraft/world/entity/monster/AbstractSkeleton.java
-@@ -163,7 +_,7 @@
+@@ -163,8 +_,8 @@
          if (this.level() != null && !this.level().isClientSide) {
              this.goalSelector.removeGoal(this.meleeGoal);
              this.goalSelector.removeGoal(this.bowGoal);
 -            ItemStack itemstack = this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, Items.BOW));
+-            if (itemstack.is(Items.BOW)) {
 +            ItemStack itemstack = this.getItemInHand(ProjectileUtil.getWeaponHoldingHand(this, item -> item instanceof net.minecraft.world.item.BowItem));
-             if (itemstack.is(Items.BOW)) {
++            if (itemstack.getItem() instanceof net.minecraft.world.item.BowItem) {
                  int i = this.getHardAttackInterval();
                  if (this.level().getDifficulty() != Difficulty.HARD) {
+                     i = this.getAttackInterval();
 @@ -188,9 +_,11 @@
  
      @Override


### PR DESCRIPTION
Looking at the history, this seems to have been broken since sometime during 1.16 because the vanilla line was still only checking for the normal Bow item. Fixes it by using the same instanceof check as the patched line above it.

[MCForge 1.14](<https://github.com/MinecraftForge/MinecraftForge/blob/a7df63e1a102363250e0d278b44442fa0f3eb8ee/patches/minecraft/net/minecraft/entity/monster/AbstractSkeletonEntity.java.patch#L8>)
1.16 PR which reimplemented it, but missing the patch line: [MCForge #7845](https://github.com/MinecraftForge/MinecraftForge/pull/7845/files#diff-202d0eeb9dc1c27a521d1acd4ad93029170160c403e99dcab5b6eba7114e7c61R9)