### PR TITLE
Fix wrong BE#getModelData javadoc

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockEntityExtension.java
@@ -85,9 +85,10 @@ public interface IBlockEntityExtension {
 
     /**
      * Allows you to return additional model data.
-     * This data can be used to provide additional functionality in your {@link BakedModel}
+     * This data can be used to provide additional functionality in your {@link BakedModel}.
      * You need to schedule a refresh of you model data via {@link #requestModelDataUpdate()} if the result of this function changes.
-     * <b>Note that this method may be called on a chunk render thread instead of the main client thread</b>
+     *
+     * <p>This method is always called on the main client thread.
      * 
      * @return Your model data
      */


### PR DESCRIPTION
Since the whole point of `getModelData` is to protect from unsafe off-thread access to BE state, it only makes sense to call it from the main client thread.