### PR TITLE
Return a singleton EMPTY map from ModelData.Builder if the built map is empty (minor optimization)

### DIFF
--- a/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
@@ -116,7 +116,7 @@ public final class ModelData {
                 return ModelData.EMPTY;
             } else {
                 return new ModelData(properties);
-                }
+            }
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
@@ -12,11 +12,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,8 +25,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @see ModelProperty
  * @see BlockEntity#getModelData()
- * @see BlockStateModel#getQuads(BlockState, Direction, RandomSource, ModelData, RenderType)
- * @see BlockStateModel#getModelData(BlockAndTintGetter, BlockPos, BlockState, ModelData)
+ * @see BlockAndTintGetter#getModelData(BlockPos)
  */
 public final class ModelData {
     public static final ModelData EMPTY = ModelData.builder().build();
@@ -115,9 +111,12 @@ public final class ModelData {
             return this;
         }
 
-        @Contract("-> new")
         public ModelData build() {
-            return new ModelData(properties);
+            if (properties.isEmpty()) {
+                return ModelData.EMPTY;
+            } else {
+                return new ModelData(properties);
+                }
         }
     }
 }


### PR DESCRIPTION
I removed the Contract annotation since it now no longer correct.