### PR TITLE
Avoid swallowing errors in case of AttachmentType Serialization failure

### DIFF
--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -121,12 +121,17 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
         CompoundTag tag = null;
         for (var entry : attachments.entrySet()) {
             var type = entry.getKey();
+            var key = NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type);
             if (type.serializer != null) {
-                Tag serialized = ((IAttachmentSerializer<?, Object>) type.serializer).write(entry.getValue(), provider);
-                if (serialized != null) {
-                    if (tag == null)
-                        tag = new CompoundTag();
-                    tag.put(NeoForgeRegistries.ATTACHMENT_TYPES.getKey(type).toString(), serialized);
+                try {
+                    Tag serialized = ((IAttachmentSerializer<?, Object>) type.serializer).write(entry.getValue(), provider);
+                    if (serialized != null) {
+                        if (tag == null)
+                            tag = new CompoundTag();
+                        tag.put(key.toString(), serialized);
+                    }
+                } catch (Exception exception) {
+                    LOGGER.error("Failed to serialize data attachment {}. Skipping.", key, exception);
                 }
             }
         }

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -217,7 +217,6 @@ public final class AttachmentType<T> {
                 }
 
                 private RuntimeException buildException(final String operation, final String error) {
-                    // TODO: Maybe find a way to let the user know *which* attachment has exploded?
                     return new IllegalStateException("Unable to " + operation + " attachment due to an internal codec error: " + error);
                 }
             });

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.attachment;
 
 import com.google.common.base.Predicates;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -198,17 +199,26 @@ public final class AttachmentType<T> {
          */
         public Builder<T> serialize(Codec<T> codec, Predicate<? super T> shouldSerialize) {
             Objects.requireNonNull(codec);
-            // TODO: better error handling
             return serialize(new IAttachmentSerializer<>() {
                 @Override
                 public T read(IAttachmentHolder holder, Tag tag, HolderLookup.Provider provider) {
-                    return codec.parse(provider.createSerializationContext(NbtOps.INSTANCE), tag).result().get();
+                    final DataResult<T> parsingResult = codec.parse(provider.createSerializationContext(NbtOps.INSTANCE), tag);
+                    return parsingResult.getOrThrow(msg -> buildException("read", msg));
                 }
 
                 @Nullable
                 @Override
                 public Tag write(T attachment, HolderLookup.Provider provider) {
-                    return shouldSerialize.test(attachment) ? codec.encodeStart(provider.createSerializationContext(NbtOps.INSTANCE), attachment).result().get() : null;
+                    if (!shouldSerialize.test(attachment)) {
+                        return null;
+                    }
+                    final DataResult<Tag> encodingResult = codec.encodeStart(provider.createSerializationContext(NbtOps.INSTANCE), attachment);
+                    return encodingResult.getOrThrow(msg -> buildException("write", msg));
+                }
+
+                private RuntimeException buildException(final String operation, final String error) {
+                    // TODO: Maybe find a way to let the user know *which* attachment has exploded?
+                    return new IllegalStateException("Unable to " + operation + " attachment due to an internal codec error: " + error);
                 }
             });
         }


### PR DESCRIPTION
Given that [this TODO](https://github.com/neoforged/NeoForge/blob/83c257a12ae695966439be48e1917ae8318148b6/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java#L201) has been here since the inception of the system, and that I've seen quite a few errors get swallowed, I figured it was time to tackle this.

The change itself is trivial, but going through `DataResult#getOrThrow` rather than first obtaining the `Optional` and then unconditionally unwrapping it gives us access to the error message that signals the issue within the codec, so the developer has a better idea of what's going on.

It would be better if we were to somehow also be able to print the ID or some other kind of identifying info to specifically indicate which attachment is exploding, but that does not seem to be possible with the system as it is currently designed. For this reason, I decided to leave that temporarily as a further TODO for discussion.
