### PR TITLE
Make Loot Function without builders Constructors public

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -255,13 +255,6 @@ protected net.minecraft.world.level.portal.PortalForcer level # level
 public net.minecraft.world.level.saveddata.maps.MapItemSavedData addDecoration(Lnet/minecraft/core/Holder;Lnet/minecraft/world/level/LevelAccessor;Ljava/lang/String;DDDLnet/minecraft/network/chat/Component;)V
 public net.minecraft.world.level.saveddata.maps.MapItemSavedData removeDecoration(Ljava/lang/String;)V
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
-public net.minecraft.world.level.storage.loot.functions.FilteredFunction <init>(Ljava/util/List;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # <init>
-public net.minecraft.world.level.storage.loot.functions.ModifyContainerContents <init>(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/ContainerComponentManipulator;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # <init>
-public net.minecraft.world.level.storage.loot.functions.SetFireworksFunction <init>(Ljava/util/List;Ljava/util/Optional;Ljava/util/Optional;)V # <init>
-public net.minecraft.world.level.storage.loot.functions.SetItemFunction <init>(Ljava/util/List;Lnet/minecraft/core/Holder;)V # <init>
-public net.minecraft.world.level.storage.loot.functions.SetWritableBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # <init>
-public net.minecraft.world.level.storage.loot.functions.SetWrittenBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # <init>
-public net.minecraft.world.level.storage.loot.functions.ToggleTooltips <init>(Ljava/util/List;Ljava/util/Map;)V # <init>
 private-f net.minecraft.world.level.storage.loot.LootPool rolls # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool bonusRolls # bonusRolls
 public net.minecraft.server.network.ServerConfigurationPacketListenerImpl finishCurrentTask(Lnet/minecraft/server/network/ConfigurationTask$Type;)V
@@ -318,3 +311,12 @@ public net.minecraft.client.data.models.ModelProvider$ItemInfoCollector register
 
 # Required to support sorting the client reload listeners.
 private-f net.minecraft.server.packs.resources.ReloadableResourceManager listeners
+
+# Made public for datagenning these loot functions
+public net.minecraft.world.level.storage.loot.functions.FilteredFunction <init>(Ljava/util/List;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.ModifyContainerContents <init>(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/ContainerComponentManipulator;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetFireworksFunction <init>(Ljava/util/List;Ljava/util/Optional;Ljava/util/Optional;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetItemFunction <init>(Ljava/util/List;Lnet/minecraft/core/Holder;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetWritableBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetWrittenBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.ToggleTooltips <init>(Ljava/util/List;Ljava/util/Map;)V # <init>

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -255,6 +255,13 @@ protected net.minecraft.world.level.portal.PortalForcer level # level
 public net.minecraft.world.level.saveddata.maps.MapItemSavedData addDecoration(Lnet/minecraft/core/Holder;Lnet/minecraft/world/level/LevelAccessor;Ljava/lang/String;DDDLnet/minecraft/network/chat/Component;)V
 public net.minecraft.world.level.saveddata.maps.MapItemSavedData removeDecoration(Ljava/lang/String;)V
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
+public net.minecraft.world.level.storage.loot.functions.FilteredFunction <init>(Ljava/util/List;Lnet/minecraft/advancements/critereon/ItemPredicate;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.ModifyContainerContents <init>(Ljava/util/List;Lnet/minecraft/world/level/storage/loot/ContainerComponentManipulator;Lnet/minecraft/world/level/storage/loot/functions/LootItemFunction;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetFireworksFunction <init>(Ljava/util/List;Ljava/util/Optional;Ljava/util/Optional;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetItemFunction <init>(Ljava/util/List;Lnet/minecraft/core/Holder;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetWritableBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.SetWrittenBookPagesFunction <init>(Ljava/util/List;Ljava/util/List;Lnet/minecraft/world/level/storage/loot/functions/ListOperation;)V # <init>
+public net.minecraft.world.level.storage.loot.functions.ToggleTooltips <init>(Ljava/util/List;Ljava/util/Map;)V # <init>
 private-f net.minecraft.world.level.storage.loot.LootPool rolls # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool bonusRolls # bonusRolls
 public net.minecraft.server.network.ServerConfigurationPacketListenerImpl finishCurrentTask(Lnet/minecraft/server/network/ConfigurationTask$Type;)V


### PR DESCRIPTION
along with LootItemConditionalFunction#simpleBuilder

Allows modders to not need AT entries to Datagen these 