### PR TITLE
Expose target mod IDs in GatherDataEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
+++ b/src/main/java/net/neoforged/neoforge/data/event/GatherDataEvent.java
@@ -46,6 +46,13 @@ public class GatherDataEvent extends Event implements IModBusEvent {
         return this.config.getInputs();
     }
 
+    /**
+     * @return the mod IDs for which data should be generated
+     */
+    public Set<String> getMods() {
+        return this.config.getMods();
+    }
+
     public DataGenerator getGenerator() {
         return this.dataGenerator;
     }


### PR DESCRIPTION
This PR exposes the mod IDs (`--mod` parameters passed to the data run) as part of the `GatherDataEvent` so that event subscribers can filter which mods to output data for.
