### PR TITLE
Allow mods with high OpenGL requirements to load during datagen

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/loading/NoVizFallback.java
+++ b/src/main/java/net/neoforged/neoforge/client/loading/NoVizFallback.java
@@ -38,7 +38,10 @@ public final class NoVizFallback {
             var min = GLFW.glfwGetWindowAttrib(WINDOW, GLFW.GLFW_CONTEXT_VERSION_MINOR);
             return maj + "." + min;
         } else {
-            return "3.2";
+            // During datagen, we return 4.6 here to allow mods with high OpenGL requirements to load,
+            // since no OpenGL context is provided anyway (datagen runs as client but the feature test
+            // should not apply, similar to the dedicated server).
+            return "4.6";
         }
     }
 }


### PR DESCRIPTION
Pretend the game is running with OpenGL 4.6 when no window has actually been created (dedicated server, datagen).
This is only really used during datagen to fill the openGl feature flag data, which is queried since datagen counts as a client-run.

Fixes #1956