### PR TITLE
Do not expose neoforge as a runtime transitive dependency of the test framework

### DIFF
--- a/testframework/build.gradle
+++ b/testframework/build.gradle
@@ -19,8 +19,15 @@ repositories {
     }
 }
 
+configurations {
+    // An alternative to implementation that doesn't expose its dependencies as transitive runtime dependencies
+    localImplementation
+    compileOnly.extendsFrom localImplementation
+    runtimeClasspath.extendsFrom localImplementation
+}
+
 dependencies {
-    implementation project(path: ':neoforge', configuration: 'runtimeElements')
+    localImplementation project(path: ':neoforge', configuration: 'runtimeElements')
 
     compileOnly(platform("org.junit:junit-bom:${project.jupiter_api_version}"))
     compileOnly "org.junit.jupiter:junit-jupiter-params"


### PR DESCRIPTION
Add a `localImplementation` configuration in the testframework project that acts as an alternative to `implementation` but without exposing the dependency as a `runtime` transitive.

Fixes #1997