### PR TITLE
Crash with a better exception when encountering an off-thread GL error

### DIFF
--- a/patches/com/mojang/blaze3d/platform/Window.java.patch
+++ b/patches/com/mojang/blaze3d/platform/Window.java.patch
@@ -18,6 +18,18 @@
  
          GLFW.glfwMakeContextCurrent(this.window);
          GL.createCapabilities();
+@@ -208,8 +_,10 @@
+     }
+ 
+     public void defaultErrorCallback(int p_85383_, long p_85384_) {
+-        RenderSystem.assertOnRenderThread();
+         String s = MemoryUtil.memUTF8(p_85384_);
++        if (!RenderSystem.isOnRenderThread()) {
++            throw new IllegalStateException("Encountered GL error off-thread @ " + errorSection + ": " + p_85383_ + ": " + s);
++        }
+         LOGGER.error("########## GL ERROR ##########");
+         LOGGER.error("@ {}", this.errorSection);
+         LOGGER.error("{}: {}", p_85383_, s);
 @@ -273,6 +_,7 @@
          GLFW.glfwGetFramebufferSize(this.window, aint, aint1);
          this.framebufferWidth = aint[0] > 0 ? aint[0] : 1;


### PR DESCRIPTION
The vanilla error callback asserts the main render thread, which means that if a mod calls a glfw method off-thread and that method errors, the game will crash with a non-descript `Rendersystem called from the wrong thread`. This PR does not prevent the game from crashing, but instead it will also log the GL error.