### PR TITLE
[1.21.5] Add system prop to runs to enable terminal colors

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -173,6 +173,7 @@ neoDev {
     runs {
         configureEach {
             gameDirectory = layout.projectDir.dir("run/$name")
+            systemProperty("terminal.ansi", "true")
         }
         client {
             client()

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -81,6 +81,7 @@ neoDev {
     runs {
         configureEach {
             gameDirectory = layout.projectDir.dir("run/$name")
+            systemProperty("terminal.ansi", "true")
         }
         client {
             client()


### PR DESCRIPTION
Super simple PR which adds a single system property to run configs (`terminal.ansi=true`), which fixes console outputs being uncolored.

This system property was not added to the `clean` runs as the vanilla log output does not seem to contain the necessary color information.

<details>

<summary>Before</summary>

![before-image](https://github.com/user-attachments/assets/a01b0bb7-e9d6-48b7-86cb-20ef0316dedb)

</details>

<details>

<summary>After</summary>

![after-image](https://github.com/user-attachments/assets/af4593a1-462c-4790-bcea-9c9bc6e792f2)

</details>