### PR TITLE
Add support for baking multiple models in the standalone API

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -104,7 +104,7 @@
              modeldiscovery.addSpecialModel(ItemModelGenerator.GENERATED_ITEM_MODEL_ID, new ItemModelGenerator());
              p_361624_.models().values().forEach(modeldiscovery::addRoot);
              p_390496_.contents().values().forEach(p_390109_ -> modeldiscovery.addRoot(p_390109_.model()));
-+            standaloneModels.models().keySet().forEach(key -> modeldiscovery.addRoot(resolver -> resolver.markDependency(key.getModelId())));
++            standaloneModels.models().values().forEach(modeldiscovery::addRoot);
              modelmanager$resolvedmodels = new ModelManager.ResolvedModels(modeldiscovery.missingModel(), modeldiscovery.resolve());
          }
  

--- a/src/client/java/net/neoforged/neoforge/client/event/ModelEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ModelEvent.java
@@ -20,7 +20,9 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.neoforge.client.model.UnbakedModelLoader;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelBaker;
+import net.neoforged.neoforge.client.model.standalone.StandaloneModelBakerWrapper;
 import net.neoforged.neoforge.client.model.standalone.StandaloneModelKey;
+import net.neoforged.neoforge.client.model.standalone.UnbakedStandaloneModel;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
@@ -141,10 +143,10 @@ public abstract class ModelEvent extends Event {
      * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RegisterStandalone extends ModelEvent implements IModBusEvent {
-        private final Map<StandaloneModelKey<?>, StandaloneModelBaker<?>> modelMap;
+        private final Map<StandaloneModelKey<?>, UnbakedStandaloneModel<?>> modelMap;
 
         @ApiStatus.Internal
-        public RegisterStandalone(Map<StandaloneModelKey<?>, StandaloneModelBaker<?>> modelMap) {
+        public RegisterStandalone(Map<StandaloneModelKey<?>, UnbakedStandaloneModel<?>> modelMap) {
             this.modelMap = modelMap;
         }
 
@@ -152,6 +154,17 @@ public abstract class ModelEvent extends Event {
          * Registers a model to be loaded, along with its dependencies.
          */
         public <T> void register(StandaloneModelKey<T> modelKey, StandaloneModelBaker<T> baker) {
+            modelMap.put(modelKey, new StandaloneModelBakerWrapper<>(modelKey.getModelId(), baker));
+        }
+
+        /**
+         * Registers a {@linkplain UnbakedStandaloneModel model} to be loaded, along with its dependencies.
+         *
+         * <p>Unlike {@link #register(StandaloneModelKey, StandaloneModelBaker)}, dependency gathering and baking is
+         * performed by an {@link UnbakedStandaloneModel}. This allows you to depend on multiple models files at once,
+         * baking them into a single dynamic model.
+         */
+        public <T> void register(StandaloneModelKey<T> modelKey, UnbakedStandaloneModel<T> baker) {
             modelMap.put(modelKey, baker);
         }
     }

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelBakerWrapper.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelBakerWrapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.standalone;
+
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.client.event.ModelEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Wraps a {@link StandaloneModelBaker} into a {@link UnbakedStandaloneModel}.
+ *
+ * <p>This should not be used directly, but instead through
+ * {@link ModelEvent.RegisterStandalone#register(StandaloneModelKey, StandaloneModelBaker)}.
+ *
+ * @param <T> The type of the baked model.
+ */
+@ApiStatus.Internal
+public final class StandaloneModelBakerWrapper<T> implements UnbakedStandaloneModel<T> {
+    private final ResourceLocation modelId;
+    private final StandaloneModelBaker<T> standaloneBaker;
+
+    public StandaloneModelBakerWrapper(ResourceLocation model, StandaloneModelBaker<T> baker) {
+        this.modelId = model;
+        this.standaloneBaker = baker;
+    }
+
+    @Override
+    public T bake(ModelBaker baker) {
+        return standaloneBaker.bake(baker.getModel(modelId), baker);
+    }
+
+    @Override
+    public void resolveDependencies(Resolver resolver) {
+        resolver.markDependency(modelId);
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelKey.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelKey.java
@@ -12,8 +12,8 @@ import net.neoforged.neoforge.client.event.ModelEvent;
 /**
  * A key referring to a model file to be loaded and baked as a standalone model (not bound to a block or item).
  * <p>
- * This key is registered together with a {@link StandaloneModelBaker} in {@link ModelEvent.RegisterStandalone}
- * and later used to retrieve the model baked by the {@link StandaloneModelBaker},
+ * This key is registered together with a {@link StandaloneModelBaker} or {@link UnbakedStandaloneModel} in
+ * {@link ModelEvent.RegisterStandalone} and later used to retrieve the model baked by the {@link StandaloneModelBaker},
  * using {@link ModelManager#getStandaloneModel(StandaloneModelKey)}.
  * <p>
  * The key is compared by identity as multiple keys may refer to the same model file while using different bakers.

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelLoader.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import net.minecraft.client.resources.model.ModelBaker;
-import net.minecraft.client.resources.model.ResolvedModel;
 import net.minecraft.util.thread.ParallelMapTransform;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.client.event.ModelEvent;
@@ -26,17 +25,16 @@ public final class StandaloneModelLoader {
 
     public static CompletableFuture<LoadedModels> load(Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
-            Map<StandaloneModelKey<?>, StandaloneModelBaker<?>> models = new IdentityHashMap<>();
+            Map<StandaloneModelKey<?>, UnbakedStandaloneModel<?>> models = new IdentityHashMap<>();
             ModLoader.postEvent(new ModelEvent.RegisterStandalone(models));
             return new LoadedModels(models);
         }, executor);
     }
 
     public static CompletableFuture<BakedModels> bake(LoadedModels standaloneModels, ModelBaker baker, Executor executor) {
-        return ParallelMapTransform.schedule(standaloneModels.models, (key, standaloneModelBaker) -> {
+        return ParallelMapTransform.schedule(standaloneModels.models, (key, model) -> {
             try {
-                ResolvedModel model = baker.getModel(key.getModelId());
-                return standaloneModelBaker.bake(model, baker);
+                return model.bake(baker);
             } catch (Exception e) {
                 LOGGER.warn("Unable to bake standalone model: '{}': {}", key.getModelId(), e);
                 return null;
@@ -44,7 +42,7 @@ public final class StandaloneModelLoader {
         }, executor).thenApply(BakedModels::new);
     }
 
-    public record LoadedModels(Map<StandaloneModelKey<?>, StandaloneModelBaker<?>> models) {
+    public record LoadedModels(Map<StandaloneModelKey<?>, UnbakedStandaloneModel<?>> models) {
         public static final LoadedModels EMPTY = new LoadedModels(Map.of());
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/UnbakedStandaloneModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/UnbakedStandaloneModel.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.standalone;
+
+import net.minecraft.client.renderer.item.ItemModel;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.resources.model.ResolvableModel;
+import net.neoforged.neoforge.client.event.ModelEvent;
+
+/**
+ * An unbaked {@linkplain StandaloneModelKey standalone model}.
+ *
+ * <p>Similar to {@link ItemModel.Unbaked} and other {@link ResolvableModel}s, this model can
+ * {@linkplain ResolvableModel.Resolver#resolveDependencies(Resolver) depend} on one or more model files, and then
+ * combine them into a single baked model.
+ *
+ * <p>The baked object can be retrieved later using {@link ModelManager#getStandaloneModel(StandaloneModelKey)}.
+ *
+ * @param <T> The type of the baked model.
+ * @see ModelEvent.RegisterStandalone#register(StandaloneModelKey, UnbakedStandaloneModel)
+ */
+public interface UnbakedStandaloneModel<T> extends ResolvableModel {
+    /**
+     * Bake this model.
+     *
+     * @param baker The current model baker.
+     * @return The fully-baked model.
+     */
+    T bake(ModelBaker baker);
+}


### PR DESCRIPTION
The current standalone model API currently is designed around baking a single model, loaded from the resource pack. However, Minecraft's other model APIs (e.g. `ItemModel.Unbaked`) work differently, with consumers being responsible for marking dependencies, fetching model(s) from the bakery, and baking them.

This adds similar support to the standalone model system, with the addition of a new interface.

```java
public interface UnbakedStandaloneModel<T> extends ResolvableModel {
    T bake(ModelBaker baker);
}
```

This allows mods to implement dynamic models for their modded game content, in the style of `ItemModel`. See [this discussion on Discord](https://discord.com/channels/313125603924639766/1342994966405845063/1355840607976947854) for more context.

In the future it would make sense to remove the `modelId` from `StandaloneModelKey` (as it is no longer tied to a single model), and have an API closer to Fabric's (https://github.com/FabricMC/fabric/pull/4565). I've not done so for now, as it felt like an unnecessary breaking change, but happy to do so now if preferred!