### PR TITLE
[1.21.5] Custom block model definitions

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/BlockModelDefinition.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/BlockModelDefinition.java.patch
@@ -12,7 +12,7 @@
              p_409074_ -> p_409074_.group(
                      BlockModelDefinition.SimpleModelSelectors.CODEC.optionalFieldOf("variants").forGetter(BlockModelDefinition::simpleModels),
                      BlockModelDefinition.MultiPartDefinition.CODEC.optionalFieldOf("multipart").forGetter(BlockModelDefinition::multiPart)
-@@ -42,8 +_,21 @@
+@@ -42,8 +_,26 @@
                  ? DataResult.error(() -> "Neither 'variants' nor 'multipart' found")
                  : DataResult.success(p_409078_)
          );
@@ -20,6 +20,11 @@
 +
 +    public BlockModelDefinition(Optional<BlockModelDefinition.SimpleModelSelectors> simpleModels, Optional<BlockModelDefinition.MultiPartDefinition> multiPart) {
 +        this(simpleModels, multiPart, Optional.empty());
++    }
++
++    // Neo: convenience constructor for datagen of custom definitions
++    public BlockModelDefinition(net.neoforged.neoforge.client.model.block.CustomBlockModelDefinition customDefinition) {
++        this(Optional.empty(), Optional.empty(), Optional.of(customDefinition));
 +    }
  
      public Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(StateDefinition<Block, BlockState> p_360641_, Supplier<String> p_405739_) {

--- a/patches/net/minecraft/client/renderer/block/model/BlockModelDefinition.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/BlockModelDefinition.java.patch
@@ -1,31 +1,30 @@
 --- a/net/minecraft/client/renderer/block/model/BlockModelDefinition.java
 +++ b/net/minecraft/client/renderer/block/model/BlockModelDefinition.java
-@@ -28,12 +_,14 @@
+@@ -28,9 +_,10 @@
  @OnlyIn(Dist.CLIENT)
  public record BlockModelDefinition(
      Optional<BlockModelDefinition.SimpleModelSelectors> simpleModels, Optional<BlockModelDefinition.MultiPartDefinition> multiPart
 +    , Optional<net.neoforged.neoforge.client.model.block.CustomBlockModelDefinition> customDefinition
  ) {
      static final Logger LOGGER = LogUtils.getLogger();
-     public static final Codec<BlockModelDefinition> CODEC = RecordCodecBuilder.<BlockModelDefinition>create(
+-    public static final Codec<BlockModelDefinition> CODEC = RecordCodecBuilder.<BlockModelDefinition>create(
++    public static final com.mojang.serialization.MapCodec<BlockModelDefinition> VANILLA_CODEC = RecordCodecBuilder.<BlockModelDefinition>mapCodec(
              p_409074_ -> p_409074_.group(
                      BlockModelDefinition.SimpleModelSelectors.CODEC.optionalFieldOf("variants").forGetter(BlockModelDefinition::simpleModels),
                      BlockModelDefinition.MultiPartDefinition.CODEC.optionalFieldOf("multipart").forGetter(BlockModelDefinition::multiPart)
-+                    , net.neoforged.neoforge.client.model.block.BlockStateModelHooks.DEFINITION_CODEC.optionalFieldOf("neoforge:custom").forGetter(BlockModelDefinition::customDefinition)
-                 )
-                 .apply(p_409074_, BlockModelDefinition::new)
-         )
-@@ -43,7 +_,19 @@
+@@ -42,8 +_,21 @@
+                 ? DataResult.error(() -> "Neither 'variants' nor 'multipart' found")
                  : DataResult.success(p_409078_)
          );
- 
++    public static final Codec<BlockModelDefinition> CODEC = net.neoforged.neoforge.client.model.block.BlockStateModelHooks.makeDefinitionCodec();
++
 +    public BlockModelDefinition(Optional<BlockModelDefinition.SimpleModelSelectors> simpleModels, Optional<BlockModelDefinition.MultiPartDefinition> multiPart) {
 +        this(simpleModels, multiPart, Optional.empty());
 +    }
-+
+ 
      public Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(StateDefinition<Block, BlockState> p_360641_, Supplier<String> p_405739_) {
 +        if (this.customDefinition.isPresent()) {
-+            return this.customDefinition.get().instantiate(this, p_360641_, p_405739_);
++            return this.customDefinition.get().instantiate(p_360641_, p_405739_);
 +        }
 +        return this.instantiateVanilla(p_360641_, p_405739_);
 +    }

--- a/patches/net/minecraft/client/renderer/block/model/BlockModelDefinition.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/BlockModelDefinition.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/client/renderer/block/model/BlockModelDefinition.java
++++ b/net/minecraft/client/renderer/block/model/BlockModelDefinition.java
+@@ -28,12 +_,14 @@
+ @OnlyIn(Dist.CLIENT)
+ public record BlockModelDefinition(
+     Optional<BlockModelDefinition.SimpleModelSelectors> simpleModels, Optional<BlockModelDefinition.MultiPartDefinition> multiPart
++    , Optional<net.neoforged.neoforge.client.model.block.CustomBlockModelDefinition> customDefinition
+ ) {
+     static final Logger LOGGER = LogUtils.getLogger();
+     public static final Codec<BlockModelDefinition> CODEC = RecordCodecBuilder.<BlockModelDefinition>create(
+             p_409074_ -> p_409074_.group(
+                     BlockModelDefinition.SimpleModelSelectors.CODEC.optionalFieldOf("variants").forGetter(BlockModelDefinition::simpleModels),
+                     BlockModelDefinition.MultiPartDefinition.CODEC.optionalFieldOf("multipart").forGetter(BlockModelDefinition::multiPart)
++                    , net.neoforged.neoforge.client.model.block.BlockStateModelHooks.DEFINITION_CODEC.optionalFieldOf("neoforge:custom").forGetter(BlockModelDefinition::customDefinition)
+                 )
+                 .apply(p_409074_, BlockModelDefinition::new)
+         )
+@@ -43,7 +_,19 @@
+                 : DataResult.success(p_409078_)
+         );
+ 
++    public BlockModelDefinition(Optional<BlockModelDefinition.SimpleModelSelectors> simpleModels, Optional<BlockModelDefinition.MultiPartDefinition> multiPart) {
++        this(simpleModels, multiPart, Optional.empty());
++    }
++
+     public Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(StateDefinition<Block, BlockState> p_360641_, Supplier<String> p_405739_) {
++        if (this.customDefinition.isPresent()) {
++            return this.customDefinition.get().instantiate(this, p_360641_, p_405739_);
++        }
++        return this.instantiateVanilla(p_360641_, p_405739_);
++    }
++
++    // Neo: split off original implementation as a separate method to allow custom definitions to instantiate the original definition and post-process the result
++    public Map<BlockState, BlockStateModel.UnbakedRoot> instantiateVanilla(StateDefinition<Block, BlockState> p_360641_, Supplier<String> p_405739_) {
+         Map<BlockState, BlockStateModel.UnbakedRoot> map = new IdentityHashMap<>();
+         this.simpleModels.ifPresent(p_409073_ -> p_409073_.instantiate(p_360641_, p_405739_, (p_409076_, p_409077_) -> {
+             BlockStateModel.UnbakedRoot blockstatemodel$unbakedroot = map.put(p_409076_, p_409077_);

--- a/patches/net/minecraft/data/DataProvider.java.patch
+++ b/patches/net/minecraft/data/DataProvider.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/data/DataProvider.java
 +++ b/net/minecraft/data/DataProvider.java
-@@ -28,7 +_,15 @@
+@@ -28,7 +_,16 @@
  import org.slf4j.Logger;
  
  public interface DataProvider {
@@ -13,6 +13,7 @@
 +        // Neo: conditions go first
 +        p_236070_.put("neoforge:conditions", -1);
 +        p_236070_.put("neoforge:ingredient_type", 0);
++        p_236070_.put("neoforge:definition_type", 0);
          p_236070_.put("type", 0);
          p_236070_.put("parent", 1);
          p_236070_.defaultReturnValue(2);

--- a/patches/net/minecraft/data/DataProvider.java.patch
+++ b/patches/net/minecraft/data/DataProvider.java.patch
@@ -12,8 +12,8 @@
      ToIntFunction<String> FIXED_ORDER_FIELDS = Util.make(new Object2IntOpenHashMap<>(), p_236070_ -> {
 +        // Neo: conditions go first
 +        p_236070_.put("neoforge:conditions", -1);
-+        p_236070_.put("neoforge:ingredient_type", 0);
 +        p_236070_.put("neoforge:definition_type", 0);
++        p_236070_.put("neoforge:ingredient_type", 0);
          p_236070_.put("type", 0);
          p_236070_.put("parent", 1);
          p_236070_.defaultReturnValue(2);

--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -247,7 +247,7 @@ public class ClientNeoForgeMod {
 
     @SubscribeEvent
     static void registerBlockStateModels(RegisterBlockStateModels event) {
-        event.register(neoForgeId("composite"), CompositeBlockModel.Unbaked.MAP_CODEC);
+        event.registerModel(neoForgeId("composite"), CompositeBlockModel.Unbaked.MAP_CODEC);
     }
 
     // TODO 1.21.4

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterBlockStateModels.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterBlockStateModels.java
@@ -10,21 +10,30 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.neoforge.client.model.block.CustomBlockModelDefinition;
 import net.neoforged.neoforge.client.model.block.CustomUnbakedBlockStateModel;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * Fire to register new types of {@link CustomUnbakedBlockStateModel}.
+ * Fire to register new types of {@link CustomUnbakedBlockStateModel} and {@link CustomBlockModelDefinition}.
  */
 public class RegisterBlockStateModels extends Event implements IModBusEvent {
-    private final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomUnbakedBlockStateModel>> idMapper;
+    private final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomUnbakedBlockStateModel>> modelIdMapper;
+    private final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomBlockModelDefinition>> defintionIdMapper;
 
     @ApiStatus.Internal
-    public RegisterBlockStateModels(ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomUnbakedBlockStateModel>> idMapper) {
-        this.idMapper = idMapper;
+    public RegisterBlockStateModels(
+            ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomUnbakedBlockStateModel>> modelIdMapper,
+            ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomBlockModelDefinition>> defintionIdMapper) {
+        this.modelIdMapper = modelIdMapper;
+        this.defintionIdMapper = defintionIdMapper;
     }
 
-    public void register(ResourceLocation location, MapCodec<? extends CustomUnbakedBlockStateModel> codec) {
-        this.idMapper.put(location, codec);
+    public void registerModel(ResourceLocation location, MapCodec<? extends CustomUnbakedBlockStateModel> codec) {
+        this.modelIdMapper.put(location, codec);
+    }
+
+    public void registerDefinition(ResourceLocation location, MapCodec<? extends CustomBlockModelDefinition> codec) {
+        this.defintionIdMapper.put(location, codec);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/model/block/BlockStateModelHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/block/BlockStateModelHooks.java
@@ -9,6 +9,7 @@ import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.function.Function;
 import net.minecraft.client.renderer.block.model.SingleVariant;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
@@ -21,9 +22,12 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public class BlockStateModelHooks {
     static final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomUnbakedBlockStateModel>> BLOCK_STATE_MODEL_IDS = new ExtraCodecs.LateBoundIdMapper<>();
+    static final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomBlockModelDefinition>> BLOCK_MODEL_DEFINITION_IDS = new ExtraCodecs.LateBoundIdMapper<>();
+    public static final Codec<CustomBlockModelDefinition> DEFINITION_CODEC = BLOCK_MODEL_DEFINITION_IDS.codec(ResourceLocation.CODEC)
+            .dispatch(CustomBlockModelDefinition::codec, Function.identity());
 
     public static void init() {
-        ModLoader.postEvent(new RegisterBlockStateModels(BLOCK_STATE_MODEL_IDS));
+        ModLoader.postEvent(new RegisterBlockStateModels(BLOCK_STATE_MODEL_IDS, BLOCK_MODEL_DEFINITION_IDS));
     }
 
     public static MapCodec<Either<CustomUnbakedBlockStateModel, SingleVariant.Unbaked>> makeSingleModelCodec() {

--- a/src/client/java/net/neoforged/neoforge/client/model/block/BlockStateModelHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/block/BlockStateModelHooks.java
@@ -9,7 +9,9 @@ import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.Optional;
 import java.util.function.Function;
+import net.minecraft.client.renderer.block.model.BlockModelDefinition;
 import net.minecraft.client.renderer.block.model.SingleVariant;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
@@ -23,8 +25,6 @@ import org.jetbrains.annotations.ApiStatus;
 public class BlockStateModelHooks {
     static final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomUnbakedBlockStateModel>> BLOCK_STATE_MODEL_IDS = new ExtraCodecs.LateBoundIdMapper<>();
     static final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends CustomBlockModelDefinition>> BLOCK_MODEL_DEFINITION_IDS = new ExtraCodecs.LateBoundIdMapper<>();
-    public static final Codec<CustomBlockModelDefinition> DEFINITION_CODEC = BLOCK_MODEL_DEFINITION_IDS.codec(ResourceLocation.CODEC)
-            .dispatch(CustomBlockModelDefinition::codec, Function.identity());
 
     public static void init() {
         ModLoader.postEvent(new RegisterBlockStateModels(BLOCK_STATE_MODEL_IDS, BLOCK_MODEL_DEFINITION_IDS));
@@ -45,6 +45,26 @@ public class BlockStateModelHooks {
                         singleModelCodec.forGetter(Weighted::value),
                         ExtraCodecs.POSITIVE_INT.optionalFieldOf("weight", 1).forGetter(Weighted::weight))
                         .apply(instance, Weighted::new));
+    }
+
+    public static Codec<BlockModelDefinition> makeDefinitionCodec() {
+        return NeoForgeExtraCodecs.dispatchMapOrElse(
+                "neoforge:definition_type",
+                BLOCK_MODEL_DEFINITION_IDS.codec(ResourceLocation.CODEC),
+                CustomBlockModelDefinition::codec,
+                Function.identity(),
+                BlockModelDefinition.VANILLA_CODEC).xmap(
+                        BlockStateModelHooks::packDefinition,
+                        BlockStateModelHooks::unpackDefinition)
+                .codec();
+    }
+
+    private static BlockModelDefinition packDefinition(Either<CustomBlockModelDefinition, BlockModelDefinition> definition) {
+        return definition.map(def -> new BlockModelDefinition(Optional.empty(), Optional.empty(), Optional.of(def)), Function.identity());
+    }
+
+    private static Either<CustomBlockModelDefinition, BlockModelDefinition> unpackDefinition(BlockModelDefinition definition) {
+        return definition.customDefinition().isPresent() ? Either.left(definition.customDefinition().get()) : Either.right(definition);
     }
 
     private BlockStateModelHooks() {}

--- a/src/client/java/net/neoforged/neoforge/client/model/block/CustomBlockModelDefinition.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/block/CustomBlockModelDefinition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.block;
+
+import com.mojang.serialization.MapCodec;
+import java.util.Map;
+import java.util.function.Supplier;
+import net.minecraft.client.renderer.block.model.BlockModelDefinition;
+import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+
+/**
+ * Custom block model definition to allow completely taking over the loading of a blockstate file
+ */
+public interface CustomBlockModelDefinition {
+    /**
+     * Instantiate this definition.
+     *
+     * @param definition     The {@link BlockModelDefinition} owning this custom definition
+     * @param states         The {@link StateDefinition} of the block this definition is being instantiated for
+     * @param sourceSupplier A {@link Supplier} providing the source file and source pack name for debugging
+     * @return a map of {@link BlockState}s to {@link BlockStateModel.UnbakedRoot}s for all states of the provided state definition
+     */
+    Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(BlockModelDefinition definition, StateDefinition<Block, BlockState> states, Supplier<String> sourceSupplier);
+
+    MapCodec<? extends CustomBlockModelDefinition> codec();
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/block/CustomBlockModelDefinition.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/block/CustomBlockModelDefinition.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.client.model.block;
 import com.mojang.serialization.MapCodec;
 import java.util.Map;
 import java.util.function.Supplier;
-import net.minecraft.client.renderer.block.model.BlockModelDefinition;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -21,12 +20,11 @@ public interface CustomBlockModelDefinition {
     /**
      * Instantiate this definition.
      *
-     * @param definition     The {@link BlockModelDefinition} owning this custom definition
      * @param states         The {@link StateDefinition} of the block this definition is being instantiated for
      * @param sourceSupplier A {@link Supplier} providing the source file and source pack name for debugging
      * @return a map of {@link BlockState}s to {@link BlockStateModel.UnbakedRoot}s for all states of the provided state definition
      */
-    Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(BlockModelDefinition definition, StateDefinition<Block, BlockState> states, Supplier<String> sourceSupplier);
+    Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(StateDefinition<Block, BlockState> states, Supplier<String> sourceSupplier);
 
     MapCodec<? extends CustomBlockModelDefinition> codec();
 }

--- a/src/client/java/net/neoforged/neoforge/client/model/block/CustomBlockModelDefinition.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/block/CustomBlockModelDefinition.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.client.model.block;
 import com.mojang.serialization.MapCodec;
 import java.util.Map;
 import java.util.function.Supplier;
+import net.minecraft.client.renderer.block.model.BlockModelDefinition;
 import net.minecraft.client.renderer.block.model.BlockStateModel;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -23,6 +24,8 @@ public interface CustomBlockModelDefinition {
      * @param states         The {@link StateDefinition} of the block this definition is being instantiated for
      * @param sourceSupplier A {@link Supplier} providing the source file and source pack name for debugging
      * @return a map of {@link BlockState}s to {@link BlockStateModel.UnbakedRoot}s for all states of the provided state definition
+     *
+     * @see BlockModelDefinition#instantiateVanilla(StateDefinition, Supplier)
      */
     Map<BlockState, BlockStateModel.UnbakedRoot> instantiate(StateDefinition<Block, BlockState> states, Supplier<String> sourceSupplier);
 

--- a/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/NeoForgeExtraCodecs.java
@@ -215,7 +215,25 @@ public class NeoForgeExtraCodecs {
      * @param <B>           fallback type
      */
     public static <A, E, B> MapCodec<Either<E, B>> dispatchMapOrElse(Codec<A> typeCodec, Function<? super E, ? extends A> type, Function<? super A, ? extends MapCodec<? extends E>> codec, MapCodec<B> fallbackCodec) {
-        var dispatchCodec = typeCodec.dispatchMap(type, codec);
+        return dispatchMapOrElse("type", typeCodec, type, codec, fallbackCodec);
+    }
+
+    /**
+     * Map dispatch codec with an alternative.
+     *
+     * <p>The alternative will only be used if the provided key is not present in the serialized object.
+     *
+     * @param key           key to dispatch on
+     * @param typeCodec     codec for the dispatch type
+     * @param type          function to retrieve the dispatch type from the dispatched type
+     * @param codec         function to retrieve the dispatched type map codec from the dispatch type
+     * @param fallbackCodec fallback to use when the deserialized object does not have a {@code "type"} key
+     * @param <A>           dispatch type
+     * @param <E>           dispatched type
+     * @param <B>           fallback type
+     */
+    public static <A, E, B> MapCodec<Either<E, B>> dispatchMapOrElse(String key, Codec<A> typeCodec, Function<? super E, ? extends A> type, Function<? super A, ? extends MapCodec<? extends E>> codec, MapCodec<B> fallbackCodec) {
+        var dispatchCodec = typeCodec.dispatchMap(key, type, codec);
         return new MapCodec<>() {
             @Override
             public <T> Stream<T> keys(DynamicOps<T> ops) {
@@ -224,7 +242,7 @@ public class NeoForgeExtraCodecs {
 
             @Override
             public <T> DataResult<Either<E, B>> decode(DynamicOps<T> ops, MapLike<T> input) {
-                if (input.get("type") != null) {
+                if (input.get(key) != null) {
                     return dispatchCodec.decode(ops, input).map(Either::left);
                 } else {
                     return fallbackCodec.decode(ops, input).map(Either::right);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
@@ -216,7 +216,7 @@ public class FullPotsAccessorDemo {
     private static class ClientHandler {
         @SubscribeEvent
         public static void registerBlockStateModelType(final RegisterBlockStateModels event) {
-            event.register(ResourceLocation.fromNamespaceAndPath(MOD_ID, "diorite_pot"), DioritePotUnbakedBlockStateModel.CODEC);
+            event.registerModel(ResourceLocation.fromNamespaceAndPath(MOD_ID, "diorite_pot"), DioritePotUnbakedBlockStateModel.CODEC);
         }
 
         private static class DioritePotUnbakedBlockStateModel implements CustomUnbakedBlockStateModel {


### PR DESCRIPTION
This PR adds custom block model definitions which allow taking over the loading of blockstate files entirely.

The change is split into two commits to discuss which variant is preferred.
The first variant puts the custom definition into an object on the same level as `variant` and `multipart`, lets the vanilla code transparently load `variant` and `multipart` (it currently doesn't allow both of them to be missing but that's a trivial change if this variant is selected) and then passes the `BlockModelDefinition` to `CustomBlockModelDefinition#instantiate()` to allow the custom definition to call the vanilla instantiation code and then post-process the result.
The second variant moves the dispatch key and any custom data to the top level of the blockstate file and gives the custom definition full control over what is loaded from the file, allowing it to entirely ignore any `variant` and/or `multipart` entry that might be present.

Datagen for both variants can be trivially handled via the existing vanilla `BlockModelDefinitionGenerator` interface, therefore no further datagen helpers are provided.