### PR TITLE
Generate ATs for villager `ItemListing`s

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -219,6 +219,17 @@ generateAccessTransformers {
             named('net/minecraft/world/item/CreativeModeTabs'),
             fieldsOfType(named('net/minecraft/resources/ResourceKey'))
     )
+
+    // Make all villager item listings classes and constructors public for use in custom trades
+    classGroup(
+            'villager item listings', PUBLIC,
+            classesWithSuperclass('net/minecraft/world/entity/npc/VillagerTrades$ItemListing')
+    )
+    methodGroup(
+            'villager item listing constructors', PUBLIC,
+            classesWithSuperclass('net/minecraft/world/entity/npc/VillagerTrades$ItemListing'),
+            named('<init>')
+    )
 }
 
 tasks.register("generateFinalizeSpawnTargets", GenerateFinalizeSpawnTargets.class) {

--- a/src/main/resources/META-INF/accesstransformergenerated.cfg
+++ b/src/main/resources/META-INF/accesstransformergenerated.cfg
@@ -378,3 +378,24 @@ public net.minecraft.world.item.CreativeModeTabs REDSTONE_BLOCKS
 public net.minecraft.world.item.CreativeModeTabs SEARCH
 public net.minecraft.world.item.CreativeModeTabs SPAWN_EGGS
 public net.minecraft.world.item.CreativeModeTabs TOOLS_AND_UTILITIES
+
+# villager item listings
+public net.minecraft.world.entity.npc.VillagerTrades$DyedArmorForEmeralds
+public net.minecraft.world.entity.npc.VillagerTrades$EmeraldForItems
+public net.minecraft.world.entity.npc.VillagerTrades$EmeraldsForVillagerTypeItem
+public net.minecraft.world.entity.npc.VillagerTrades$EnchantBookForEmeralds
+public net.minecraft.world.entity.npc.VillagerTrades$EnchantedItemForEmeralds
+public net.minecraft.world.entity.npc.VillagerTrades$FailureItemListing
+public net.minecraft.world.entity.npc.VillagerTrades$ItemsAndEmeraldsToItems
+public net.minecraft.world.entity.npc.VillagerTrades$ItemsForEmeralds
+public net.minecraft.world.entity.npc.VillagerTrades$SuspiciousStewForEmerald
+public net.minecraft.world.entity.npc.VillagerTrades$TippedArrowForItemsAndEmeralds
+public net.minecraft.world.entity.npc.VillagerTrades$TreasureMapForEmeralds
+public net.minecraft.world.entity.npc.VillagerTrades$TypeSpecificTrade
+public net.minecraft.world.entity.npc.VillagerTrades$TypeSpecificTrade <init>(Ljava/util/Map;)V
+
+# villager item listing constructors
+public net.minecraft.world.entity.npc.VillagerTrades$FailureItemListing <init>()V
+public net.minecraft.world.entity.npc.VillagerTrades$ItemsAndEmeraldsToItems <init>(Lnet/minecraft/world/level/ItemLike;IILnet/minecraft/world/item/ItemStack;IIIF)V
+public net.minecraft.world.entity.npc.VillagerTrades$ItemsAndEmeraldsToItems <init>(Lnet/minecraft/world/level/ItemLike;IILnet/minecraft/world/level/ItemLike;IIIFLnet/minecraft/resources/ResourceKey;)V
+public net.minecraft.world.entity.npc.VillagerTrades$TypeSpecificTrade <init>(Ljava/util/Map;)V


### PR DESCRIPTION
Add rules to generate ATs that make `ItemListing`s and their constructors public for use in mods that add custom trades.