### PR TITLE
Fix ModelData.EMPTY requiring itself to initialize

### DIFF
--- a/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * @see BlockAndTintGetter#getModelData(BlockPos)
  */
 public final class ModelData {
-    public static final ModelData EMPTY = ModelData.builder().build();
+    public static final ModelData EMPTY = new ModelData(Map.of());
 
     private final Map<ModelProperty<?>, Object> properties;
 


### PR DESCRIPTION
As things stand, we are initializing `EMPTY` to `null`, so instead of going through the builder, we now construct an instance directly with an immutable map.