### PR TITLE
Add fallbacks to all command translation strings

### DIFF
--- a/src/main/java/net/neoforged/neoforge/server/command/CommandUtils.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/CommandUtils.java
@@ -15,6 +15,9 @@ import java.util.function.Function;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.core.Registry;
+import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 
@@ -52,5 +55,15 @@ public final class CommandUtils {
         // Don't inline to avoid an unchecked cast warning due to raw types
         final ResourceKey<?> key = ctx.getArgument(name, ResourceKey.class);
         return key.cast(registryKey);
+    }
+
+    public static MutableComponent makeTranslatableWithFallback(String key, Object... args) {
+        String fallback = Language.getInstance().getOrDefault(key);
+        return Component.translatableWithFallback(key, fallback, args);
+    }
+
+    public static MutableComponent makeTranslatableWithFallback(String key) {
+        String fallback = Language.getInstance().getOrDefault(key);
+        return Component.translatableWithFallback(key, fallback);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/server/command/ConfigCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/ConfigCommand.java
@@ -68,11 +68,11 @@ public class ConfigCommand {
                     fileComponent.withStyle((style) -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, f.getAbsolutePath())));
                 }
 
-                context.getSource().sendSuccess(() -> Component.translatable("commands.config.getwithtype",
+                context.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.config.getwithtype",
                         modId, type.toString(), fileComponent), true);
             }
             if (configFileNames.isEmpty()) {
-                context.getSource().sendSuccess(() -> Component.translatable("commands.config.noconfig", modId, type.toString()),
+                context.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.config.noconfig", modId, type.toString()),
                         true);
             }
             return 0;

--- a/src/main/java/net/neoforged/neoforge/server/command/DataComponentCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/DataComponentCommand.java
@@ -27,7 +27,7 @@ import net.minecraft.world.item.ItemStack;
 
 class DataComponentCommand {
     private static final SimpleCommandExceptionType ERROR_NO_ITEM = new SimpleCommandExceptionType(
-            Component.translatableEscape("commands.neoforge.data_components.list.error.held_stack_empty"));
+            CommandUtils.makeTranslatableWithFallback("commands.neoforge.data_components.list.error.held_stack_empty"));
 
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         return Commands.literal("data_components")
@@ -47,24 +47,24 @@ class DataComponentCommand {
         ctx.getSource().sendSuccess(() -> {
             // Use Item#getName() instead if ItemStack#getDisplayName() to display the actual item name without influence
             // of a written book's title or the ITEM_NAME or CUSTOM_NAME data components
-            MutableComponent text = Component.translatable("commands.neoforge.data_components.list.title", stack.getItem().getName(stack));
+            MutableComponent text = CommandUtils.makeTranslatableWithFallback("commands.neoforge.data_components.list.title", stack.getItem().getName(stack));
             DataComponentMap prototype = stack.getPrototype();
             DataComponentPatch patch = stack.getComponentsPatch();
             prototype.forEach(component -> {
                 Optional<?> optData = patch.get(component.type());
                 if (optData == null) { // Component is default
-                    Component tooltip = Component.translatable(
+                    Component tooltip = CommandUtils.makeTranslatableWithFallback(
                             "commands.neoforge.data_components.list.tooltip.default",
                             getTypeId(component.type()));
                     text.append(print(component.type(), component.value(), ChatFormatting.WHITE, tooltip));
                 } else if (optData.isEmpty()) { // Component is deleted
-                    Component tooltip = Component.translatable(
+                    Component tooltip = CommandUtils.makeTranslatableWithFallback(
                             "commands.neoforge.data_components.list.tooltip.deleted",
                             getTypeId(component.type()),
                             component.value().toString());
                     text.append(print(component.type(), component.value(), ChatFormatting.RED, tooltip));
                 } else { // Component is modified
-                    Component tooltip = Component.translatable(
+                    Component tooltip = CommandUtils.makeTranslatableWithFallback(
                             "commands.neoforge.data_components.list.tooltip.modified",
                             getTypeId(component.type()),
                             component.value().toString(),
@@ -74,7 +74,7 @@ class DataComponentCommand {
             });
             patch.entrySet().forEach(entry -> {
                 if (!prototype.has(entry.getKey()) && entry.getValue().isPresent()) { // New component added
-                    Component tooltip = Component.translatable(
+                    Component tooltip = CommandUtils.makeTranslatableWithFallback(
                             "commands.neoforge.data_components.list.tooltip.added",
                             getTypeId(entry.getKey()),
                             entry.getValue().get().toString());
@@ -92,8 +92,8 @@ class DataComponentCommand {
     }
 
     private static Component print(DataComponentType<?> type, Object data, ChatFormatting color, Component tooltip) {
-        MutableComponent entry = Component.translatable("commands.neoforge.data_components.list.entry.key_value", getTypeId(type), data.toString());
-        return Component.translatable("commands.neoforge.data_components.list.entry", entry.withStyle(color))
+        MutableComponent entry = CommandUtils.makeTranslatableWithFallback("commands.neoforge.data_components.list.entry.key_value", getTypeId(type), data.toString());
+        return CommandUtils.makeTranslatableWithFallback("commands.neoforge.data_components.list.entry", entry.withStyle(color))
                 .withStyle(style -> style.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, tooltip)));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/server/command/DimensionsCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/DimensionsCommand.java
@@ -24,7 +24,7 @@ class DimensionsCommand {
         return Commands.literal("dimensions")
                 .requires(cs -> cs.hasPermission(0)) //permission
                 .executes(ctx -> {
-                    ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.dimensions.list"), true);
+                    ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.dimensions.list"), true);
                     final Registry<DimensionType> reg = ctx.getSource().registryAccess().lookupOrThrow(Registries.DIMENSION_TYPE);
 
                     Map<ResourceLocation, List<Component>> types = new HashMap<>();

--- a/src/main/java/net/neoforged/neoforge/server/command/DumpCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/DumpCommand.java
@@ -40,7 +40,7 @@ class DumpCommand {
     private static final String ALPHABETICAL_SORT_PARAM = "alphabetical_sort";
     private static final String PRINT_NUMERIC_ID_PARAM = "print_numeric_ids";
 
-    private static final DynamicCommandExceptionType UNKNOWN_REGISTRY = new DynamicCommandExceptionType(key -> Component.translatable("commands.neoforge.dump.error.unknown_registry", key));
+    private static final DynamicCommandExceptionType UNKNOWN_REGISTRY = new DynamicCommandExceptionType(key -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.dump.error.unknown_registry", key));
 
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         /*
@@ -96,7 +96,7 @@ class DumpCommand {
                 filePathComponent.withStyle((style) -> style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, registryDumpFile.toString())));
             }
 
-            ctx.getSource().sendSuccess(() -> Component.translatable(
+            ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback(
                     "commands.neoforge.dump.success",
                     Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.YELLOW),
                     filePathComponent),
@@ -106,7 +106,7 @@ class DumpCommand {
         } catch (Exception e) {
 
             ctx.getSource().sendFailure(
-                    Component.translatable(
+                    CommandUtils.makeTranslatableWithFallback(
                             "commands.neoforge.dump.failure",
                             Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.YELLOW),
                             Component.literal(fileLocationForErrorReporting).withStyle(ChatFormatting.GOLD)));

--- a/src/main/java/net/neoforged/neoforge/server/command/EntityCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/EntityCommand.java
@@ -38,9 +38,9 @@ class EntityCommand {
     }
 
     private static class EntityListCommand {
-        private static final SimpleCommandExceptionType INVALID_FILTER = new SimpleCommandExceptionType(Component.translatable("commands.neoforge.entity.list.invalid"));
-        private static final DynamicCommandExceptionType INVALID_DIMENSION = new DynamicCommandExceptionType(dim -> Component.translatable("commands.neoforge.entity.list.invalidworld", dim));
-        private static final SimpleCommandExceptionType NO_ENTITIES = new SimpleCommandExceptionType(Component.translatable("commands.neoforge.entity.list.none"));
+        private static final SimpleCommandExceptionType INVALID_FILTER = new SimpleCommandExceptionType(CommandUtils.makeTranslatableWithFallback("commands.neoforge.entity.list.invalid"));
+        private static final DynamicCommandExceptionType INVALID_DIMENSION = new DynamicCommandExceptionType(dim -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.entity.list.invalidworld", dim));
+        private static final SimpleCommandExceptionType NO_ENTITIES = new SimpleCommandExceptionType(CommandUtils.makeTranslatableWithFallback("commands.neoforge.entity.list.none"));
 
         static ArgumentBuilder<CommandSourceStack, ?> register() {
             return Commands.literal("list")
@@ -79,7 +79,7 @@ class EntityCommand {
                 if (info == null)
                     throw NO_ENTITIES.create();
 
-                sender.sendSuccess(() -> Component.translatable("commands.neoforge.entity.list.single.header", name.toString(), info.getLeft()), false);
+                sender.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.entity.list.single.header", name.toString(), info.getLeft()), false);
                 List<Map.Entry<ChunkPos, Integer>> toSort = new ArrayList<>();
                 toSort.addAll(info.getRight().entrySet());
                 toSort.sort((a, b) -> {
@@ -115,7 +115,7 @@ class EntityCommand {
                     throw NO_ENTITIES.create();
 
                 int count = info.stream().mapToInt(Pair::getRight).sum();
-                sender.sendSuccess(() -> Component.translatable("commands.neoforge.entity.list.multiple.header", count), false);
+                sender.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.entity.list.multiple.header", count), false);
                 info.forEach(e -> sender.sendSuccess(() -> Component.literal("  " + e.getValue() + ": " + e.getKey()), false));
                 return info.size();
             }

--- a/src/main/java/net/neoforged/neoforge/server/command/EnumArgument.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/EnumArgument.java
@@ -22,11 +22,10 @@ import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.SharedSuggestionProvider;
 import net.minecraft.commands.synchronization.ArgumentTypeInfo;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.Component;
 
 public class EnumArgument<T extends Enum<T>> implements ArgumentType<T> {
     private static final Dynamic2CommandExceptionType INVALID_ENUM = new Dynamic2CommandExceptionType(
-            (found, constants) -> Component.translatable("commands.neoforge.arguments.enum.invalid", constants, found));
+            (found, constants) -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.arguments.enum.invalid", constants, found));
     private final Class<T> enumClass;
 
     public static <R extends Enum<R>> EnumArgument<R> enumArgument(Class<R> enumClass) {

--- a/src/main/java/net/neoforged/neoforge/server/command/GenerateCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/GenerateCommand.java
@@ -15,7 +15,6 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.neoforged.neoforge.server.command.generation.GenerationBar;
@@ -61,7 +60,7 @@ class GenerateCommand {
 
     private static int executeGeneration(CommandSourceStack source, BlockPos pos, int chunkRadius, boolean progressBar) {
         if (activeTask != null) {
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.already_running"), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.already_running"), true);
             return Command.SINGLE_SUCCESS;
         }
 
@@ -78,7 +77,7 @@ class GenerateCommand {
             }
         }
 
-        source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.started",
+        source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.started",
                 activeTask.getTotalCount(), diameter, diameter, diameter * 16, diameter * 16), true);
 
         activeTask.run(createPregenListener(source));
@@ -94,7 +93,7 @@ class GenerateCommand {
             int total = activeTask.getTotalCount();
 
             double percent = (double) count / total * 100.0;
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.stopped", count, total, percent), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.stopped", count, total, percent), true);
 
             if (generationBar != null) {
                 generationBar.close();
@@ -102,7 +101,7 @@ class GenerateCommand {
             }
             activeTask = null;
         } else {
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.not_running"), false);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.not_running"), false);
         }
 
         return Command.SINGLE_SUCCESS;
@@ -114,16 +113,16 @@ class GenerateCommand {
             int total = activeTask.getTotalCount();
 
             double percent = (double) count / total * 100.0;
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.status", count, total, percent), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.status", count, total, percent), true);
         } else {
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.not_running"), false);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.not_running"), false);
         }
 
         return Command.SINGLE_SUCCESS;
     }
 
     private static int getGenerationHelp(CommandSourceStack source) {
-        source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.help_line"), false);
+        source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.help_line"), false);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -138,10 +137,10 @@ class GenerateCommand {
 
             @Override
             public void complete(int error) {
-                source.sendSuccess(() -> Component.translatable("commands.neoforge.chunkgen.success"), true);
+                source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.success"), true);
 
                 if (error > 0) {
-                    source.sendFailure(Component.translatable("commands.neoforge.chunkgen.error"));
+                    source.sendFailure(CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.error"));
                 }
 
                 if (generationBar != null) {

--- a/src/main/java/net/neoforged/neoforge/server/command/ModListCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/ModListCommand.java
@@ -10,7 +10,6 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
-import net.minecraft.network.chat.Component;
 import net.neoforged.fml.ModList;
 
 class ModListCommand {
@@ -18,7 +17,7 @@ class ModListCommand {
         return Commands.literal("mods")
                 .requires(cs -> cs.hasPermission(0)) //permission
                 .executes(ctx -> {
-                    ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.mods.list",
+                    ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.mods.list",
                             ModList.get().applyForEachModFile(modFile ->
                     // locator - filename : firstmod (version) - numberofmods\n
                     String.format(Locale.ROOT, "%s : %s (%s) - %d %s",

--- a/src/main/java/net/neoforged/neoforge/server/command/TPSCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TPSCommand.java
@@ -72,21 +72,21 @@ class TPSCommand {
         MutableComponent component;
 
         if (dimension == null) {
-            component = Component.translatable("commands.neoforge.tps.overall", tpsComponent, tickTimeComponent);
+            component = CommandUtils.makeTranslatableWithFallback("commands.neoforge.tps.overall", tpsComponent, tickTimeComponent);
         } else {
             var dimensionType = dimension.dimensionTypeRegistration();
 
             var dimensionName = Component.empty().append(dimension.getDescription()).withStyle(style -> style
                     .withColor(ChatFormatting.GREEN)
-                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.translatable(
+                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, CommandUtils.makeTranslatableWithFallback(
                             "commands.neoforge.tps.dimension.tooltip",
                             dimension.dimension().location().toString(),
                             dimensionType.getRegisteredName()))));
 
-            component = Component.translatable("commands.neoforge.tps.dimension", dimensionName, tpsComponent, tickTimeComponent);
+            component = CommandUtils.makeTranslatableWithFallback("commands.neoforge.tps.dimension", dimensionName, tpsComponent, tickTimeComponent);
         }
 
-        return component.withStyle(style -> style.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.translatable("commands.neoforge.tps.tooltip", tickRateManager.tickrate()))));
+        return component.withStyle(style -> style.withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, CommandUtils.makeTranslatableWithFallback("commands.neoforge.tps.tooltip", tickRateManager.tickrate()))));
     }
 
     private static int calculateTPSColor(TickRateManager tickRateManager, double tps) {

--- a/src/main/java/net/neoforged/neoforge/server/command/TagsCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TagsCommand.java
@@ -58,9 +58,9 @@ class TagsCommand {
     private static final long PAGE_SIZE = 8;
     private static final ResourceKey<Registry<Registry<?>>> ROOT_REGISTRY_KEY = ResourceKey.createRegistryKey(ResourceLocation.withDefaultNamespace("root"));
 
-    private static final DynamicCommandExceptionType UNKNOWN_REGISTRY = new DynamicCommandExceptionType(key -> Component.translatable("commands.neoforge.tags.error.unknown_registry", key.toString()));
-    private static final Dynamic2CommandExceptionType UNKNOWN_TAG = new Dynamic2CommandExceptionType((tag, registry) -> Component.translatable("commands.neoforge.tags.error.unknown_tag", tag.toString(), registry.toString()));
-    private static final Dynamic2CommandExceptionType UNKNOWN_ELEMENT = new Dynamic2CommandExceptionType((tag, registry) -> Component.translatable("commands.neoforge.tags.error.unknown_element", tag.toString(), registry.toString()));
+    private static final DynamicCommandExceptionType UNKNOWN_REGISTRY = new DynamicCommandExceptionType(key -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.error.unknown_registry", key.toString()));
+    private static final Dynamic2CommandExceptionType UNKNOWN_TAG = new Dynamic2CommandExceptionType((tag, registry) -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.error.unknown_tag", tag.toString(), registry.toString()));
+    private static final Dynamic2CommandExceptionType UNKNOWN_ELEMENT = new Dynamic2CommandExceptionType((tag, registry) -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.error.unknown_element", tag.toString(), registry.toString()));
 
     public static ArgumentBuilder<CommandSourceStack, ?> register() {
         /*
@@ -99,7 +99,7 @@ class TagsCommand {
         final long tagCount = registry.getTags().count();
 
         ctx.getSource().sendSuccess(() -> createMessage(
-                Component.translatable("commands.neoforge.tags.registry_key", Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.GOLD)),
+                CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.registry_key", Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.GOLD)),
                 "commands.neoforge.tags.tag_count",
                 "commands.neoforge.tags.copy_tag_names",
                 tagCount,
@@ -126,7 +126,7 @@ class TagsCommand {
         final HolderSet.Named<?> tag = optional.orElseThrow(() -> UNKNOWN_TAG.create(tagKey.location(), registryKey.location()));
 
         ctx.getSource().sendSuccess(() -> createMessage(
-                Component.translatable("commands.neoforge.tags.tag_key",
+                CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.tag_key",
                         Component.literal(tagKey.registry().location().toString()).withStyle(ChatFormatting.GOLD),
                         Component.literal(tagKey.location().toString()).withStyle(ChatFormatting.DARK_GREEN)),
                 "commands.neoforge.tags.element_count",
@@ -155,7 +155,7 @@ class TagsCommand {
         final long containingTagsCount = elementHolder.tags().count();
 
         ctx.getSource().sendSuccess(() -> createMessage(
-                Component.translatable("commands.neoforge.tags.element",
+                CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.element",
                         Component.literal(registryKey.location().toString()).withStyle(ChatFormatting.GOLD),
                         Component.literal(elementLocation.toString()).withStyle(ChatFormatting.YELLOW)),
                 "commands.neoforge.tags.containing_tag_count",
@@ -178,7 +178,7 @@ class TagsCommand {
         final long totalPages = (count - 1) / PAGE_SIZE + 1;
         final long actualPage = (long) Mth.clamp(currentPage, 1, totalPages);
 
-        MutableComponent containsComponent = Component.translatable(containsText, count);
+        MutableComponent containsComponent = CommandUtils.makeTranslatableWithFallback(containsText, count);
         if (count > 0) // Highlight the count text, make it clickable, and append page counters
         {
             final String clipboardText;
@@ -215,8 +215,8 @@ class TagsCommand {
                     .withColor(ChatFormatting.GREEN)
                     .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, clipboardText))
                     .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                            Component.translatable(copyHoverText)))));
-            containsComponent = Component.translatable("commands.neoforge.tags.page_info",
+                            CommandUtils.makeTranslatableWithFallback(copyHoverText)))));
+            containsComponent = CommandUtils.makeTranslatableWithFallback("commands.neoforge.tags.page_info",
                     containsComponent, actualPage, totalPages);
         }
 
@@ -227,7 +227,7 @@ class TagsCommand {
                 .limit(PAGE_SIZE)
                 .map(Component::literal)
                 .map(t -> t.withStyle(elementColor))
-                .map(t -> Component.translatable("\n - ").append(t))
+                .map(t -> CommandUtils.makeTranslatableWithFallback("\n - ").append(t))
                 .forEach(tagElements::append);
 
         return header.append("\n").append(tagElements);

--- a/src/main/java/net/neoforged/neoforge/server/command/TimeSpeedCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TimeSpeedCommand.java
@@ -36,9 +36,9 @@ class TimeSpeedCommand {
     private static int query(CommandSourceStack source) {
         final float speed = source.getLevel().getDayTimePerTick();
         if (speed < 0) {
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.query.default", levelName(source)), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.timespeed.query.default", levelName(source)), true);
         } else {
-            source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.query", levelName(source), speed, minutes(speed)), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.timespeed.query", levelName(source), speed, minutes(speed)), true);
         }
         return Command.SINGLE_SUCCESS;
     }
@@ -55,14 +55,14 @@ class TimeSpeedCommand {
         final BooleanValue rule = source.getLevel().getGameRules().getRule(GameRules.RULE_DAYLIGHT);
         if (!rule.get() && speed > 0) {
             rule.set(true, null);
-            source.sendSuccess(() -> Component.translatable("commands.gamerule.set", GameRules.RULE_DAYLIGHT.getId(), rule.toString()), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.gamerule.set", GameRules.RULE_DAYLIGHT.getId(), rule.toString()), true);
         } else if (rule.get() && speed == 0) {
             rule.set(false, null);
-            source.sendSuccess(() -> Component.translatable("commands.gamerule.set", GameRules.RULE_DAYLIGHT.getId(), rule.toString()), true);
+            source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.gamerule.set", GameRules.RULE_DAYLIGHT.getId(), rule.toString()), true);
             return Command.SINGLE_SUCCESS;
         }
         source.getLevel().setDayTimePerTick(speed);
-        source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.set", levelName(source), speed, minutes(speed)), true);
+        source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.timespeed.set", levelName(source), speed, minutes(speed)), true);
         return Command.SINGLE_SUCCESS;
     }
 
@@ -75,7 +75,7 @@ class TimeSpeedCommand {
 
     private static int setDefault(CommandSourceStack source) {
         source.getLevel().setDayTimePerTick(-1f);
-        source.sendSuccess(() -> Component.translatable("commands.neoforge.timespeed.set.default", levelName(source)), true);
+        source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.timespeed.set.default", levelName(source)), true);
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/server/command/TrackCommand.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/TrackCommand.java
@@ -45,7 +45,7 @@ class TrackCommand {
                                         int duration = IntegerArgumentType.getInteger(ctx, "duration");
                                         TimeTracker.BLOCK_ENTITY_UPDATE.reset();
                                         TimeTracker.BLOCK_ENTITY_UPDATE.enable(duration);
-                                        ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.tracking.be.enabled", duration), true);
+                                        ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.be.enabled", duration), true);
                                         return 0;
                                     })))
                     .then(Commands.literal("entity")
@@ -54,7 +54,7 @@ class TrackCommand {
                                         int duration = IntegerArgumentType.getInteger(ctx, "duration");
                                         TimeTracker.ENTITY_UPDATE.reset();
                                         TimeTracker.ENTITY_UPDATE.enable(duration);
-                                        ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.tracking.entity.enabled", duration), true);
+                                        ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.entity.enabled", duration), true);
                                         return 0;
                                     })));
         }
@@ -67,13 +67,13 @@ class TrackCommand {
                     .then(Commands.literal("blockentity")
                             .executes(ctx -> {
                                 TimeTracker.BLOCK_ENTITY_UPDATE.reset();
-                                ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.tracking.be.reset"), true);
+                                ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.be.reset"), true);
                                 return 0;
                             }))
                     .then(Commands.literal("entity")
                             .executes(ctx -> {
                                 TimeTracker.ENTITY_UPDATE.reset();
-                                ctx.getSource().sendSuccess(() -> Component.translatable("commands.neoforge.tracking.entity.reset"), true);
+                                ctx.getSource().sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.entity.reset"), true);
                                 return 0;
                             }));
         }
@@ -98,7 +98,7 @@ class TrackCommand {
         private static <T> int execute(CommandSourceStack source, TimeTracker<T> tracker, Function<ObjectTimings<T>, Component> toString) {
             List<ObjectTimings<T>> timingsList = getSortedTimings(tracker);
             if (timingsList.isEmpty()) {
-                source.sendSuccess(() -> Component.translatable("commands.neoforge.tracking.no_data"), true);
+                source.sendSuccess(() -> CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.no_data"), true);
             } else {
                 timingsList.stream()
                         .filter(timings -> timings.getObject().get() != null)
@@ -114,13 +114,13 @@ class TrackCommand {
             return Commands.literal("entity").executes(ctx -> TrackResults.execute(ctx.getSource(), TimeTracker.ENTITY_UPDATE, data -> {
                 Entity entity = data.getObject().get();
                 if (entity == null)
-                    return Component.translatable("commands.neoforge.tracking.invalid");
+                    return CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.invalid");
 
                 BlockPos pos = entity.blockPosition();
                 double averageTimings = data.getAverageTimings();
                 String tickTime = (averageTimings > 1000 ? TIME_FORMAT.format(averageTimings / 1000) : TIME_FORMAT.format(averageTimings)) + (averageTimings < 1000 ? "\u03bcs" : "ms");
 
-                return Component.translatable("commands.neoforge.tracking.timing_entry", BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString(), entity.level().dimension().location().toString(), pos.getX(), pos.getY(), pos.getZ(), tickTime);
+                return CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.timing_entry", BuiltInRegistries.ENTITY_TYPE.getKey(entity.getType()).toString(), entity.level().dimension().location().toString(), pos.getX(), pos.getY(), pos.getZ(), tickTime);
             }));
         }
     }
@@ -130,13 +130,13 @@ class TrackCommand {
             return Commands.literal("blockentity").executes(ctx -> TrackResults.execute(ctx.getSource(), TimeTracker.BLOCK_ENTITY_UPDATE, data -> {
                 BlockEntity be = data.getObject().get();
                 if (be == null)
-                    return Component.translatable("commands.neoforge.tracking.invalid");
+                    return CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.invalid");
 
                 BlockPos pos = be.getBlockPos();
 
                 double averageTimings = data.getAverageTimings();
                 String tickTime = (averageTimings > 1000 ? TIME_FORMAT.format(averageTimings / 1000) : TIME_FORMAT.format(averageTimings)) + (averageTimings < 1000 ? "\u03bcs" : "ms");
-                return Component.translatable("commands.neoforge.tracking.timing_entry", BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(be.getType()).toString(), be.getLevel().dimension().location().toString(), pos.getX(), pos.getY(), pos.getZ(), tickTime);
+                return CommandUtils.makeTranslatableWithFallback("commands.neoforge.tracking.timing_entry", BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(be.getType()).toString(), be.getLevel().dimension().location().toString(), pos.getX(), pos.getY(), pos.getZ(), tickTime);
             }));
         }
     }

--- a/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationBar.java
+++ b/src/main/java/net/neoforged/neoforge/server/command/generation/GenerationBar.java
@@ -7,12 +7,12 @@ package net.neoforged.neoforge.server.command.generation;
 
 import java.text.DecimalFormat;
 import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.server.level.ServerBossEvent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.BossEvent;
+import net.neoforged.neoforge.server.command.CommandUtils;
 
 /**
  * Special thanks to Jasmine and Gegy for allowing us to use their pregenerator mod as a model to use in NeoForge!
@@ -24,7 +24,7 @@ public class GenerationBar implements AutoCloseable {
     private final ServerBossEvent bar;
 
     public GenerationBar() {
-        this.bar = new ServerBossEvent(Component.translatable("commands.neoforge.chunkgen.progress_bar_title"), BossEvent.BossBarColor.YELLOW, BossEvent.BossBarOverlay.PROGRESS);
+        this.bar = new ServerBossEvent(CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.progress_bar_title"), BossEvent.BossBarColor.YELLOW, BossEvent.BossBarOverlay.PROGRESS);
         this.bar.setPlayBossMusic(false);
         this.bar.setCreateWorldFog(false);
         this.bar.setDarkenScreen(false);
@@ -35,12 +35,12 @@ public class GenerationBar implements AutoCloseable {
 
         float percent = (float) count / total;
 
-        MutableComponent title = Component.translatable("commands.neoforge.chunkgen.progress_bar_progress", total)
-                .append(Component.translatable(PERCENT_FORMAT.format(percent * 100.0F) + "%")
+        MutableComponent title = CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.progress_bar_progress", total)
+                .append(CommandUtils.makeTranslatableWithFallback(PERCENT_FORMAT.format(percent * 100.0F) + "%")
                         .setStyle(Style.EMPTY.withColor(ChatFormatting.GOLD)));
 
         if (error > 0) {
-            title = title.append(Component.translatable("commands.neoforge.chunkgen.progress_bar_errors")
+            title = title.append(CommandUtils.makeTranslatableWithFallback("commands.neoforge.chunkgen.progress_bar_errors")
                     .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)));
         }
 


### PR DESCRIPTION
This solves https://github.com/neoforged/NeoForge/issues/1974 by ~~copying the translated text from the lang file into the source~~ loading the server's default translation for all neoforge command outputs, and ~~changing `translatable` methods to~~ using `translatableWithFallback`  to add those as fallbacks.

This also includes a couple of other changes that I noticed, namely two uses of `Component.translatable` being used for literals (changed to `Component.literal`) and one use of `translatableEscape` to `translatableWithFallback`, which shouldn't change anything as `translatableEscape` was being passed an empty array and all it does differently to `translatable` is modify the array.