### PR TITLE
Rebuild blockstate caches of oxidizables after datamaps are loaded

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/DataMapHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/DataMapHooks.java
@@ -88,6 +88,7 @@ public class DataMapHooks {
                 INVERSE_OXIDIZABLES_DATAMAP_INTERNAL.put(oxidizable.nextOxidationStage(), block);
 
                 // Rebuild blockstate caches of oxidizables after datamaps are loaded so that they can recompute isRandomlyTicking while having access to the data map value
+                // TODO - revisit this in the future if other datamaps will require rebuilding caches to avoid doing it multiple times
                 for (BlockState state : block.getStateDefinition().getPossibleStates()) {
                     state.initCache();
                 }

--- a/src/main/java/net/neoforged/neoforge/common/DataMapHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/DataMapHooks.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.WeatheringCopper;
 import net.minecraft.world.level.block.entity.FuelValues;
+import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.registries.datamaps.DataMapsUpdatedEvent;
 import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
@@ -82,7 +83,14 @@ public class DataMapHooks {
             INVERSE_WAXABLES_DATAMAP_INTERNAL.clear();
 
             registry.getDataMap(NeoForgeDataMaps.OXIDIZABLES).forEach((resourceKey, oxidizable) -> {
-                INVERSE_OXIDIZABLES_DATAMAP_INTERNAL.put(oxidizable.nextOxidationStage(), BuiltInRegistries.BLOCK.getValue(resourceKey));
+                var block = BuiltInRegistries.BLOCK.getValue(resourceKey);
+
+                INVERSE_OXIDIZABLES_DATAMAP_INTERNAL.put(oxidizable.nextOxidationStage(), block);
+
+                // Rebuild blockstate caches of oxidizables after datamaps are loaded so that they can recompute isRandomlyTicking while having access to the data map value
+                for (BlockState state : block.getStateDefinition().getPossibleStates()) {
+                    state.initCache();
+                }
             });
 
             //noinspection deprecation

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -433,6 +433,7 @@ public class DataMapTests {
             helper.setBlock(blockPos, lightlyOxidizedIron.value());
             if (DataMapHooks.getNextOxidizedStage(lightlyOxidizedIron.value()) == null)
                 helper.fail("Next oxidization state for lightly oxidized iron was null!");
+            helper.assertTrue(lightlyOxidizedIron.value().defaultBlockState().isRandomlyTicking(), "Lightly Oxidized Iron is not randomly ticking. Its state cache was not invalidated!");
             helper.setBlock(blockPos, DataMapHooks.getNextOxidizedStage(lightlyOxidizedIron.value()));
             helper.assertBlock(blockPos, block -> moreOxidizedIron.value().equals(block), "Wanted: More Oxidized Iron but found something else!");
 


### PR DESCRIPTION
Fixes #2109