### PR TITLE
[1.21.5] Fix render reload happening off-thread when toggling the light pipeline in the config file

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
+++ b/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.client.config;
 
+import net.minecraft.client.Minecraft;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.client.ClientHooks;
@@ -64,7 +65,7 @@ public final class NeoForgeClientConfig {
             boolean experimentalPipelineActive = INSTANCE.experimentalForgeLightPipelineEnabled.getAsBoolean();
             if (experimentalPipelineActive != INSTANCE.experimentalPipelineActive) {
                 INSTANCE.experimentalPipelineActive = experimentalPipelineActive;
-                ClientHooks.reloadRenderer();
+                Minecraft.getInstance().submit(ClientHooks::reloadRenderer);
             }
         }
     }


### PR DESCRIPTION
This PR fixes the render reload happening off-thread when the light pipeline is toggled in the config file instead of through the config GUI.

Fixes #2079