### PR TITLE
Add a method to get the registry name of an element, that returns null from defaulted registries when not present

### DIFF
--- a/patches/net/minecraft/core/DefaultedMappedRegistry.java.patch
+++ b/patches/net/minecraft/core/DefaultedMappedRegistry.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/core/DefaultedMappedRegistry.java
++++ b/net/minecraft/core/DefaultedMappedRegistry.java
+@@ -40,6 +_,12 @@
+         return resourcelocation == null ? this.defaultKey : resourcelocation;
+     }
+ 
++    @Nullable
++    @Override
++    public ResourceLocation getKeyOrNull(T element) {
++        return super.getKey(element);
++    }
++
+     @Nonnull
+     @Override
+     public T getValue(@Nullable ResourceLocation p_368576_) {

--- a/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.registries;
 
 import java.util.Map;
+import org.jetbrains.annotations.Nullable;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -22,6 +23,10 @@ import net.neoforged.neoforge.registries.datamaps.DataMapType;
  * @param <T> the type of registry entries
  */
 public interface IRegistryExtension<T> {
+    private Registry<T> self() {
+        return (Registry<T>) this;
+    }
+
     /**
      * {@return whether this registry should be synced to clients}
      */
@@ -124,4 +129,16 @@ public interface IRegistryExtension<T> {
      * @param <A> the data type
      */
     <A> Map<ResourceKey<T>, A> getDataMap(DataMapType<T, A> type);
+
+    /**
+     * {@return the key of the element, or null if it is not present in this registry}
+     *
+     * @apiNote This method is different from {@link Registry#getKey(Object)} as it does not return the default key for
+     *          {@link net.minecraft.core.DefaultedRegistry defaulted registries}
+     */
+    @Nullable
+    default ResourceLocation getKeyOrNull(T element) {
+        //Note: We override the cases when getKey would return the default rather than just going via getResourceKey to find it
+        return self().getKey(element);
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.registries;
 
 import java.util.Map;
-import org.jetbrains.annotations.Nullable;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -15,6 +14,7 @@ import net.neoforged.neoforge.registries.callback.BakeCallback;
 import net.neoforged.neoforge.registries.callback.ClearCallback;
 import net.neoforged.neoforge.registries.callback.RegistryCallback;
 import net.neoforged.neoforge.registries.datamaps.DataMapType;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An extension for {@link Registry}, adding some additional functionality to vanilla registries, such as


### PR DESCRIPTION
While I know this could be done via: `Registry#getResourceKey(Object).map(ResourceKey::location).orElse(null)`, I think it would be convenient to have a better way to look this up that doesn't require chaining so many optionals. This is useful for modders when using `Util#makeDescriptionId` so that if it isn't registered it will express that to anyone who sees the translation key, rather than pretending it is the default element. While Mojang just uses `Registry#getKey` for things like Item translation names, and thus has unregistered ones just translate as air, I think we should give modders a choice whether they have it display the default key or that it is unregistered.