### PR TITLE
Making entires field public for loot pool modifcation purposes

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -265,6 +265,7 @@ public net.minecraft.world.level.saveddata.maps.MapItemSavedData removeDecoratio
 public net.minecraft.world.level.storage.LevelResource <init>(Ljava/lang/String;)V # constructor
 private-f net.minecraft.world.level.storage.loot.LootPool rolls # rolls
 private-f net.minecraft.world.level.storage.loot.LootPool bonusRolls # bonusRolls
+public net.minecraft.world.level.storage.loot.LootPool entries # entries
 public net.minecraft.server.network.ServerConfigurationPacketListenerImpl finishCurrentTask(Lnet/minecraft/server/network/ConfigurationTask$Type;)V
 public-f net.minecraft.world.entity.npc.VillagerTrades WANDERING_TRADER_TRADES # WANDERING_TRADER_TRADES
 


### PR DESCRIPTION
Im making a neoforge mod and i m coming across an issue where i cant modify the loot pool because certain fields are private
so i made a mixin for that
```java
@Mixin(LootPool.class)
public interface LootPoolAccessor {
    @Accessor("entries")
    List<LootPoolEntryContainer> getEntries();
}
```
But doing it like this makes it so that i need to have multiple accessors 
How i add items to the loot pool right now is very messy

```java
    @SubscribeEvent
    public static void onLootTableLoad(LootTableLoadEvent event) {
        ResourceLocation lootTableId = event.getName();
        ResourceLocation desertPyramidLootTable = ResourceLocation.fromNamespaceAndPath("minecraft", "archaeology/desert_pyramid");
        ResourceLocation desertWellLootTable = ResourceLocation.fromNamespaceAndPath("minecraft", "archaeology/desert_well");

        LootTable table = event.getTable();
        LootPool mainPool = table.getPool("main");
        LootPoolAccessor poolAccessor = (LootPoolAccessor) mainPool;

        if (mainPool != null && !mainPool.isFrozen()) {
            LootPool.Builder newPoolBuilder = LootPool.lootPool()
                    .setRolls(mainPool.getRolls())
                    .setBonusRolls(mainPool.getBonusRolls());

            poolAccessor.getEntries().forEach(entry ->
                    newPoolBuilder.add(new LootPoolEntryContainer.Builder() {
                        @Override
                        protected LootPoolEntryContainer.Builder getThis() {
                            return null;
                        }

                        @Override
                        public LootPoolEntryContainer build() {
                            return entry;
                        }
                    })
            );

            if (desertPyramidLootTable.equals(lootTableId) || desertWellLootTable.equals(lootTableId)) {
                newPoolBuilder.add(LootItem.lootTableItem(MegaStones.RED_ORB)
                        .setWeight(1));

                // Preserve the name
                if (mainPool.getName() != null) {
                    newPoolBuilder.name(mainPool.getName());
                }

                // Replace the old pool with the new one
                table.removePool("main");
                table.addPool(newPoolBuilder.build());
            }
        }
    }
```

So i hope this pull request can be accepted so i can modify the loot pools properly 