### PR TITLE
Fix note block interaction causing doubled note increase

### DIFF
--- a/patches/net/minecraft/world/level/block/NoteBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/NoteBlock.java.patch
@@ -1,9 +1,10 @@
 --- a/net/minecraft/world/level/block/NoteBlock.java
 +++ b/net/minecraft/world/level/block/NoteBlock.java
-@@ -122,6 +_,9 @@
+@@ -121,7 +_,9 @@
+     @Override
      protected InteractionResult useWithoutItem(BlockState p_316441_, Level p_316774_, BlockPos p_316344_, Player p_316884_, BlockHitResult p_316631_) {
          if (!p_316774_.isClientSide) {
-             p_316441_ = p_316441_.cycle(NOTE);
+-            p_316441_ = p_316441_.cycle(NOTE);
 +            int _new = net.neoforged.neoforge.common.CommonHooks.onNoteChange(p_316774_, p_316344_, p_316441_, p_316441_.getValue(NOTE), p_316441_.cycle(NOTE).getValue(NOTE));
 +            if (_new == -1) return InteractionResult.FAIL;
 +            p_316441_ = p_316441_.setValue(NOTE, _new);


### PR DESCRIPTION
This PR fixes #1938 by removing the original `cycle` call (as was done in the pre-1.21.2 patch), which is already replicated in the event firing call.

Tested to work using same steps in linked issue; upon interaction, `note` state property is only increased by one value instead of two.