### PR TITLE
Prevent swim speed attribute applying to lava movement

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -35,6 +35,7 @@ import net.minecraft.world.damagesource.DamageSources;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -449,6 +450,12 @@ public class NeoForgeMod {
         public void setItemMovement(ItemEntity entity) {
             Vec3 vec3 = entity.getDeltaMovement();
             entity.setDeltaMovement(vec3.x * (double) 0.95F, vec3.y + (double) (vec3.y < (double) 0.06F ? 5.0E-4F : 0.0F), vec3.z * (double) 0.95F);
+        }
+
+        @Override
+        public boolean move(FluidState state, LivingEntity entity, Vec3 movementVector, double gravity) {
+            // Prevent water movement logic (which is denoted by returning false) being used for lava
+            return true;
         }
     });
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILivingEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILivingEntityExtension.java
@@ -30,7 +30,9 @@ public interface ILivingEntityExtension extends IEntityExtension {
      * @param type the type of the fluid
      */
     default void jumpInFluid(FluidType type) {
-        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double) 0.04F * self().getAttributeValue(NeoForgeMod.SWIM_SPEED), 0.0D));
+        // Apply swim speed only to WATER fluid types
+        double multiplier = type == NeoForgeMod.WATER_TYPE.value() ? self().getAttributeValue(NeoForgeMod.SWIM_SPEED) : 1.0D;
+        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double) 0.04F * multiplier, 0.0D));
     }
 
     /**
@@ -39,7 +41,9 @@ public interface ILivingEntityExtension extends IEntityExtension {
      * @param type the type of the fluid
      */
     default void sinkInFluid(FluidType type) {
-        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double) -0.04F * self().getAttributeValue(NeoForgeMod.SWIM_SPEED), 0.0D));
+        // Apply swim speed only to WATER fluid types
+        double multiplier = type == NeoForgeMod.WATER_TYPE.value() ? self().getAttributeValue(NeoForgeMod.SWIM_SPEED) : 1.0D;
+        self().setDeltaMovement(self().getDeltaMovement().add(0.0D, (double) -0.04F * multiplier, 0.0D));
     }
 
     /**


### PR DESCRIPTION
This PR fixes #1852 by ensuring the movement logic for water (which is affected by the `SWIM_SPEED` attribute) is not applied for the lava fluid (and similarly for any fluids not using the water fluid type).

Tested by using `/attribute @s neoforge:swim_speed base set 10` and trying to swim in a pool of lava (manually made) and confirmed that the swim speed is the same as vanilla, while the attribute still affects swim speed in water.

---

For testing:

- `/fill ~-1 ~-1 ~-1 ~-18 ~-18 ~-18 glass` to construct a glass tank.
- `/fill ~-2 ~-1 ~-2 ~-17 ~-17 ~-17 water` to fill the tank with water.
- `/fill ~-2 ~-1 ~-2 ~-17 ~-17 ~-17 lava` to fill the tank with lava.