### PR TITLE
Backport to 1.21.1: Add system prop to runs to enable terminal colors

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -191,6 +191,10 @@ runTypes {
         arguments.addAll '--fml.mcVersion', project.minecraft_version
         arguments.addAll '--fml.neoFormVersion', project.neoform_version
     }
+
+    configureEach {
+        systemProperty("terminal.ansi", "true")
+    }
 }
 
 runs {


### PR DESCRIPTION
Manual backport of #2069 to 1.21.1

In 21.5 the system property was added via `runs.configureEach` in each project, however since the build system is drastically different here on 21.1 its better to add it via `runTypes.configureEach` in the `neoforge` project since all project runs inherit from here.