### PR TITLE
[1.21.4] Add support for double modifier keybinds

### DIFF
--- a/patches/net/minecraft/client/KeyMapping.java.patch
+++ b/patches/net/minecraft/client/KeyMapping.java.patch
@@ -29,7 +29,7 @@
 -        if (keymapping != null) {
 -            keymapping.setDown(p_90839_);
 -        }
-+        for (KeyMapping keymapping : MAP.getAll(p_90838_))
++        for (KeyMapping keymapping : MAP.getAll(p_90838_, !p_90839_))
 +            if (keymapping != null) {
 +                keymapping.setDown(p_90839_);
 +            }

--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
@@ -27,7 +27,7 @@
          if (this.selectedKey != null) {
 -            if (p_345810_ == 256) {
 +            var key = InputConstants.getKey(p_345810_, p_345447_);
-+            if (net.neoforged.neoforge.client.settings.KeyModifier.isKeyCodeModifier(key)) {
++            if (lastPressedModifier == InputConstants.UNKNOWN && net.neoforged.neoforge.client.settings.KeyModifier.isKeyCodeModifier(key)) {
 +                lastPressedModifier = key;
 +                isLastModifierHeldDown = true;
 +            } else {

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -47,36 +47,40 @@ public class KeyMappingLookup {
         List<KeyMapping> matchingBindings = new ArrayList<>();
         // Get a list of all active modifiers
         List<KeyModifier> activeModifiers = KeyModifier.getActiveModifiers();
+        // Get modifier for key code
+        KeyModifier keyCodeModifier = KeyModifier.getKeyModifier(keyCode);
 
         for (var modifier : activeModifiers) {
             // If modifier matches, add other modifiers
             if (modifier.matches(keyCode)) {
                 // Check if binding matches with another modifier
-                for (var key : activeModifiers) {
+                for (var otherModifier : activeModifiers) {
 
-                    // Skip if modifier matches
-                    if (key.matches(keyCode)) {
+                    // Skip if modifier matches current key code
+                    if (otherModifier == keyCodeModifier) {
                         continue;
                     }
 
                     // Loop through all modifier codes
-                    for (var modifierKey : key.codes()) {
-                        if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), modifierKey.getValue())) {
-                            matchingBindings.addAll(findKeybinds(modifierKey, modifier));
+                    for (var otherModifierCode : otherModifier.codes()) {
+                        if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), otherModifierCode.getValue())) {
+                            matchingBindings.addAll(findKeybinds(otherModifierCode, modifier));
                         }
                     }
                 }
             } else {
-                // Attempt to add all keybinds where the keycode and the modifier are different
+                // Attempt to add all bindings where the keycode and the modifier are different
                 matchingBindings.addAll(findKeybinds(keyCode, modifier));
             }
         }
 
-        // Release all keys which use this as a modifier
-        if (releasing && KeyModifier.isKeyCodeModifier(keyCode)) {
-            matchingBindings.addAll(map.get(KeyModifier.getKeyModifier(keyCode)).entrySet().stream()
+        // Release all bindings which use this key code as a modifier
+        if (releasing && keyCodeModifier != KeyModifier.NONE) {
+            matchingBindings.addAll(map.get(keyCodeModifier).entrySet().stream()
+                    // Only match keys that are mapped
                     .filter(entry -> entry.getKey() != InputConstants.UNKNOWN)
                     .flatMap(entry -> entry.getValue().stream())
+                    // Make sure the key is active in the current context
                     .filter(mapping -> mapping.getKeyConflictContext().isActive())
                     .toList());
         }

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -14,6 +14,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 
 public class KeyMappingLookup {
     private static final EnumMap<KeyModifier, Map<InputConstants.Key, Collection<KeyMapping>>> map = new EnumMap<>(KeyModifier.class);
@@ -31,13 +32,60 @@ public class KeyMappingLookup {
      * @return the list of key mappings
      */
     public List<KeyMapping> getAll(InputConstants.Key keyCode) {
+        return this.getAll(keyCode, false);
+    }
+
+    /**
+     * Returns all active keys associated with the given key code and the active
+     * modifiers and conflict context.
+     *
+     * @param keyCode the key being pressed
+     * @param releasing if the key is being released
+     * @return the list of key mappings
+     */
+    public List<KeyMapping> getAll(InputConstants.Key keyCode, boolean releasing) {
         List<KeyMapping> matchingBindings = new ArrayList<>();
-        KeyModifier activeModifier = KeyModifier.getActiveModifier();
-        // Apply active modifier only if the pressed key is not the modifier itself
-        // Otherwise, look for key bindings without modifiers
-        if (activeModifier == KeyModifier.NONE || activeModifier.matches(keyCode) || !matchingBindings.addAll(findKeybinds(keyCode, activeModifier))) {
+        // Get a list of all active modifiers
+        List<KeyModifier> activeModifiers = KeyModifier.getActiveModifiers();
+
+        for (var modifier : activeModifiers) {
+            // If modifier matches, add other modifiers
+            if (modifier.matches(keyCode)) {
+                // Check if binding matches with another modifier
+                for (var key : activeModifiers) {
+
+                    // Skip if modifier matches
+                    if (key.matches(keyCode)) {
+                        continue;
+                    }
+
+                    // Loop through all modifier codes
+                    for (var modifierKey : key.codes()) {
+                        if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), modifierKey.getValue())) {
+                            matchingBindings.addAll(findKeybinds(modifierKey, modifier));
+                        }
+                    }
+                }
+            } else {
+                // Attempt to add all keybinds where the keycode and the modifier are different
+                matchingBindings.addAll(findKeybinds(keyCode, modifier));
+            }
+        }
+
+        // Release all keys which use this as a modifier
+        if (releasing && KeyModifier.isKeyCodeModifier(keyCode)) {
+            matchingBindings.addAll(map.get(KeyModifier.getKeyModifier(keyCode)).entrySet().stream()
+                    .filter(entry -> entry.getKey() != InputConstants.UNKNOWN)
+                    .flatMap(entry -> entry.getValue().stream())
+                    .filter(mapping -> mapping.getKeyConflictContext().isActive())
+                    .toList());
+        }
+
+        // If there were no matches, check the key without any modifiers
+        if (matchingBindings.isEmpty()) {
             matchingBindings.addAll(findKeybinds(keyCode, KeyModifier.NONE));
         }
+
         return matchingBindings;
     }
 

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -39,7 +39,7 @@ public class KeyMappingLookup {
      * Returns all active keys associated with the given key code and the active
      * modifiers and conflict context.
      *
-     * @param keyCode the key being pressed
+     * @param keyCode   the key being pressed
      * @param releasing if the key is being released
      * @return the list of key mappings
      */

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -184,5 +184,8 @@ public enum KeyModifier {
 
     public abstract Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic);
 
-    public abstract InputConstants.Key[] codes();
+    // Neo: Make abstract in 1.21.5
+    public InputConstants.Key[] codes() {
+        return null;
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -137,6 +137,7 @@ public enum KeyModifier {
 
     public static final KeyModifier[] MODIFIER_VALUES = { SHIFT, CONTROL, ALT };
 
+    /** @deprecated Use {@link #getActiveModifiers()} instead. */
     @Deprecated(forRemoval = true, since = "1.21.4")
     public static KeyModifier getActiveModifier() {
         for (KeyModifier keyModifier : MODIFIER_VALUES) {

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -6,6 +6,9 @@
 package net.neoforged.neoforge.client.settings;
 
 import com.mojang.blaze3d.platform.InputConstants;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
@@ -15,6 +18,16 @@ import org.lwjgl.glfw.GLFW;
 
 public enum KeyModifier {
     CONTROL {
+
+        private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_CONTROL),
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_CONTROL)
+        };
+        private static final InputConstants.Key[] OSX_KEYS = new InputConstants.Key[] {
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SUPER),
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_SUPER)
+        };
+
         @Override
         public boolean matches(InputConstants.Key key) {
             int keyCode = key.getValue();
@@ -35,8 +48,19 @@ public enum KeyModifier {
             String localizationFormatKey = Minecraft.ON_OSX ? "neoforge.controlsgui.control.mac" : "neoforge.controlsgui.control";
             return Component.translatable(localizationFormatKey, defaultLogic.get());
         }
+
+        @Override
+        public InputConstants.Key[] codes() {
+            return Minecraft.ON_OSX ? OSX_KEYS : KEYS;
+        }
     },
     SHIFT {
+
+        private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SHIFT),
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_SHIFT)
+        };
+
         @Override
         public boolean matches(InputConstants.Key key) {
             return key.getValue() == GLFW.GLFW_KEY_LEFT_SHIFT || key.getValue() == GLFW.GLFW_KEY_RIGHT_SHIFT;
@@ -51,8 +75,19 @@ public enum KeyModifier {
         public Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic) {
             return Component.translatable("neoforge.controlsgui.shift", defaultLogic.get());
         }
+
+        @Override
+        public InputConstants.Key[] codes() {
+            return KEYS;
+        }
     },
     ALT {
+
+        private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_ALT),
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_ALT)
+        };
+
         @Override
         public boolean matches(InputConstants.Key key) {
             return key.getValue() == GLFW.GLFW_KEY_LEFT_ALT || key.getValue() == GLFW.GLFW_KEY_RIGHT_ALT;
@@ -67,8 +102,16 @@ public enum KeyModifier {
         public Component getCombinedName(InputConstants.Key keyCode, Supplier<Component> defaultLogic) {
             return Component.translatable("neoforge.controlsgui.alt", defaultLogic.get());
         }
+
+        @Override
+        public InputConstants.Key[] codes() {
+            return KEYS;
+        }
     },
     NONE {
+
+        private static final InputConstants.Key[] KEYS = new InputConstants.Key[0];
+
         @Override
         public boolean matches(InputConstants.Key key) {
             return false;
@@ -90,10 +133,16 @@ public enum KeyModifier {
         public Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic) {
             return defaultLogic.get();
         }
+
+        @Override
+        public InputConstants.Key[] codes() {
+            return KEYS;
+        }
     };
 
     public static final KeyModifier[] MODIFIER_VALUES = { SHIFT, CONTROL, ALT };
 
+    @Deprecated(forRemoval = true, since = "1.21.4")
     public static KeyModifier getActiveModifier() {
         for (KeyModifier keyModifier : MODIFIER_VALUES) {
             if (keyModifier.isActive(null)) {
@@ -101,6 +150,16 @@ public enum KeyModifier {
             }
         }
         return NONE;
+    }
+
+    public static List<KeyModifier> getActiveModifiers() {
+        List<KeyModifier> modifiers = new ArrayList<>();
+        for (KeyModifier keyModifier : MODIFIER_VALUES) {
+            if (keyModifier.isActive(null)) {
+                modifiers.add(keyModifier);
+            }
+        }
+        return modifiers;
     }
 
     public static KeyModifier getKeyModifier(InputConstants.Key key) {
@@ -129,4 +188,6 @@ public enum KeyModifier {
     public abstract boolean isActive(@Nullable IKeyConflictContext conflictContext);
 
     public abstract Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic);
+
+    public abstract InputConstants.Key[] codes();
 }

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.client.settings;
 
 import com.mojang.blaze3d.platform.InputConstants;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -18,7 +17,6 @@ import org.lwjgl.glfw.GLFW;
 
 public enum KeyModifier {
     CONTROL {
-
         private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_CONTROL),
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_CONTROL)
@@ -55,7 +53,6 @@ public enum KeyModifier {
         }
     },
     SHIFT {
-
         private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SHIFT),
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_SHIFT)
@@ -82,7 +79,6 @@ public enum KeyModifier {
         }
     },
     ALT {
-
         private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_ALT),
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_ALT)
@@ -109,7 +105,6 @@ public enum KeyModifier {
         }
     },
     NONE {
-
         private static final InputConstants.Key[] KEYS = new InputConstants.Key[0];
 
         @Override


### PR DESCRIPTION
Closes #2012 

Modifies the key lookup code to handle key mappings that use double modifiers (e.g. Ctrl + Shift). Most of the logic just goes towards allowing the key mappings to be pressed in any order while being removed properly from the associated map on release of either modifier.