### PR TITLE
[1.21.4] Register Particle Types before blocks and mob effects

### DIFF
--- a/src/generated/resources/reports/registry_order.json
+++ b/src/generated/resources/reports/registry_order.json
@@ -2,6 +2,7 @@
   "order": [
     "minecraft:attribute",
     "minecraft:data_component_type",
+    "minecraft:particle_type",
     "minecraft:game_event",
     "minecraft:sound_event",
     "minecraft:fluid",
@@ -10,7 +11,6 @@
     "minecraft:entity_type",
     "minecraft:item",
     "minecraft:potion",
-    "minecraft:particle_type",
     "minecraft:block_entity_type",
     "minecraft:custom_stat",
     "minecraft:chunk_status",

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -126,6 +126,7 @@ public class GameData {
         Set<ResourceLocation> ordered = new LinkedHashSet<>();
         ordered.add(Registries.ATTRIBUTE.location()); // Vanilla order is incorrect, both Item and MobEffect depend on Attribute at construction time.
         ordered.add(Registries.DATA_COMPONENT_TYPE.location()); // Vanilla order is incorrect, Item depends on data components at construction time.
+        ordered.add(Registries.PARTICLE_TYPE.location()); // Vanilla order is incorrect, both Block and MobEffect depend on ParticleType at construction time.
         ordered.addAll(BuiltInRegistries.getVanillaRegistrationOrder());
         ordered.addAll(BuiltInRegistries.REGISTRY.keySet().stream().sorted(ResourceLocation::compareNamespaced).toList());
         return ordered;


### PR DESCRIPTION
Closes #1987 

Changes the registration order to register `ParticleType` before `Block` and `MobEffect`. `ParticleOptions` usage is typically attached to the `ParticleType` registration via `SimpleParticleType`, hence the mention of `MobEffect` here.