### PR TITLE
Make empty model data use existing map type

### DIFF
--- a/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
+++ b/src/main/java/net/neoforged/neoforge/model/data/ModelData.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  * @see BlockAndTintGetter#getModelData(BlockPos)
  */
 public final class ModelData {
-    public static final ModelData EMPTY = new ModelData(Map.of());
+    public static final ModelData EMPTY = new ModelData(new Reference2ReferenceArrayMap<>());
 
     private final Map<ModelProperty<?>, Object> properties;
 


### PR DESCRIPTION
Using `Map.of` causes `ModelData` objects to potentially be created with three different map types (`ImmutableCollections` empty map, `Reference2ReferenceArrayMap`, `Reference2ReferenceOpenHashMap`) which breaks JVM heuristics that apply only when virtual method calls are made to at most two backing map implementations. This strategy was previously introduced in https://github.com/neoforged/NeoForge/pull/772 but regressed in the recent https://github.com/neoforged/NeoForge/pull/2094.