### PR TITLE
Release April Fools snapshot branches via Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ name: Release
 on:
   push:
     branches:
-      - '1.*'
-      - '[0-9][0-9]w14[a-z]+'
+      - '1.*'                 # Mainline release branches 
+      - '[0-9][0-9]w14[a-z]+' # w14 April Fools Snapshots
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - '1.*'
+      - '[0-9][0-9]w14[a-z]+'
 
 permissions:
   contents: read


### PR DESCRIPTION
The new filter is effectively the same as `\d\dw14.+`, which you can convince yourself is true using the Github Filter cheatsheet: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

With any luck, as soon as this PR is merged, the 25w14craftmine branch should be ready for build and release.