### PR TITLE
[1.21.5] Allow baking a SimpleModelWrapper from an existing ResolvedModel

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/SimpleModelWrapper.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/SimpleModelWrapper.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/block/model/SimpleModelWrapper.java
 +++ b/net/minecraft/client/renderer/block/model/SimpleModelWrapper.java
-@@ -13,18 +_,30 @@
+@@ -13,18 +_,35 @@
  import net.neoforged.api.distmarker.OnlyIn;
  
  @OnlyIn(Dist.CLIENT)
@@ -13,6 +13,11 @@
 +
      public static SimpleModelWrapper bake(ModelBaker p_405335_, ResourceLocation p_405098_, ModelState p_405869_) {
          ResolvedModel resolvedmodel = p_405335_.getModel(p_405098_);
++        return bake(p_405335_, resolvedmodel, p_405869_);
++    }
++
++    // Neo: split off to allow baking an existing ResolvedModel into a BlockModelPart
++    public static SimpleModelWrapper bake(ModelBaker p_405335_, ResolvedModel resolvedmodel, ModelState p_405869_) {
          TextureSlots textureslots = resolvedmodel.getTopTextureSlots();
          boolean flag = resolvedmodel.getTopAmbientOcclusion();
          TextureAtlasSprite textureatlassprite = resolvedmodel.resolveParticleSprite(textureslots, p_405335_);

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelBaker.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelBaker.java
@@ -5,8 +5,14 @@
 
 package net.neoforged.neoforge.client.model.standalone;
 
+import net.minecraft.client.renderer.block.model.BlockStateModel;
+import net.minecraft.client.renderer.block.model.SimpleModelWrapper;
+import net.minecraft.client.renderer.block.model.SingleVariant;
+import net.minecraft.client.resources.model.BlockModelRotation;
 import net.minecraft.client.resources.model.ModelBaker;
 import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.resources.model.ModelState;
+import net.minecraft.client.resources.model.QuadCollection;
 import net.minecraft.client.resources.model.ResolvedModel;
 import net.neoforged.neoforge.client.event.ModelEvent;
 
@@ -27,4 +33,46 @@ import net.neoforged.neoforge.client.event.ModelEvent;
 @FunctionalInterface
 public interface StandaloneModelBaker<T> {
     T bake(ResolvedModel model, ModelBaker baker);
+
+    /**
+     * {@return a standalone baker for a {@link SimpleModelWrapper}, baked without additional transformations}
+     */
+    static StandaloneModelBaker<SimpleModelWrapper> simpleModelWrapper() {
+        return (model, baker) -> SimpleModelWrapper.bake(baker, model, BlockModelRotation.X0_Y0);
+    }
+
+    /**
+     * {@return a standalone baker for a {@link SimpleModelWrapper}, baked with the provided {@link ModelState} transformations}
+     */
+    static StandaloneModelBaker<SimpleModelWrapper> simpleModelWrapper(ModelState modelState) {
+        return (model, baker) -> SimpleModelWrapper.bake(baker, model, modelState);
+    }
+
+    /**
+     * {@return a standalone baker for a {@link BlockStateModel}, baked without additional transformations}
+     */
+    static StandaloneModelBaker<BlockStateModel> blockStateModel() {
+        return (model, baker) -> new SingleVariant(SimpleModelWrapper.bake(baker, model, BlockModelRotation.X0_Y0));
+    }
+
+    /**
+     * {@return a standalone baker for a {@link BlockStateModel}, baked with the provided {@link ModelState} transformations}
+     */
+    static StandaloneModelBaker<BlockStateModel> blockStateModel(ModelState modelState) {
+        return (model, baker) -> new SingleVariant(SimpleModelWrapper.bake(baker, model, modelState));
+    }
+
+    /**
+     * {@return a standalone baker for a {@link QuadCollection}, baked without additional transformations}
+     */
+    static StandaloneModelBaker<QuadCollection> quadCollection() {
+        return (model, baker) -> model.bakeTopGeometry(model.getTopTextureSlots(), baker, BlockModelRotation.X0_Y0);
+    }
+
+    /**
+     * {@return a standalone baker for a {@link QuadCollection}, baked with the provided {@link ModelState} transformations}
+     */
+    static StandaloneModelBaker<QuadCollection> quadCollection(ModelState modelState) {
+        return (model, baker) -> model.bakeTopGeometry(model.getTopTextureSlots(), baker, modelState);
+    }
 }


### PR DESCRIPTION
This PR splits the `SimpleModelWrapper.bake()` helper to allow baking a `SimpleModelWrapper` from an existing `ResolvedModel`. This is useful in scenarios like standalone models or certain custom unbaked models where a `ResolvedModel` is provided (standalone models) or one is created by resolving an `UnbakedModel` through the `ModelBakerExtension#resolveInlineModel()` helper (custom unbaked models) and needs to be baked into a `BlockModelPart`.