### PR TITLE
[1.21.1] Fix render reload happening off-thread when toggling the light pipeline in the config file

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -1123,7 +1123,7 @@ public class ClientHooks {
     }
 
     public static void reloadRenderer() {
-        Minecraft.getInstance().levelRenderer.allChanged();
+        Minecraft.getInstance().submit(Minecraft.getInstance().levelRenderer::allChanged);
     }
 
     public static Map<ResourceLocation, ResourceLocation> gatherMaterialAtlases(Map<ResourceLocation, ResourceLocation> vanillaAtlases) {


### PR DESCRIPTION
This PR fixes the render reload happening off-thread when the light pipeline is toggled in the config file instead of through the config GUI.

1.21.1 backport of #2098
Fixes #2079