### PR TITLE
Fix early client lifecyle events and introduce ClientResourceLoadFinishedEvent. The NeoForge event bus also starts earlier now.

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -1,3 +1,5 @@
+--- a/net/minecraft/client/Minecraft.java
++++ b/net/minecraft/client/Minecraft.java
 @@ -430,7 +_,6 @@
              }
          }, Util.nonCriticalIoPool());

--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -1,5 +1,3 @@
---- a/net/minecraft/client/Minecraft.java
-+++ b/net/minecraft/client/Minecraft.java
 @@ -430,7 +_,6 @@
              }
          }, Util.nonCriticalIoPool());
@@ -90,6 +88,14 @@
                          this.selfTest();
                      }
  
+@@ -668,6 +_,7 @@
+     }
+ 
+     private void onResourceLoadFinished(@Nullable Minecraft.GameLoadCookie p_299896_) {
++        net.neoforged.neoforge.client.ClientHooks.fireResourceLoadFinishedEvent(!this.gameLoadFinished);
+         if (!this.gameLoadFinished) {
+             this.gameLoadFinished = true;
+             this.onGameLoadFinished(p_299896_);
 @@ -704,6 +_,8 @@
              runnable = () -> this.setScreen(screen);
          }
@@ -311,11 +317,13 @@
                      if (!itemstack.isEmpty()
                          && this.gameMode.useItem(this.player, interactionhand) instanceof InteractionResult.Success interactionresult$success1) {
                          if (interactionresult$success1.swingSource() == InteractionResult.SwingSource.CLIENT) {
-@@ -1675,6 +_,8 @@
+@@ -1675,6 +_,10 @@
  
      public void tick() {
          this.clientTickCount++;
-+        net.neoforged.neoforge.client.ClientHooks.fireClientTickPre();
++        if (this.gameLoadFinished) {
++            net.neoforged.neoforge.client.ClientHooks.fireClientTickPre();
++        }
 +
          if (this.level != null && !this.pause) {
              this.level.tickRateManager().tick();
@@ -336,12 +344,14 @@
              }
  
              profilerfiller.popPush("animateTick");
-@@ -1810,6 +_,8 @@
+@@ -1810,6 +_,10 @@
          profilerfiller.popPush("keyboard");
          this.keyboardHandler.tick();
          profilerfiller.pop();
 +
-+        net.neoforged.neoforge.client.ClientHooks.fireClientTickPost();
++        if (this.gameLoadFinished) {
++            net.neoforged.neoforge.client.ClientHooks.fireClientTickPost();
++        }
      }
  
      private boolean isLevelRunningNormally() {

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -150,6 +150,7 @@ import net.neoforged.neoforge.client.event.ClientChatReceivedEvent;
 import net.neoforged.neoforge.client.event.ClientPauseChangeEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerChangeGameTypeEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientResourceLoadFinishedEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
 import net.neoforged.neoforge.client.event.ConfigureMainRenderTargetEvent;
@@ -1050,6 +1051,13 @@ public class ClientHooks {
     public static void fireRenderFramePost(DeltaTracker partialTick) {
         NeoForge.EVENT_BUS.post(new RenderFrameEvent.Post(partialTick));
         RenderSystem.ensurePipelineModifiersEmpty();
+    }
+
+    /**
+     * Fires {@link ClientResourceLoadFinishedEvent}.
+     */
+    public static void fireResourceLoadFinishedEvent(boolean initial) {
+        NeoForge.EVENT_BUS.post(new ClientResourceLoadFinishedEvent(initial));
     }
 
     /**

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientResourceLoadFinishedEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientResourceLoadFinishedEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import net.neoforged.bus.api.Event;
+
+/**
+ * Fires after the client has completed loading or reloading its resources
+ * successfully.
+ * <p>
+ * When the client first starts up, this event is fired after the resource
+ * load, but before the client has set up the initial screens, and before
+ * we emit the first {@link ClientTickEvent}.
+ */
+public class ClientResourceLoadFinishedEvent extends Event {
+    private final boolean initial;
+
+    public ClientResourceLoadFinishedEvent(boolean initial) {
+        this.initial = initial;
+    }
+
+    /**
+     * @return True if the reload that completed was the initial resource load of the client.
+     */
+    public boolean isInitial() {
+        return initial;
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientTickEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientTickEvent.java
@@ -11,6 +11,8 @@ import net.neoforged.bus.api.Event;
  * Base class of the two client tick events.
  * <p>
  * For the event that fires once per frame (instead of per tick), see {@link RenderFrameEvent}.
+ * <p>
+ * Note that tick events will only start being emitted once the first {@link ClientResourceLoadFinishedEvent resource reload has completed}.
  * 
  * @see ClientTickEvent.Pre
  * @see ClientTickEvent.Post

--- a/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
@@ -26,7 +26,6 @@ import net.neoforged.fml.VersionChecker;
 import net.neoforged.fml.loading.EarlyLoadingScreenController;
 import net.neoforged.neoforge.client.config.NeoForgeClientConfig;
 import net.neoforged.neoforge.client.gui.LoadingErrorScreen;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.internal.CommonModLoader;
 import net.neoforged.neoforge.logging.CrashReportExtender;
 import net.neoforged.neoforge.resource.ResourcePackLoader;
@@ -127,9 +126,6 @@ public class ClientModLoader extends CommonModLoader {
             // Ignore incoming initial screens task, the subsequent screens are unreachable in an error state
             return () -> Minecraft.getInstance().setScreen(new LoadingErrorScreen(error.getIssues(), dumpedLocation, () -> {}));
         }
-
-        // We can finally start the game eventbus up
-        NeoForge.EVENT_BUS.start();
 
         if (!warnings.isEmpty()) {
             if (showWarnings) {

--- a/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
@@ -20,6 +20,7 @@ import net.neoforged.fml.event.lifecycle.InterModEnqueueEvent;
 import net.neoforged.fml.event.lifecycle.InterModProcessEvent;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLPaths;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.registries.GameData;
 import net.neoforged.neoforge.registries.RegistryManager;
@@ -63,6 +64,8 @@ public abstract class CommonModLoader {
                 ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
             });
         }
+
+        NeoForge.EVENT_BUS.start();
     }
 
     protected static void load(Executor syncExecutor, Executor parallelExecutor) {

--- a/src/main/java/net/neoforged/neoforge/server/loading/ServerModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/server/loading/ServerModLoader.java
@@ -11,7 +11,6 @@ import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.ModLoadingException;
 import net.neoforged.fml.ModLoadingIssue;
 import net.neoforged.fml.ModWorkManager;
-import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.internal.CommonModLoader;
 import net.neoforged.neoforge.logging.CrashReportExtender;
 import net.neoforged.neoforge.server.LanguageHook;
@@ -44,7 +43,6 @@ public class ServerModLoader extends CommonModLoader {
                 LOGGER.warn(Logging.LOADING, "{} [{}]", issue.translationKey(), issue.translationArgs());
             }
         }
-        NeoForge.EVENT_BUS.start();
     }
 
     public static boolean hasErrors() {


### PR DESCRIPTION
This fixes #2096, since the event will be dropped while the NeoForge event bus has not yet been started.
The fix for that is starting the event bus earlier, which introduces the problem of tick events being fired before the game has finished loading (the demarcation for this in Vanilla is the completion of the first resource load).

To then fix *that* problem, the tick events are now only emitted if Vanilla considers the game to be fully loaded.

Additionally, at that precise location we introduce a new event that allows mods to react to the first successful (or any subsequent successful) resource loads (`ClientResourceLoadFinishedEvent`).