### PR TITLE
Fix `ParametrizedGameTestSequence` swallowing exceptions

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ParametrizedGameTestSequence.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ParametrizedGameTestSequence.java
@@ -24,11 +24,25 @@ public class ParametrizedGameTestSequence<T> {
         this.info = info;
         this.sequence = sequence;
 
+        final AtomicReference<RuntimeException> capturedException = new AtomicReference<>();
         final AtomicReference<T> val = new AtomicReference<>();
-        sequence.thenExecute(() -> val.set(value.get()));
+        sequence.thenExecute(() -> {
+            try {
+                val.set(value.get());
+            } catch (RuntimeException ex) {
+                // Capture the exception to rethrow later, to avoid overwriting it with our own
+                capturedException.set(ex);
+                throw ex;
+            }
+        });
         this.value = () -> {
             final var v = val.get();
             if (v == null) {
+                // Rethrow the captured exception if any before throwing our own exception
+                final var ex = capturedException.get();
+                if (ex != null) {
+                    throw ex;
+                }
                 throw new GameTestAssertException("Expected value to be non-null!");
             }
             return v;

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ParametrizedGameTestSequence.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ParametrizedGameTestSequence.java
@@ -24,12 +24,12 @@ public class ParametrizedGameTestSequence<T> {
         this.info = info;
         this.sequence = sequence;
 
-        final AtomicReference<RuntimeException> capturedException = new AtomicReference<>();
+        final AtomicReference<Throwable> capturedException = new AtomicReference<>();
         final AtomicReference<T> val = new AtomicReference<>();
         sequence.thenExecute(() -> {
             try {
                 val.set(value.get());
-            } catch (RuntimeException ex) {
+            } catch (Throwable ex) {
                 // Capture the exception to rethrow later, to avoid overwriting it with our own
                 capturedException.set(ex);
                 throw ex;
@@ -41,7 +41,7 @@ public class ParametrizedGameTestSequence<T> {
                 // Rethrow the captured exception if any before throwing our own exception
                 final var ex = capturedException.get();
                 if (ex != null) {
-                    throw ex;
+                    sneakyThrow(ex);
                 }
                 throw new GameTestAssertException("Expected value to be non-null!");
             }
@@ -150,5 +150,11 @@ public class ParametrizedGameTestSequence<T> {
 
     public GameTestSequence.Condition thenTrigger() {
         return sequence.thenTrigger();
+    }
+
+    // Never returns normally.
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void sneakyThrow(Throwable exception) throws E {
+        throw (E) exception;
     }
 }


### PR DESCRIPTION
This PR fixes #1998 by making `ParametrizedGameTestSequence` rethrow the exception from the previous value supplier (which may be a `ParametrizedGameTestSequence`) before throwing its own exception about the value being `null`.

When a previous `ParametrizedGameTestSequence` throws an exception, its returned value will be `null`, causing a succeeding `ParametrizedGameTestSequence` to throw its own error about the value being `null`, hiding the original exception as `GameTestInfo` only stores a single failure exception.

To avoid this, `ParametrizedGameTestSequence` now stores the exception thrown from the previous step and rethrows it, so the `GameTestInfo` will always have the original exception. This also has the side-effect that further steps of `thenMap(Function)` (in unbroken continuity with the first erroring one) will not execute but instead rethrow the original exception.

---

You can test this behavior through this adapted case from the issue:

```java
@GameTest
@EmptyTemplate
@TestHolder(description = "Shows the original error message is displayed.")
public static void testOriginalErrorMessage(final ExtendedGameTestHelper helper) {
    helper.startSequence()
            .thenMap(() -> {
                helper.fail("This error message should display");
                return "unused return value";
            })
            .thenMap(Function.identity())
            .thenMap(Function.identity())
            .thenMap(value -> {
                helper.fail("This error message should NOT display");
                return "unused return value";
            })
            .thenMap(Function.identity())
            .thenMap(Function.identity())
            .thenSucceed();
}
```

The first error message should be displayed, and not the second one. 

Note that a `thenMap` call with a `Supplier` provided will 'reset' the trace, and will always execute regardless of the previous step (and thus future sequence steps will also execute). However, that will not reset the status of the game test -- the failure will persist until something else calls the appropriate methods on the game test helper. 

You can test this by changing the second substantial `thenMap` call to provide a `Supplier` (`value ->` becomes `() ->`): the second error message will always display in that case. If the second `helper.fail` is also removed with that change to `Supplier` still in effect, then the first error message will be displayed, but the rest of the steps after that second substantial `thenMap` will still execute.