### PR TITLE
Fix ClientCommandSourceStack crashing or returning improper values for certain method calls

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
@@ -109,7 +109,7 @@ public class ClientCommandSourceStack extends CommandSourceStack {
     }
 
     /**
-     * {@return the {@link FeatureFlagSet } from the client side}
+     * {@return the {@link FeatureFlagSet} from the client side}
      */
     @Override
     public FeatureFlagSet enabledFeatures() {

--- a/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
@@ -56,9 +56,8 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public void sendSuccess(Supplier<Component> message, boolean sendToAdmins) {
-        if (this.source.acceptsSuccess() && !isSilent()) {
-            this.source.sendSystemMessage(message.get());
-        }
+        //Don't send the message to admins, as that requires querying the server for the list of admins, and would cause a NPE
+        super.sendSuccess(message, false);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientCommandSourceStack.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.commands.CommandSource;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
@@ -27,6 +28,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec2;
 import net.minecraft.world.phys.Vec3;
@@ -43,11 +45,20 @@ public class ClientCommandSourceStack extends CommandSourceStack {
     }
 
     /**
+     * {@return the current connection, used to shorten method calls and hide the nullability warnings}
+     */
+    private ClientPacketListener connection() {
+        return Minecraft.getInstance().getConnection();
+    }
+
+    /**
      * Sends a success message without attempting to get the server side list of admins
      */
     @Override
     public void sendSuccess(Supplier<Component> message, boolean sendToAdmins) {
-        Minecraft.getInstance().gui.getChat().addMessage(message.get());
+        if (this.source.acceptsSuccess() && !isSilent()) {
+            this.source.sendSystemMessage(message.get());
+        }
     }
 
     /**
@@ -55,7 +66,7 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public Collection<String> getAllTeams() {
-        return Minecraft.getInstance().level.getScoreboard().getTeamNames();
+        return getScoreboard().getTeamNames();
     }
 
     /**
@@ -63,20 +74,23 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public Collection<String> getOnlinePlayerNames() {
-        return Minecraft.getInstance().getConnection().getOnlinePlayers().stream().map((player) -> player.getProfile().getName()).collect(Collectors.toList());
+        return connection().getOnlinePlayers().stream().map(player -> player.getProfile().getName()).collect(Collectors.toList());
     }
 
     @Override
     public CompletableFuture<Suggestions> suggestRegistryElements(
-            ResourceKey<? extends Registry<?>> p_212330_,
-            SharedSuggestionProvider.ElementSuggestionType p_212331_,
-            SuggestionsBuilder p_212332_,
-            CommandContext<?> p_212333_) {
-        // TODO 1.21.2: Not sure what to do here. Letting super get called will cause an NPE on this.server.
-        if (p_212330_ == Registries.RECIPE || p_212330_ == Registries.ADVANCEMENT) {
+            ResourceKey<? extends Registry<?>> registry,
+            SharedSuggestionProvider.ElementSuggestionType suggestionType,
+            SuggestionsBuilder suggestionsBuilder,
+            CommandContext<?> context) {
+        if (registry == Registries.RECIPE) {
+            // TODO 1.21.2: Not sure what to do here as the client doesn't receive recipe names. Letting super get called will cause an NPE on this.server.
             return Suggestions.empty();
+        } else if (registry == Registries.ADVANCEMENT) {
+            //Only suggest from advancements that are visible to the player
+            return SharedSuggestionProvider.suggestResource(connection().getAdvancements().getTree().nodes().stream().map(node -> node.holder().id()), suggestionsBuilder);
         }
-        return super.suggestRegistryElements(p_212330_, p_212331_, p_212332_, p_212333_);
+        return super.suggestRegistryElements(registry, suggestionType, suggestionsBuilder, context);
     }
 
     /**
@@ -84,7 +98,7 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public Set<ResourceKey<Level>> levels() {
-        return Minecraft.getInstance().getConnection().levels();
+        return connection().levels();
     }
 
     /**
@@ -92,7 +106,15 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public RegistryAccess registryAccess() {
-        return Minecraft.getInstance().getConnection().registryAccess();
+        return connection().registryAccess();
+    }
+
+    /**
+     * {@return the {@link FeatureFlagSet } from the client side}
+     */
+    @Override
+    public FeatureFlagSet enabledFeatures() {
+        return connection().enabledFeatures();
     }
 
     /**
@@ -100,7 +122,7 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public Scoreboard getScoreboard() {
-        return Minecraft.getInstance().level.getScoreboard();
+        return connection().scoreboard();
     }
 
     /**
@@ -109,7 +131,7 @@ public class ClientCommandSourceStack extends CommandSourceStack {
     @Override
     @Nullable
     public AdvancementHolder getAdvancement(ResourceLocation id) {
-        return Minecraft.getInstance().getConnection().getAdvancements().get(id);
+        return connection().getAdvancements().get(id);
     }
 
     /**
@@ -117,7 +139,7 @@ public class ClientCommandSourceStack extends CommandSourceStack {
      */
     @Override
     public Level getUnsidedLevel() {
-        return Minecraft.getInstance().level;
+        return connection().getLevel();
     }
 
     /**


### PR DESCRIPTION
- Reimplement `ClientCommandSourceStack#suggestRegistryElements` for advancements based on the list of visible advancements on the client (fixes a regression/addresses a TODO from the port to 1.21.2. The other part for recipes, I didn't fix as I don't think there is any way to suggest recipe names on the client as it no longer receives them)
- Added an override for `ClientCommandSourceStack#enabledFeatures` to provide the enabled features instead of throwing a NPE due to server being null.
- Made `ClientCommandSourceStack#sendSuccess` properly make use of the `CommandSource`'s settings and if the command source stack is set to silent. Now it just calls super, but explicitly marks that the success should not be sent to admins. This way we won't have to worry about divergence in our copy if vanilla makes any changes.
- Slightly cleaned up implementation by making everything just go through the connection instead of some things go through `Minecraft#getInstance`'s copy of various fields (for example levels), and hiding the fact that it technically can be nullable to reduce overall warnings when viewing the code.