### PR TITLE
[1.21.4] Fix `TagsCommand` tag cast error

### DIFF
--- a/src/main/java/net/neoforged/neoforge/server/command/TagsCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TagsCommand.java
@@ -122,7 +122,7 @@ class TagsCommand {
         final TagKey<?> tagKey = TagKey.create(cast(registryKey), tagLocation);
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        Optional<HolderSet.Named<?>> optional = registry.get(TagsCommand.<ResourceKey>cast(tagKey));
+        Optional<HolderSet.Named<?>> optional = registry.get(TagsCommand.<TagKey>cast(tagKey));
         final HolderSet.Named<?> tag = optional.orElseThrow(() -> UNKNOWN_TAG.create(tagKey.location(), registryKey.location()));
 
         ctx.getSource().sendSuccess(() -> createMessage(


### PR DESCRIPTION
Code was incorrectly adjusted to a `<ResourceKey>cast` rather than a `<TagKey>cast` in [commit e18c200](https://github.com/neoforged/NeoForge/commit/e18c20024a7f81d3ab7a4f625d6bcfa13c217767#diff-9a0aeabd160061540cccd0b73a4cf5437ae998b5863fe3ed697d8a83b92865acR121). This simply corrects it to the right type for the right `get` method.

Closes #1850