### PR TITLE
Add `genPatches` task alias to 1.21.1

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -138,6 +138,10 @@ dependencies {
     compileOnly(jarJar(project(":neoforge-coremods")))
 }
 
+tasks.register('genPatches') {
+    dependsOn(tasks.named('unpackSourcePatches'))
+}
+
 runTypes {
     client {
         singleInstance false


### PR DESCRIPTION
Add a `genPatches` alias to the unpackSourcePatches task to match 1.21.2+ builds and allow the backporting bot same task across 1.21.1 and newer (and future) versions. 