### PR TITLE
Fix /config showfileclient not being registered

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -26,6 +26,7 @@ import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfigs;
 import net.neoforged.neoforge.client.color.item.FluidContentsTint;
+import net.neoforged.neoforge.client.command.ClientConfigCommand;
 import net.neoforged.neoforge.client.data.internal.NeoForgeSpriteSourceProvider;
 import net.neoforged.neoforge.client.entity.animation.json.AnimationLoader;
 import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
@@ -72,7 +73,6 @@ import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.neoforge.internal.BrandingControl;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
-import net.neoforged.neoforge.server.command.ConfigCommand;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
@@ -102,7 +102,7 @@ public class ClientNeoForgeMod {
         });
 
         NeoForge.EVENT_BUS.addListener(RegisterClientCommandsEvent.class, event -> {
-            ConfigCommand.register(event.getDispatcher());
+            ClientConfigCommand.register(event.getDispatcher());
         });
     }
 


### PR DESCRIPTION
This PR fixes #2059 by modifying `ClientNeoForgeMod` to correctly call `ClientConfigCommand#register` rather than `ConfigCommand#register`.

Tested by checking in-world that both commands now show up and work.