### PR TITLE
[1.21.4] Revert Registries to Frozen on Disconnect when a connection is present

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -324,7 +324,7 @@
          this.level = p_91157_;
          this.updateLevelInEngines(p_91157_);
          if (!this.isLocalServer) {
-@@ -2030,6 +_,7 @@
+@@ -2030,13 +_,16 @@
          IntegratedServer integratedserver = this.singleplayerServer;
          this.singleplayerServer = null;
          this.gameRenderer.resetData();
@@ -332,7 +332,8 @@
          this.gameMode = null;
          this.narrator.clear();
          this.clientLevelTeardownInProgress = true;
-@@ -2037,6 +_,7 @@
+ 
++        var connection = this.getConnection() != null ? this.getConnection().getConnection() : null; // Neo: Hold connection to revert after shutdown
          try {
              this.updateScreenAndTick(p_320248_);
              if (this.level != null) {
@@ -340,6 +341,14 @@
                  if (integratedserver != null) {
                      ProfilerFiller profilerfiller = Profiler.get();
                      profilerfiller.push("waitForServer");
+@@ -2060,6 +_,7 @@
+         }
+ 
+         SkullBlockEntity.clear();
++        if(connection != null) net.neoforged.neoforge.registries.RegistryManager.revertToFrozen(); // Neo: Revert registries to frozen on disconnect
+     }
+ 
+     public void clearDownloadedResourcePacks() {
 @@ -2197,6 +_,7 @@
  
      private void pickBlock() {

--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -333,7 +333,7 @@
          this.narrator.clear();
          this.clientLevelTeardownInProgress = true;
  
-+        var connection = this.getConnection() != null ? this.getConnection().getConnection() : null; // Neo: Hold connection to revert after shutdown
++        var shouldRevertRegistriesToFrozen = this.getConnection() != null && this.getConnection().getConnection() != null; // Neo: Track whether to revert registries after disconnect
          try {
              this.updateScreenAndTick(p_320248_);
              if (this.level != null) {
@@ -345,7 +345,7 @@
          }
  
          SkullBlockEntity.clear();
-+        if(connection != null) net.neoforged.neoforge.registries.RegistryManager.revertToFrozen(); // Neo: Revert registries to frozen on disconnect
++        if(shouldRevertRegistriesToFrozen) net.neoforged.neoforge.registries.RegistryManager.revertToFrozen(); // Neo: Revert registries to frozen on disconnect
      }
  
      public void clearDownloadedResourcePacks() {

--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -63,16 +63,6 @@
          this.connection.send(p_295097_);
      }
  
-@@ -285,6 +_,9 @@
-     public void onDisconnect(DisconnectionDetails p_350760_) {
-         this.telemetryManager.onDisconnect();
-         this.minecraft.disconnect(this.createDisconnectScreen(p_350760_), this.isTransferring);
-+        if (!this.connection.isMemoryConnection()) {
-+            net.neoforged.neoforge.registries.RegistryManager.revertToFrozen();
-+        }
-         LOGGER.warn("Client disconnected with reason: {}", p_350760_.reason().getString());
-     }
- 
 @@ -409,5 +_,10 @@
          @OnlyIn(Dist.CLIENT)
          static record PendingRequest(UUID id, URL url, String hash) {

--- a/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
@@ -49,7 +49,6 @@ import net.neoforged.neoforge.gametest.GameTestHooks;
 import net.neoforged.neoforge.mixins.MappedRegistryAccessor;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.NeoForgeRegistries.Keys;
-import net.neoforged.neoforge.registries.RegistryManager;
 import net.neoforged.neoforge.server.permission.PermissionAPI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -123,7 +122,6 @@ public class ServerLifecycleHooks {
     }
 
     public static void handleServerStopped(final MinecraftServer server) {
-        if (!server.isDedicatedServer()) RegistryManager.revertToFrozen();
         NeoForge.EVENT_BUS.post(new ServerStoppedEvent(server));
         currentServer = null;
         LogicalSidedProvider.setServer(null);


### PR DESCRIPTION
Closes #1932 

Moves the call to `RegistryManager#revertToFrozen` to `Minecraft#disconnect` to handle every case of the vanilla client disconnecting from some server instance. As we don't want to revert the registries until after all potential usecases are handled, the logic is cached before the connection is released and ran at the end of the method. There is no need to include the memory connection check as this is called regardless of the type of channel used, as evidenced by its prior use in `ServerLifecycleHooks#handleServerStopped`.

The test provided in the issue was used to verify the logic.