### PR TITLE
Fix damage-blocking items not working

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -262,8 +262,8 @@
 +                        var ev = net.neoforged.neoforge.common.CommonHooks.onDamageBlock(this, this.damageContainers.peek(), f, !blocksattacks.bypassedBy().map(p_401067_::is).orElse(false));
 +                        if (!ev.getBlocked()) return 0.0F;
 +
-+                        this.damageContainers.peek().setBlockedDamage(ev);
 +                        f = ev.getBlockedDamage();
++                        this.damageContainers.peek().setBlockedDamage(ev);
 +
 +                        blocksattacks.hurtBlockingItem(this.level(), itemstack, this, this.getUsedItemHand(), f, ev.shieldDamage());
                          if (!p_401067_.is(DamageTypeTags.IS_PROJECTILE) && p_401067_.getDirectEntity() instanceof LivingEntity livingentity) {


### PR DESCRIPTION
This PR fixes #2066 by switching the order of the two calls so the blocked damage is stored first from the event before the damage container is updated.

The incorrect order of `DamageContainer#setBlockedDamage` and `LivingShieldBlockEvent#getBlockedDamage` causes the latter to return an incorrect value since its presumption that the container still holds the original damage is broken.

See my comment on the linked issue (https://github.com/neoforged/NeoForge/issues/2066#issuecomment-2758101989) for more details.