### PR TITLE
Register item handler capability for pale oak chest boats

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
@@ -114,6 +114,7 @@ public class CapabilityHooks {
                 EntityType.OAK_CHEST_BOAT,
                 EntityType.SPRUCE_CHEST_BOAT,
                 EntityType.BAMBOO_CHEST_RAFT,
+                EntityType.PALE_OAK_CHEST_BOAT,
                 EntityType.CHEST_MINECART,
                 EntityType.HOPPER_MINECART);
         for (var entityType : containerEntities) {


### PR DESCRIPTION
This PR fixes #2134 by registering the requisite item handler capabilities for the pale oak chest boat, which was missing beforehand.