### PR TITLE
Egg tag docs and recipe hookup

### DIFF
--- a/src/generated/resources/data/minecraft/recipe/cake.json
+++ b/src/generated/resources/data/minecraft/recipe/cake.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "A": "minecraft:milk_bucket",
+    "B": "minecraft:sugar",
+    "C": "minecraft:wheat",
+    "E": "#c:eggs"
+  },
+  "pattern": [
+    "AAA",
+    "BEB",
+    "CCC"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:cake"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/pumpkin_pie.json
+++ b/src/generated/resources/data/minecraft/recipe/pumpkin_pie.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:pumpkin",
+    "minecraft:sugar",
+    "#c:eggs"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:pumpkin_pie"
+  }
+}

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -436,6 +436,9 @@ public class Tags {
         public static final TagKey<Item> DYES_ORANGE = DyeColor.ORANGE.getTag();
         public static final TagKey<Item> DYES_WHITE = DyeColor.WHITE.getTag();
 
+        /**
+         * For eggs to use for culinary purposes in recipes such as baking a cake.
+         */
         public static final TagKey<Item> EGGS = tag("eggs");
         public static final TagKey<Item> END_STONES = tag("end_stones");
         public static final TagKey<Item> ENDER_PEARLS = tag("ender_pearls");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
@@ -93,6 +93,7 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
         replace(Blocks.COBBLESTONE, Tags.Items.COBBLESTONES_NORMAL);
         replace(Blocks.COBBLED_DEEPSLATE, Tags.Items.COBBLESTONES_DEEPSLATE);
 
+        replace(Items.EGG, Tags.Items.EGGS);
         replace(Items.STRING, Tags.Items.STRINGS);
         exclude(getConversionRecipeName(Blocks.WHITE_WOOL, Items.STRING));
 


### PR DESCRIPTION
Just to round out the documentation a bit better. Figured this might help people understand why only chicken egg is in it and not turtle egg. I haven't see anyone confused by this but just wanted to stay a step ahead

Also now hooks up the tag to the recipes so modded eggs work for cake and pumpkin pie

Fabric PR: https://github.com/FabricMC/fabric/pull/4445

Closes https://github.com/neoforged/NeoForge/issues/1951