### PR TITLE
[26.1] Add model loading plugins to replace `ModelEvent.ModifyBakingResult`

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,22 +1,23 @@
 --- a/net/minecraft/client/resources/model/ModelBakery.java
 +++ b/net/minecraft/client/resources/model/ModelBakery.java
-@@ -67,7 +_,11 @@
+@@ -67,7 +_,12 @@
      private final Map<Identifier, ClientItem> clientInfos;
      private final Map<Identifier, ResolvedModel> resolvedModels;
      private final ResolvedModel missingModel;
 +    private final net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels;
 +    private final net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations;
++    private final net.neoforged.neoforge.client.model.loadingplugin.@org.jspecify.annotations.Nullable ModelLoadingPluginManager pluginManager;
  
-+    /// @deprecated Neo: use [#ModelBakery(EntityModelSet, SpriteGetter, PlayerSkinRenderCache, Map, Map, Map, ResolvedModel, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations)] instead
++    /// @deprecated Neo: use [#ModelBakery(EntityModelSet, SpriteGetter, PlayerSkinRenderCache, Map, Map, Map, ResolvedModel, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations, net.neoforged.neoforge.client.model.loadingplugin.ModelLoadingPluginManager)] instead
 +    @Deprecated
      public ModelBakery(
          EntityModelSet entityModelSet,
          SpriteGetter sprites,
-@@ -77,6 +_,20 @@
+@@ -77,6 +_,21 @@
          Map<Identifier, ResolvedModel> resolvedModels,
          ResolvedModel missingModel
      ) {
-+        this(entityModelSet, sprites, playerSkinRenderCache, unbakedBlockStateModels, clientInfos, resolvedModels, missingModel, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels.EMPTY, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations.EMPTY);
++        this(entityModelSet, sprites, playerSkinRenderCache, unbakedBlockStateModels, clientInfos, resolvedModels, missingModel, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels.EMPTY, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations.EMPTY, null);
 +    }
 +
 +    public ModelBakery(
@@ -28,29 +29,63 @@
 +        Map<Identifier, ResolvedModel> resolvedModels,
 +        ResolvedModel missingModel,
 +        net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels,
-+        net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
++        net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations,
++        net.neoforged.neoforge.client.model.loadingplugin.@org.jspecify.annotations.Nullable ModelLoadingPluginManager pluginManager
 +    ) {
          this.entityModelSet = entityModelSet;
          this.sprites = sprites;
          this.playerSkinRenderCache = playerSkinRenderCache;
-@@ -84,6 +_,8 @@
+@@ -84,6 +_,9 @@
          this.clientInfos = clientInfos;
          this.resolvedModels = resolvedModels;
          this.missingModel = missingModel;
 +        this.standaloneModels = standaloneModels;
 +        this.pendingAnimations = pendingAnimations;
++        this.pluginManager = pluginManager;
      }
  
      public CompletableFuture<ModelBakery.BakingResult> bakeModels(MaterialBaker materials, Executor taskExecutor) {
-@@ -107,7 +_,7 @@
-                     return clientInfo.model()
-                         .bake(
-                             new ItemModel.BakingContext(
+@@ -93,7 +_,14 @@
+         CompletableFuture<Map<BlockState, BlockStateModel>> bakedBlockStateModelFuture = ParallelMapTransform.schedule(
+             this.unbakedBlockStateModels, (blockState, model) -> {
+                 try {
+-                    return model.bake(blockState, baker);
++                    if (this.pluginManager != null) {
++                        model = this.pluginManager.modifyBlockModelBeforeBake(blockState, model, baker);
++                    }
++                    BlockStateModel bakedModel = model.bake(blockState, baker);
++                    if (this.pluginManager != null) {
++                        bakedModel = this.pluginManager.modifyBlockModelAfterBake(blockState, bakedModel, model, baker);
++                    }
++                    return bakedModel;
+                 } catch (Exception var4x) {
+                     LOGGER.warn("Unable to bake model: '{}': {}", blockState, var4x);
+                     return null;
+@@ -104,13 +_,18 @@
+             this.clientInfos,
+             (location, clientInfo) -> {
+                 try {
+-                    return clientInfo.model()
+-                        .bake(
+-                            new ItemModel.BakingContext(
 -                                baker, this.entityModelSet, this.sprites, this.playerSkinRenderCache, missingModels.item, clientInfo.registrySwapper()
+-                            ),
+-                            IDENTITY
++                    ItemModel.BakingContext bakingContext = new ItemModel.BakingContext(
 +                                baker, this.entityModelSet, this.sprites, this.playerSkinRenderCache, missingModels.item, clientInfo.registrySwapper(), this.pendingAnimations
-                             ),
-                             IDENTITY
                          );
++                    ItemModel.Unbaked unbakedModel = clientInfo.model();
++                    if (this.pluginManager != null) {
++                        unbakedModel = this.pluginManager.modifyItemModelBeforeBake(location, unbakedModel, clientInfo, bakingContext);
++                    }
++                    ItemModel bakedModel = unbakedModel.bake(bakingContext, IDENTITY);
++                    if (this.pluginManager != null) {
++                        bakedModel = this.pluginManager.modifyItemModelAfterBake(location, bakedModel, unbakedModel, clientInfo, bakingContext);
++                    }
++                    return bakedModel;
+                 } catch (Exception var6x) {
+                     LOGGER.warn("Unable to bake item model: '{}'", location, var6x);
+                     return null;
 @@ -118,6 +_,8 @@
              },
              taskExecutor

--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -26,7 +26,18 @@
      }
  
      public ClientItem.Properties getItemProperties(Identifier id) {
-@@ -119,8 +_,10 @@
+@@ -113,14 +_,19 @@
+     ) {
+         ResourceManager manager = currentReload.resourceManager();
+         CompletableFuture<EntityModelSet> entityModelSet = CompletableFuture.supplyAsync(EntityModelSet::vanilla, taskExecutor);
+-        CompletableFuture<Map<Identifier, UnbakedModel>> modelCache = loadBlockModels(manager, taskExecutor);
+-        CompletableFuture<BlockStateModelLoader.LoadedModels> blockStateModels = BlockStateModelLoader.loadBlockStates(manager, taskExecutor);
++        var pluginFuture = net.neoforged.neoforge.client.model.loadingplugin.ModelLoadingPluginManager.prepare(currentReload, taskExecutor);
++        CompletableFuture<Map<Identifier, UnbakedModel>> modelCache = loadBlockModels(manager, taskExecutor)
++                .thenCombine(pluginFuture, (models, pluginManager) -> pluginManager.modifyModelsOnLoad(models));
++        CompletableFuture<BlockStateModelLoader.LoadedModels> blockStateModels = BlockStateModelLoader.loadBlockStates(manager, taskExecutor)
++                .thenCombine(pluginFuture, (models, pluginManager) -> pluginManager.modifyBlockModelsOnLoad(models));
+         CompletableFuture<Map<BlockState, BlockModel.Unbaked>> blockModelContents = CompletableFuture.supplyAsync(
              () -> BuiltInBlockModels.createBlockModels(this.blockColors), taskExecutor
          );
          CompletableFuture<ClientItemInfoLoader.LoadedClientInfos> itemStackModels = ClientItemInfoLoader.scheduleLoad(manager, taskExecutor);
@@ -47,22 +58,24 @@
          return CompletableFuture.allOf(
                  pendingBlockAtlasSprites,
                  pendingItemAtlasSprites,
-@@ -138,7 +_,8 @@
+@@ -138,7 +_,9 @@
                  itemStackModels,
                  entityModelSet,
                  blockModels,
 -                modelCache
 +                modelCache,
-+                standaloneModelsFuture
++                standaloneModelsFuture,
++                pluginFuture
              )
              .thenComposeAsync(
                  var11x -> {
-@@ -162,8 +_,11 @@
+@@ -162,8 +_,12 @@
                          itemStackModels.join().contents(),
                          resolvedModels.models(),
                          resolvedModels.missing()
 +                        , standaloneModelsFuture.join(),
-+                        pendingAnimations
++                        pendingAnimations,
++                        pluginFuture.join()
                      );
 -                    return loadModels(blockAtlasSprites, itemAtlasSprites, bakery, blockModels.join(), groups, entityModelSet.join(), taskExecutor);
 +                    this.modelBakery.set(bakery);

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -198,6 +198,7 @@ import net.neoforged.neoforge.client.gui.PictureInPictureRendererRegistration;
 import net.neoforged.neoforge.client.gui.map.MapDecorationRendererManager;
 import net.neoforged.neoforge.client.loading.NeoForgeLoadingOverlay;
 import net.neoforged.neoforge.client.model.block.BlockStateModelHooks;
+import net.neoforged.neoforge.client.model.loadingplugin.ModelLoadingPluginManager;
 import net.neoforged.neoforge.client.pipeline.PipelineModifiers;
 import net.neoforged.neoforge.client.renderstate.RegisterRenderStateModifiersEvent;
 import net.neoforged.neoforge.common.CommonHooks;
@@ -858,6 +859,7 @@ public class ClientHooks {
         RenderPipelines.registerCustomPipelines();
         PipelineModifiers.init();
         GameRuleEntryFactoryManager.register();
+        ModelLoadingPluginManager.init();
     }
 
     // Runs during Minecraft construction, before initial resource loading and during datagen startup

--- a/src/client/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.client.event;
 
 import com.google.common.base.Preconditions;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -18,6 +19,10 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.neoforge.client.model.UnbakedModelLoader;
+import net.neoforged.neoforge.client.model.block.CustomBlockModelDefinition;
+import net.neoforged.neoforge.client.model.loadingplugin.ModelLoadingPlugin;
+import net.neoforged.neoforge.client.model.loadingplugin.ModelModifier;
+import net.neoforged.neoforge.client.model.loadingplugin.PreparableModelLoadingPlugin;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
 import net.neoforged.neoforge.client.model.standalone.UnbakedStandaloneModel;
 import org.jetbrains.annotations.ApiStatus;
@@ -43,7 +48,10 @@ public abstract class ModelEvent extends Event {
      * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
      *
      * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+     *
+     * @deprecated Use {@link CustomBlockModelDefinition}s or {@link ModelModifier}s instead
      */
+    @Deprecated(forRemoval = true, since = "1.21.8")
     public static class ModifyBakingResult extends ModelEvent implements IModBusEvent {
         private final ModelBakery.BakingResult bakingResult;
         private final Function<Identifier, TextureAtlasSprite> textureGetter;
@@ -84,7 +92,7 @@ public abstract class ModelEvent extends Event {
      * Fired when the {@link ModelManager} is notified of the resource manager reloading.
      * Called after the model registry is set up and cached in the {@link net.minecraft.client.renderer.block.BlockModelShaper}.<br>
      * The model registry given by this event is unmodifiable. To modify the model registry, use
-     * {@link ModelEvent.ModifyBakingResult} instead.
+     * {@link CustomBlockModelDefinition}s or {@link ModelModifier}s instead.
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
      *
@@ -177,6 +185,54 @@ public abstract class ModelEvent extends Event {
         public void register(Identifier key, UnbakedModelLoader<?> loader) {
             Preconditions.checkArgument(!loaders.containsKey(key), "Unbaked model loader already registered: " + key);
             loaders.put(key, loader);
+        }
+    }
+
+    /// Fired during client startup to register [ModelLoadingPlugin]s and [PreparableModelLoadingPlugin]s.
+    ///
+    /// This event is not [cancellable][ICancellableEvent].
+    ///
+    /// This event is fired on the mod-specific event bus, only on the [logical client][LogicalSide#CLIENT].
+    public static class RegisterLoadingPlugins extends ModelEvent implements IModBusEvent {
+        private final Map<Identifier, ModelLoadingPlugin> plugins;
+        private final Map<Identifier, PreparableModelLoadingPlugin<?>> preparablePlugins;
+
+        @ApiStatus.Internal
+        public RegisterLoadingPlugins(Map<Identifier, ModelLoadingPlugin> plugins, Map<Identifier, PreparableModelLoadingPlugin<?>> preparablePlugins) {
+            this.plugins = plugins;
+            this.preparablePlugins = preparablePlugins;
+        }
+
+        /// Register a [ModelLoadingPlugin] with the provided ID.
+        ///
+        /// @param id     The ID of the plugin
+        /// @param plugin The plugin to register
+        public void registerPlugin(Identifier id, ModelLoadingPlugin plugin) {
+            ModelLoadingPlugin prevPlugin = plugins.putIfAbsent(id, plugin);
+            if (prevPlugin != null) {
+                throw new IllegalStateException(String.format(
+                        Locale.ROOT,
+                        "Duplicate ModelLoadingPlugin registration with ID %s (old: %s, new: %s)",
+                        id,
+                        prevPlugin,
+                        plugin));
+            }
+        }
+
+        /// Register a [PreparableModelLoadingPlugin] with the provided ID.
+        ///
+        /// @param id     The ID of the plugin
+        /// @param plugin The plugin to register
+        public void registerPlugin(Identifier id, PreparableModelLoadingPlugin<?> plugin) {
+            PreparableModelLoadingPlugin<?> prevPlugin = preparablePlugins.putIfAbsent(id, plugin);
+            if (prevPlugin != null) {
+                throw new IllegalStateException(String.format(
+                        Locale.ROOT,
+                        "Duplicate PreparableModelLoadingPlugin registration with ID %s (old: %s, new: %s)",
+                        id,
+                        prevPlugin,
+                        plugin));
+            }
         }
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelLoadingPlugin.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelLoadingPlugin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.loadingplugin;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/// A plugin into the model loading process.
+///
+/// Model loading plugins should ideally be stateless. If additional data needs to be loaded, then a
+/// [PreparableModelLoadingPlugin] should be used instead.
+public interface ModelLoadingPlugin {
+    /// Called at the start of model loading during every resource reload.
+    ///
+    /// @param context The context to use for registering [ModelModifier]s
+    void initialize(Context context);
+
+    @ApiStatus.NonExtendable
+    interface Context {
+        /// Register the provided [ModelModifier] in the {@linkplain ModelModifier.Phase#DEFAULT default phase}.
+        ///
+        /// @param modifier The modifier to register
+        default void registerModifier(ModelModifier modifier) {
+            registerModifier(ModelModifier.Phase.DEFAULT, modifier);
+        }
+
+        /// Register the provided [ModelModifier] in the provided [ModelModifier.Phase].
+        ///
+        /// @param phase    The phase the modifier should execute in
+        /// @param modifier The modifier to register
+        void registerModifier(ModelModifier.Phase phase, ModelModifier modifier);
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelLoadingPluginManager.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelLoadingPluginManager.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.loadingplugin;
+
+import com.mojang.logging.LogUtils;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceLinkedOpenHashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.item.ClientItem;
+import net.minecraft.client.renderer.item.ItemModel;
+import net.minecraft.client.resources.model.BlockStateModelLoader;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+import net.minecraft.util.Util;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.client.event.ModelEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.UnknownNullability;
+import org.slf4j.Logger;
+
+public final class ModelLoadingPluginManager {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final Map<Identifier, ModelLoadingPlugin> PLUGINS = new Object2ReferenceLinkedOpenHashMap<>();
+    private static final Map<Identifier, PreparableModelLoadingPlugin<?>> PREPARABLE_PLUGINS = new Object2ReferenceLinkedOpenHashMap<>();
+
+    private final List<ModifierEntry<ModelModifier.ModifyOnLoad>> onLoadModifiers = new ArrayList<>();
+    private final List<ModifierEntry<ModelModifier.ModifyBlockOnLoad>> onLoadBlockModifiers = new ArrayList<>();
+    private final List<ModifierEntry<ModelModifier.ModifyBlockBeforeBake>> beforeBakeBlockModifiers = new ArrayList<>();
+    private final List<ModifierEntry<ModelModifier.ModifyBlockAfterBake>> afterBakeBlockModifiers = new ArrayList<>();
+    private final List<ModifierEntry<ModelModifier.ModifyItemBeforeBake>> beforeBakeItemModifiers = new ArrayList<>();
+    private final List<ModifierEntry<ModelModifier.ModifyItemAfterBake>> afterBakeItemModifiers = new ArrayList<>();
+    private final ThreadLocal<BlockBeforeBakeContextImpl> beforeBakeBlockContext = ThreadLocal.withInitial(BlockBeforeBakeContextImpl::new);
+    private final ThreadLocal<BlockAfterBakeContextImpl> afterBakeBlockContext = ThreadLocal.withInitial(BlockAfterBakeContextImpl::new);
+    private final ThreadLocal<ItemBeforeBakeContextImpl> beforeBakeItemContext = ThreadLocal.withInitial(ItemBeforeBakeContextImpl::new);
+    private final ThreadLocal<ItemAfterBakeContextImpl> afterBakeItemContext = ThreadLocal.withInitial(ItemAfterBakeContextImpl::new);
+
+    private ModelLoadingPluginManager(List<PluginEntry> plugins) {
+        var context = new ModelLoadingPlugin.Context() {
+            @UnknownNullability
+            private Identifier pluginId;
+
+            @Override
+            public void registerModifier(ModelModifier.Phase phase, ModelModifier modifier) {
+                switch (modifier) {
+                    case ModelModifier.ModifyOnLoad onLoad -> onLoadModifiers.add(new ModifierEntry<>(pluginId, phase, onLoad));
+                    case ModelModifier.ModifyBlockOnLoad onLoadBlock -> onLoadBlockModifiers.add(new ModifierEntry<>(pluginId, phase, onLoadBlock));
+                    case ModelModifier.ModifyBlockBeforeBake beforeBakeBlock -> beforeBakeBlockModifiers.add(new ModifierEntry<>(pluginId, phase, beforeBakeBlock));
+                    case ModelModifier.ModifyBlockAfterBake afterBakeBlock -> afterBakeBlockModifiers.add(new ModifierEntry<>(pluginId, phase, afterBakeBlock));
+                    case ModelModifier.ModifyItemBeforeBake beforeBakeItem -> beforeBakeItemModifiers.add(new ModifierEntry<>(pluginId, phase, beforeBakeItem));
+                    case ModelModifier.ModifyItemAfterBake afterBakeItem -> afterBakeItemModifiers.add(new ModifierEntry<>(pluginId, phase, afterBakeItem));
+                }
+            }
+        };
+        for (PluginEntry plugin : plugins) {
+            context.pluginId = plugin.id;
+            plugin.plugin.initialize(context);
+        }
+
+        Comparator<ModifierEntry<?>> comp = Comparator.comparing(ModifierEntry::phase);
+        this.onLoadModifiers.sort(comp);
+        this.onLoadBlockModifiers.sort(comp);
+        this.beforeBakeBlockModifiers.sort(comp);
+        this.afterBakeBlockModifiers.sort(comp);
+        this.beforeBakeItemModifiers.sort(comp);
+        this.afterBakeItemModifiers.sort(comp);
+    }
+
+    @ApiStatus.Internal
+    public static void init() {
+        ModLoader.postEvent(new ModelEvent.RegisterLoadingPlugins(PLUGINS, PREPARABLE_PLUGINS));
+    }
+
+    public static CompletableFuture<ModelLoadingPluginManager> prepare(PreparableReloadListener.SharedState sharedState, Executor executor) {
+        List<CompletableFuture<PluginEntry>> pluginFutures = new ArrayList<>();
+        for (Map.Entry<Identifier, ModelLoadingPlugin> entry : PLUGINS.entrySet()) {
+            pluginFutures.add(CompletableFuture.completedFuture(new PluginEntry(entry.getKey(), entry.getValue())));
+        }
+        for (Map.Entry<Identifier, PreparableModelLoadingPlugin<?>> entry : PREPARABLE_PLUGINS.entrySet()) {
+            pluginFutures.add(preparePlugin(entry.getKey(), entry.getValue(), sharedState, executor));
+        }
+        return Util.sequence(pluginFutures).thenApplyAsync(ModelLoadingPluginManager::new, executor);
+    }
+
+    private static <T> CompletableFuture<PluginEntry> preparePlugin(
+            Identifier pluginId,
+            PreparableModelLoadingPlugin<T> plugin,
+            PreparableReloadListener.SharedState sharedState,
+            Executor executor) {
+        CompletableFuture<T> dataFuture = plugin.load(sharedState, executor);
+        return dataFuture.thenApply(data -> new PluginEntry(pluginId, ctx -> plugin.initialize(data, ctx)));
+    }
+
+    public Map<Identifier, UnbakedModel> modifyModelsOnLoad(Map<Identifier, UnbakedModel> models) {
+        if (onLoadModifiers.isEmpty()) return models;
+
+        if (!(models instanceof HashMap)) {
+            models = new HashMap<>(models);
+        }
+
+        var context = new ModelModifier.ModifyOnLoad.Context() {
+            @UnknownNullability
+            private Identifier id;
+
+            @Override
+            public Identifier id() {
+                return this.id;
+            }
+        };
+
+        models.replaceAll((id, model) -> {
+            context.id = id;
+            return modifyModelOnLoad(model, context);
+        });
+        return models;
+    }
+
+    public UnbakedModel modifyModelOnLoad(UnbakedModel model, ModelModifier.ModifyOnLoad.Context context) {
+        for (ModifierEntry<ModelModifier.ModifyOnLoad> entry : onLoadModifiers) {
+            try {
+                model = entry.modifier.modifyModelOnLoad(model, context);
+            } catch (Throwable t) {
+                LOGGER.error("On-load modifier {} from plugin {} threw an exception", entry.modifier, entry.owningPlugin, t);
+            }
+        }
+        return model;
+    }
+
+    public BlockStateModelLoader.LoadedModels modifyBlockModelsOnLoad(BlockStateModelLoader.LoadedModels models) {
+        if (onLoadBlockModifiers.isEmpty()) return models;
+
+        Map<BlockState, BlockStateModel.UnbakedRoot> map = models.models();
+        if (!(map instanceof IdentityHashMap)) {
+            map = new IdentityHashMap<>(map);
+            models = new BlockStateModelLoader.LoadedModels(map);
+        }
+
+        var context = new ModelModifier.ModifyBlockOnLoad.Context() {
+            @UnknownNullability
+            private BlockState state;
+
+            @Override
+            public BlockState state() {
+                return state;
+            }
+        };
+        map.replaceAll((state, model) -> {
+            context.state = state;
+            return modifyBlockModelOnLoad(model, context);
+        });
+
+        return models;
+    }
+
+    public BlockStateModel.UnbakedRoot modifyBlockModelOnLoad(BlockStateModel.UnbakedRoot model, ModelModifier.ModifyBlockOnLoad.Context context) {
+        for (ModifierEntry<ModelModifier.ModifyBlockOnLoad> entry : onLoadBlockModifiers) {
+            try {
+                model = entry.modifier.modifyBlockModelOnLoad(model, context);
+            } catch (Throwable t) {
+                LOGGER.error("On-load-block modifier {} from plugin {} threw an exception", entry.modifier, entry.owningPlugin, t);
+            }
+        }
+        return model;
+    }
+
+    public BlockStateModel.UnbakedRoot modifyBlockModelBeforeBake(BlockState state, BlockStateModel.UnbakedRoot model, ModelBaker baker) {
+        if (beforeBakeBlockModifiers.isEmpty()) return model;
+
+        BlockBeforeBakeContextImpl context = beforeBakeBlockContext.get().setup(state, baker);
+        for (ModifierEntry<ModelModifier.ModifyBlockBeforeBake> entry : beforeBakeBlockModifiers) {
+            try {
+                model = entry.modifier.modifyBlockModelBeforeBake(model, context);
+            } catch (Throwable t) {
+                LOGGER.error("Before-bake-block modifier {} from plugin {} threw an exception", entry.modifier, entry.owningPlugin, t);
+            }
+        }
+        return model;
+    }
+
+    public BlockStateModel modifyBlockModelAfterBake(BlockState state, BlockStateModel model, BlockStateModel.UnbakedRoot sourceModel, ModelBaker baker) {
+        if (afterBakeBlockModifiers.isEmpty()) return model;
+
+        BlockAfterBakeContextImpl context = afterBakeBlockContext.get().setup(state, sourceModel, baker);
+        for (ModifierEntry<ModelModifier.ModifyBlockAfterBake> entry : afterBakeBlockModifiers) {
+            try {
+                model = entry.modifier.modifyBlockModelAfterBake(model, context);
+            } catch (Throwable t) {
+                LOGGER.error("After-bake-block modifier {} from plugin {} threw an exception", entry.modifier, entry.owningPlugin, t);
+            }
+        }
+        return model;
+    }
+
+    public ItemModel.Unbaked modifyItemModelBeforeBake(Identifier id, ItemModel.Unbaked model, ClientItem clientItem, ItemModel.BakingContext bakingContext) {
+        if (beforeBakeItemModifiers.isEmpty()) return model;
+
+        ItemBeforeBakeContextImpl context = beforeBakeItemContext.get().setup(id, clientItem, bakingContext);
+        for (ModifierEntry<ModelModifier.ModifyItemBeforeBake> entry : beforeBakeItemModifiers) {
+            try {
+                model = entry.modifier.modifyItemModelBeforeBake(model, context);
+            } catch (Throwable t) {
+                LOGGER.error("Before-bake-item modifier {} from plugin {} threw an exception", entry.modifier, entry.owningPlugin, t);
+            }
+        }
+        return model;
+    }
+
+    public ItemModel modifyItemModelAfterBake(Identifier id, ItemModel model, ItemModel.Unbaked sourceModel, ClientItem clientItem, ItemModel.BakingContext bakingContext) {
+        if (afterBakeItemModifiers.isEmpty()) return model;
+
+        ItemAfterBakeContextImpl context = afterBakeItemContext.get().setup(id, sourceModel, clientItem, bakingContext);
+        for (ModifierEntry<ModelModifier.ModifyItemAfterBake> entry : afterBakeItemModifiers) {
+            try {
+                model = entry.modifier.modifyItemModelAfterBake(model, context);
+            } catch (Throwable t) {
+                LOGGER.error("After-bake-item modifier {} from plugin {} threw an exception", entry.modifier, entry.owningPlugin, t);
+            }
+        }
+        return model;
+    }
+
+    private record PluginEntry(Identifier id, ModelLoadingPlugin plugin) {}
+
+    private record ModifierEntry<T extends ModelModifier>(Identifier owningPlugin, ModelModifier.Phase phase, T modifier) {}
+
+    private static final class BlockBeforeBakeContextImpl implements ModelModifier.ModifyBlockBeforeBake.Context {
+        @UnknownNullability
+        private BlockState state;
+        @UnknownNullability
+        private ModelBaker baker;
+
+        @Override
+        public BlockState state() {
+            return this.state;
+        }
+
+        @Override
+        public ModelBaker baker() {
+            return this.baker;
+        }
+
+        public BlockBeforeBakeContextImpl setup(BlockState state, ModelBaker baker) {
+            this.state = state;
+            this.baker = baker;
+            return this;
+        }
+    }
+
+    private static final class BlockAfterBakeContextImpl implements ModelModifier.ModifyBlockAfterBake.Context {
+        @UnknownNullability
+        private BlockState state;
+        private BlockStateModel.@UnknownNullability UnbakedRoot sourceModel;
+        @UnknownNullability
+        private ModelBaker baker;
+
+        @Override
+        public BlockState state() {
+            return this.state;
+        }
+
+        @Override
+        public BlockStateModel.UnbakedRoot sourceModel() {
+            return this.sourceModel;
+        }
+
+        @Override
+        public ModelBaker baker() {
+            return this.baker;
+        }
+
+        public BlockAfterBakeContextImpl setup(BlockState state, BlockStateModel.UnbakedRoot sourceModel, ModelBaker baker) {
+            this.state = state;
+            this.sourceModel = sourceModel;
+            this.baker = baker;
+            return this;
+        }
+    }
+
+    private static final class ItemBeforeBakeContextImpl implements ModelModifier.ModifyItemBeforeBake.Context {
+        @UnknownNullability
+        private Identifier id;
+        @UnknownNullability
+        private ClientItem clientItem;
+        private ItemModel.@UnknownNullability BakingContext bakingContext;
+
+        @Override
+        public Identifier id() {
+            return this.id;
+        }
+
+        @Override
+        public ClientItem clientItem() {
+            return this.clientItem;
+        }
+
+        @Override
+        public ItemModel.BakingContext bakingContext() {
+            return this.bakingContext;
+        }
+
+        public ItemBeforeBakeContextImpl setup(Identifier id, ClientItem clientItem, ItemModel.BakingContext bakingContext) {
+            this.id = id;
+            this.clientItem = clientItem;
+            this.bakingContext = bakingContext;
+            return this;
+        }
+    }
+
+    private static final class ItemAfterBakeContextImpl implements ModelModifier.ModifyItemAfterBake.Context {
+        @UnknownNullability
+        private Identifier id;
+        private ItemModel.@UnknownNullability Unbaked sourceModel;
+        @UnknownNullability
+        private ClientItem clientItem;
+        private ItemModel.@UnknownNullability BakingContext bakingContext;
+
+        @Override
+        public Identifier id() {
+            return this.id;
+        }
+
+        @Override
+        public ItemModel.Unbaked sourceModel() {
+            return this.sourceModel;
+        }
+
+        @Override
+        public ClientItem clientItem() {
+            return this.clientItem;
+        }
+
+        @Override
+        public ItemModel.BakingContext bakingContext() {
+            return this.bakingContext;
+        }
+
+        public ItemAfterBakeContextImpl setup(Identifier id, ItemModel.Unbaked sourceModel, ClientItem clientItem, ItemModel.BakingContext bakingContext) {
+            this.id = id;
+            this.sourceModel = sourceModel;
+            this.clientItem = clientItem;
+            this.bakingContext = bakingContext;
+            return this;
+        }
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelLoadingPluginManager.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelLoadingPluginManager.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.item.ClientItem;
 import net.minecraft.client.renderer.item.ItemModel;

--- a/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/ModelModifier.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.loadingplugin;
+
+import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelDispatcher;
+import net.minecraft.client.renderer.item.ClientItem;
+import net.minecraft.client.renderer.item.ItemModel;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Modifiers called at various points during model loading to allow modification of models loaded from JSON files.
+ */
+public sealed interface ModelModifier {
+    /**
+     * Called when an {@link UnbakedModel} has been loaded from a resource pack.
+     */
+    non-sealed interface ModifyOnLoad extends ModelModifier {
+        /**
+         * Modify the incoming model
+         *
+         * @param model   The model to be modified
+         * @param context Additional information about the model being modified
+         * @return the modified model or, if no modifications were applied, the original model
+         */
+        default UnbakedModel modifyModelOnLoad(UnbakedModel model, Context context) {
+            return model;
+        }
+
+        interface Context {
+            /** {@return the ID of the model being modified} */
+            Identifier id();
+        }
+    }
+
+    /**
+     * Called after a {@link BlockStateModel.UnbakedRoot} has been instantiated in a {@link BlockStateModelDispatcher}.
+     */
+    non-sealed interface ModifyBlockOnLoad extends ModelModifier {
+        /**
+         * Modify the incoming model
+         *
+         * @param model   The model to be modified
+         * @param context Additional information about the model being modified
+         * @return the modified model or, if no modifications were applied, the original model
+         */
+        default BlockStateModel.UnbakedRoot modifyBlockModelOnLoad(BlockStateModel.UnbakedRoot model, Context context) {
+            return model;
+        }
+
+        interface Context {
+            /** {@return the {@link BlockState} the model being modified is assigned to} */
+            BlockState state();
+        }
+    }
+
+    /**
+     * Called before a {@link BlockStateModel.UnbakedRoot} is about to be baked into a {@link BlockStateModel}.
+     */
+    non-sealed interface ModifyBlockBeforeBake extends ModelModifier {
+        /**
+         * Modify the incoming model
+         *
+         * @param model   The model to be modified
+         * @param context Additional information about the model being modified
+         * @return the modified model or, if no modifications were applied, the original model
+         */
+        default BlockStateModel.UnbakedRoot modifyBlockModelBeforeBake(BlockStateModel.UnbakedRoot model, Context context) {
+            return model;
+        }
+
+        interface Context {
+            /** {@return the {@link BlockState} the model being modified is assigned to} */
+            BlockState state();
+
+            /** {@return the {@link ModelBaker} the model will be baked with} */
+            ModelBaker baker();
+        }
+    }
+
+    /**
+     * Called after a {@link BlockStateModel.UnbakedRoot} has been baked into a {@link BlockStateModel}.
+     */
+    non-sealed interface ModifyBlockAfterBake extends ModelModifier {
+        /**
+         * Modify the incoming model
+         *
+         * @param model   The model to be modified
+         * @param context Additional information about the model being modified
+         * @return the modified model or, if no modifications were applied, the original model
+         */
+        default BlockStateModel modifyBlockModelAfterBake(BlockStateModel model, Context context) {
+            return model;
+        }
+
+        interface Context {
+            /** {@return the {@link BlockState} the model being modified is assigned to} */
+            BlockState state();
+
+            /** {@return the {@link BlockStateModel.UnbakedRoot} the model was baked from} */
+            BlockStateModel.UnbakedRoot sourceModel();
+
+            /** {@return the {@link ModelBaker} the model was baked with} */
+            ModelBaker baker();
+        }
+    }
+
+    /**
+     * Called before an {@link ItemModel.Unbaked} is about to be baked into an {@link ItemModel}.
+     */
+    non-sealed interface ModifyItemBeforeBake extends ModelModifier {
+        /**
+         * Modify the incoming model
+         *
+         * @param model   The model to be modified
+         * @param context Additional information about the model being modified
+         * @return the modified model or, if no modifications were applied, the original model
+         */
+        default ItemModel.Unbaked modifyItemModelBeforeBake(ItemModel.Unbaked model, Context context) {
+            return model;
+        }
+
+        interface Context {
+            /** {@return the ID of the model being modified} */
+            Identifier id();
+
+            /** {@return the {@link ClientItem} the model is declared by} */
+            ClientItem clientItem();
+
+            /** {@return the {@link ItemModel.BakingContext} the model will be baked with} */
+            ItemModel.BakingContext bakingContext();
+        }
+    }
+
+    /**
+     * Called after an {@link ItemModel.Unbaked} has been baked into an {@link ItemModel}.
+     */
+    non-sealed interface ModifyItemAfterBake extends ModelModifier {
+        /**
+         * Modify the incoming model
+         *
+         * @param model   The model to be modified
+         * @param context Additional information about the model being modified
+         * @return the modified model or, if no modifications were applied, the original model
+         */
+        default ItemModel modifyItemModelAfterBake(ItemModel model, Context context) {
+            return model;
+        }
+
+        interface Context {
+            /** {@return the ID of the model being modified} */
+            Identifier id();
+
+            /** {@return the {@link ItemModel.Unbaked} the model was baked from} */
+            ItemModel.Unbaked sourceModel();
+
+            /** {@return the {@link ClientItem} the model is declared by} */
+            ClientItem clientItem();
+
+            /** {@return the {@link ItemModel.BakingContext} the model was baked with} */
+            ItemModel.BakingContext bakingContext();
+        }
+    }
+
+    /**
+     * Different phases of modifier application to provide a rough order between modifiers with different intentions.
+     */
+    enum Phase {
+        /**
+         * Intended for modifiers which entirely override the incoming model
+         */
+        OVERRIDE,
+        /**
+         * Default catch-all phase
+         */
+        DEFAULT,
+        /**
+         * Intended for modifiers which wrap the incoming model
+         */
+        WRAP,
+        /**
+         * Intended for modifiers which wrap the incoming model and need to be the last to do so
+         */
+        WRAP_LAST,
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/PreparableModelLoadingPlugin.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/PreparableModelLoadingPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.loadingplugin;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+import net.minecraft.server.packs.resources.ResourceManager;
+
+/// A plugin into the model loading process which can load additional data from resource packs to drive model modification.
+public interface PreparableModelLoadingPlugin<T> {
+    /// Load additional data from resource packs and/or context provided by other reload listeners
+    ///
+    /// Implementors of this method must not append any additional data to the [PreparableReloadListener.SharedState]
+    /// as this method runs too late for the data to be accessed safely by other reload listeners!
+    ///
+    /// @param sharedState The [PreparableReloadListener.SharedState] providing the [ResourceManager] and
+    ///                    additional state provided by other reload listeners.
+    /// @param executor    The executor to run the loading future on
+    /// @return a future used for loading additional data, driven by the provided executor
+    CompletableFuture<T> load(PreparableReloadListener.SharedState sharedState, Executor executor);
+
+    /// Called at the start of model loading during every resource reload.
+    ///
+    /// Receives the data loaded in the future returned by [#load(PreparableReloadListener.SharedState, Executor)].
+    ///
+    /// @param data    The additional data loaded by [#load(PreparableReloadListener.SharedState, Executor)]
+    /// @param context The context to use for registering [ModelModifier]s
+    void initialize(T data, ModelLoadingPlugin.Context context);
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/package-info.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/loadingplugin/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@NullMarked
+package net.neoforged.neoforge.client.model.loadingplugin;
+
+import org.jspecify.annotations.NullMarked;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
@@ -19,6 +19,7 @@ import net.minecraft.client.resources.model.geometry.QuadCollection;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
@@ -42,6 +43,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.model.DelegateBlockStateModel;
+import net.neoforged.neoforge.client.model.loadingplugin.ModelModifier;
 import net.neoforged.neoforge.client.model.quad.QuadTransforms;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.model.data.ModelData;
@@ -98,10 +100,16 @@ public class MegaModelTest {
     @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID)
     public static class ClientEvents {
         @SubscribeEvent
-        public static void onModelBakingCompleted(ModelEvent.ModifyBakingResult event) {
-            event.getBakingResult().blockStateModels().computeIfPresent(
-                    TEST_BLOCK.value().defaultBlockState(),
-                    (n, m) -> new TransformingModelWrapper(m));
+        public static void onRegisterModelLoadingPlugins(ModelEvent.RegisterLoadingPlugins event) {
+            event.registerPlugin(Identifier.fromNamespaceAndPath(MOD_ID, "wrap"), ctx -> ctx.registerModifier(new ModelModifier.ModifyBlockAfterBake() {
+                @Override
+                public BlockStateModel modifyBlockModelAfterBake(BlockStateModel model, Context context) {
+                    if (context.state().is(TEST_BLOCK)) {
+                        return new TransformingModelWrapper(model);
+                    }
+                    return model;
+                }
+            }));
         }
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/TRSRTransformerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/TRSRTransformerTest.java
@@ -6,10 +6,9 @@
 package net.neoforged.neoforge.oldtest.client.model;
 
 import com.mojang.math.Transformation;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/TRSRTransformerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/TRSRTransformerTest.java
@@ -6,10 +6,10 @@
 package net.neoforged.neoforge.oldtest.client.model;
 
 import com.mojang.math.Transformation;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
@@ -18,6 +18,7 @@ import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.client.resources.model.geometry.QuadCollection;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.Util;
 import net.minecraft.world.item.BlockItem;
@@ -30,6 +31,7 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.model.DelegateBlockStateModel;
+import net.neoforged.neoforge.client.model.loadingplugin.ModelModifier;
 import net.neoforged.neoforge.client.model.quad.QuadTransforms;
 import net.neoforged.neoforge.common.util.TransformationHelper;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
@@ -52,7 +54,7 @@ public class TRSRTransformerTest {
 
     public TRSRTransformerTest(IEventBus modEventBus) {
         if (FMLEnvironment.getDist().isClient()) {
-            modEventBus.addListener(TRSRTransformerTest::onModelBake);
+            modEventBus.addListener(TRSRTransformerTest::onRegisterModelLoadingPlugins);
         }
         BLOCKS.register(modEventBus);
         ITEMS.register(modEventBus);
@@ -64,13 +66,16 @@ public class TRSRTransformerTest {
             event.accept(TEST_ITEM);
     }
 
-    private static void onModelBake(ModelEvent.ModifyBakingResult e) {
-        Map<BlockState, BlockStateModel> models = e.getBakingResult().blockStateModels();
-        for (BlockState state : models.keySet()) {
-            if (state.is(TEST_BLOCK)) {
-                models.put(state, new MyBakedModel(models.get(state)));
+    private static void onRegisterModelLoadingPlugins(ModelEvent.RegisterLoadingPlugins event) {
+        event.registerPlugin(Identifier.fromNamespaceAndPath(MODID, "wrap"), ctx -> ctx.registerModifier(new ModelModifier.ModifyBlockAfterBake() {
+            @Override
+            public BlockStateModel modifyBlockModelAfterBake(BlockStateModel model, Context context) {
+                if (context.state().is(TEST_BLOCK)) {
+                    return new MyBakedModel(model);
+                }
+                return model;
             }
-        }
+        }));
     }
 
     private static class MyBakedModel extends DelegateBlockStateModel {


### PR DESCRIPTION
This PR adds model loading plugins which are intended to replace `ModelEvent.ModifyBakingResult`. These allow more precise model wrapping, including wrapping unbaked models. Another benefit of this API design is that it allows mods which implement on-demand model loading/baking a lot more control and improves compatibility between those mods and ones using the model wrapping APIs.
As is probably very obvious, this PR is very heavily inspired by Fabric API's model loading APIs and therefor has an almost 100% overlap in terms of API surface and injection points.

The model loading plugins provide seven entrypoints into the model loading and baking process:
- On-load/on-load-block modifiers: on-load modifiers are registered globally and allow wrapping unbaked models and unbaked blockstate models as they are loaded and therefor affect all further uses of the model in question
- Pre-bake-block/pre-bake-item modifiers: pre-bake modifiers are registered globally and allow wrapping unbaked blockstate models and unbaked item models respectively right before baking and therefor only affect the specific baking process following their execution
- Post-bake-block/post-bake-item modifiers: post-bake modifiers are registered globally and allow wrapping baked blockstate models and baked item models respectively right after baking (effectively equivalent to wrapping models in `ModelEvent.ModifyBakingResult`)

Apart from the missing documentation, there are still a few questions open:
- Should we try to aggressively re-use context objects?
- What would be the preferred way of exposing the plugins to mods implementing on-demand loading/baking?