### PR TITLE
Use custom composite checkout action and fix builds

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -20,22 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
-
-      # GradleUtils will append the branch name to the version,
-      # but for that we need a properly checked out branch
-      - name: Create branch for commit (PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        run:
-          git switch -C pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.ref }}
-
-      - name: Create branch for commit
-        if: ${{ github.event_name != 'pull_request' }}
-        run:
-          git switch -C ${{ github.ref_name }}
+        uses: neoforged/actions/checkout@main
 
       - name: Setup JDK 21
         uses: neoforged/actions/setup-java@main

--- a/.github/workflows/check-local-changes.yml
+++ b/.github/workflows/check-local-changes.yml
@@ -13,16 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
-
-      # GradleUtils will append the branch name to the version,
-      # but for that we need a properly checked out branch
-      - name: Create branch for commit
-        run:
-          git switch -C pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.ref }}
+        uses: neoforged/actions/checkout@main
 
       - name: Setup JDK 21
         uses: neoforged/actions/setup-java@main

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -17,16 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
-
-      # GradleUtils will append the branch name to the version,
-      # but for that we need a properly checked out branch
-      - name: Create branch for commit
-        run:
-          git switch -C pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.ref }}
+        uses: neoforged/actions/checkout@main
 
       - name: Setup JDK 21
         uses: neoforged/actions/setup-java@main


### PR DESCRIPTION
This PR fixes PR builds by replacing the duplicate code to check out the repository with a custom composite action that is patched to account for https://github.com/actions/checkout/issues/2041 as the Git version on GitHub-hosted runners [was updated](https://github.com/actions/runner-images/commit/9303ddeb0cd4899812a8fbfdf19e64dc0319bfe5) to 2.48.1 a few hours ago.