### PR TITLE
Cleanup cross-project dependencies

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevConfigurations.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevConfigurations.java
@@ -138,7 +138,7 @@ class NeoDevConfigurations {
 
         // Libraries & module libraries & MC dependencies need to be available when compiling in NeoDev,
         // and on the runtime classpath too for IDE debugging support.
-        configurations.getByName("implementation").extendsFrom(libraries, moduleLibraries, neoFormDependencies);
+        configurations.getByName("api").extendsFrom(libraries, moduleLibraries, neoFormDependencies);
 
         // runtimeClasspath is our reference for all MC dependency versions.
         // Make sure that any classpath we resolve is consistent with it.

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -267,8 +267,8 @@ javaComponent.withVariantsFromConfiguration(configurations.runtimeElements) {
 configurations {
     runtimeElements {
         attributes {
-            // Add an internal attribute to disambiguate with the universalJar
-            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+            // Add an attribute to disambiguate with the universalJar
+            attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
         }
     }
     modDevBundle {

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -319,7 +319,7 @@ configurations {
             attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.current().majorVersion.toInteger())
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, java_version as Integer)
             attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
         }
         // Publish it

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -265,6 +265,12 @@ javaComponent.withVariantsFromConfiguration(configurations.runtimeElements) {
 
 // Resolvable configurations only
 configurations {
+    runtimeElements {
+        attributes {
+            // Add an internal attribute to disambiguate with the universalJar
+            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+        }
+    }
     modDevBundle {
         canBeDeclared = false
         canBeResolved = false

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -10,7 +10,7 @@ java.withSourcesJar()
 apply plugin : net.neoforged.minecraftdependencies.MinecraftDependenciesPlugin
 
 dependencies {
-    compileOnly(project(path: ':neoforge'))
+    compileOnly project(path: ':neoforge')
 
     compileOnly(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
     compileOnly "org.junit.jupiter:junit-jupiter-params"

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     compileOnly(project(path: ':neoforge')) {
         // Select runtimeElements rather than universalJar from the neoforge project
         attributes {
-            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+            attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
         }
     }
 

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -10,25 +10,18 @@ java.withSourcesJar()
 apply plugin : net.neoforged.minecraftdependencies.MinecraftDependenciesPlugin
 
 dependencies {
-    // TODO: is this leaking in the POM? (most likely yes)
-    // TODO: does this need to be changed back to runtimeDependencies?
-    // TODO: should use attributes to resolve the right variant instead of hardcoding
-    compileOnly project(path: ':neoforge', configuration: 'apiElements')
-    runtimeOnly project(path: ':neoforge', configuration: 'runtimeElements')
+    compileOnly(project(path: ':neoforge')) {
+        // Select runtimeElements rather than universalJar from the neoforge project
+        attributes {
+            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+        }
+    }
 
     compileOnly(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
     compileOnly "org.junit.jupiter:junit-jupiter-params"
 
     compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
     compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-}
-
-sourceSets {
-    main {
-        // TODO: cursed
-        compileClasspath += project(':neoforge').sourceSets.main.compileClasspath
-        runtimeClasspath += project(':neoforge').sourceSets.main.runtimeClasspath
-    }
 }
 
 license {

--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -10,12 +10,7 @@ java.withSourcesJar()
 apply plugin : net.neoforged.minecraftdependencies.MinecraftDependenciesPlugin
 
 dependencies {
-    compileOnly(project(path: ':neoforge')) {
-        // Select runtimeElements rather than universalJar from the neoforge project
-        attributes {
-            attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
-        }
-    }
+    compileOnly(project(path: ':neoforge'))
 
     compileOnly(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
     compileOnly "org.junit.jupiter:junit-jupiter-params"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -22,12 +22,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation(neoforgeProject) {
-        // Select runtimeElements rather than universalJar from the neoforge project
-        attributes {
-            attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
-        }
-    }
+    implementation(neoforgeProject)
     implementation(testframeworkProject)
 
     junitImplementation(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
@@ -36,15 +31,19 @@ dependencies {
 
     junitImplementation("org.assertj:assertj-core:${project.assertj_core}")
     junitImplementation "net.neoforged.fancymodloader:junit-fml:${project.fancy_mod_loader_version}"
-    junitImplementation(neoforgeProject) {
-        // Select runtimeElements rather than universalJar from the neoforge project
+    junitImplementation(neoforgeProject)
+    junitImplementation(testframeworkProject)
+
+    compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
+}
+
+// Select runtimeElements rather than universalJar from the neoforge project
+sourceSets.each {
+    configurations.named(it.runtimeClasspathConfigurationName) {
         attributes {
             attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
         }
     }
-    junitImplementation(testframeworkProject)
-
-    compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 }
 
 junitTest {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -22,7 +22,12 @@ sourceSets {
 }
 
 dependencies {
-    implementation project(path: ':neoforge', configuration: 'runtimeElements')
+    implementation(neoforgeProject) {
+        // Select runtimeElements rather than universalJar from the neoforge project
+        attributes {
+            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+        }
+    }
     implementation(testframeworkProject)
 
     junitImplementation(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
@@ -31,7 +36,12 @@ dependencies {
 
     junitImplementation("org.assertj:assertj-core:${project.assertj_core}")
     junitImplementation "net.neoforged.fancymodloader:junit-fml:${project.fancy_mod_loader_version}"
-    junitImplementation project(path: ':neoforge', configuration: 'runtimeElements')
+    junitImplementation(neoforgeProject) {
+        // Select runtimeElements rather than universalJar from the neoforge project
+        attributes {
+            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+        }
+    }
     junitImplementation(testframeworkProject)
 
     compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation(neoforgeProject) {
         // Select runtimeElements rather than universalJar from the neoforge project
         attributes {
-            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+            attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
         }
     }
     implementation(testframeworkProject)
@@ -39,7 +39,7 @@ dependencies {
     junitImplementation(neoforgeProject) {
         // Select runtimeElements rather than universalJar from the neoforge project
         attributes {
-            attribute(Attribute.of("net.neoforged.neoforge.internal", Boolean), true)
+            attribute(Attribute.of("net.neoforged.neoforge.includes-minecraft", Boolean), true)
         }
     }
     junitImplementation(testframeworkProject)


### PR DESCRIPTION
- Use attributes to resolve the correct variant of the `neoforge` project, in `tests`. Since `runtimeElements` and `universalJar` have the same attributes, and adding attributes to `universalJar` would be a breaking change, I added an internal attribute to `runtimeElements` instead.
- Fix `testframework` being published with a runtime dependency on the universal jar. Now there is no dependency whatsoever.
- Fix java version attribute of the `universalJar` being the Java version used to run Gradle rather than the Java version of the toolchain.