### PR TITLE
[1.21.4] Re-implement item re-equip animation hook

### DIFF
--- a/patches/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
@@ -76,3 +76,24 @@
                  if (p_109372_.isUsingItem() && p_109372_.getUseItemRemainingTicks() > 0 && p_109372_.getUsedItemHand() == p_109375_) {
                      switch (p_109377_.getUseAnimation()) {
                          case NONE:
+@@ -595,9 +_,18 @@
+             this.mainHandHeight = Mth.clamp(this.mainHandHeight - 0.4F, 0.0F, 1.0F);
+             this.offHandHeight = Mth.clamp(this.offHandHeight - 0.4F, 0.0F, 1.0F);
+         } else {
++            // Neo: allow suppressing re-equip animation when only the stack's data changes
++            boolean swapAnimMain = net.neoforged.neoforge.client.ClientHooks.shouldCauseReequipAnimation(this.mainHandItem, itemstack, localplayer.getInventory().selected);
++            boolean swapAnimOff = net.neoforged.neoforge.client.ClientHooks.shouldCauseReequipAnimation(this.offHandItem, itemstack1, -1);
++
++            if (!swapAnimMain && this.mainHandItem != itemstack)
++                this.mainHandItem = itemstack;
++            if (!swapAnimOff && this.offHandItem != itemstack1)
++                this.offHandItem = itemstack1;
++
+             float f = localplayer.getAttackStrengthScale(1.0F);
+-            float f1 = this.mainHandItem != itemstack ? 0.0F : f * f * f;
+-            float f2 = this.offHandItem != itemstack1 ? 0.0F : 1.0F;
++            float f1 = swapAnimMain ? 0.0F : f * f * f;
++            float f2 = swapAnimOff ? 0.0F : 1.0F;
+             this.mainHandHeight = this.mainHandHeight + Mth.clamp(f1 - this.mainHandHeight, -0.4F, 0.4F);
+             this.offHandHeight = this.offHandHeight + Mth.clamp(f2 - this.offHandHeight, -0.4F, 0.4F);
+         }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -461,7 +461,7 @@ public interface IItemExtension {
      * @return True to play the item change animation
      */
     default boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
-        return !oldStack.equals(newStack); // !ItemStack.areItemStacksEqual(oldStack, newStack);
+        return oldStack != newStack;
     }
 
     /**


### PR DESCRIPTION
This PR re-implements the item re-equip animation hook to allow suppressing the animation when a stack's data changes.

As mentioned on the linked issue, vanilla introduced a similar flag in 1.21.4 to allow suppressing the animation. This flag applies not only to changing the stack's data but also switching between slots and swapping the slot's contents for a completely different item (my explanation on the issue was not 100% correct). Due to the attack strength system, both slot switching and swapping the slot's contents for a different item causes the item to play the animation regardless of the flag while instantly switching the actual item (see the video in the linked issue). This issue can happen with the Neo hook as well, however, compared to the vanilla flag, the Neo hook allows handling these cases trivially.
This PR makes no effort to fix these particular cases, neither for the Neo hook nor for the vanilla flag, primarily because it has been held up long enough by the attempts to resolve them.

Fixes #1883