### PR TITLE
Move patched code to iface injection

### DIFF
--- a/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java
 +++ b/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java
-@@ -254,7 +_,7 @@
-     }
- 
-     @OnlyIn(Dist.CLIENT)
--    public class RenderSection implements net.neoforged.neoforge.client.IRenderableSection {
-+    public class RenderSection {
-         public static final int SIZE = 16;
-         public final int index;
-         public final AtomicReference<SectionRenderDispatcher.CompiledSection> compiled = new AtomicReference<>(
 @@ -399,9 +_,10 @@
  
          public SectionRenderDispatcher.RenderSection.CompileTask createCompileTask(RenderRegionCache p_295324_) {

--- a/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionRenderDispatcher.java.patch
@@ -4,8 +4,8 @@
      }
  
      @OnlyIn(Dist.CLIENT)
--    public class RenderSection {
-+    public class RenderSection implements net.neoforged.neoforge.client.IRenderableSection {
+-    public class RenderSection implements net.neoforged.neoforge.client.IRenderableSection {
++    public class RenderSection {
          public static final int SIZE = 16;
          public final int index;
          public final AtomicReference<SectionRenderDispatcher.CompiledSection> compiled = new AtomicReference<>(

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -234,6 +234,9 @@
   "net/minecraft/client/data/models/model/TexturedModel$Provider": [
     "net/neoforged/neoforge/client/extensions/ITexturedModelExtension$Provider"
   ],
+  "net/minecraft/client/renderer/chunk/SectionRenderDispatcher$RenderSection": [
+    "net/neoforged/neoforge/client/IRenderableSection"
+  ],
   "com/mojang/blaze3d/vertex/VertexFormatElement$Usage": [
     "net/neoforged/fml/common/asm/enumextension/IExtensibleEnum"
   ],


### PR DESCRIPTION
This PR fixes an issue with #1472 in which an interface was patched into the vanilla code, when it should have been injected.