### PR TITLE
Pass the menu to the function that sends custom extra data to the client for opening said menu

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -130,11 +130,11 @@
  
      @Override
      public OptionalInt openMenu(@Nullable MenuProvider p_9033_) {
-+        return openMenu(p_9033_, (java.util.function.BiConsumer<AbstractContainerMenu, net.minecraft.network.RegistryFriendlyByteBuf>) null);
++        return openMenu(p_9033_, (java.util.function.Consumer<net.minecraft.network.RegistryFriendlyByteBuf>) null);
 +    }
 +
 +    @Override
-+    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable java.util.function.BiConsumer<AbstractContainerMenu, net.minecraft.network.RegistryFriendlyByteBuf> extraDataWriter) {
++    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable java.util.function.Consumer<net.minecraft.network.RegistryFriendlyByteBuf> extraDataWriter) {
          if (p_9033_ == null) {
              return OptionalInt.empty();
          } else {
@@ -146,11 +146,20 @@
              }
  
              this.nextContainerCounter();
-@@ -1222,10 +_,25 @@
+@@ -1222,10 +_,31 @@
  
                  return OptionalInt.empty();
              } else {
-+                if (extraDataWriter == null) {
++                var extraData = net.neoforged.neoforge.common.util.FriendlyByteBufUtil.writeCustomData(
++                        buffer -> {
++                            p_9033_.writeClientSideData(abstractcontainermenu, buffer);
++                            if (extraDataWriter != null) {
++                                extraDataWriter.accept(buffer);
++                            }
++                        },
++                        registryAccess()
++                );
++                if (extraData.length == 0) {
                  this.connection
                      .send(new ClientboundOpenScreenPacket(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName()));
 +                } else {
@@ -159,10 +168,7 @@
 +                            abstractcontainermenu.containerId,
 +                            abstractcontainermenu.getType(),
 +                            p_9033_.getDisplayName(),
-+                            net.neoforged.neoforge.common.util.FriendlyByteBufUtil.writeCustomData(
-+                                    buffer -> extraDataWriter.accept(abstractcontainermenu, buffer),
-+                                    registryAccess()
-+                            )
++                            extraData
 +                        )
 +                    );
 +                }

--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -134,7 +134,7 @@
 +    }
 +
 +    @Override
-+    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable java.util.function.Consumer<net.minecraft.network.RegistryFriendlyByteBuf> extraDataWriter) {
++    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable java.util.function.BiConsumer<AbstractContainerMenu, net.minecraft.network.RegistryFriendlyByteBuf> extraDataWriter) {
          if (p_9033_ == null) {
              return OptionalInt.empty();
          } else {
@@ -146,7 +146,7 @@
              }
  
              this.nextContainerCounter();
-@@ -1222,10 +_,16 @@
+@@ -1222,10 +_,25 @@
  
                  return OptionalInt.empty();
              } else {
@@ -154,8 +154,17 @@
                  this.connection
                      .send(new ClientboundOpenScreenPacket(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName()));
 +                } else {
-+                    this.connection
-+                        .send(new net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName(), net.neoforged.neoforge.common.util.FriendlyByteBufUtil.writeCustomData(extraDataWriter, registryAccess())));
++                    this.connection.send(
++                        new net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload(
++                            abstractcontainermenu.containerId,
++                            abstractcontainermenu.getType(),
++                            p_9033_.getDisplayName(),
++                            net.neoforged.neoforge.common.util.FriendlyByteBufUtil.writeCustomData(
++                                    buffer -> extraDataWriter.accept(abstractcontainermenu, buffer),
++                                    registryAccess()
++                            )
++                        )
++                    );
 +                }
                  this.initMenu(abstractcontainermenu);
                  this.containerMenu = abstractcontainermenu;

--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -130,7 +130,7 @@
  
      @Override
      public OptionalInt openMenu(@Nullable MenuProvider p_9033_) {
-+        return openMenu(p_9033_, (java.util.function.Consumer<net.minecraft.network.RegistryFriendlyByteBuf>) null);
++        return openMenu(p_9033_, (java.util.function.BiConsumer<AbstractContainerMenu, net.minecraft.network.RegistryFriendlyByteBuf>) null);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -146,10 +146,11 @@
              }
  
              this.nextContainerCounter();
-@@ -1222,10 +_,31 @@
+@@ -1222,10 +_,32 @@
  
                  return OptionalInt.empty();
              } else {
++                // Neo: Support sending additional arbitrary data to menu factories on the client-side
 +                var extraData = net.neoforged.neoforge.common.util.FriendlyByteBufUtil.writeCustomData(
 +                        buffer -> {
 +                            p_9033_.writeClientSideData(abstractcontainermenu, buffer);
@@ -159,10 +160,7 @@
 +                        },
 +                        registryAccess()
 +                );
-+                if (extraData.length == 0) {
-                 this.connection
-                     .send(new ClientboundOpenScreenPacket(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName()));
-+                } else {
++                if (extraData.length != 0) {
 +                    this.connection.send(
 +                        new net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload(
 +                            abstractcontainermenu.containerId,
@@ -171,6 +169,9 @@
 +                            extraData
 +                        )
 +                    );
++                } else {
+                 this.connection
+                     .send(new ClientboundOpenScreenPacket(abstractcontainermenu.containerId, abstractcontainermenu.getType(), p_9033_.getDisplayName()));
 +                }
                  this.initMenu(abstractcontainermenu);
                  this.containerMenu = abstractcontainermenu;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IMenuProviderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IMenuProviderExtension.java
@@ -5,6 +5,10 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+
 /**
  * Extension type for the {@link net.minecraft.world.MenuProvider} interface.
  */
@@ -17,4 +21,13 @@ public interface IMenuProviderExtension {
     default boolean shouldTriggerClientSideContainerClosingOnOpen() {
         return true;
     }
+
+    /**
+     * Allows the menu provider to write additional data to be read by {@link net.neoforged.neoforge.network.IContainerFactory#create(int, Inventory, RegistryFriendlyByteBuf)}
+     * when the menu is created on the client-side.
+     *
+     * @param menu   A server-side menu created by this menu provider.
+     * @param buffer Additional data that will be sent to the client.
+     */
+    default void writeClientSideData(AbstractContainerMenu menu, RegistryFriendlyByteBuf buffer) {}
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IMenuTypeExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IMenuTypeExtension.java
@@ -5,7 +5,10 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -13,6 +16,13 @@ import net.minecraft.world.inventory.MenuType;
 import net.neoforged.neoforge.network.IContainerFactory;
 
 public interface IMenuTypeExtension<T> {
+    /**
+     * Use this method to create a menu type that uses additional data sent by the server when it creates
+     * the client-side instances of its menus.
+     *
+     * @see IPlayerExtension#openMenu(MenuProvider, BiConsumer)
+     * @see IPlayerExtension#openMenu(MenuProvider, Consumer)
+     */
     static <T extends AbstractContainerMenu> MenuType<T> create(IContainerFactory<T> factory) {
         return new MenuType<>(factory, FeatureFlags.DEFAULT_FLAGS);
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IMenuTypeExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IMenuTypeExtension.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.common.extensions;
 
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
@@ -20,7 +19,7 @@ public interface IMenuTypeExtension<T> {
      * Use this method to create a menu type that uses additional data sent by the server when it creates
      * the client-side instances of its menus.
      *
-     * @see IPlayerExtension#openMenu(MenuProvider, BiConsumer)
+     * @see IMenuProviderExtension#writeClientSideData(AbstractContainerMenu, RegistryFriendlyByteBuf)
      * @see IPlayerExtension#openMenu(MenuProvider, Consumer)
      */
     static <T extends AbstractContainerMenu> MenuType<T> create(IContainerFactory<T> factory) {

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.OptionalInt;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -13,6 +14,7 @@ import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -66,6 +68,22 @@ public interface IPlayerExtension {
      * @return The window ID of the opened GUI, or empty if the GUI could not be opened
      */
     default OptionalInt openMenu(MenuProvider menuProvider, Consumer<RegistryFriendlyByteBuf> extraDataWriter) {
+        return openMenu(menuProvider, (menu, buffer) -> extraDataWriter.accept(buffer));
+    }
+
+    /**
+     * Request to open a GUI on the client, from the server
+     * <p>
+     * Refer to {@link MenuType#create(IContainerFactory)} for how to provide a function to consume
+     * these GUI requests on the client.
+     * <p>
+     * The maximum size for #extraDataWriter is 32600 bytes.
+     *
+     * @param menuProvider    A supplier of container properties including the registry name of the container
+     * @param extraDataWriter Consumer to write any additional data the GUI needs
+     * @return The window ID of the opened GUI, or empty if the GUI could not be opened
+     */
+    default OptionalInt openMenu(MenuProvider menuProvider, BiConsumer<AbstractContainerMenu, RegistryFriendlyByteBuf> extraDataWriter) {
         return OptionalInt.empty();
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -9,6 +9,7 @@ import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.Entity;
@@ -44,8 +45,10 @@ public interface IPlayerExtension {
     /**
      * Request to open a GUI on the client, from the server
      * <p>
-     * Refer to {@link MenuType#create(IContainerFactory)} for how to provide a function to consume
-     * these GUI requests on the client.
+     * Refer to {@link MenuType#create(IContainerFactory)} for creating a {@link MenuType} that can consume the
+     * extra data sent to the client by this method.
+     * <p>
+     * Use {@link FriendlyByteBuf#readBlockPos()} to read the position you pass to this method.
      *
      * @param menuProvider A supplier of container properties including the registry name of the container
      * @param pos          A block pos, which will be encoded into the additional data for this request
@@ -58,8 +61,8 @@ public interface IPlayerExtension {
     /**
      * Request to open a GUI on the client, from the server
      * <p>
-     * Refer to {@link MenuType#create(IContainerFactory)} for how to provide a function to consume
-     * these GUI requests on the client.
+     * Refer to {@link MenuType#create(IContainerFactory)} for creating a {@link MenuType} that can consume the
+     * extra data sent to the client by this method.
      * <p>
      * The maximum size for #extraDataWriter is 32600 bytes.
      *
@@ -74,8 +77,8 @@ public interface IPlayerExtension {
     /**
      * Request to open a GUI on the client, from the server
      * <p>
-     * Refer to {@link MenuType#create(IContainerFactory)} for how to provide a function to consume
-     * these GUI requests on the client.
+     * Refer to {@link MenuType#create(IContainerFactory)} for creating a {@link MenuType} that can consume the
+     * extra data sent to the client by this method.
      * <p>
      * The maximum size for #extraDataWriter is 32600 bytes.
      *

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -51,7 +50,8 @@ public interface IPlayerExtension {
      * Use {@link FriendlyByteBuf#readBlockPos()} to read the position you pass to this method.
      *
      * @param menuProvider A supplier of container properties including the registry name of the container
-     * @param pos          A block pos, which will be encoded into the additional data for this request
+     * @param pos          A block pos, which will be encoded into the additional data for this request, after
+     *                     data written by {@link IMenuProviderExtension#writeClientSideData(AbstractContainerMenu, RegistryFriendlyByteBuf)}.
      *
      */
     default OptionalInt openMenu(MenuProvider menuProvider, BlockPos pos) {
@@ -67,26 +67,11 @@ public interface IPlayerExtension {
      * The maximum size for #extraDataWriter is 32600 bytes.
      *
      * @param menuProvider    A supplier of container properties including the registry name of the container
-     * @param extraDataWriter Consumer to write any additional data the GUI needs
+     * @param extraDataWriter Consumer to write any additional data the GUI needs.
+     *                        This data is written after {@link IMenuProviderExtension#writeClientSideData(AbstractContainerMenu, RegistryFriendlyByteBuf)}.
      * @return The window ID of the opened GUI, or empty if the GUI could not be opened
      */
     default OptionalInt openMenu(MenuProvider menuProvider, Consumer<RegistryFriendlyByteBuf> extraDataWriter) {
-        return openMenu(menuProvider, extraDataWriter != null ? (menu, buffer) -> extraDataWriter.accept(buffer) : null);
-    }
-
-    /**
-     * Request to open a GUI on the client, from the server
-     * <p>
-     * Refer to {@link MenuType#create(IContainerFactory)} for creating a {@link MenuType} that can consume the
-     * extra data sent to the client by this method.
-     * <p>
-     * The maximum size for #extraDataWriter is 32600 bytes.
-     *
-     * @param menuProvider    A supplier of container properties including the registry name of the container
-     * @param extraDataWriter Consumer to write any additional data the GUI needs
-     * @return The window ID of the opened GUI, or empty if the GUI could not be opened
-     */
-    default OptionalInt openMenu(MenuProvider menuProvider, BiConsumer<AbstractContainerMenu, RegistryFriendlyByteBuf> extraDataWriter) {
         return OptionalInt.empty();
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -68,7 +68,7 @@ public interface IPlayerExtension {
      * @return The window ID of the opened GUI, or empty if the GUI could not be opened
      */
     default OptionalInt openMenu(MenuProvider menuProvider, Consumer<RegistryFriendlyByteBuf> extraDataWriter) {
-        return openMenu(menuProvider, (menu, buffer) -> extraDataWriter.accept(buffer));
+        return openMenu(menuProvider, extraDataWriter != null ? (menu, buffer) -> extraDataWriter.accept(buffer) : null);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
@@ -6,15 +6,12 @@
 package net.neoforged.neoforge.common.util;
 
 import com.mojang.authlib.GameProfile;
-import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.Consumer;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.network.Connection;
 import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.network.PacketListener;
 import net.minecraft.network.PacketSendListener;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.PlayerChatMessage;
@@ -74,7 +71,6 @@ import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.stats.Stat;
 import net.minecraft.world.Container;
-import net.minecraft.world.MenuProvider;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.PositionMoveRotation;
@@ -113,11 +109,6 @@ public class FakePlayer extends ServerPlayer {
 
     @Override
     public void updateOptions(ClientInformation p_301998_) {}
-
-    @Override
-    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable Consumer<RegistryFriendlyByteBuf> extraDataWriter) {
-        return OptionalInt.empty();
-    }
 
     @Override
     public void openHorseInventory(AbstractHorse horse, Container container) {}

--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
@@ -8,7 +8,7 @@ package net.neoforged.neoforge.common.util;
 import com.mojang.authlib.GameProfile;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.network.Connection;
 import net.minecraft.network.DisconnectionDetails;
@@ -81,7 +81,6 @@ import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.entity.animal.horse.AbstractHorse;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.Nullable;
 
@@ -116,7 +115,7 @@ public class FakePlayer extends ServerPlayer {
     public void updateOptions(ClientInformation p_301998_) {}
 
     @Override
-    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable BiConsumer<AbstractContainerMenu, RegistryFriendlyByteBuf> extraDataWriter) {
+    public OptionalInt openMenu(@Nullable MenuProvider menuProvider, @Nullable Consumer<RegistryFriendlyByteBuf> extraDataWriter) {
         return OptionalInt.empty();
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
@@ -6,12 +6,15 @@
 package net.neoforged.neoforge.common.util;
 
 import com.mojang.authlib.GameProfile;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.network.Connection;
 import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.network.PacketListener;
 import net.minecraft.network.PacketSendListener;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.PlayerChatMessage;
@@ -71,12 +74,14 @@ import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.stats.Stat;
 import net.minecraft.world.Container;
+import net.minecraft.world.MenuProvider;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.entity.animal.horse.AbstractHorse;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.Nullable;
 
@@ -109,6 +114,11 @@ public class FakePlayer extends ServerPlayer {
 
     @Override
     public void updateOptions(ClientInformation p_301998_) {}
+
+    @Override
+    public OptionalInt openMenu(@Nullable MenuProvider p_9033_, @Nullable BiConsumer<AbstractContainerMenu, RegistryFriendlyByteBuf> extraDataWriter) {
+        return OptionalInt.empty();
+    }
 
     @Override
     public void openHorseInventory(AbstractHorse horse, Container container) {}

--- a/src/main/java/net/neoforged/neoforge/network/IContainerFactory.java
+++ b/src/main/java/net/neoforged/neoforge/network/IContainerFactory.java
@@ -5,12 +5,27 @@
 
 package net.neoforged.neoforge.network;
 
+import java.util.function.BiConsumer;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 
+/**
+ * This extension of {@link MenuType.MenuSupplier} allows a mod to handle the extra data it sent to the client
+ * when creating the client-side copy of a menu.
+ */
 public interface IContainerFactory<T extends AbstractContainerMenu> extends MenuType.MenuSupplier<T> {
+    /**
+     * Constructs a menu instance on the client-side in response to a menu being opened on the server-side for a player.
+     *
+     * @param windowId The {@link AbstractContainerMenu#containerId} of the menu on the server-side.
+     * @param inv      Player inventory of the player for whom the menu is being created.
+     * @param data     Additional data written by the server when the menu was opened, by the {@code extraDataWriter} argument
+     *                 to {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#openMenu(MenuProvider, BiConsumer)}.
+     * @return The menu instance to use on the client-side.
+     */
     T create(int windowId, Inventory inv, RegistryFriendlyByteBuf data);
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/network/IContainerFactory.java
+++ b/src/main/java/net/neoforged/neoforge/network/IContainerFactory.java
@@ -5,7 +5,7 @@
 
 package net.neoforged.neoforge.network;
 
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
@@ -22,8 +22,10 @@ public interface IContainerFactory<T extends AbstractContainerMenu> extends Menu
      *
      * @param windowId The {@link AbstractContainerMenu#containerId} of the menu on the server-side.
      * @param inv      Player inventory of the player for whom the menu is being created.
-     * @param data     Additional data written by the server when the menu was opened, by the {@code extraDataWriter} argument
-     *                 to {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#openMenu(MenuProvider, BiConsumer)}.
+     * @param data     Additional data written by the server when the menu was opened.
+     *                 It contains any data written by {@link net.neoforged.neoforge.common.extensions.IMenuProviderExtension#writeClientSideData(AbstractContainerMenu, RegistryFriendlyByteBuf)},
+     *                 followed by optional contextual data written by the {@code extraDataWriter} argument to
+     *                 {@link net.neoforged.neoforge.common.extensions.IPlayerExtension#openMenu(MenuProvider, Consumer)}.
      * @return The menu instance to use on the client-side.
      */
     T create(int windowId, Inventory inv, RegistryFriendlyByteBuf data);


### PR DESCRIPTION
This change (which should be backwards compatible) allows the function that writes additional data to the open menu packet to access the menu that was just created server-side. Otherwise writing data from the menu to the initial packet is impossible.

This allows the menu factory on the client-side to immediately restore the server-side state as part of the constructor call rather than setting it using a follow-up packet.

Usage is simply:

```java
player.openMenu(... opener as before ..., (menu, buffer) -> { ... });
```

p.s.: I would have preferred if the menu opener was a generic type allowing the extra-data-writer to access the concrete type of the menu without casts, but that would require more changes.