### PR TITLE
[1.21.5] Fix lighting of uncullable quads without AO

### DIFF
--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -137,7 +137,7 @@
              if (!list1.isEmpty()) {
 +                if (!ao) {
 +                    this.renderModelFaceFlat(
-+                            p_234391_, p_234393_, p_234394_, -1, p_234400_, false, p_234395_, p_234396_, list1, modelblockrenderer$ambientocclusionrenderstorage
++                            p_234391_, p_234393_, p_234394_, -1, p_234400_, true, p_234395_, p_234396_, list1, modelblockrenderer$ambientocclusionrenderstorage
 +                    );
 +                } else
                  this.renderModelFaceAO(

--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -8,7 +8,7 @@
      public void tesselateBlock(
          BlockAndTintGetter p_234380_,
          List<BlockModelPart> p_410025_,
-@@ -47,15 +_,34 @@
+@@ -47,15 +_,33 @@
          boolean p_234386_,
          int p_234389_
      ) {
@@ -28,10 +28,9 @@
          if (!p_410025_.isEmpty()) {
 -            boolean flag = Minecraft.useAmbientOcclusion() && p_234382_.getLightEmission() == 0 && p_410025_.getFirst().useAmbientOcclusion();
 +            boolean perPartAO = net.neoforged.neoforge.client.config.NeoForgeClientConfig.INSTANCE.handleAmbientOcclusionPerPart.getAsBoolean();
-+            int lightEmission = -1;
 +            boolean flag = Minecraft.useAmbientOcclusion() && (perPartAO || switch(p_410025_.getFirst().ambientOcclusion()) {
 +                case TRUE -> true;
-+                case DEFAULT -> (lightEmission = p_234382_.getLightEmission(p_234380_, p_234383_)) == 0;
++                case DEFAULT -> p_234382_.getLightEmission(p_234380_, p_234383_) == 0;
 +                case FALSE -> false;
 +            });
              p_234384_.translate(p_234382_.getOffset(p_234383_));
@@ -39,7 +38,7 @@
              try {
                  if (flag) {
 -                    this.tesselateWithAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, p_234385_, p_234386_, p_234389_);
-+                    this.tesselateWithAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, bufferLookup, p_234386_, p_234389_, perPartAO, lightEmission);
++                    this.tesselateWithAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, bufferLookup, p_234386_, p_234389_);
                  } else {
 -                    this.tesselateWithoutAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, p_234385_, p_234386_, p_234389_);
 +                    this.tesselateWithoutAO(p_234380_, p_410025_, p_234382_, p_234383_, p_234384_, bufferLookup, p_234386_, p_234389_);
@@ -76,7 +75,7 @@
          boolean p_234397_,
          int p_234400_
      ) {
-+        this.tesselateWithAO(p_234391_, p_410478_, p_234393_, p_234394_, p_234395_, type -> p_234396_, p_234397_, p_234400_, false, -1);
++        this.tesselateWithAO(p_234391_, p_410478_, p_234393_, p_234394_, p_234395_, type -> p_234396_, p_234397_, p_234400_);
 +    }
 +
 +    public void tesselateWithAO(
@@ -87,11 +86,11 @@
 +        PoseStack p_234395_,
 +        java.util.function.Function<net.minecraft.client.renderer.RenderType, VertexConsumer> bufferLookup,
 +        boolean p_234397_,
-+        int p_234400_,
-+        boolean perPartAO,
-+        int lightEmission
++        int p_234400_
 +    ) {
          ModelBlockRenderer.AmbientOcclusionRenderStorage modelblockrenderer$ambientocclusionrenderstorage = new ModelBlockRenderer.AmbientOcclusionRenderStorage();
++        boolean perPartAO = net.neoforged.neoforge.client.config.NeoForgeClientConfig.INSTANCE.handleAmbientOcclusionPerPart.getAsBoolean();
++        int lightEmission = -1;
          int i = 0;
          int j = 0;
  

--- a/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
+++ b/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
@@ -31,6 +31,7 @@ public final class NeoForgeClientConfig {
     public final ModConfigSpec.BooleanValue reducedDepthStencilFormat;
 
     public final ModConfigSpec.BooleanValue handleAmbientOcclusionPerPart;
+    boolean perPartAoActive;
 
     private NeoForgeClientConfig(ModConfigSpec.Builder builder) {
         experimentalForgeLightPipelineEnabled = builder
@@ -63,6 +64,7 @@ public final class NeoForgeClientConfig {
     static void onLoad(final ModConfigEvent.Loading configEvent) {
         if (configEvent.getConfig().getSpec() == SPEC) {
             INSTANCE.experimentalPipelineActive = INSTANCE.experimentalForgeLightPipelineEnabled.getAsBoolean();
+            INSTANCE.perPartAoActive = INSTANCE.handleAmbientOcclusionPerPart.getAsBoolean();
         }
     }
 
@@ -70,8 +72,10 @@ public final class NeoForgeClientConfig {
     static void onFileChange(final ModConfigEvent.Reloading configEvent) {
         if (configEvent.getConfig().getSpec() == SPEC) {
             boolean experimentalPipelineActive = INSTANCE.experimentalForgeLightPipelineEnabled.getAsBoolean();
-            if (experimentalPipelineActive != INSTANCE.experimentalPipelineActive) {
+            boolean perPartAoActive = INSTANCE.handleAmbientOcclusionPerPart.getAsBoolean();
+            if (experimentalPipelineActive != INSTANCE.experimentalPipelineActive || perPartAoActive != INSTANCE.perPartAoActive) {
                 INSTANCE.experimentalPipelineActive = experimentalPipelineActive;
+                INSTANCE.perPartAoActive = perPartAoActive;
                 Minecraft.getInstance().submit(ClientHooks::reloadRenderer);
             }
         }

--- a/src/client/java/net/neoforged/neoforge/client/model/lighting/LightPipelineAwareModelBlockRenderer.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/lighting/LightPipelineAwareModelBlockRenderer.java
@@ -40,31 +40,33 @@ public class LightPipelineAwareModelBlockRenderer extends ModelBlockRenderer {
     @Override
     public void tesselateWithoutAO(BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, Function<RenderType, VertexConsumer> bufferLookup, boolean checkSides, int packedOverlay) {
         if (NeoForgeClientConfig.INSTANCE.experimentalForgeLightPipelineEnabled.get()) {
-            render(bufferLookup, flatLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay, false, -1);
+            render(bufferLookup, flatLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay);
         } else {
             super.tesselateWithoutAO(level, modelParts, state, pos, poseStack, bufferLookup, checkSides, packedOverlay);
         }
     }
 
     @Override
-    public void tesselateWithAO(BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, Function<RenderType, VertexConsumer> bufferLookup, boolean checkSides, int packedOverlay, boolean perPartAO, int lightEmission) {
+    public void tesselateWithAO(BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, Function<RenderType, VertexConsumer> bufferLookup, boolean checkSides, int packedOverlay) {
         if (NeoForgeClientConfig.INSTANCE.experimentalForgeLightPipelineEnabled.get()) {
-            render(bufferLookup, smoothLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay, perPartAO, lightEmission);
+            render(bufferLookup, smoothLighter.get(), level, modelParts, state, pos, poseStack, checkSides, packedOverlay);
         } else {
-            super.tesselateWithAO(level, modelParts, state, pos, poseStack, bufferLookup, checkSides, packedOverlay, perPartAO, lightEmission);
+            super.tesselateWithAO(level, modelParts, state, pos, poseStack, bufferLookup, checkSides, packedOverlay);
         }
     }
 
-    public static boolean render(Function<RenderType, VertexConsumer> bufferLookup, QuadLighter lighter, BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, boolean checkSides, int packedOverlay, boolean perPartAO, int lightEmission) {
+    public static boolean render(Function<RenderType, VertexConsumer> bufferLookup, QuadLighter lighter, BlockAndTintGetter level, List<BlockModelPart> modelParts, BlockState state, BlockPos pos, PoseStack poseStack, boolean checkSides, int packedOverlay) {
         LightPipelineAwareModelBlockRenderer renderer = (LightPipelineAwareModelBlockRenderer) Minecraft.getInstance().getBlockRenderer().getModelRenderer();
         ModelBlockRenderer.Cache cache = ModelBlockRenderer.CACHE.get();
         var pose = poseStack.last();
         var empty = true;
         var smoothLighter = lighter instanceof SmoothQuadLighter;
+        boolean perPartAO = smoothLighter && net.neoforged.neoforge.client.config.NeoForgeClientConfig.INSTANCE.handleAmbientOcclusionPerPart.getAsBoolean();
         QuadLighter flatLighter = null;
         BlockPos.MutableBlockPos scratchPos = new BlockPos.MutableBlockPos();
         int checkedSides = 0;
         int visibleSides = 0;
+        int lightEmission = -1;
 
         for (BlockModelPart part : modelParts) {
             VertexConsumer vertexConsumer = bufferLookup.apply(part.getRenderType(state));


### PR DESCRIPTION
This PR fixes uncullable quads rendering almost black when they are drawn without AO while per-part AO is enabled.