### PR TITLE
Add support for modded tridents to trigger the thrown trident advancement

### DIFF
--- a/src/generated/resources/data/minecraft/advancement/adventure/throw_trident.json
+++ b/src/generated/resources/data/minecraft/advancement/adventure/throw_trident.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:adventure/kill_a_mob",
+  "criteria": {
+    "shot_trident": {
+      "conditions": {
+        "damage": {
+          "type": {
+            "direct_entity": {
+              "type_specific": {
+                "type": "neoforge:is_trident"
+              }
+            },
+            "tags": [
+              {
+                "expected": true,
+                "id": "minecraft:is_projectile"
+              }
+            ]
+          }
+        }
+      },
+      "trigger": "minecraft:player_hurt_entity"
+    }
+  },
+  "display": {
+    "description": {
+      "translate": "advancements.adventure.throw_trident.description"
+    },
+    "icon": {
+      "count": 1,
+      "id": "minecraft:trident"
+    },
+    "title": {
+      "translate": "advancements.adventure.throw_trident.title"
+    }
+  },
+  "requirements": [
+    [
+      "shot_trident"
+    ]
+  ],
+  "sends_telemetry_event": true
+}

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -80,6 +80,7 @@ import net.neoforged.neoforge.common.advancements.critereon.ItemAbilityPredicate
 import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEntityPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.SnowBootsEntityPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.TridentEntityPredicate;
 import net.neoforged.neoforge.common.conditions.AlwaysCondition;
 import net.neoforged.neoforge.common.conditions.AndCondition;
 import net.neoforged.neoforge.common.conditions.FeatureFlagsEnabledCondition;
@@ -370,6 +371,7 @@ public class NeoForgeMod {
     private static final DeferredRegister<MapCodec<? extends EntitySubPredicate>> ENTITY_PREDICATE_CODECS = DeferredRegister.create(Registries.ENTITY_SUB_PREDICATE_TYPE, NeoForgeVersion.MOD_ID);
     public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<PiglinNeutralArmorEntityPredicate>> PIGLIN_NEUTRAL_ARMOR_PREDICATE = ENTITY_PREDICATE_CODECS.register("piglin_neutral_armor", () -> PiglinNeutralArmorEntityPredicate.CODEC);
     public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<SnowBootsEntityPredicate>> SNOW_BOOTS_PREDICATE = ENTITY_PREDICATE_CODECS.register("snow_boots", () -> SnowBootsEntityPredicate.CODEC);
+    public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<TridentEntityPredicate>> IS_TRIDENT_PREDICATE = ENTITY_PREDICATE_CODECS.register("is_trident", () -> TridentEntityPredicate.CODEC);
 
     private static final DeferredRegister<ItemSubPredicate.Type<?>> ITEM_SUB_PREDICATES = DeferredRegister.create(Registries.ITEM_SUB_PREDICATE_TYPE, NeoForgeVersion.MOD_ID);
     public static final DeferredHolder<ItemSubPredicate.Type<?>, ItemSubPredicate.Type<ItemAbilityPredicate>> ITEM_ABILITY_PREDICATE = ITEM_SUB_PREDICATES.register("item_ability", () -> ItemAbilityPredicate.TYPE);

--- a/src/main/java/net/neoforged/neoforge/common/advancements/critereon/TridentEntityPredicate.java
+++ b/src/main/java/net/neoforged/neoforge/common/advancements/critereon/TridentEntityPredicate.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.advancements.critereon;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.advancements.critereon.EntitySubPredicate;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.projectile.ThrownTrident;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+public class TridentEntityPredicate implements EntitySubPredicate {
+    public static final TridentEntityPredicate INSTANCE = new TridentEntityPredicate();
+    public static final MapCodec<TridentEntityPredicate> CODEC = MapCodec.unit(INSTANCE);
+
+    private TridentEntityPredicate() {}
+
+    @Override
+    public MapCodec<TridentEntityPredicate> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public boolean matches(Entity entity, ServerLevel level, @Nullable Vec3 position) {
+        return entity instanceof ThrownTrident;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeAdvancementProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeAdvancementProvider.java
@@ -24,11 +24,15 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.critereon.ContextAwarePredicate;
+import net.minecraft.advancements.critereon.DamagePredicate;
+import net.minecraft.advancements.critereon.DamageSourcePredicate;
 import net.minecraft.advancements.critereon.EntityEquipmentPredicate;
 import net.minecraft.advancements.critereon.EntityPredicate;
 import net.minecraft.advancements.critereon.EntitySubPredicate;
+import net.minecraft.advancements.critereon.EntityTypePredicate;
 import net.minecraft.advancements.critereon.ItemPredicate;
 import net.minecraft.advancements.critereon.ItemUsedOnLocationTrigger;
+import net.minecraft.advancements.critereon.PlayerHurtEntityTrigger;
 import net.minecraft.advancements.critereon.PlayerInteractTrigger;
 import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
 import net.minecraft.core.HolderLookup;
@@ -45,6 +49,7 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.monster.piglin.PiglinAi;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -60,6 +65,7 @@ import net.neoforged.neoforge.common.advancements.critereon.ItemAbilityPredicate
 import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.PiglinNeutralArmorEntityPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.SnowBootsEntityPredicate;
+import net.neoforged.neoforge.common.advancements.critereon.TridentEntityPredicate;
 import org.jetbrains.annotations.Nullable;
 
 public class NeoForgeAdvancementProvider extends AdvancementProvider {
@@ -72,18 +78,37 @@ public class NeoForgeAdvancementProvider extends AdvancementProvider {
         criteriaReplacers.add(replaceMatchToolCriteria(ItemAbilities.AXE_WAX_OFF, getPrivateValue(VanillaHusbandryAdvancements.class, null, "WAX_SCRAPING_TOOLS")));
         criteriaReplacers.add(replaceInteractCriteria(ItemPredicate.Builder.item().withSubPredicate(ItemAbilityPredicate.TYPE, new ItemAbilityPredicate(ItemAbilities.SHEARS_REMOVE_ARMOR)).build(), Items.SHEARS));
         criteriaReplacers.add(replaceInteractCriteria(ItemPredicate.Builder.item().withSubPredicate(PiglinCurrencyItemPredicate.TYPE, PiglinCurrencyItemPredicate.INSTANCE).build(), PiglinAi.BARTERING_ITEM));
-        criteriaReplacers.add(replaceWearingPredicate(PiglinNeutralArmorEntityPredicate.INSTANCE, predicate -> {
-            if (predicate.head().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent()) {
-                return true;
-            } else if (predicate.chest().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent()) {
-                return true;
-            } else if (predicate.legs().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent()) {
+        criteriaReplacers.add(replaceLootEntityPredicate(helper -> {
+            if (helper.clearEquipmentIfMatches(predicate -> {
+                if (predicate.head().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent()) {
+                    return true;
+                } else if (predicate.chest().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent()) {
+                    return true;
+                } else if (predicate.legs().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent()) {
+                    return true;
+                }
+                return predicate.feet().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent();
+            })) {
+                helper.replaceSubPredicate(PiglinNeutralArmorEntityPredicate.INSTANCE);
                 return true;
             }
-            return predicate.feet().filter(item -> predicateMatches(item, ItemTags.PIGLIN_SAFE_ARMOR)).isPresent();
+            return false;
+        }));
+        criteriaReplacers.add(replacePlayerHurtEntityCriteria(helper -> {
+            if (helper.clearTypeIfMatches(EntityType.TRIDENT)) {
+                helper.replaceSubPredicate(TridentEntityPredicate.INSTANCE);
+                return true;
+            }
+            return false;
         }));
         //Walk on powdered snow
-        criteriaReplacers.add(replaceWearingPredicate(SnowBootsEntityPredicate.INSTANCE, predicate -> predicate.feet().filter(item -> predicateMatches(item, Items.LEATHER_BOOTS)).isPresent()));
+        criteriaReplacers.add(replaceLootEntityPredicate(helper -> {
+            if (helper.clearEquipmentIfMatches(predicate -> predicate.feet().filter(item -> predicateMatches(item, Items.LEATHER_BOOTS)).isPresent())) {
+                helper.replaceSubPredicate(SnowBootsEntityPredicate.INSTANCE);
+                return true;
+            }
+            return false;
+        }));
 
         List<AdvancementSubProvider> subProviders = getPrivateValue(AdvancementProvider.class, VanillaAdvancementProvider.create(output, registries), "subProviders");
         return subProviders.stream()
@@ -120,6 +145,30 @@ public class NeoForgeAdvancementProvider extends AdvancementProvider {
         };
     }
 
+    private static BiFunction<Criterion<?>, HolderLookup.Provider, Criterion<?>> replacePlayerHurtEntityCriteria(Predicate<EntityPredicateReplacementHelper> predicateHelper) {
+        return (criterion, registries) -> {
+            if (criterion.trigger() instanceof PlayerHurtEntityTrigger trigger && criterion.triggerInstance() instanceof PlayerHurtEntityTrigger.TriggerInstance instance) {
+                if (instance.damage().isPresent()) {
+                    DamagePredicate damagePredicate = instance.damage().get();
+                    if (damagePredicate.type().isPresent()) {
+                        DamageSourcePredicate sourcePredicate = damagePredicate.type().get();
+                        if (sourcePredicate.directEntity().isPresent()) {
+                            EntityPredicateReplacementHelper helper = new EntityPredicateReplacementHelper(sourcePredicate.directEntity().get());
+                            if (predicateHelper.test(helper)) {
+                                DamageSourcePredicate replacementSourcePredicate = new DamageSourcePredicate(sourcePredicate.tags(),
+                                        Optional.of(helper.create()), sourcePredicate.sourceEntity(), sourcePredicate.isDirect());
+                                DamagePredicate replacement = new DamagePredicate(damagePredicate.dealtDamage(), damagePredicate.takenDamage(), damagePredicate.sourceEntity(),
+                                        damagePredicate.blocked(), Optional.of(replacementSourcePredicate));
+                                return new Criterion<>(trigger, new PlayerHurtEntityTrigger.TriggerInstance(instance.player(), Optional.of(replacement), instance.entity()));
+                            }
+                        }
+                    }
+                }
+            }
+            return null;
+        };
+    }
+
     private static boolean predicateMatches(ItemPredicate predicate, ItemLike... targets) {
         Optional<HolderSet<Item>> items = predicate.items();
         if (items.isEmpty()) {
@@ -141,7 +190,7 @@ public class NeoForgeAdvancementProvider extends AdvancementProvider {
                 .orElse(false);
     }
 
-    private static BiFunction<Criterion<?>, HolderLookup.Provider, Criterion<?>> replaceWearingPredicate(EntitySubPredicate subPredicate, Predicate<EntityEquipmentPredicate> shouldReplace) {
+    private static BiFunction<Criterion<?>, HolderLookup.Provider, Criterion<?>> replaceLootEntityPredicate(Predicate<EntityPredicateReplacementHelper> predicateHelper) {
         return replacePlayerPredicate(condition -> {
             boolean invert = false;
             if (condition instanceof InvertedLootItemCondition inverted) {
@@ -151,28 +200,9 @@ public class NeoForgeAdvancementProvider extends AdvancementProvider {
             if (condition instanceof LootItemEntityPropertyCondition entityPropertyCondition) {
                 Optional<EntityPredicate> predicate = entityPropertyCondition.predicate();
                 if (predicate.isPresent()) {
-                    EntityPredicate entityPredicate = predicate.get();
-                    if (entityPredicate.equipment().filter(shouldReplace).isPresent()) {
-                        if (entityPredicate.subPredicate().isPresent()) {
-                            throw new IllegalStateException("Attempting to replace an entity predicate that already has a sub predicate");
-                        }
-                        EntityPredicate replacement = new EntityPredicate(
-                                entityPredicate.entityType(),
-                                entityPredicate.distanceToPlayer(),
-                                entityPredicate.movement(),
-                                entityPredicate.location(),
-                                entityPredicate.effects(),
-                                entityPredicate.nbt(),
-                                entityPredicate.flags(),
-                                Optional.empty(),
-                                Optional.of(subPredicate),
-                                entityPredicate.periodicTick(),
-                                entityPredicate.vehicle(),
-                                entityPredicate.passenger(),
-                                entityPredicate.targetedEntity(),
-                                entityPredicate.team(),
-                                entityPredicate.slots());
-                        LootItemCondition.Builder conditionBuilder = LootItemEntityPropertyCondition.hasProperties(entityPropertyCondition.entityTarget(), replacement);
+                    EntityPredicateReplacementHelper helper = new EntityPredicateReplacementHelper(predicate.get());
+                    if (predicateHelper.test(helper)) {
+                        LootItemCondition.Builder conditionBuilder = LootItemEntityPropertyCondition.hasProperties(entityPropertyCondition.entityTarget(), helper.create());
                         if (invert) {
                             return conditionBuilder.invert().build();
                         }
@@ -331,6 +361,62 @@ public class NeoForgeAdvancementProvider extends AdvancementProvider {
                 builder.sendsTelemetryEvent();
             }
             return builder;
+        }
+    }
+
+    private static class EntityPredicateReplacementHelper {
+        private final EntityPredicate source;
+        private Optional<EntityTypePredicate> entityType;
+        private Optional<EntityEquipmentPredicate> equipment;
+        private Optional<EntitySubPredicate> subPredicate;
+
+        public EntityPredicateReplacementHelper(EntityPredicate source) {
+            this.source = source;
+            this.entityType = this.source.entityType();
+            this.equipment = this.source.equipment();
+            this.subPredicate = this.source.subPredicate();
+        }
+
+        public boolean clearTypeIfMatches(EntityType<?> type) {
+            if (entityType.isPresent() && entityType.get().matches(type)) {
+                entityType = Optional.empty();
+                return true;
+            }
+            return false;
+        }
+
+        public boolean clearEquipmentIfMatches(Predicate<EntityEquipmentPredicate> shouldReplace) {
+            if (equipment.isPresent() && shouldReplace.test(equipment.get())) {
+                equipment = Optional.empty();
+                return true;
+            }
+            return false;
+        }
+
+        public void replaceSubPredicate(EntitySubPredicate predicate) {
+            if (subPredicate.isPresent()) {
+                throw new IllegalStateException("Attempting to replace an entity predicate that already has a sub predicate");
+            }
+            subPredicate = Optional.of(predicate);
+        }
+
+        public EntityPredicate create() {
+            return new EntityPredicate(
+                    entityType,
+                    source.distanceToPlayer(),
+                    source.movement(),
+                    source.location(),
+                    source.effects(),
+                    source.nbt(),
+                    source.flags(),
+                    equipment,
+                    subPredicate,
+                    source.periodicTick(),
+                    source.vehicle(),
+                    source.passenger(),
+                    source.targetedEntity(),
+                    source.team(),
+                    source.slots());
         }
     }
 }


### PR DESCRIPTION
Eventually Mojang might end up making an entity type tag for tridents similar to the one they have for arrows, but until then there isn't a way for mods to have custom tridents trigger the thrown_trident advancement. This PR has us override the advancement to check for any subclass of ThrownTrident. Given I advancement criteria are only checked server side, if it is preferred we could instead add a entity type tag for tridents, and then check that instead of a custom sub predicate that does an instance check.

I also slightly refactored the code I wrote previously for replacing entity predicates (for worn equipment checks) to make it easier to extend for replacing different parts of an `EntityPredicate`