### PR TITLE
Patch methods in `EquipmentModelProvider` to be more mod compatible

### DIFF
--- a/patches/net/minecraft/client/data/models/EquipmentAssetProvider.java.patch
+++ b/patches/net/minecraft/client/data/models/EquipmentAssetProvider.java.patch
@@ -11,6 +11,24 @@
      private static void bootstrap(BiConsumer<ResourceKey<EquipmentAsset>, EquipmentClientInfo> p_387865_) {
          p_387865_.accept(
              EquipmentAssets.LEATHER,
+@@ -91,14 +_,14 @@
+     }
+ 
+     public static EquipmentClientInfo onlyHumanoid(String p_388505_) {
+-        return EquipmentClientInfo.builder().addHumanoidLayers(ResourceLocation.withDefaultNamespace(p_388505_)).build();
++        return EquipmentClientInfo.builder().addHumanoidLayers(ResourceLocation.parse(p_388505_)).build();
+     }
+ 
+     public static EquipmentClientInfo humanoidAndHorse(String p_386720_) {
+         return EquipmentClientInfo.builder()
+-            .addHumanoidLayers(ResourceLocation.withDefaultNamespace(p_386720_))
++            .addHumanoidLayers(ResourceLocation.parse(p_386720_))
+             .addLayers(
+-                EquipmentClientInfo.LayerType.HORSE_BODY, EquipmentClientInfo.Layer.leatherDyeable(ResourceLocation.withDefaultNamespace(p_386720_), false)
++                EquipmentClientInfo.LayerType.HORSE_BODY, EquipmentClientInfo.Layer.leatherDyeable(ResourceLocation.parse(p_386720_), false)
+             )
+             .build();
+     }
 @@ -106,7 +_,7 @@
      @Override
      public CompletableFuture<?> run(CachedOutput p_387304_) {


### PR DESCRIPTION
This PR patches 2 methods in `EquipmentModelProvider` to be more mod compatible, this is done by swapping out `ResourceLocation.withDefaultNamespace` with `ResourceLocation.parse`.

Fixes #1842 