### PR TITLE
Fix global block entities not being updated for empty sections

### DIFF
--- a/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
@@ -31,6 +31,15 @@
              }
  
              @Override
+@@ -489,6 +_,8 @@
+                     RenderChunkRegion renderchunkregion = this.region;
+                     this.region = null;
+                     if (renderchunkregion == null) {
++                        // Neo: Fix MC-279596 (global block entities not being updated for empty sections)
++                        RenderSection.this.updateGlobalBlockEntities(Set.of());
+                         RenderSection.this.setCompiled(SectionRenderDispatcher.CompiledSection.EMPTY);
+                         return CompletableFuture.completedFuture(SectionRenderDispatcher.SectionTaskResult.SUCCESSFUL);
+                     } else {
 @@ -499,7 +_,7 @@
                              SectionCompiler.Results sectioncompiler$results;
                              try (Zone zone = Profiler.get().zone("Compile Section")) {


### PR DESCRIPTION
Without this fix, "ghost" global BERs can continue to be rendered when the section becomes empty. This can be reproduced with structure blocks in vanilla, see [MC-279596](https://bugs.mojang.com/browse/MC-279596) that I just opened.

Credits to XFact who found the right place to fix the issue.

Fixes https://github.com/AztechMC/Modern-Industrialization/issues/1008.