### PR TITLE
Add back missing AbstractVillager.teleport method

### DIFF
--- a/patches/net/minecraft/world/entity/npc/AbstractVillager.java.patch
+++ b/patches/net/minecraft/world/entity/npc/AbstractVillager.java.patch
@@ -8,17 +8,3 @@
      }
  
      protected abstract void rewardTradeXp(MerchantOffer p_35299_);
-@@ -185,13 +_,6 @@
-         }
- 
-         this.readInventoryFromTag(p_35290_, this.registryAccess());
--    }
--
--    @Nullable
--    @Override
--    public Entity teleport(TeleportTransition p_379715_) {
--        this.stopTrading();
--        return super.teleport(p_379715_);
-     }
- 
-     protected void stopTrading() {


### PR DESCRIPTION
I appear to have removed this by accident during the port to 1.21. This should be backported to 1.21.1.