### PR TITLE
[1.21.4] Serialise `lightEmission` value when generating model files

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/generators/template/ElementBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/template/ElementBuilder.java
@@ -199,7 +199,7 @@ public final class ElementBuilder {
      * @return this builder
      */
     public ElementBuilder lightEmission(int lightEmission) {
-        Preconditions.checkArgument(lightEmission < 16 && lightEmission >= 0, "lightEmission %d not in valid range - [0,15)", lightEmission);
+        Preconditions.checkArgument(lightEmission < 16 && lightEmission >= 0, "lightEmission %s not in valid range - [0,15)", lightEmission);
         this.lightEmission = lightEmission;
         return this;
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/template/ElementBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/template/ElementBuilder.java
@@ -199,6 +199,7 @@ public final class ElementBuilder {
      * @return this builder
      */
     public ElementBuilder lightEmission(int lightEmission) {
+        Preconditions.checkArgument(lightEmission < 16 && lightEmission >= 0, "lightEmission %d not in valid range - [0,15)", lightEmission);
         this.lightEmission = lightEmission;
         return this;
     }

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/template/ExtendedModelTemplate.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/template/ExtendedModelTemplate.java
@@ -110,6 +110,10 @@ public final class ExtendedModelTemplate extends ModelTemplate {
                     partObj.addProperty("shade", false);
                 }
 
+                if (part.lightEmission != 0) {
+                    partObj.addProperty("light_emission", part.lightEmission);
+                }
+
                 if (!part.getFaceData().equals(ExtraFaceData.DEFAULT)) {
                     partObj.add("neoforge_data", ExtraFaceData.CODEC.encodeStart(JsonOps.INSTANCE, part.getFaceData()).result().get());
                 }


### PR DESCRIPTION
This PR aims to fix https://github.com/neoforged/NeoForge/issues/2001 by serializing the `lightEmission` value when generating model files using `ExtendedModelTemplate`s during data gen.

This PR also adds a validation check to `lightEmission` to ensure modders are not setting it to values outside of the supported 0-15 range.