### PR TITLE
Patch `EmeraldsForVillagerTypeItem` to allow modders to make Custom `VillagerType`s

### DIFF
--- a/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -4,7 +4,7 @@
          private final int villagerXp;
  
          public EmeraldsForVillagerTypeItem(int p_35669_, int p_35670_, int p_35671_, Map<VillagerType, Item> p_35672_) {
-+            if (false) // Neo: disable this check so that mods can add custom villager
++            if (false) // Neo: disable this check so that mods can add custom villager types
              BuiltInRegistries.VILLAGER_TYPE.stream().filter(p_35680_ -> !p_35672_.containsKey(p_35680_)).findAny().ifPresent(p_339515_ -> {
                  throw new IllegalStateException("Missing trade for villager type: " + BuiltInRegistries.VILLAGER_TYPE.getKey(p_339515_));
              });
@@ -14,7 +14,7 @@
              if (p_219685_ instanceof VillagerDataHolder villagerdataholder) {
 -                ItemCost itemcost = new ItemCost(this.trades.get(villagerdataholder.getVillagerData().getType()), this.cost);
 +                Item item = this.trades.get(villagerdataholder.getVillagerData().getType());
-+                if (item == null) return null;  // Neo: add a check for custom villager
++                if (item == null) return null;  // Neo: add a check for unknown villager types
 +                ItemCost itemcost = new ItemCost(item, this.cost);
                  return new MerchantOffer(itemcost, new ItemStack(Items.EMERALD), this.maxUses, this.villagerXp, 0.05F);
              } else {

--- a/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -8,11 +8,14 @@
              BuiltInRegistries.VILLAGER_TYPE.stream().filter(p_35680_ -> !p_35672_.containsKey(p_35680_)).findAny().ifPresent(p_339515_ -> {
                  throw new IllegalStateException("Missing trade for villager type: " + BuiltInRegistries.VILLAGER_TYPE.getKey(p_339515_));
              });
-@@ -1498,6 +_,7 @@
+@@ -1497,7 +_,9 @@
+         @Override
          public MerchantOffer getOffer(Entity p_219685_, RandomSource p_219686_) {
              if (p_219685_ instanceof VillagerDataHolder villagerdataholder) {
-                 ItemCost itemcost = new ItemCost(this.trades.get(villagerdataholder.getVillagerData().getType()), this.cost);
-+                if (itemcost.itemStack().isEmpty()) return null; // Neo: add a check for custom villager 
+-                ItemCost itemcost = new ItemCost(this.trades.get(villagerdataholder.getVillagerData().getType()), this.cost);
++                Item item = this.trades.get(villagerdataholder.getVillagerData().getType());
++                if (item == null) return null;  // Neo: add a check for custom villager
++                ItemCost itemcost = new ItemCost(item, this.cost);
                  return new MerchantOffer(itemcost, new ItemStack(Items.EMERALD), this.maxUses, this.villagerXp, 0.05F);
              } else {
                  return null;

--- a/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -1,22 +1,18 @@
 --- a/net/minecraft/world/entity/npc/VillagerTrades.java
 +++ b/net/minecraft/world/entity/npc/VillagerTrades.java
-@@ -1484,9 +_,6 @@
+@@ -1484,6 +_,7 @@
          private final int villagerXp;
  
          public EmeraldsForVillagerTypeItem(int p_35669_, int p_35670_, int p_35671_, Map<VillagerType, Item> p_35672_) {
--            BuiltInRegistries.VILLAGER_TYPE.stream().filter(p_35680_ -> !p_35672_.containsKey(p_35680_)).findAny().ifPresent(p_339515_ -> {
--                throw new IllegalStateException("Missing trade for villager type: " + BuiltInRegistries.VILLAGER_TYPE.getKey(p_339515_));
--            });
-             this.trades = p_35672_;
-             this.cost = p_35669_;
-             this.maxUses = p_35670_;
-@@ -1498,6 +_,9 @@
++            if (false) // Neo: disable this check so that mods can add custom villager
+             BuiltInRegistries.VILLAGER_TYPE.stream().filter(p_35680_ -> !p_35672_.containsKey(p_35680_)).findAny().ifPresent(p_339515_ -> {
+                 throw new IllegalStateException("Missing trade for villager type: " + BuiltInRegistries.VILLAGER_TYPE.getKey(p_339515_));
+             });
+@@ -1498,6 +_,7 @@
          public MerchantOffer getOffer(Entity p_219685_, RandomSource p_219686_) {
              if (p_219685_ instanceof VillagerDataHolder villagerdataholder) {
                  ItemCost itemcost = new ItemCost(this.trades.get(villagerdataholder.getVillagerData().getType()), this.cost);
-+                if (itemcost.itemStack().isEmpty()) {
-+                    return null;
-+                }
++                if (itemcost.itemStack().isEmpty()) return null; // Neo: add a check for custom villager 
                  return new MerchantOffer(itemcost, new ItemStack(Items.EMERALD), this.maxUses, this.villagerXp, 0.05F);
              } else {
                  return null;

--- a/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
+++ b/patches/net/minecraft/world/entity/npc/VillagerTrades.java.patch
@@ -1,0 +1,22 @@
+--- a/net/minecraft/world/entity/npc/VillagerTrades.java
++++ b/net/minecraft/world/entity/npc/VillagerTrades.java
+@@ -1484,9 +_,6 @@
+         private final int villagerXp;
+ 
+         public EmeraldsForVillagerTypeItem(int p_35669_, int p_35670_, int p_35671_, Map<VillagerType, Item> p_35672_) {
+-            BuiltInRegistries.VILLAGER_TYPE.stream().filter(p_35680_ -> !p_35672_.containsKey(p_35680_)).findAny().ifPresent(p_339515_ -> {
+-                throw new IllegalStateException("Missing trade for villager type: " + BuiltInRegistries.VILLAGER_TYPE.getKey(p_339515_));
+-            });
+             this.trades = p_35672_;
+             this.cost = p_35669_;
+             this.maxUses = p_35670_;
+@@ -1498,6 +_,9 @@
+         public MerchantOffer getOffer(Entity p_219685_, RandomSource p_219686_) {
+             if (p_219685_ instanceof VillagerDataHolder villagerdataholder) {
+                 ItemCost itemcost = new ItemCost(this.trades.get(villagerdataholder.getVillagerData().getType()), this.cost);
++                if (itemcost.itemStack().isEmpty()) {
++                    return null;
++                }
+                 return new MerchantOffer(itemcost, new ItemStack(Items.EMERALD), this.maxUses, this.villagerXp, 0.05F);
+             } else {
+                 return null;


### PR DESCRIPTION
Currently if you make a custom Villager type the game will crash when you Load into or Create a world, since mc throws an exception when a VillagerType has no Trades, This makes sense in Vanilla's case but makes it impossible for modders to make there own villager types without extreme difficulty.  

- The first change in the patch simply removes the check completely, preventing the crash.  (The other option would be to leave the check but make the list empty so it never throws the exception, I decided against this as then the check here would just be pointless code to run but I am willing to do it this way if need be)

- The second change in the patch makes sure that the item cost itemstack isn't empty since there will be no trades of this type for Modded VillagerTypes, if it is empty we return null, if we don't include this check we would get air trades 

Fabric has a very similar mixin to allow this:
https://github.com/FabricMC/fabric/blob/1.21.4/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/mixin/object/builder/TradeOffersTypeAwareBuyForOneEmeraldFactoryMixin.java