### PR TITLE
No longer ship the Nashorn JS Engine for JS Coremods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,6 @@ apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
 fancy_mod_loader_version=7.0.1
 typetools_version=0.6.3
-nashorn_core_version=15.3
 mixin_extras_version=0.4.1
 
 jupiter_api_version=5.10.2

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -133,7 +133,6 @@ dependencies {
     libraries "net.jodah:typetools:${project.typetools_version}"
     libraries "net.minecrell:terminalconsoleappender:${project.terminalconsoleappender_version}"
     libraries("net.fabricmc:sponge-mixin:${project.mixin_version}") { transitive = false }
-    libraries "org.openjdk.nashorn:nashorn-core:${project.nashorn_core_version}"
     libraries ("net.neoforged:JarJarSelector:${project.jarjar_version}") {
         exclude group: 'org.slf4j'
     }


### PR DESCRIPTION
We've introduced Java-based Coremods a while ago, the point of removing Nashorn now is to remove a few megabytes of distribution size.