### PR TITLE
Check if main render target is initialized before resizing it

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -179,7 +179,7 @@
          this.deltaTracker.updatePauseState(this.pause);
          this.deltaTracker.updateFrozenState(!this.isLevelRunningNormally());
          long l = Util.getNanos();
-@@ -1351,10 +_,12 @@
+@@ -1351,10 +_,13 @@
          this.window.setGuiScale((double)i);
          if (this.screen != null) {
              this.screen.resize(this, this.window.getGuiScaledWidth(), this.window.getGuiScaledHeight());
@@ -187,6 +187,7 @@
          }
  
          RenderTarget rendertarget = this.getMainRenderTarget();
++        if (rendertarget != null)
          rendertarget.resize(this.window.getWidth(), this.window.getHeight());
 +        if (this.gameRenderer != null)
          this.gameRenderer.resize(this.window.getWidth(), this.window.getHeight());


### PR DESCRIPTION
If the user resizes the window after the early display has handed off to Minecraft, but prior to Minecraft finishing initialization of the renderer, a crash can occur due to the render target not yet being present. The crash can occasionally be reproduced by continuously resizing the window during startup. 

This patch fixes the problem by checking if the main render target is initialized before trying to resize it.