### PR TITLE
Hanging Pale Moss not dropping with modded shears

### DIFF
--- a/src/generated/resources/data/minecraft/loot_table/blocks/pale_hanging_moss.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/pale_hanging_moss.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:any_of",
+          "terms": [
+            {
+              "ability": "shears_dig",
+              "condition": "neoforge:can_item_perform_ability"
+            },
+            {
+              "condition": "minecraft:match_tool",
+              "predicate": {
+                "predicates": {
+                  "minecraft:enchantments": [
+                    {
+                      "enchantments": "minecraft:silk_touch",
+                      "levels": {
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pale_hanging_moss"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "minecraft:blocks/pale_hanging_moss"
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLootTableProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLootTableProvider.java
@@ -144,6 +144,8 @@ public final class NeoForgeLootTableProvider extends LootTableProvider {
                 } else {
                     found |= replaceCondition(invLootCondition, consumer);
                 }
+            } else if (lootCondition instanceof CompositeLootItemCondition composite) {
+                found |= findAndReplaceInComposite(composite, poolBuilder::when);
             } else {
                 found |= replaceCondition(lootCondition, poolBuilder::when);
             }


### PR DESCRIPTION
Pale Hanging Moss is not dropping when sheared with modded shears, because the loot table is not changed by the data generation.

This PR adds CompositeLootItemCondition to first level loot table condition detection to support pale hanging moss.