### PR TITLE
Implement BEFORE stages for extra control

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -54,9 +54,12 @@
                  } catch (Throwable throwable1) {
                      CrashReport crashreport1 = CrashReport.forThrowable(throwable1, "Rendering screen");
                      CrashReportCategory crashreportcategory1 = crashreport1.addCategory("Screen render details");
-@@ -689,6 +_,8 @@
+@@ -688,7 +_,11 @@
+         Matrix4f matrix4f2 = new Matrix4f().rotation(quaternionf);
          this.minecraft.levelRenderer.prepareCullFrustum(camera.getPosition(), matrix4f2, matrix4f1);
          this.minecraft.getMainRenderTarget().bindWrite(true);
++        profilerfiller.popPush("neoforge_render_first");
++        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.BEFORE_LEVEL, this.minecraft.levelRenderer, null, matrix4f1, matrix4f, this.minecraft.levelRenderer.getTicks(), camera, this.minecraft.levelRenderer.getFrustum());
          this.minecraft.levelRenderer.renderLevel(this.resourcePool, p_348589_, flag, camera, this, matrix4f2, matrix4f);
 +        profilerfiller.popPush("neoforge_render_last");
 +        net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_LEVEL, this.minecraft.levelRenderer, null, matrix4f1, matrix4f, this.minecraft.levelRenderer.getTicks(), camera, this.minecraft.levelRenderer.getFrustum());

--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -47,14 +47,20 @@
              this.renderSectionLayer(RenderType.cutout(), d0, d1, d2, p_362420_, p_361272_);
              if (this.level.effects().constantAmbientLight()) {
                  Lighting.setupNetherLevel();
-@@ -603,6 +_,7 @@
+@@ -601,10 +_,13 @@
+             MultiBufferSource.BufferSource multibuffersource$buffersource = this.renderBuffers.bufferSource();
+             MultiBufferSource.BufferSource multibuffersource$buffersource1 = this.renderBuffers.crumblingBufferSource();
              p_362234_.popPush("entities");
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.BEFORE_ENTITIES, this, posestack, p_362420_, p_361272_, this.ticks, p_363453_, p_366590_);
              this.renderEntities(posestack, multibuffersource$buffersource, p_363453_, p_360931_, this.visibleEntities);
              multibuffersource$buffersource.endLastBatch();
 +            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.AFTER_ENTITIES, this, posestack, p_362420_, p_361272_, this.ticks, p_363453_, p_366590_);
              this.checkPoseStack(posestack);
              p_362234_.popPush("blockentities");
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.BEFORE_BLOCK_ENTITIES, this, posestack, p_362420_, p_361272_, this.ticks, p_363453_, p_366590_);
              this.renderBlockEntities(posestack, multibuffersource$buffersource, multibuffersource$buffersource1, p_363453_, f);
+             multibuffersource$buffersource.endLastBatch();
+             this.checkPoseStack(posestack);
 @@ -619,6 +_,7 @@
              multibuffersource$buffersource.endBatch(Sheets.hangingSignSheet());
              multibuffersource$buffersource.endBatch(Sheets.chestSheet());
@@ -91,6 +97,14 @@
          FramePass framepass = p_363357_.addPass("particles");
          if (this.targets.particles != null) {
              this.targets.particles = framepass.readsAndWrites(this.targets.particles);
+@@ -671,6 +_,7 @@
+         ResourceHandle<RenderTarget> resourcehandle = this.targets.main;
+         ResourceHandle<RenderTarget> resourcehandle1 = this.targets.particles;
+         framepass.executes(() -> {
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.BEFORE_PARTICLES, this, null, modelViewMatrix, projectionMatrix, this.ticks, p_365299_, getFrustum());
+             RenderSystem.setShaderFog(p_362149_);
+             if (resourcehandle1 != null) {
+                 resourcehandle1.get().setClearColor(0.0F, 0.0F, 0.0F, 0.0F);
 @@ -678,7 +_,8 @@
                  resourcehandle1.get().copyDepthFrom(resourcehandle.get());
              }
@@ -122,7 +136,11 @@
          int i = this.minecraft.options.getEffectiveRenderDistance() * 16;
          float f = this.minecraft.gameRenderer.getDepthFar();
          FramePass framepass = p_364025_.addPass("weather");
-@@ -724,6 +_,7 @@
+@@ -721,9 +_,11 @@
+         }
+ 
+         framepass.executes(() -> {
++            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.BEFORE_PARTICLES, this, null, modelViewMatrix, projectionMatrix, this.ticks, camera, getFrustum());
              RenderSystem.setShaderFog(p_360974_);
              MultiBufferSource.BufferSource multibuffersource$buffersource = this.renderBuffers.bufferSource();
              this.weatherEffectRenderer.render(this.minecraft.level, multibuffersource$buffersource, this.ticks, p_362434_, p_360771_);
@@ -190,11 +208,19 @@
                      if (flag != p_361698_) {
                          return;
                      }
+@@ -984,6 +_,7 @@
+         ObjectListIterator<SectionRenderDispatcher.RenderSection> objectlistiterator = this.visibleSections
+             .listIterator(flag ? 0 : this.visibleSections.size());
+         p_294513_.setupRenderState();
++        net.neoforged.neoforge.client.ClientHooks.dispatchBeforeRenderStage(p_294513_, this, p_294782_, p_324517_, this.ticks, this.minecraft.gameRenderer.getMainCamera(), this.getFrustum());
+         CompiledShaderProgram compiledshaderprogram = RenderSystem.getShader();
+         if (compiledshaderprogram == null) {
+             p_294513_.clearRenderState();
 @@ -1019,6 +_,7 @@
              compiledshaderprogram.clear();
              VertexBuffer.unbind();
              zone.close();
-+            net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(p_294513_, this, p_294782_, p_324517_, this.ticks, this.minecraft.gameRenderer.getMainCamera(), this.getFrustum());
++            net.neoforged.neoforge.client.ClientHooks.dispatchAfterRenderStage(p_294513_, this, p_294782_, p_324517_, this.ticks, this.minecraft.gameRenderer.getMainCamera(), this.getFrustum());
              p_294513_.clearRenderState();
          }
      }
@@ -214,10 +240,11 @@
          FogType fogtype = p_362177_.getFluidInCamera();
          if (fogtype != FogType.POWDER_SNOW && fogtype != FogType.LAVA && !this.doesMobEffectBlockSky(p_362177_)) {
              DimensionSpecialEffects dimensionspecialeffects = this.level.effects();
-@@ -1068,6 +_,7 @@
+@@ -1068,6 +_,8 @@
                  FramePass framepass = p_362870_.addPass("sky");
                  this.targets.main = framepass.readsAndWrites(this.targets.main);
                  framepass.executes(() -> {
++                    net.neoforged.neoforge.client.ClientHooks.dispatchRenderStage(net.neoforged.neoforge.client.event.RenderLevelStageEvent.Stage.BEFORE_SKY, this, null, modelViewMatrix, projectionMatrix, this.ticks, p_362177_, getFrustum());
 +                    if (!level.effects().renderSky(level, ticks, p_363799_, modelViewMatrix, p_362177_, projectionMatrix, () -> RenderSystem.setShaderFog(p_364999_))) {
                      RenderSystem.setShaderFog(p_364999_);
                      if (dimensionspecialeffects$skytype == DimensionSpecialEffects.SkyType.END) {

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -281,8 +281,19 @@ public class ClientHooks {
         profiler.pop();
     }
 
+    @Deprecated(forRemoval = true, since = "21.4")
     public static void dispatchRenderStage(RenderType renderType, LevelRenderer levelRenderer, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, Camera camera, Frustum frustum) {
-        RenderLevelStageEvent.Stage stage = RenderLevelStageEvent.Stage.fromRenderType(renderType);
+        dispatchAfterRenderStage(renderType, levelRenderer, modelViewMatrix, projectionMatrix, renderTick, camera, frustum);
+    }
+
+    public static void dispatchBeforeRenderStage(RenderType renderType, LevelRenderer levelRenderer, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, Camera camera, Frustum frustum) {
+        RenderLevelStageEvent.Stage stage = RenderLevelStageEvent.Stage.stageBeforeRenderType(renderType);
+        if (stage != null)
+            dispatchRenderStage(stage, levelRenderer, null, modelViewMatrix, projectionMatrix, renderTick, camera, frustum);
+    }
+
+    public static void dispatchAfterRenderStage(RenderType renderType, LevelRenderer levelRenderer, Matrix4f modelViewMatrix, Matrix4f projectionMatrix, int renderTick, Camera camera, Frustum frustum) {
+        RenderLevelStageEvent.Stage stage = RenderLevelStageEvent.Stage.stageAfterRenderType(renderType);
         if (stage != null)
             dispatchRenderStage(stage, levelRenderer, null, modelViewMatrix, projectionMatrix, renderTick, camera, frustum);
     }

--- a/src/main/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
@@ -6,8 +6,11 @@
 package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import java.util.HashMap;
+import it.unimi.dsi.fastutil.Pair;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.GameRenderer;
@@ -139,7 +142,7 @@ public class RenderLevelStageEvent extends Event {
          * @throws IllegalArgumentException if the RenderType passed is already mapped to a Stage.
          */
         public Stage register(ResourceLocation name, @Nullable RenderType renderType) throws IllegalArgumentException {
-            return Stage.register(name, renderType);
+            return new Stage(name.toString(), renderType); //Stage(name, renderType);
         }
     }
 
@@ -149,44 +152,86 @@ public class RenderLevelStageEvent extends Event {
      * @see RegisterStageEvent
      */
     public static class Stage {
-        private static final Map<RenderType, Stage> RENDER_TYPE_STAGES = new HashMap<>();
-
         /**
-         * Use this to render custom objects into the skybox.
+         * Use this to render custom objects into the skybox before it is rendered.
          * Called regardless of if they sky actually renders or not.
          */
-        public static final Stage AFTER_SKY = register("after_sky", null);
+        public static final Stage BEFORE_SKY = new Stage("before_sky", null);
+        /**
+         * Use this to render custom objects into the skybox after it is rendered.
+         * Called regardless of if they sky actually renders or not.
+         */
+        public static final Stage AFTER_SKY = new Stage("after_sky", null);
+
+        /**
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
+         */
+        public static final Stage BEFORE_SOLID_BLOCKS = new Stage("before_solid_blocks", RenderType.solid());
+        /**
+         * Use this to render custom block-like geometry into the world, after vanilla renders any.
+         */
+        public static final Stage AFTER_SOLID_BLOCKS = new Stage("after_solid_blocks", RenderType.solid());
+
+        /**
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
+         */
+        public static final Stage BEFORE_CUTOUT_MIPPED_BLOCKS_BLOCKS = new Stage("before_cutout_mipped_blocks", RenderType.cutoutMipped());
+        /**
+         * Use this to render custom block-like geometry into the world, after vanilla renders any.
+         */
+        public static final Stage AFTER_CUTOUT_MIPPED_BLOCKS_BLOCKS = new Stage("after_cutout_mipped_blocks", RenderType.cutoutMipped());
+
+        /**
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
+         */
+        public static final Stage BEFORE_CUTOUT_BLOCKS = new Stage("before_cutout_blocks", RenderType.cutout());
+        /**
+         * Use this to render custom block-like geometry into the world, after vanilla renders any.
+         */
+        public static final Stage AFTER_CUTOUT_BLOCKS = new Stage("after_cutout_blocks", RenderType.cutout());
+
+        /**
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
+         */
+        public static final Stage BEFORE_ENTITIES = new Stage("before_entities", null);
+        /**
+         * Use this to render custom block-like geometry into the world, after vanilla renders any.
+         */
+        public static final Stage AFTER_ENTITIES = new Stage("after_entities", null);
+
+        /**
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
+         */
+        public static final Stage BEFORE_BLOCK_ENTITIES = new Stage("before_block_entities", null);
         /**
          * Use this to render custom block-like geometry into the world.
          */
-        public static final Stage AFTER_SOLID_BLOCKS = register("after_solid_blocks", RenderType.solid());
+        public static final Stage AFTER_BLOCK_ENTITIES = new Stage("after_block_entities", null);
+
         /**
-         * Use this to render custom block-like geometry into the world.
-         */
-        public static final Stage AFTER_CUTOUT_MIPPED_BLOCKS_BLOCKS = register("after_cutout_mipped_blocks", RenderType.cutoutMipped());
-        /**
-         * Use this to render custom block-like geometry into the world.
-         */
-        public static final Stage AFTER_CUTOUT_BLOCKS = register("after_cutout_blocks", RenderType.cutout());
-        /**
-         * Use this to render custom block-like geometry into the world.
-         */
-        public static final Stage AFTER_ENTITIES = register("after_entities", null);
-        /**
-         * Use this to render custom block-like geometry into the world.
-         */
-        public static final Stage AFTER_BLOCK_ENTITIES = register("after_block_entities", null);
-        /**
-         * Use this to render custom block-like geometry into the world.
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
          * Due to how transparency sorting works, this stage may not work properly with translucency. If you intend to render translucency,
          * try using {@link #AFTER_TRIPWIRE_BLOCKS} or {@link #AFTER_PARTICLES}.
          * Although this is called within a fabulous graphics target, it does not function properly in many cases.
          */
-        public static final Stage AFTER_TRANSLUCENT_BLOCKS = register("after_translucent_blocks", RenderType.translucent());
+        public static final Stage BEFORE_TRANSLUCENT_BLOCKS = new Stage("before_translucent_blocks", RenderType.translucent());
         /**
-         * Use this to render custom block-like geometry into the world.
+         * Use this to render custom block-like geometry into the world, after vanilla renders any.
+         * Due to how transparency sorting works, this stage may not work properly with translucency. If you intend to render translucency,
+         * try using {@link #AFTER_TRIPWIRE_BLOCKS} or {@link #AFTER_PARTICLES}.
+         * Although this is called within a fabulous graphics target, it does not function properly in many cases.
          */
-        public static final Stage AFTER_TRIPWIRE_BLOCKS = register("after_tripwire_blocks", RenderType.tripwire());
+        public static final Stage AFTER_TRANSLUCENT_BLOCKS = new Stage("after_translucent_blocks", RenderType.translucent());
+
+        /**
+         * Use this to render custom block-like geometry into the world, before vanilla renders any.
+         */
+        public static final Stage BEFORE_TRIPWIRE_BLOCKS = new Stage("before_tripwire_blocks", RenderType.tripwire());
+        /**
+         * Use this to render custom block-like geometry into the world, after vanilla renders any.
+         */
+        public static final Stage AFTER_TRIPWIRE_BLOCKS = new Stage("after_tripwire_blocks", RenderType.tripwire());
+
         /**
          * Use this to render custom effects into the world, such as custom entity-like objects or special rendering effects.
          * Called within a fabulous graphics target.
@@ -194,33 +239,62 @@ public class RenderLevelStageEvent extends Event {
          *
          * @see NeoForgeRenderTypes#TRANSLUCENT_ON_PARTICLES_TARGET
          */
-        public static final Stage AFTER_PARTICLES = register("after_particles", null);
+        public static final Stage BEFORE_PARTICLES = new Stage("before_particles", null);
         /**
-         * Use this to render custom weather effects into the world.
+         * Use this to render custom effects into the world, such as custom entity-like objects or special rendering effects.
+         * Called within a fabulous graphics target.
+         * Happens after entities render.
+         *
+         * @see NeoForgeRenderTypes#TRANSLUCENT_ON_PARTICLES_TARGET
+         */
+        public static final Stage AFTER_PARTICLES = new Stage("after_particles", null);
+
+        /**
+         * Use this to render custom weather effects into the world, before vanilla renders any.
          * Called within a fabulous graphics target.
          */
-        public static final Stage AFTER_WEATHER = register("after_weather", null);
+        public static final Stage BEFORE_WEATHER = new Stage("before_weather", null);
+        /**
+         * Use this to render custom weather effects into the world, before vanilla renders any.
+         * Called within a fabulous graphics target.
+         */
+        public static final Stage AFTER_WEATHER = new Stage("after_weather", null);
+
+        /**
+         * Use this to render before everything in the level has been rendered.
+         * Called before {@link LevelRenderer#renderLevel(float, long, boolean, Camera, GameRenderer, LightTexture, Matrix4f, Matrix4f)} begins rendering geometry.
+         */
+        public static final Stage BEFORE_LEVEL = new Stage("before_level", null);
         /**
          * Use this to render after everything in the level has been rendered.
          * Called after {@link LevelRenderer#renderLevel(float, long, boolean, Camera, GameRenderer, LightTexture, Matrix4f, Matrix4f)} finishes.
          */
-        public static final Stage AFTER_LEVEL = register("after_level", null);
+        public static final Stage AFTER_LEVEL = new Stage("after_level", null);
+
+        private static final Map<RenderType, Pair<Stage, Stage>> PAIRS = Stream.of(
+                Pair.of(BEFORE_SKY, AFTER_SKY),
+                Pair.of(BEFORE_SOLID_BLOCKS, AFTER_SOLID_BLOCKS),
+                Pair.of(BEFORE_CUTOUT_MIPPED_BLOCKS_BLOCKS, AFTER_CUTOUT_MIPPED_BLOCKS_BLOCKS),
+                Pair.of(BEFORE_CUTOUT_BLOCKS, AFTER_CUTOUT_BLOCKS),
+                Pair.of(BEFORE_ENTITIES, AFTER_ENTITIES),
+                Pair.of(BEFORE_BLOCK_ENTITIES, AFTER_BLOCK_ENTITIES),
+                Pair.of(BEFORE_TRANSLUCENT_BLOCKS, AFTER_TRANSLUCENT_BLOCKS),
+                Pair.of(BEFORE_TRIPWIRE_BLOCKS, AFTER_TRIPWIRE_BLOCKS),
+                Pair.of(BEFORE_PARTICLES, AFTER_PARTICLES),
+                Pair.of(BEFORE_WEATHER, AFTER_WEATHER),
+                Pair.of(BEFORE_LEVEL, AFTER_LEVEL))
+                .filter(pair -> pair.first().renderType != null)
+                .collect(Collectors.toMap(
+                        pair -> pair.first().renderType,
+                        Function.identity()));
 
         private final String name;
+        @Nullable
+        private final RenderType renderType;
 
-        private Stage(String name) {
+        private Stage(String name, @Nullable RenderType renderType) {
             this.name = name;
-        }
-
-        private static Stage register(ResourceLocation name, @Nullable RenderType renderType) throws IllegalArgumentException {
-            Stage stage = new Stage(name.toString());
-            if (renderType != null && RENDER_TYPE_STAGES.putIfAbsent(renderType, stage) != null)
-                throw new IllegalArgumentException("Attempted to replace an existing RenderLevelStageEvent.Stage for a RenderType: Stage = " + stage + ", RenderType = " + renderType);
-            return stage;
-        }
-
-        private static Stage register(String name, @Nullable RenderType renderType) throws IllegalArgumentException {
-            return register(ResourceLocation.parse(name), renderType);
+            this.renderType = renderType;
         }
 
         @Override
@@ -232,8 +306,33 @@ public class RenderLevelStageEvent extends Event {
          * {@return the {@linkplain Stage stage} bound to the {@linkplain RenderType render type}, or null if no value is present}
          */
         @Nullable
+        @Deprecated(forRemoval = true, since = "21.4")
         public static Stage fromRenderType(RenderType renderType) {
-            return RENDER_TYPE_STAGES.get(renderType);
+            return stageAfterRenderType(renderType);
+        }
+
+        /**
+         * {@return the {@linkplain Stage stage} bound to the {@linkplain RenderType render type}, or null if no value is present}
+         */
+        @Nullable
+        public static Stage stageBeforeRenderType(RenderType renderType) {
+            var pair = PAIRS.get(renderType);
+            if (pair == null)
+                return null;
+
+            return pair.first();
+        }
+
+        /**
+         * {@return the {@linkplain Stage stage} bound to the {@linkplain RenderType render type}, or null if no value is present}
+         */
+        @Nullable
+        public static Stage stageAfterRenderType(RenderType renderType) {
+            var pair = PAIRS.get(renderType);
+            if (pair == null)
+                return null;
+
+            return pair.second();
         }
     }
 }


### PR DESCRIPTION
This is a relatively naive modification to the existing RenderLevelStageEvent system to implement an additional set of BEFORE stages. The goal is to give more control over geometry rendering at a per-rendertype level. For example, currently, it is rather difficult to render translucent non-chunk based geometry (e.g. the contents of a multi-block tank which spans multiple chunks) as the current events are fired after the game has already rendered to the appropriate buffers, breaking depth sorting and blending.

Admittedly, it is likely that this would then introduce the reverse issue: geometry rendered by a mod will interfere with vanilla geometry (hence my opening of this PR as a draft) but providing these hooks should in theory provide for more control while fitting into the constraints of the existing system.

I think that going forward we need to completely redesign this interface, instead giving modders access to the FrameGraphBuilder in order to configure their own render passes. However, this will need a lot more thought as the frame graph is intended to be a DAG where resources are only written once. 