### PR TITLE
[1.21.4] Use Thread-Safe Collections and Maps for Key Mappings

### DIFF
--- a/patches/net/minecraft/client/KeyMapping.java.patch
+++ b/patches/net/minecraft/client/KeyMapping.java.patch
@@ -1,14 +1,18 @@
 --- a/net/minecraft/client/KeyMapping.java
 +++ b/net/minecraft/client/KeyMapping.java
-@@ -17,7 +_,7 @@
+@@ -16,9 +_,9 @@
+ 
  @OnlyIn(Dist.CLIENT)
  public class KeyMapping implements Comparable<KeyMapping>, net.neoforged.neoforge.client.extensions.IKeyMappingExtension {
-     private static final Map<String, KeyMapping> ALL = Maps.newHashMap();
+-    private static final Map<String, KeyMapping> ALL = Maps.newHashMap();
 -    private static final Map<InputConstants.Key, KeyMapping> MAP = Maps.newHashMap();
+-    private static final Set<String> CATEGORIES = Sets.newHashSet();
++    private static final Map<String, KeyMapping> ALL = Maps.newConcurrentMap();
 +    private static final net.neoforged.neoforge.client.settings.KeyMappingLookup MAP = new net.neoforged.neoforge.client.settings.KeyMappingLookup();
-     private static final Set<String> CATEGORIES = Sets.newHashSet();
++    private static final Set<String> CATEGORIES = Sets.newConcurrentHashSet();
      public static final String CATEGORY_MOVEMENT = "key.categories.movement";
      public static final String CATEGORY_MISC = "key.categories.misc";
+     public static final String CATEGORY_MULTIPLAYER = "key.categories.multiplayer";
 @@ -43,17 +_,17 @@
      private int clickCount;
  

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -5,11 +5,12 @@
 
 package net.neoforged.neoforge.client.settings;
 
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.mojang.blaze3d.platform.InputConstants;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.client.KeyMapping;
@@ -18,7 +19,7 @@ public class KeyMappingLookup {
     private static final EnumMap<KeyModifier, Map<InputConstants.Key, Collection<KeyMapping>>> map = new EnumMap<>(KeyModifier.class);
     static {
         for (KeyModifier modifier : KeyModifier.values()) {
-            map.put(modifier, new HashMap<>());
+            map.put(modifier, Maps.newConcurrentMap());
         }
     }
 
@@ -53,7 +54,7 @@ public class KeyMappingLookup {
     public void put(InputConstants.Key keyCode, KeyMapping keyBinding) {
         KeyModifier keyModifier = keyBinding.getKeyModifier();
         Map<InputConstants.Key, Collection<KeyMapping>> bindingsMap = map.get(keyModifier);
-        Collection<KeyMapping> bindingsForKey = bindingsMap.computeIfAbsent(keyCode, k -> new ArrayList<>());
+        Collection<KeyMapping> bindingsForKey = bindingsMap.computeIfAbsent(keyCode, k -> Sets.newConcurrentHashSet());
         bindingsForKey.add(keyBinding);
     }
 

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -5,8 +5,8 @@
 
 package net.neoforged.neoforge.client.settings;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.mojang.blaze3d.platform.InputConstants;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,7 +54,7 @@ public class KeyMappingLookup {
     public void put(InputConstants.Key keyCode, KeyMapping keyBinding) {
         KeyModifier keyModifier = keyBinding.getKeyModifier();
         Map<InputConstants.Key, Collection<KeyMapping>> bindingsMap = map.get(keyModifier);
-        Collection<KeyMapping> bindingsForKey = bindingsMap.computeIfAbsent(keyCode, k -> Sets.newConcurrentHashSet());
+        Collection<KeyMapping> bindingsForKey = bindingsMap.computeIfAbsent(keyCode, k -> Lists.newCopyOnWriteArrayList());
         bindingsForKey.add(keyBinding);
     }
 


### PR DESCRIPTION
Closes #1983 

As most mods construct their `KeyMapping` during mod construction, which runs in parallel, the construction may stumble upon a CME. To prevent this, all collections and maps within `KeyMapping` and `KeyMappingLookup` now use either a concurrent set or map implementation . The `EnumMap` that holds the modifiers did not need to be replaced due to the vanilla entries that classload `KeyMappingLookup`.