### PR TITLE
[1.21.5] Add per-BlockModelPart AO handling

### DIFF
--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -8,7 +8,7 @@
      public void tesselateBlock(
          BlockAndTintGetter p_234380_,
          List<BlockModelPart> p_410025_,
-@@ -47,15 +_,32 @@
+@@ -47,15 +_,34 @@
          boolean p_234386_,
          int p_234389_
      ) {
@@ -27,17 +27,19 @@
 +    ) {
          if (!p_410025_.isEmpty()) {
 -            boolean flag = Minecraft.useAmbientOcclusion() && p_234382_.getLightEmission() == 0 && p_410025_.getFirst().useAmbientOcclusion();
-+            boolean flag = Minecraft.useAmbientOcclusion() && switch(p_410025_.getFirst().ambientOcclusion()) {
++            boolean perPartAO = net.neoforged.neoforge.client.config.NeoForgeClientConfig.INSTANCE.handleAmbientOcclusionPerPart.getAsBoolean();
++            int lightEmission = -1;
++            boolean flag = Minecraft.useAmbientOcclusion() && (perPartAO || switch(p_410025_.getFirst().ambientOcclusion()) {
 +                case TRUE -> true;
-+                case DEFAULT -> p_234382_.getLightEmission(p_234380_, p_234383_) == 0;
++                case DEFAULT -> (lightEmission = p_234382_.getLightEmission(p_234380_, p_234383_)) == 0;
 +                case FALSE -> false;
-+            };
++            });
              p_234384_.translate(p_234382_.getOffset(p_234383_));
  
              try {
                  if (flag) {
 -                    this.tesselateWithAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, p_234385_, p_234386_, p_234389_);
-+                    this.tesselateWithAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, bufferLookup, p_234386_, p_234389_);
++                    this.tesselateWithAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, bufferLookup, p_234386_, p_234389_, perPartAO, lightEmission);
                  } else {
 -                    this.tesselateWithoutAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, p_234385_, p_234386_, p_234389_);
 +                    this.tesselateWithoutAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, bufferLookup, p_234386_, p_234389_);
@@ -70,11 +72,11 @@
      public void tesselateWithAO(
          BlockAndTintGetter p_234391_,
          List<BlockModelPart> p_410478_,
-@@ -86,11 +_,25 @@
+@@ -86,11 +_,37 @@
          boolean p_234397_,
          int p_234400_
      ) {
-+        this.tesselateWithAO(p_234391_, p_410478_, p_234393_, p_234394_, p_234395_, type -> p_234396_, p_234397_, p_234400_);
++        this.tesselateWithAO(p_234391_, p_410478_, p_234393_, p_234394_, p_234395_, type -> p_234396_, p_234397_, p_234400_, false, -1);
 +    }
 +
 +    public void tesselateWithAO(
@@ -85,7 +87,9 @@
 +        PoseStack p_234395_,
 +        java.util.function.Function<net.minecraft.client.renderer.RenderType, VertexConsumer> bufferLookup,
 +        boolean p_234397_,
-+        int p_234400_
++        int p_234400_,
++        boolean perPartAO,
++        int lightEmission
 +    ) {
          ModelBlockRenderer.AmbientOcclusionRenderStorage modelblockrenderer$ambientocclusionrenderstorage = new ModelBlockRenderer.AmbientOcclusionRenderStorage();
          int i = 0;
@@ -93,6 +97,16 @@
  
          for (BlockModelPart blockmodelpart : p_410478_) {
 +            VertexConsumer p_234396_ = bufferLookup.apply(blockmodelpart.getRenderType(p_234393_));
++            boolean ao = !perPartAO || switch (blockmodelpart.ambientOcclusion()) {
++                case TRUE -> true;
++                case DEFAULT -> {
++                    if (lightEmission == -1) {
++                        lightEmission = p_234393_.getLightEmission(p_234391_, p_234394_);
++                    }
++                    yield lightEmission == 0;
++                }
++                case FALSE -> false;
++            };
              for (Direction direction : DIRECTIONS) {
                  int k = 1 << direction.ordinal();
                  boolean flag = (i & k) == 1;
@@ -104,6 +118,31 @@
                                  p_234393_,
                                  p_234397_,
                                  direction,
+@@ -113,6 +_,12 @@
+                         }
+ 
+                         if (flag1) {
++                            if (!ao) {
++                                int light = modelblockrenderer$ambientocclusionrenderstorage.cache.getLightColor(p_234393_, p_234391_, modelblockrenderer$ambientocclusionrenderstorage.scratchPos.setWithOffset(p_234394_, direction));
++                                this.renderModelFaceFlat(
++                                        p_234391_, p_234393_, p_234394_, light, p_234400_, false, p_234395_, p_234396_, list, modelblockrenderer$ambientocclusionrenderstorage
++                                );
++                            } else
+                             this.renderModelFaceAO(
+                                 p_234391_, p_234393_, p_234394_, p_234395_, p_234396_, list, modelblockrenderer$ambientocclusionrenderstorage, p_234400_
+                             );
+@@ -123,6 +_,11 @@
+ 
+             List<BakedQuad> list1 = blockmodelpart.getQuads(null);
+             if (!list1.isEmpty()) {
++                if (!ao) {
++                    this.renderModelFaceFlat(
++                            p_234391_, p_234393_, p_234394_, -1, p_234400_, false, p_234395_, p_234396_, list1, modelblockrenderer$ambientocclusionrenderstorage
++                    );
++                } else
+                 this.renderModelFaceAO(
+                     p_234391_, p_234393_, p_234394_, p_234395_, p_234396_, list1, modelblockrenderer$ambientocclusionrenderstorage, p_234400_
+                 );
 @@ -130,6 +_,7 @@
          }
      }

--- a/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
+++ b/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
@@ -29,6 +29,8 @@ public final class NeoForgeClientConfig {
 
     public final ModConfigSpec.BooleanValue reducedDepthStencilFormat;
 
+    public final ModConfigSpec.BooleanValue handleAmbientOcclusionPerPart;
+
     private NeoForgeClientConfig(ModConfigSpec.Builder builder) {
         experimentalForgeLightPipelineEnabled = builder
                 .comment("EXPERIMENTAL: Enable the NeoForge block rendering pipeline - fixes the lighting of custom models.")
@@ -49,6 +51,11 @@ public final class NeoForgeClientConfig {
                 .comment("Configures how many bits are used for the depth buffer when stenciling has been enabled by a mod. Set to true for 24+8 bits and to false for 32+8 bits. Setting to true will slightly reduce VRAM usage, but risks introducing visual artifacts.")
                 .translation("neoforge.configgui.reducedDepthStencilFormat")
                 .define("reducedDepthStencilFormat", false);
+
+        handleAmbientOcclusionPerPart = builder
+                .comment("When enabled, AO will be handled per BlockModelPart instead of using the first part's AO setting")
+                .translation("neoforge.configgui.handleAmbientOcclusionPerPart")
+                .define("handleAmbientOcclusionPerPart", true);
     }
 
     @SubscribeEvent

--- a/src/client/java/net/neoforged/neoforge/client/model/lighting/LightPipelineAwareModelBlockRenderer.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/lighting/LightPipelineAwareModelBlockRenderer.java
@@ -40,22 +40,22 @@ public class LightPipelineAwareModelBlockRenderer extends ModelBlockRenderer {
     @Override
     public void tesselateWithoutAO(BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, Function<RenderType, VertexConsumer> bufferLookup, boolean checkSides, int packedOverlay) {
         if (NeoForgeClientConfig.INSTANCE.experimentalForgeLightPipelineEnabled.get()) {
-            render(bufferLookup, flatLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay);
+            render(bufferLookup, flatLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay, false, -1);
         } else {
             super.tesselateWithoutAO(level, modelParts, state, pos, poseStack, bufferLookup, checkSides, packedOverlay);
         }
     }
 
     @Override
-    public void tesselateWithAO(BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, Function<RenderType, VertexConsumer> bufferLookup, boolean checkSides, int packedOverlay) {
+    public void tesselateWithAO(BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, Function<RenderType, VertexConsumer> bufferLookup, boolean checkSides, int packedOverlay, boolean perPartAO, int lightEmission) {
         if (NeoForgeClientConfig.INSTANCE.experimentalForgeLightPipelineEnabled.get()) {
-            render(bufferLookup, smoothLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay);
+            render(bufferLookup, smoothLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay, perPartAO, lightEmission);
         } else {
-            super.tesselateWithAO(level, modelParts, state, pos, poseStack, bufferLookup, checkSides, packedOverlay);
+            super.tesselateWithAO(level, modelParts, state, pos, poseStack, bufferLookup, checkSides, packedOverlay, perPartAO, lightEmission);
         }
     }
 
-    public static boolean render(Function<RenderType, VertexConsumer> bufferLookup, QuadLighter lighter, BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, boolean checkSides, int packedOverlay) {
+    public static boolean render(Function<RenderType, VertexConsumer> bufferLookup, QuadLighter lighter, BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, boolean checkSides, int packedOverlay, boolean perPartAO, int lightEmission) {
         LightPipelineAwareModelBlockRenderer renderer = (LightPipelineAwareModelBlockRenderer) Minecraft.getInstance().getBlockRenderer().getModelRenderer();
         ModelBlockRenderer.Cache cache = ModelBlockRenderer.CACHE.get();
         var pose = poseStack.last();
@@ -68,13 +68,23 @@ public class LightPipelineAwareModelBlockRenderer extends ModelBlockRenderer {
 
         for (BlockModelPart part : modelParts) {
             VertexConsumer vertexConsumer = bufferLookup.apply(part.getRenderType(state));
+            boolean ao = !perPartAO || switch (part.ambientOcclusion()) {
+                case TRUE -> true;
+                case DEFAULT -> {
+                    if (lightEmission == -1) {
+                        lightEmission = state.getLightEmission(level, pos);
+                    }
+                    yield lightEmission == 0;
+                }
+                case FALSE -> false;
+            };
 
             List<BakedQuad> quads = part.getQuads(null);
             if (!quads.isEmpty()) {
                 empty = false;
                 lighter.setup(level, pos, state, cache);
                 for (BakedQuad quad : quads) {
-                    if (smoothLighter && !quad.hasAmbientOcclusion()) {
+                    if (smoothLighter && (!ao || !quad.hasAmbientOcclusion())) {
                         if (flatLighter == null) {
                             flatLighter = renderer.flatLighter.get();
                             flatLighter.setup(level, pos, state, cache);
@@ -109,7 +119,7 @@ public class LightPipelineAwareModelBlockRenderer extends ModelBlockRenderer {
                         lighter.setup(level, pos, state, cache);
                     }
                     for (BakedQuad quad : quads) {
-                        if (smoothLighter && !quad.hasAmbientOcclusion()) {
+                        if (smoothLighter && (!ao || !quad.hasAmbientOcclusion())) {
                             if (flatLighter == null) {
                                 flatLighter = renderer.flatLighter.get();
                                 flatLighter.setup(level, pos, state, cache);

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -198,6 +198,8 @@
   "neoforge.configgui.forgeLightPipelineEnabled.tooltip": "Enable the NeoForge block rendering pipeline - fixes the lighting of custom models.",
   "neoforge.configgui.fullBoundingBoxLadders": "Full Bounding Box Ladders",
   "neoforge.configgui.fullBoundingBoxLadders.tooltip": "Set this to true to check the entire entity's collision bounding box for ladders instead of just the block they are in. Causes noticeable differences in mechanics so default is vanilla behavior. Default: false.",
+  "neoforge.configgui.handleAmbientOcclusionPerPart": "Per-part block AO handling",
+  "neoforge.configgui.handleAmbientOcclusionPerPart.tooltip": "When enabled, AO will be handled per BlockModelPart instead of using the first part's AO setting.",
   "neoforge.configgui.logLegacyTagWarnings": "Log Legacy Tags",
   "neoforge.configgui.logLegacyTagWarnings.tooltip": "A config option mainly for developers. Logs out modded tags that are using the 'forge' namespace when running on integrated server. Defaults to DEV_SHORT.",
   "neoforge.configgui.logUntranslatedConfigurationWarnings": "Log Untranslated Configuration Keys",


### PR DESCRIPTION
This PR modifies block model rendering to respect the AO flag of every `BlockModelPart` individually instead of using the first part's AO flag as the authority. This expands on vanilla's partial change from model-controlled AO to part-controlled AO.
Any individual quad within a part that does not disable AO can still disable AO for itself specifically as before.

This allows having separate sets of quads with different AO settings by combining `BlockModelPart`s instead of deep-copying parts (including shallow-copying the quads themselves) in order to set the AO flag on each quad individually.

This PR currently makes a minor breaking change in the patched vanilla code (adding two params to a method added by Neo). If desired, this can be avoided but introduces an, arguably minor, inefficiency due to needing to look up the config and block light emission up to twice instead of at most once.