### PR TITLE
Remove ICancellableEvent from LivingShieldBlockEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingShieldBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingShieldBlockEvent.java
@@ -24,7 +24,7 @@ import net.neoforged.neoforge.common.damagesource.DamageContainer;
  * 
  * @see DamageContainer for more information on the damage sequence
  */
-public class LivingShieldBlockEvent extends LivingEvent implements ICancellableEvent {
+public class LivingShieldBlockEvent extends LivingEvent {
     private final DamageContainer container;
     private float dmgBlocked;
     private final float originalDmgBlocked;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingShieldBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingShieldBlockEvent.java
@@ -9,7 +9,6 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.component.BlocksAttacks;
-import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.damagesource.DamageContainer;
 
 /**


### PR DESCRIPTION
This PR fixes #2086 by removing the `ICancellableEvent` interface from `LivingShieldBlockEvent`, as discussed in the comments of that linked issue. The event being cancellable serves no purpose, since blocking can be partial.