### PR TITLE
Reimplement on-demand synchronization of recipe data to clients

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -100,19 +100,12 @@
      }
  
      @Override
-@@ -1574,6 +_,15 @@
+@@ -1574,6 +_,8 @@
      public void handleUpdateRecipes(ClientboundUpdateRecipesPacket p_105132_) {
          PacketUtils.ensureRunningOnSameThread(p_105132_, this, this.minecraft);
          this.recipes = new ClientRecipeContainer(p_105132_.itemSets(), p_105132_.stonecutterRecipes());
 +
-+        // Neo: abuse recipe sync to overwrite fuel values with datamap values after their sync (tag update doesn't fire on initial sync and the constructor is too early)
-+        if (this.connectionType.isNeoForge()) {
-+            this.fuelValues = net.neoforged.neoforge.common.DataMapHooks.populateFuelValues(this.registryAccess, this.enabledFeatures);
-+        } else {
-+            // Notify client mods that they're connected to a Vanilla server, which will never give them recipe data
-+            var event = new net.neoforged.neoforge.client.event.RecipesReceivedEvent(java.util.Set.of(), net.minecraft.world.item.crafting.RecipeMap.create(java.util.List.of()));
-+            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
-+        }
++        net.neoforged.neoforge.client.ClientHooks.handleUpdateRecipes(this, v -> this.fuelValues = v);
      }
  
      @Override

--- a/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -100,7 +100,7 @@
      }
  
      @Override
-@@ -1574,6 +_,11 @@
+@@ -1574,6 +_,15 @@
      public void handleUpdateRecipes(ClientboundUpdateRecipesPacket p_105132_) {
          PacketUtils.ensureRunningOnSameThread(p_105132_, this, this.minecraft);
          this.recipes = new ClientRecipeContainer(p_105132_.itemSets(), p_105132_.stonecutterRecipes());
@@ -108,6 +108,10 @@
 +        // Neo: abuse recipe sync to overwrite fuel values with datamap values after their sync (tag update doesn't fire on initial sync and the constructor is too early)
 +        if (this.connectionType.isNeoForge()) {
 +            this.fuelValues = net.neoforged.neoforge.common.DataMapHooks.populateFuelValues(this.registryAccess, this.enabledFeatures);
++        } else {
++            // Notify client mods that they're connected to a Vanilla server, which will never give them recipe data
++            var event = new net.neoforged.neoforge.client.event.RecipesReceivedEvent(java.util.Set.of(), net.minecraft.world.item.crafting.RecipeMap.create(java.util.List.of()));
++            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
 +        }
      }
  

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
+@@ -21,7 +_,6 @@
+ import java.util.function.Predicate;
+ import javax.annotation.Nullable;
+ import net.minecraft.ChatFormatting;
+-import net.minecraft.FileUtil;
+ import net.minecraft.commands.CommandSourceStack;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.LayeredRegistryAccess;
 @@ -129,6 +_,7 @@
      private boolean allowCommandsForAllPlayers;
      private static final boolean ALLOW_LOGOUTIVATOR = false;
@@ -23,7 +31,7 @@
          servergamepacketlistenerimpl.send(new ClientboundSetHeldSlotPacket(p_11263_.getInventory().selected));
 +        var dataSyncEvent = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.OnDatapackSyncEvent(this, p_11263_));
          RecipeManager recipemanager = this.server.getRecipeManager();
-+        net.neoforged.neoforge.common.CommonHooks.sendRecipes(p_11263_, dataSyncEvent.getRequestedRecipeTypes(), recipemanager.recipeMap());
++        net.neoforged.neoforge.common.CommonHooks.sendRecipes(p_11263_, dataSyncEvent.getRecipeTypesToSend(), recipemanager.recipeMap());
          servergamepacketlistenerimpl.send(
              new ClientboundUpdateRecipesPacket(recipemanager.getSynchronizedItemProperties(), recipemanager.getSynchronizedStonecutterRecipes())
          );
@@ -162,7 +170,7 @@
          for (ServerPlayer serverplayer : this.players) {
              serverplayer.connection.send(clientboundupdaterecipespacket);
              serverplayer.getRecipeBook().sendInitialRecipeBook(serverplayer);
-+            net.neoforged.neoforge.common.CommonHooks.sendRecipes(serverplayer, dataSyncEvent.getRequestedRecipeTypes(), recipemanager.recipeMap());
++            net.neoforged.neoforge.common.CommonHooks.sendRecipes(serverplayer, dataSyncEvent.getRecipeTypesToSend(), recipemanager.recipeMap());
          }
      }
  

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -17,14 +17,16 @@
          );
          GameRules gamerules = serverlevel1.getGameRules();
          boolean flag = gamerules.getBoolean(GameRules.RULE_DO_IMMEDIATE_RESPAWN);
-@@ -202,6 +_,7 @@
+@@ -202,7 +_,9 @@
          servergamepacketlistenerimpl.send(new ClientboundChangeDifficultyPacket(leveldata.getDifficulty(), leveldata.isDifficultyLocked()));
          servergamepacketlistenerimpl.send(new ClientboundPlayerAbilitiesPacket(p_11263_.getAbilities()));
          servergamepacketlistenerimpl.send(new ClientboundSetHeldSlotPacket(p_11263_.getInventory().selected));
-+        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.OnDatapackSyncEvent(this, p_11263_));
++        var dataSyncEvent = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.OnDatapackSyncEvent(this, p_11263_));
          RecipeManager recipemanager = this.server.getRecipeManager();
++        net.neoforged.neoforge.common.CommonHooks.sendRecipes(p_11263_, dataSyncEvent.getRequestedRecipeTypes(), recipemanager.recipeMap());
          servergamepacketlistenerimpl.send(
              new ClientboundUpdateRecipesPacket(recipemanager.getSynchronizedItemProperties(), recipemanager.getSynchronizedStonecutterRecipes())
+         );
 @@ -236,6 +_,7 @@
          p_11263_.loadAndSpawnEnderpearls(optional1);
          p_11263_.loadAndSpawnParentVehicle(optional1);
@@ -152,7 +154,15 @@
              playeradvancements.reload(this.server.getAdvancements());
          }
  
-+        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.OnDatapackSyncEvent(this, null));
++        var dataSyncEvent = net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.OnDatapackSyncEvent(this, null));
          this.broadcastAll(new ClientboundUpdateTagsPacket(TagNetworkSerialization.serializeTagsToNetwork(this.registries)));
          RecipeManager recipemanager = this.server.getRecipeManager();
          ClientboundUpdateRecipesPacket clientboundupdaterecipespacket = new ClientboundUpdateRecipesPacket(
+@@ -862,6 +_,7 @@
+         for (ServerPlayer serverplayer : this.players) {
+             serverplayer.connection.send(clientboundupdaterecipespacket);
+             serverplayer.getRecipeBook().sendInitialRecipeBook(serverplayer);
++            net.neoforged.neoforge.common.CommonHooks.sendRecipes(serverplayer, dataSyncEvent.getRequestedRecipeTypes(), recipemanager.recipeMap());
+         }
+     }
+ 

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -1,13 +1,5 @@
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
-@@ -21,7 +_,6 @@
- import java.util.function.Predicate;
- import javax.annotation.Nullable;
- import net.minecraft.ChatFormatting;
--import net.minecraft.FileUtil;
- import net.minecraft.commands.CommandSourceStack;
- import net.minecraft.core.BlockPos;
- import net.minecraft.core.LayeredRegistryAccess;
 @@ -129,6 +_,7 @@
      private boolean allowCommandsForAllPlayers;
      private static final boolean ALLOW_LOGOUTIVATOR = false;

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -128,6 +128,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SkullBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.FuelValues;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.FogType;
@@ -752,6 +753,18 @@ public class ClientHooks {
     public static String onClientSendMessage(String message) {
         ClientChatEvent event = new ClientChatEvent(message);
         return NeoForge.EVENT_BUS.post(event).isCanceled() ? "" : event.getMessage();
+    }
+
+    @ApiStatus.Internal
+    public static void handleUpdateRecipes(ClientPacketListener packetListener, Consumer<FuelValues> fuelValuesSetter) {
+        // Neo: abuse recipe sync to overwrite fuel values with datamap values after their sync (tag update doesn't fire on initial sync and the constructor is too early)
+        if (packetListener.getConnectionType().isNeoForge()) {
+            fuelValuesSetter.accept(net.neoforged.neoforge.common.DataMapHooks.populateFuelValues(packetListener.registryAccess(), packetListener.enabledFeatures()));
+        } else {
+            // Notify client mods that they're connected to a Vanilla server, which will never give them recipe data
+            var event = new net.neoforged.neoforge.client.event.RecipesReceivedEvent(java.util.Set.of(), net.minecraft.world.item.crafting.RecipeMap.create(java.util.List.of()));
+            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
+        }
     }
 
     @EventBusSubscriber(value = Dist.CLIENT, modid = "neoforge", bus = EventBusSubscriber.Bus.MOD)

--- a/src/main/java/net/neoforged/neoforge/client/event/RecipesReceivedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RecipesReceivedEvent.java
@@ -20,6 +20,9 @@ import org.jetbrains.annotations.ApiStatus;
  * will only be sent for recipe types requested using {@link net.neoforged.neoforge.event.OnDatapackSyncEvent#sendRecipes}
  * on the server-side.
  *
+ * <p>You should clean up any data you kept from this event when the player disconnects,
+ * for example when {@link ClientPlayerNetworkEvent.LoggingOut} is fired.
+ *
  * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */

--- a/src/main/java/net/neoforged/neoforge/client/event/RecipesReceivedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/client/event/RecipesReceivedEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import java.util.Set;
+import net.minecraft.world.item.crafting.RecipeMap;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * This event is fired on the client when it has finished receiving recipe data
+ * from the server. This will be the case shortly after first entering the world,
+ * and whenever the server decides to reload its datapacks. Note that recipe data
+ * will only be sent for recipe types requested using {@link net.neoforged.neoforge.event.OnDatapackSyncEvent#sendRecipes}
+ * on the server-side.
+ *
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main event bus},
+ * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class RecipesReceivedEvent extends Event {
+    private final Set<RecipeType<?>> recipeTypes;
+    private final RecipeMap recipeMap;
+
+    @ApiStatus.Internal
+    public RecipesReceivedEvent(Set<RecipeType<?>> recipeTypes, RecipeMap recipeMap) {
+        this.recipeTypes = Set.copyOf(recipeTypes);
+        this.recipeMap = recipeMap;
+    }
+
+    /**
+     * @return The recipe types that were requested by mods on the server to be sent to the client. This may
+     *         be a subset of available recipes types or even empty if no mods requested recipes to be sent.
+     */
+    public Set<RecipeType<?>> getRecipeTypes() {
+        return recipeTypes;
+    }
+
+    /**
+     * @return The recipes received from the server.
+     */
+    public RecipeMap getRecipeMap() {
+        return recipeMap;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1596,4 +1596,12 @@ public class CommonHooks {
         }
         return RecipeBookType.values();
     }
+
+    /**
+     * Determines whether the given players should be sent full recipe content or not and handles the sending.
+     */
+    public static void sendRecipes(ServerPlayer player) {
+        var recipeMap = player.server.getRecipeManager().recipeMap();
+
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -116,6 +116,8 @@ import net.minecraft.world.item.alchemy.Potion;
 import net.minecraft.world.item.alchemy.PotionContents;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.item.crafting.RecipeMap;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
@@ -208,6 +210,8 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.NoteBlockEvent;
 import net.neoforged.neoforge.event.level.block.CropGrowEvent;
 import net.neoforged.neoforge.fluids.FluidType;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.neoforged.neoforge.network.payload.RecipeContentPayload;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.resource.ResourcePackLoader;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
@@ -1600,8 +1604,10 @@ public class CommonHooks {
     /**
      * Determines whether the given players should be sent full recipe content or not and handles the sending.
      */
-    public static void sendRecipes(ServerPlayer player) {
-        var recipeMap = player.server.getRecipeManager().recipeMap();
-
+    public static void sendRecipes(ServerPlayer player, Set<RecipeType<?>> requestedRecipeTypes, RecipeMap recipeMap) {
+        if (player.connection.getConnectionType().isNeoForge()) {
+            var payload = RecipeContentPayload.create(requestedRecipeTypes, recipeMap);
+            PacketDistributor.sendToPlayer(player, payload);
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1604,9 +1604,10 @@ public class CommonHooks {
     /**
      * Determines whether the given players should be sent full recipe content or not and handles the sending.
      */
-    public static void sendRecipes(ServerPlayer player, Set<RecipeType<?>> requestedRecipeTypes, RecipeMap recipeMap) {
+    public static void sendRecipes(ServerPlayer player, Set<RecipeType<?>> recipeTypesToSend, RecipeMap recipeMap) {
         if (player.connection.getConnectionType().isNeoForge()) {
-            var payload = RecipeContentPayload.create(requestedRecipeTypes, recipeMap);
+            var payload = RecipeContentPayload.create(recipeTypesToSend, recipeMap);
+            LOGGER.debug("Sending {} recipes of the following types: {}", payload.recipes().size(), payload.recipeTypes());
             PacketDistributor.sendToPlayer(player, payload);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
@@ -5,8 +5,9 @@
 
 package net.neoforged.neoforge.event;
 
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Set;
 import java.util.stream.Stream;
 import net.minecraft.server.level.ServerPlayer;
@@ -25,7 +26,7 @@ public class OnDatapackSyncEvent extends Event {
     @Nullable
     private final ServerPlayer player;
 
-    private final Set<RecipeType<?>> requestedRecipeTypes = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final ReferenceSet<RecipeType<?>> recipeTypesToSend = new ReferenceOpenHashSet<>();
 
     public OnDatapackSyncEvent(PlayerList playerList, @Nullable ServerPlayer player) {
         this.playerList = playerList;
@@ -66,7 +67,7 @@ public class OnDatapackSyncEvent extends Event {
      * @see net.neoforged.neoforge.client.event.RecipesReceivedEvent
      */
     public void sendRecipes(RecipeType<?>... recipeTypes) {
-        Collections.addAll(this.requestedRecipeTypes, recipeTypes);
+        Collections.addAll(this.recipeTypesToSend, recipeTypes);
     }
 
     /**
@@ -76,14 +77,14 @@ public class OnDatapackSyncEvent extends Event {
      */
     public void sendRecipes(Iterable<RecipeType<?>> recipeTypes) {
         for (var recipeType : recipeTypes) {
-            this.requestedRecipeTypes.add(recipeType);
+            this.recipeTypesToSend.add(recipeType);
         }
     }
 
     /**
      * @return The recipe types that have already been requested to be sent to the players.
      */
-    public Set<RecipeType<?>> getRequestedRecipeTypes() {
-        return Collections.unmodifiableSet(requestedRecipeTypes);
+    public Set<RecipeType<?>> getRecipeTypesToSend() {
+        return Collections.unmodifiableSet(recipeTypesToSend);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/OnDatapackSyncEvent.java
@@ -5,9 +5,13 @@
 
 package net.neoforged.neoforge.event;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.stream.Stream;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.neoforged.bus.api.Event;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +24,8 @@ public class OnDatapackSyncEvent extends Event {
     private final PlayerList playerList;
     @Nullable
     private final ServerPlayer player;
+
+    private final Set<RecipeType<?>> requestedRecipeTypes = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public OnDatapackSyncEvent(PlayerList playerList, @Nullable ServerPlayer player) {
         this.playerList = playerList;
@@ -52,5 +58,32 @@ public class OnDatapackSyncEvent extends Event {
     @Nullable
     public ServerPlayer getPlayer() {
         return this.player;
+    }
+
+    /**
+     * Requests that all recipes of the given types should be sent to the players.
+     * 
+     * @see net.neoforged.neoforge.client.event.RecipesReceivedEvent
+     */
+    public void sendRecipes(RecipeType<?>... recipeTypes) {
+        Collections.addAll(this.requestedRecipeTypes, recipeTypes);
+    }
+
+    /**
+     * Requests that all recipes of the given types should be sent to the players.
+     * 
+     * @see net.neoforged.neoforge.client.event.RecipesReceivedEvent
+     */
+    public void sendRecipes(Iterable<RecipeType<?>> recipeTypes) {
+        for (var recipeType : recipeTypes) {
+            this.requestedRecipeTypes.add(recipeType);
+        }
+    }
+
+    /**
+     * @return The recipe types that have already been requested to be sent to the players.
+     */
+    public Set<RecipeType<?>> getRequestedRecipeTypes() {
+        return Collections.unmodifiableSet(requestedRecipeTypes);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -29,6 +29,7 @@ import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncStartPayload;
 import net.neoforged.neoforge.network.payload.KnownRegistryDataMapsPayload;
 import net.neoforged.neoforge.network.payload.KnownRegistryDataMapsReplyPayload;
+import net.neoforged.neoforge.network.payload.RecipeContentPayload;
 import net.neoforged.neoforge.network.payload.RegistryDataMapSyncPayload;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import net.neoforged.neoforge.registries.ClientRegistryManager;
@@ -105,6 +106,10 @@ public class NetworkInitialization {
                 .playToClient(
                         ClientboundCustomSetTimePayload.TYPE,
                         ClientboundCustomSetTimePayload.STREAM_CODEC,
+                        ClientPayloadHandler::handle)
+                .playToClient(
+                        RecipeContentPayload.TYPE,
+                        RecipeContentPayload.STREAM_CODEC,
                         ClientPayloadHandler::handle);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
+++ b/src/main/java/net/neoforged/neoforge/network/handlers/ClientPayloadHandler.java
@@ -24,6 +24,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.crafting.RecipeMap;
+import net.neoforged.neoforge.client.event.RecipesReceivedEvent;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.common.world.LevelChunkAuxiliaryLightManager;
 import net.neoforged.neoforge.entity.IEntityWithComplexSpawn;
@@ -38,6 +41,7 @@ import net.neoforged.neoforge.network.payload.ConfigFilePayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistryPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncCompletedPayload;
 import net.neoforged.neoforge.network.payload.FrozenRegistrySyncStartPayload;
+import net.neoforged.neoforge.network.payload.RecipeContentPayload;
 import net.neoforged.neoforge.registries.RegistryManager;
 import net.neoforged.neoforge.registries.RegistrySnapshot;
 import org.jetbrains.annotations.ApiStatus;
@@ -154,5 +158,10 @@ public final class ClientPayloadHandler {
         level.setTimeFromServer(payload.gameTime(), payload.dayTime(), payload.gameRule());
         level.setDayTimeFraction(payload.dayTimeFraction());
         level.setDayTimePerTick(payload.dayTimePerTick());
+    }
+
+    public static void handle(final RecipeContentPayload payload, final IPayloadContext context) {
+        var recipeMap = RecipeMap.create(payload.recipes());
+        NeoForge.EVENT_BUS.post(new RecipesReceivedEvent(payload.recipeTypes(), recipeMap));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/network/payload/RecipeContentPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/RecipeContentPayload.java
@@ -1,0 +1,60 @@
+package net.neoforged.neoforge.network.payload;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import net.neoforged.neoforge.network.connection.ConnectionType;
+
+import java.util.List;
+
+/**
+ * We use this to transfer the actual recipe content from server to client.
+ */
+public final class RecipeContentPayload implements CustomPacketPayload {
+    public static final Type<RecipeContentPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "recipe_content"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, RecipeContentPayload> STREAM_CODEC = StreamCodec.ofMember(
+            RecipeContentPayload::write,
+            RecipeContentPayload::read
+    );
+    private static final StreamCodec<RegistryFriendlyByteBuf, List<RecipeHolder<?>>> RECIPES_STREAM_CODEC = RecipeHolder.STREAM_CODEC.apply(ByteBufCodecs.list());
+
+    private volatile RegistryFriendlyByteBuf cachedPayload;
+
+    private static RecipeContentPayload read(RegistryFriendlyByteBuf buffer) {
+        var recipes = RECIPES_STREAM_CODEC.decode(buffer);
+        return new RecipeContentPayload(recipes);
+    }
+
+    private void write(RegistryFriendlyByteBuf buffer) {
+        if (cachedPayload == null) {
+            synchronized (this) {
+                var cachedBuffer = new RegistryFriendlyByteBuf(Unpooled.buffer(), buffer.registryAccess(), ConnectionType.NEOFORGE);
+                RECIPES_STREAM_CODEC.encode(buffer, recipes);
+                cachedPayload = cachedBuffer;
+            }
+        }
+        buffer.writeBytes(cachedPayload, 0, cachedPayload.readableBytes());
+    }
+
+    private final List<RecipeHolder<?>> recipes;
+
+    public RecipeContentPayload(
+            List<RecipeHolder<?>> recipes
+    ) {
+        this.recipes = recipes;
+    }
+
+    @Override
+    public Type<RecipeContentPayload> type() {
+        return TYPE;
+    }
+
+    public List<RecipeHolder<?>> recipes() {
+        return recipes;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/payload/RecipeContentPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/RecipeContentPayload.java
@@ -20,8 +20,6 @@ import net.minecraft.world.item.crafting.RecipeMap;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import org.jetbrains.annotations.ApiStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * We use this to transfer the actual recipe content from server to client.
@@ -30,8 +28,6 @@ import org.slf4j.LoggerFactory;
 public record RecipeContentPayload(
         Set<RecipeType<?>> recipeTypes,
         List<RecipeHolder<?>> recipes) implements CustomPacketPayload {
-    private static final Logger LOG = LoggerFactory.getLogger(RecipeContentPayload.class);
-
     public static final Type<RecipeContentPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "recipe_content"));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, RecipeContentPayload> STREAM_CODEC = StreamCodec.composite(
@@ -43,11 +39,9 @@ public record RecipeContentPayload(
         var recipeTypeSet = Set.copyOf(recipeTypes);
         // Fast-path for empty recipe type set (if no mod wants to sync anything)
         if (recipeTypeSet.isEmpty()) {
-            LOG.debug("Not sending any recipe data to clients.");
             return new RecipeContentPayload(recipeTypeSet, List.of());
         } else {
             var recipeSubset = recipes.values().stream().filter(h -> recipeTypeSet.contains(h.value().getType())).toList();
-            LOG.debug("Sending {} recipes of the following types: {}", recipeSubset.size(), recipeTypeSet);
             return new RecipeContentPayload(recipeTypeSet, recipeSubset);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/network/payload/RecipeContentPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/RecipeContentPayload.java
@@ -1,60 +1,59 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.network.payload;
 
-import io.netty.buffer.Unpooled;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeMap;
+import net.minecraft.world.item.crafting.RecipeType;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
-import net.neoforged.neoforge.network.connection.ConnectionType;
-
-import java.util.List;
+import org.jetbrains.annotations.ApiStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * We use this to transfer the actual recipe content from server to client.
  */
-public final class RecipeContentPayload implements CustomPacketPayload {
+@ApiStatus.Internal
+public record RecipeContentPayload(
+        Set<RecipeType<?>> recipeTypes,
+        List<RecipeHolder<?>> recipes) implements CustomPacketPayload {
+    private static final Logger LOG = LoggerFactory.getLogger(RecipeContentPayload.class);
+
     public static final Type<RecipeContentPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "recipe_content"));
-    public static final StreamCodec<RegistryFriendlyByteBuf, RecipeContentPayload> STREAM_CODEC = StreamCodec.ofMember(
-            RecipeContentPayload::write,
-            RecipeContentPayload::read
-    );
-    private static final StreamCodec<RegistryFriendlyByteBuf, List<RecipeHolder<?>>> RECIPES_STREAM_CODEC = RecipeHolder.STREAM_CODEC.apply(ByteBufCodecs.list());
 
-    private volatile RegistryFriendlyByteBuf cachedPayload;
+    public static final StreamCodec<RegistryFriendlyByteBuf, RecipeContentPayload> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.registry(Registries.RECIPE_TYPE).apply(ByteBufCodecs.collection(HashSet::new)), RecipeContentPayload::recipeTypes,
+            RecipeHolder.STREAM_CODEC.apply(ByteBufCodecs.list()), RecipeContentPayload::recipes,
+            RecipeContentPayload::new);
 
-    private static RecipeContentPayload read(RegistryFriendlyByteBuf buffer) {
-        var recipes = RECIPES_STREAM_CODEC.decode(buffer);
-        return new RecipeContentPayload(recipes);
-    }
-
-    private void write(RegistryFriendlyByteBuf buffer) {
-        if (cachedPayload == null) {
-            synchronized (this) {
-                var cachedBuffer = new RegistryFriendlyByteBuf(Unpooled.buffer(), buffer.registryAccess(), ConnectionType.NEOFORGE);
-                RECIPES_STREAM_CODEC.encode(buffer, recipes);
-                cachedPayload = cachedBuffer;
-            }
+    public static RecipeContentPayload create(Collection<RecipeType<?>> recipeTypes, RecipeMap recipes) {
+        var recipeTypeSet = Set.copyOf(recipeTypes);
+        // Fast-path for empty recipe type set (if no mod wants to sync anything)
+        if (recipeTypeSet.isEmpty()) {
+            LOG.debug("Not sending any recipe data to clients.");
+            return new RecipeContentPayload(recipeTypeSet, List.of());
+        } else {
+            var recipeSubset = recipes.values().stream().filter(h -> recipeTypeSet.contains(h.value().getType())).toList();
+            LOG.debug("Sending {} recipes of the following types: {}", recipeSubset.size(), recipeTypeSet);
+            return new RecipeContentPayload(recipeTypeSet, recipeSubset);
         }
-        buffer.writeBytes(cachedPayload, 0, cachedPayload.readableBytes());
-    }
-
-    private final List<RecipeHolder<?>> recipes;
-
-    public RecipeContentPayload(
-            List<RecipeHolder<?>> recipes
-    ) {
-        this.recipes = recipes;
     }
 
     @Override
     public Type<RecipeContentPayload> type() {
         return TYPE;
-    }
-
-    public List<RecipeHolder<?>> recipes() {
-        return recipes;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -57,7 +57,8 @@ public class NeoForgeRegistriesSetup {
             BuiltInRegistries.CONSUME_EFFECT_TYPE, // ConsumeEffect.STREAM_CODEC
             BuiltInRegistries.RECIPE_DISPLAY, // RecipeDisplay.STREAM_CODEC
             BuiltInRegistries.SLOT_DISPLAY, // SlotDisplay.STREAM_CODEC
-            BuiltInRegistries.RECIPE_BOOK_CATEGORY // RecipeDisplayEntry.STREAM_CODEC
+            BuiltInRegistries.RECIPE_BOOK_CATEGORY, // RecipeDisplayEntry.STREAM_CODEC
+            BuiltInRegistries.RECIPE_TYPE // RecipeContentPayload.STREAM_CODEC
     );
 
     private static void registerRegistries(NewRegistryEvent event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/RecipeSyncTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/RecipeSyncTest.java
@@ -7,7 +7,6 @@ package net.neoforged.neoforge.oldtest.client;
 
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.crafting.RecipeType;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/RecipeSyncTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/RecipeSyncTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.oldtest.client;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.event.RecipesReceivedEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.OnDatapackSyncEvent;
+
+@Mod(value = RecipeSyncTest.MOD_ID, dist = Dist.CLIENT)
+public class RecipeSyncTest {
+    private static final boolean ENABLED = true;
+    static final String MOD_ID = "recipe_sync_test";
+
+    // request two particular recipe types but not the others
+    private static final Set<RecipeType<?>> RECIPE_TYPES = Set.of(
+            RecipeType.BLASTING, RecipeType.SMOKING);
+
+    public RecipeSyncTest() {
+        if (ENABLED) {
+            // This handler would obviously go on the server-side
+            NeoForge.EVENT_BUS.addListener((OnDatapackSyncEvent event) -> {
+                event.sendRecipes(RECIPE_TYPES);
+            });
+            NeoForge.EVENT_BUS.addListener((RecipesReceivedEvent event) -> {
+                if (!event.getRecipeTypes().equals(RECIPE_TYPES)) {
+                    throw new AssertionError("Expected to receive recipe types " + RECIPE_TYPES + " but got: " + event.getRecipeTypes());
+                }
+
+                // This assumes there actually are any recipes for BLASTING and SMOKING, which is the case in Vanilla
+                var recipesForTypes = event.getRecipeMap().values().stream().map(r -> r.value().getType()).collect(Collectors.toSet());
+                if (!recipesForTypes.equals(RECIPE_TYPES)) {
+                    throw new AssertionError("Expected to receive recipes only for " + RECIPE_TYPES + ", but got recipes for: " + recipesForTypes);
+                }
+                Minecraft.getInstance().gui.getChat().addMessage(Component.literal("Received " + event.getRecipeMap().values().size() + " recipes from server"));
+            });
+        }
+    }
+}

--- a/tests/src/main/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/main/resources/META-INF/neoforge.mods.toml
@@ -251,5 +251,7 @@ modId="client_information_updated_test"
 [[mods]]
 modId="custom_feature_flags_pack_test"
 featureFlags="game_test_feature_flags.json"
+[[mods]]
+modId="recipe_sync_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
Motivation: Mods like JEI and EMI have signaled that they plan to synchronize all recipe data to clients following the removal of that from Vanilla after 1.21.1. If these rather ubiquitous mods plan to do this, having this feature as part of the platform would allow a lot of other mods to have a far easier time porting, so this PR aims to introduce said platform feature.

Design: We reuse the existing OnDatapackSync event, which fires server-side, to allow mods to request specific recipe types to be sent to the player. We then collect all recipes for these recipe types and send them similar to how they've been sent in previous Minecraft versions. When the client-side receives the payload, it fires a new event `RecipesReceivedEvent`, which signals 1) for which recipe types the client received data and 2) a `RecipeMap` containing these recipes.

Notes:
- We send the payload (only to NeoForge clients) even if no recipe types were requested to be synced, with an empty list of recipes. This allows a client-side only mod to notify the player that a server-side component may be required to make use of the full feature set.
- Currently there is no additional payload caching or splitting, mirroring Vanillas original design. Ingredient serialization should now be much more efficient (since they serialize as HolderSets now instead of being exploded into item lists), which means even for large packs post 1.21.1 the recipe packet size should be greatly reduced.
- We opted to *require* a server-side component to request synchronization of recipes to not leak information (such as custom server recipes) if a server has no such mods installed. We dropped the alternative of allowing clients to request this information even when no server-side mod is present.
- The idea behind allowing individual recipe types to be requested is for mods that use custom recipe types for making some of their tools or items data-driven, and only need those recipes on the client to function (examples: AE2 entropy manipulator, disk disassembly recipes, etc.).