### PR TITLE
[1.21.4] Release all keys when key or modifier is released

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -85,7 +85,7 @@ public class KeyMappingLookup {
                     .toList());
         }
 
-        // If there were no matches, check the key without any modifiers
+        // If there were no matches or a key is being released, check the key without any modifiers
         if (releasing || matchingBindings.isEmpty()) {
             matchingBindings.addAll(findKeybinds(keyCode, KeyModifier.NONE));
         }

--- a/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
+++ b/src/main/java/net/neoforged/neoforge/client/settings/KeyMappingLookup.java
@@ -86,7 +86,7 @@ public class KeyMappingLookup {
         }
 
         // If there were no matches, check the key without any modifiers
-        if (matchingBindings.isEmpty()) {
+        if (releasing || matchingBindings.isEmpty()) {
             matchingBindings.addAll(findKeybinds(keyCode, KeyModifier.NONE));
         }
 


### PR DESCRIPTION
Fixes an issue with keybindings when one key is mapped to a modifier and the other is mapped to the modifier and some other key not releasing properly.