### PR TITLE
Fix entity movement in custom fluid types

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -492,6 +492,18 @@
      }
  
      protected float getWaterSlowDown() {
+@@ -2193,8 +_,9 @@
+     public void travel(Vec3 p_21280_) {
+         if (this.isControlledByLocalInstance()) {
+             FluidState fluidstate = this.level().getFluidState(this.blockPosition());
+-            if ((this.isInWater() || this.isInLava()) && this.isAffectedByFluids() && !this.canStandOnFluid(fluidstate)) {
+-                this.travelInFluid(p_21280_);
++            // Neo: Call (patched-in overload of) #travelInFluid for custom fluid types
++            if ((this.isInWater() || this.isInLava() || this.isInFluidType(fluidstate)) && this.isAffectedByFluids() && !this.canStandOnFluid(fluidstate)) {
++                this.travelInFluid(p_21280_, fluidstate);
+             } else if (this.isFallFlying()) {
+                 this.travelFallFlying();
+             } else {
 @@ -2205,7 +_,7 @@
  
      private void travelInAir(Vec3 p_362457_) {


### PR DESCRIPTION
This PR fixes #1832 by patching `LivingEntity#travel` to handle custom fluid types, reimplementing a missing patch from 1.21.1 as described in the description of the linked issue.

Tested through the `tests` client by diving into a pool filled with `new_fluid_test:test_fluid` (the creative search tab should yield a bucket for it) and trying to swim upwards. Before the fix, the player falls through it as if it wasn't there, but could not jump. After the fix, the player moves in the fluid like if it were water or lava, and can jump.