### PR TITLE
Use property assignment in buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ if (isPreReleaseVersion) {
 System.out.println("NeoForge version ${project.version}")
 
 allprojects {
-    version rootProject.version
-    group 'net.neoforged'
+    version = rootProject.version
+    group = 'net.neoforged'
 
     apply plugin: 'java'
 


### PR DESCRIPTION
This PR fixes a few Gradle-raised deprecation problems by switching from the use of Gradle-generated property assignment methods (`propName value` or `propName(value`) to the explicit property assignment syntax involving `=` (`propName = value`).

The use of the Gradle-generated property assignment methods is deprecated for removal in Gradle 10.0.

The problem is only seen when running the build without using the configuration cache, whether due to being the first run after a change that caused the cache to invalidate or through the `--no-configuration-cache` command-line option.