### PR TITLE
[1.21.5] Disable particle culling for the elder guardian particle

### DIFF
--- a/patches/net/minecraft/client/particle/MobAppearanceParticle.java.patch
+++ b/patches/net/minecraft/client/particle/MobAppearanceParticle.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/client/particle/MobAppearanceParticle.java
++++ b/net/minecraft/client/particle/MobAppearanceParticle.java
+@@ -56,6 +_,13 @@
+     public void render(VertexConsumer p_107125_, Camera p_107126_, float p_107127_) {
+     }
+ 
++    // Neo: this "particle" is locked to the player's camera, a render BB at the particle's in-world position
++    // therefore makes no sense
++    @Override
++    public net.minecraft.world.phys.AABB getRenderBoundingBox(float partialTicks) {
++        return net.minecraft.world.phys.AABB.INFINITE;
++    }
++
+     @OnlyIn(Dist.CLIENT)
+     public static class Provider implements ParticleProvider<SimpleParticleType> {
+         public Particle createParticle(


### PR DESCRIPTION
This PR disables particle culling for the elder guardian particle (`MobAppearanceParticle`) as it is locked to the player's camera instead of an in-world position which causes the render bounding box to break the particle depending on the player's position and camera orientation.

Fixes #2127 