### PR TITLE
Preserve datagen insertion order for GLMs

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/data/GlobalLootModifierProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/GlobalLootModifierProvider.java
@@ -12,7 +12,7 @@ import com.google.gson.JsonObject;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,7 +39,7 @@ public abstract class GlobalLootModifierProvider implements DataProvider {
     private final CompletableFuture<HolderLookup.Provider> registriesLookup;
     protected HolderLookup.Provider registries;
     private final String modid;
-    private final Map<String, WithConditions<IGlobalLootModifier>> toSerialize = new HashMap<>();
+    private final Map<String, WithConditions<IGlobalLootModifier>> toSerialize = new LinkedHashMap<>();
     private boolean replace = false;
 
     public GlobalLootModifierProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries, String modid) {


### PR DESCRIPTION
Use a `LinkedHashMap` instead of a `HashMap` to preserve insertion order and allow mods to control the order their GLMs will apply in.
Fixes #1828