### PR TITLE
Add EntityType DeferredRegister

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -25,6 +25,9 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -168,6 +171,18 @@ public class DeferredRegister<T> {
      */
     public static DataComponents createDataComponents(ResourceKey<Registry<DataComponentType<?>>> registryKey, String modid) {
         return new DataComponents(registryKey, modid);
+    }
+
+    /**
+     * Factory for a specialized DeferredRegister for {@link EntityType EntityTypes}.
+     *
+     * @param modid The namespace for all objects registered to this DeferredRegister
+     * @see #create(Registry, String)
+     * @see #create(ResourceKey, String)
+     * @see #create(ResourceLocation, String)
+     */
+    public static EntityTypes createEntityTypes(String modid) {
+        return new EntityTypes(modid);
     }
 
     private final ResourceKey<? extends Registry<T>> registryKey;
@@ -645,6 +660,29 @@ public class DeferredRegister<T> {
          */
         public <D> DeferredHolder<DataComponentType<?>, DataComponentType<D>> registerComponentType(String name, UnaryOperator<DataComponentType.Builder<D>> builder) {
             return this.register(name, () -> builder.apply(DataComponentType.builder()).build());
+        }
+    }
+
+    /**
+     * Specialized DeferredRegister for {@link EntityType EntityTypes}.
+     */
+    public static class EntityTypes extends DeferredRegister<EntityType<?>> {
+        protected EntityTypes(String namespace) {
+            super(Registries.ENTITY_TYPE, namespace);
+        }
+
+        /**
+         * Convenience method that constructs a builder for use in the operator. Use this to avoid inference issues.
+         *
+         * @param name     The name for this entity type. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param factory  The factory used to typically construct the entity when using an existing helper from the type.
+         * @param category The category of the entity, typically {@link MobCategory#MISC} for non-living entities, or one of the others for living entities.
+         * @param builder  The unary operator, which is passed a new builder for user operators, then builds it upon registration.
+         * @return A {@link DeferredHolder} which reflects the data that will be registered.
+         * @param <E> the type of the entity
+         */
+        public <E extends Entity> DeferredHolder<EntityType<?>, EntityType<E>> registerType(String name, EntityType.EntityFactory<E> factory, MobCategory category, UnaryOperator<EntityType.Builder<E>> builder) {
+            return this.register(name, key -> builder.apply(EntityType.Builder.of(factory, category)).build(ResourceKey.create(Registries.ENTITY_TYPE, key)));
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -181,8 +181,8 @@ public class DeferredRegister<T> {
      * @see #create(ResourceKey, String)
      * @see #create(ResourceLocation, String)
      */
-    public static EntityTypes createEntityTypes(String modid) {
-        return new EntityTypes(modid);
+    public static Entities createEntities(String modid) {
+        return new Entities(modid);
     }
 
     private final ResourceKey<? extends Registry<T>> registryKey;
@@ -666,9 +666,22 @@ public class DeferredRegister<T> {
     /**
      * Specialized DeferredRegister for {@link EntityType EntityTypes}.
      */
-    public static class EntityTypes extends DeferredRegister<EntityType<?>> {
-        protected EntityTypes(String namespace) {
+    public static class Entities extends DeferredRegister<EntityType<?>> {
+        protected Entities(String namespace) {
             super(Registries.ENTITY_TYPE, namespace);
+        }
+
+        /**
+         * Convenience method that constructs a builder. Use this to avoid inference issues.
+         *
+         * @param name     The name for this entity type. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param factory  The factory used to typically construct the entity when using an existing helper from the type.
+         * @param category The category of the entity, typically {@link MobCategory#MISC} for non-living entities, or one of the others for living entities.
+         * @return A {@link DeferredHolder} which reflects the data that will be registered.
+         * @param <E> the type of the entity
+         */
+        public <E extends Entity> DeferredHolder<EntityType<?>, EntityType<E>> registerEntityType(String name, EntityType.EntityFactory<E> factory, MobCategory category) {
+            return this.registerEntityType(name, factory, category, UnaryOperator.identity());
         }
 
         /**
@@ -681,7 +694,7 @@ public class DeferredRegister<T> {
          * @return A {@link DeferredHolder} which reflects the data that will be registered.
          * @param <E> the type of the entity
          */
-        public <E extends Entity> DeferredHolder<EntityType<?>, EntityType<E>> registerType(String name, EntityType.EntityFactory<E> factory, MobCategory category, UnaryOperator<EntityType.Builder<E>> builder) {
+        public <E extends Entity> DeferredHolder<EntityType<?>, EntityType<E>> registerEntityType(String name, EntityType.EntityFactory<E> factory, MobCategory category, UnaryOperator<EntityType.Builder<E>> builder) {
             return this.register(name, key -> builder.apply(EntityType.Builder.of(factory, category)).build(ResourceKey.create(Registries.ENTITY_TYPE, key)));
         }
     }

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredEntityTypes.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredEntityTypes.java
@@ -5,20 +5,20 @@
 
 package net.neoforged.testframework.registration;
 
-import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
-public class DeferredEntityTypes extends DeferredRegister<EntityType<?>> {
+public class DeferredEntityTypes extends DeferredRegister.EntityTypes {
     private final RegistrationHelper helper;
 
     public DeferredEntityTypes(String namespace, RegistrationHelper helper) {
-        super(Registries.ENTITY_TYPE, namespace);
+        super(namespace);
         this.helper = helper;
     }
 
@@ -27,7 +27,8 @@ public class DeferredEntityTypes extends DeferredRegister<EntityType<?>> {
         return new DeferredEntityTypeBuilder(ResourceKey.create(registryKey, key), helper);
     }
 
-    public <E extends Entity> DeferredEntityTypeBuilder<E, EntityType<E>> registerType(String name, Supplier<EntityType.Builder<E>> sup) {
-        return (DeferredEntityTypeBuilder<E, EntityType<E>>) super.register(name, rl -> sup.get().build(ResourceKey.create(getRegistryKey(), rl)));
+    @Override
+    public <E extends Entity> DeferredEntityTypeBuilder<E, EntityType<E>> registerType(String name, EntityType.EntityFactory<E> factory, MobCategory category, UnaryOperator<EntityType.Builder<E>> builder) {
+        return (DeferredEntityTypeBuilder<E, EntityType<E>>) super.registerType(name, factory, category, builder);
     }
 }

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredEntityTypes.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredEntityTypes.java
@@ -14,7 +14,7 @@ import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
-public class DeferredEntityTypes extends DeferredRegister.EntityTypes {
+public class DeferredEntityTypes extends DeferredRegister.Entities {
     private final RegistrationHelper helper;
 
     public DeferredEntityTypes(String namespace, RegistrationHelper helper) {
@@ -28,7 +28,7 @@ public class DeferredEntityTypes extends DeferredRegister.EntityTypes {
     }
 
     @Override
-    public <E extends Entity> DeferredEntityTypeBuilder<E, EntityType<E>> registerType(String name, EntityType.EntityFactory<E> factory, MobCategory category, UnaryOperator<EntityType.Builder<E>> builder) {
-        return (DeferredEntityTypeBuilder<E, EntityType<E>>) super.registerType(name, factory, category, builder);
+    public <E extends Entity> DeferredEntityTypeBuilder<E, EntityType<E>> registerEntityType(String name, EntityType.EntityFactory<E> factory, MobCategory category, UnaryOperator<EntityType.Builder<E>> builder) {
+        return (DeferredEntityTypeBuilder<E, EntityType<E>>) super.registerEntityType(name, factory, category, builder);
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityDataSerializerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityDataSerializerTest.java
@@ -54,7 +54,7 @@ public class EntityDataSerializerTest {
     @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if custom EntityDataSerializers are properly handled")
     static void customEntityDataSerializer(final DynamicTest test, final RegistrationHelper reg) {
-        var testEntity = reg.entityTypes().registerType("serializer_test_entity", TestEntity::new, MobCategory.CREATURE, builder -> builder.sized(1, 1))
+        var testEntity = reg.entityTypes().registerEntityType("serializer_test_entity", TestEntity::new, MobCategory.CREATURE, builder -> builder.sized(1, 1))
                 .withRenderer(() -> TestEntityRenderer::new);
 
         test.onGameTest(helper -> {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityDataSerializerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityDataSerializerTest.java
@@ -54,8 +54,8 @@ public class EntityDataSerializerTest {
     @EmptyTemplate(floor = true)
     @TestHolder(description = "Tests if custom EntityDataSerializers are properly handled")
     static void customEntityDataSerializer(final DynamicTest test, final RegistrationHelper reg) {
-        var testEntity = reg.entityTypes().registerType("serializer_test_entity", () -> EntityType.Builder.of(TestEntity::new, MobCategory.CREATURE)
-                .sized(1, 1)).withRenderer(() -> TestEntityRenderer::new);
+        var testEntity = reg.entityTypes().registerType("serializer_test_entity", TestEntity::new, MobCategory.CREATURE, builder -> builder.sized(1, 1))
+                .withRenderer(() -> TestEntityRenderer::new);
 
         test.onGameTest(helper -> {
             var entity = helper.spawn(testEntity.get(), 1, 2, 1);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
@@ -41,12 +41,12 @@ public class EntityTests {
     @EmptyTemplate
     @TestHolder(description = "Tests if custom fence gates without wood types work, allowing for the use of the vanilla block for non-wooden gates")
     static void customSpawnLogic(final DynamicTest test, final RegistrationHelper reg) {
-        final var usingForgeAdvancedSpawn = reg.entityTypes().registerType("complex_spawn", () -> EntityType.Builder.of(CustomComplexSpawnEntity::new, MobCategory.AMBIENT)
-                .sized(1, 1)).withLang("Custom complex spawn egg").withRenderer(() -> NoopRenderer::new);
-        final var usingCustomPayloadsSpawn = reg.entityTypes().registerType("adapted_spawn", () -> EntityType.Builder.of(AdaptedSpawnEntity::new, MobCategory.AMBIENT)
-                .sized(1, 1)).withLang("Adapted complex spawn egg").withRenderer(() -> NoopRenderer::new);
-        final var simpleSpawn = reg.entityTypes().registerType("simple_spawn", () -> EntityType.Builder.of(SimpleEntity::new, MobCategory.AMBIENT)
-                .sized(1, 1)).withLang("Simple spawn egg").withRenderer(() -> NoopRenderer::new);
+        final var usingForgeAdvancedSpawn = reg.entityTypes().registerType("complex_spawn", CustomComplexSpawnEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
+                .withLang("Custom complex spawn egg").withRenderer(() -> NoopRenderer::new);
+        final var usingCustomPayloadsSpawn = reg.entityTypes().registerType("adapted_spawn", AdaptedSpawnEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
+                .withLang("Adapted complex spawn egg").withRenderer(() -> NoopRenderer::new);
+        final var simpleSpawn = reg.entityTypes().registerType("simple_spawn", SimpleEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
+                .withLang("Simple spawn egg").withRenderer(() -> NoopRenderer::new);
 
         reg.eventListeners().accept((Consumer<RegisterPayloadHandlersEvent>) event -> event.registrar("1")
                 .playToClient(EntityTests.CustomSyncPayload.TYPE, CustomSyncPayload.STREAM_CODEC, (payload, context) -> {}));

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/EntityTests.java
@@ -41,11 +41,11 @@ public class EntityTests {
     @EmptyTemplate
     @TestHolder(description = "Tests if custom fence gates without wood types work, allowing for the use of the vanilla block for non-wooden gates")
     static void customSpawnLogic(final DynamicTest test, final RegistrationHelper reg) {
-        final var usingForgeAdvancedSpawn = reg.entityTypes().registerType("complex_spawn", CustomComplexSpawnEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
+        final var usingForgeAdvancedSpawn = reg.entityTypes().registerEntityType("complex_spawn", CustomComplexSpawnEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
                 .withLang("Custom complex spawn egg").withRenderer(() -> NoopRenderer::new);
-        final var usingCustomPayloadsSpawn = reg.entityTypes().registerType("adapted_spawn", AdaptedSpawnEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
+        final var usingCustomPayloadsSpawn = reg.entityTypes().registerEntityType("adapted_spawn", AdaptedSpawnEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
                 .withLang("Adapted complex spawn egg").withRenderer(() -> NoopRenderer::new);
-        final var simpleSpawn = reg.entityTypes().registerType("simple_spawn", SimpleEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
+        final var simpleSpawn = reg.entityTypes().registerEntityType("simple_spawn", SimpleEntity::new, MobCategory.AMBIENT, builder -> builder.sized(1, 1))
                 .withLang("Simple spawn egg").withRenderer(() -> NoopRenderer::new);
 
         reg.eventListeners().accept((Consumer<RegisterPayloadHandlersEvent>) event -> event.registrar("1")

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.debug.entity.vehicle;
 
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.vehicle.Boat;
@@ -13,7 +14,6 @@ import net.minecraft.world.entity.vehicle.ChestBoat;
 import net.minecraft.world.entity.vehicle.ChestRaft;
 import net.minecraft.world.entity.vehicle.Raft;
 import net.minecraft.world.item.BoatItem;
-import net.minecraft.world.item.Item;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.Test;
 import net.neoforged.testframework.annotation.ForEachTest;
@@ -32,10 +32,10 @@ public class CustomBoatTest {
     @EmptyTemplate
     @TestHolder(description = "Tests that custom boat types work")
     static void customBoatType(final DynamicTest test, final RegistrationHelper reg) {
-        Supplier<EntityType<Boat>> paperBoat = reg.entityTypes().registerType("paper_boat", () -> EntityType.Builder.<Boat>of((type, level) -> new Boat(type, level, (Supplier<Item>) () -> paperBoatItem.get()), MobCategory.MISC));
-        Supplier<EntityType<ChestBoat>> paperChestBoat = reg.entityTypes().registerType("paper_chest_boat", () -> EntityType.Builder.<ChestBoat>of((type, level) -> new ChestBoat(type, level, (Supplier<Item>) () -> paperChestBoatItem.get()), MobCategory.MISC));
-        Supplier<EntityType<Raft>> paperRaft = reg.entityTypes().registerType("paper_raft", () -> EntityType.Builder.<Raft>of((type, level) -> new Raft(type, level, (Supplier<Item>) () -> paperRaftItem.get()), MobCategory.MISC));
-        Supplier<EntityType<ChestRaft>> paperChestRaft = reg.entityTypes().registerType("paper_chest_raft", () -> EntityType.Builder.<ChestRaft>of((type, level) -> new ChestRaft(type, level, (Supplier<Item>) () -> paperChestRaftItem.get()), MobCategory.MISC));
+        Supplier<EntityType<Boat>> paperBoat = reg.entityTypes().registerType("paper_boat", (type, level) -> new Boat(type, level, () -> paperBoatItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<ChestBoat>> paperChestBoat = reg.entityTypes().registerType("paper_chest_boat", (type, level) -> new ChestBoat(type, level, () -> paperChestBoatItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<Raft>> paperRaft = reg.entityTypes().registerType("paper_raft", (type, level) -> new Raft(type, level, () -> paperRaftItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<ChestRaft>> paperChestRaft = reg.entityTypes().registerType("paper_chest_raft", (type, level) -> new ChestRaft(type, level, () -> paperChestRaftItem.get()), MobCategory.MISC, UnaryOperator.identity());
 
         paperBoatItem = reg.items().registerItem("paper_boat", props -> new BoatItem(paperBoat.get(), props))
                 .withLang("Paper Boat");

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/vehicle/CustomBoatTest.java
@@ -32,10 +32,10 @@ public class CustomBoatTest {
     @EmptyTemplate
     @TestHolder(description = "Tests that custom boat types work")
     static void customBoatType(final DynamicTest test, final RegistrationHelper reg) {
-        Supplier<EntityType<Boat>> paperBoat = reg.entityTypes().registerType("paper_boat", (type, level) -> new Boat(type, level, () -> paperBoatItem.get()), MobCategory.MISC, UnaryOperator.identity());
-        Supplier<EntityType<ChestBoat>> paperChestBoat = reg.entityTypes().registerType("paper_chest_boat", (type, level) -> new ChestBoat(type, level, () -> paperChestBoatItem.get()), MobCategory.MISC, UnaryOperator.identity());
-        Supplier<EntityType<Raft>> paperRaft = reg.entityTypes().registerType("paper_raft", (type, level) -> new Raft(type, level, () -> paperRaftItem.get()), MobCategory.MISC, UnaryOperator.identity());
-        Supplier<EntityType<ChestRaft>> paperChestRaft = reg.entityTypes().registerType("paper_chest_raft", (type, level) -> new ChestRaft(type, level, () -> paperChestRaftItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<Boat>> paperBoat = reg.entityTypes().registerEntityType("paper_boat", (type, level) -> new Boat(type, level, () -> paperBoatItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<ChestBoat>> paperChestBoat = reg.entityTypes().registerEntityType("paper_chest_boat", (type, level) -> new ChestBoat(type, level, () -> paperChestBoatItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<Raft>> paperRaft = reg.entityTypes().registerEntityType("paper_raft", (type, level) -> new Raft(type, level, () -> paperRaftItem.get()), MobCategory.MISC, UnaryOperator.identity());
+        Supplier<EntityType<ChestRaft>> paperChestRaft = reg.entityTypes().registerEntityType("paper_chest_raft", (type, level) -> new ChestRaft(type, level, () -> paperChestRaftItem.get()), MobCategory.MISC, UnaryOperator.identity());
 
         paperBoatItem = reg.items().registerItem("paper_boat", props -> new BoatItem(paperBoat.get(), props))
                 .withLang("Paper Boat");

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -120,7 +120,7 @@ public class ItemTests {
             "Tests if the forge spawn egg works"
     })
     static void forgeSpawnEggTest(final DynamicTest test, final RegistrationHelper reg) {
-        final var testEntity = reg.entityTypes().registerType("test_entity", Pig::new, MobCategory.CREATURE, builder -> builder.sized(1, 1))
+        final var testEntity = reg.entityTypes().registerEntityType("test_entity", Pig::new, MobCategory.CREATURE, builder -> builder.sized(1, 1))
                 .withAttributes(Pig::createAttributes)
                 .withRenderer(() -> PigRenderer::new)
                 .withLang("Test Pig spawn egg");

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -120,8 +120,7 @@ public class ItemTests {
             "Tests if the forge spawn egg works"
     })
     static void forgeSpawnEggTest(final DynamicTest test, final RegistrationHelper reg) {
-        final var testEntity = reg.entityTypes().registerType("test_entity", () -> EntityType.Builder.of(Pig::new, MobCategory.CREATURE)
-                .sized(1, 1))
+        final var testEntity = reg.entityTypes().registerType("test_entity", Pig::new, MobCategory.CREATURE, builder -> builder.sized(1, 1))
                 .withAttributes(Pig::createAttributes)
                 .withRenderer(() -> PigRenderer::new)
                 .withLang("Test Pig spawn egg");


### PR DESCRIPTION
Adds a `DeferredRegister` subclass for `EntityType`s to fix the potential generic inference issues when there are multiple constructors present and the entity factory is constructed within a lambda. This also auto resolves the builder by supplying the `ResourceKey` in the `build` method.

The following will now resolve correctly when using the `registerType` method:

```java
public class ExampleEntity extends Entity {

    public ExampleEntity(EntityType<? extends ExampleEntity> type, Level level) { /*...*/ }

    public ExampleEntity(/*...*/) { /*...*/ }

    // Other methods here
}

public static final DeferredRegister.EntityTypes REGISTRAR = DeferredRegister.createEntityTypes("examplemod");

// Can also be Supplier or Holder
public static final DeferredHolder<EntityType<?>, EntityType<ExampleEntity>> EXAMPLE_ENTITY =
    REGISTRAR.registerType("example_entity", ExampleEntity::new, MobCategory.MISC, builder -> builder);
```

Technically, `var` will still throw an exception as it will once again infer that the type of the entity is `Entity` if there is more than one constructor. This could be fixed by just having the `EntityType` in the constructor just take in a wildcard rather than be bounded, but that is not best practice, so I will be considering `var` a non-issue.