### PR TITLE
Make any holdersets always serialize and the not one delegate the check

### DIFF
--- a/patches/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/patches/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -52,15 +52,42 @@
              p_256495_.forEach(p_256603_ -> builder.put(p_256603_.location(), registrysetbuilder$universallookup));
              return new RegistrySetBuilder.BuildState(
                  registrysetbuilder$universalowner, registrysetbuilder$universallookup, builder.build(), new HashMap<>(), list
-@@ -259,6 +_,11 @@
-                 @Override
+@@ -260,6 +_,11 @@
                  public <S> HolderGetter<S> lookup(ResourceKey<? extends Registry<? extends S>> p_255961_) {
                      return (HolderGetter<S>)BuildState.this.registries.getOrDefault(p_255961_.location(), BuildState.this.lookup);
-+                }
+                 }
 +
 +                @Override
 +                public <S> Optional<HolderLookup.RegistryLookup<S>> registryLookup(ResourceKey<? extends Registry<? extends S>> registry) {
 +                    return Optional.ofNullable((HolderLookup.RegistryLookup<S>) BuildState.this.registries.get(registry.location()));
-                 }
++                }
              };
          }
+ 
+@@ -417,6 +_,26 @@
+         @Override
+         public Optional<Holder.Reference<Object>> get(ResourceKey<Object> p_256303_) {
+             return Optional.of(this.getOrCreate(p_256303_));
++        }
++
++        @Override
++        public Stream<Holder.Reference<Object>> listElements() {
++            return holders.values().stream();
++        }
++
++        @Override
++        public Stream<ResourceKey<Object>> listElementIds() {
++            return holders.keySet().stream();
++        }
++
++        @Override
++        public Stream<HolderSet.Named<Object>> listTags() {
++            return Stream.empty();
++        }
++
++        @Override
++        public Stream<TagKey<Object>> listTagIds() {
++            return Stream.empty();
+         }
+ 
+         <T> Holder.Reference<T> getOrCreate(ResourceKey<T> p_256298_) {

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
@@ -86,7 +86,7 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
 
     @Override
     public boolean canSerializeIn(HolderOwner<T> holderOwner) {
-        return this.registryLookup.canSerializeIn(holderOwner);
+        return true;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
@@ -115,7 +115,7 @@ public class NotHolderSet<T> implements ICustomHolderSet<T> {
 
     @Override
     public boolean canSerializeIn(HolderOwner<T> holderOwner) {
-        return this.registryLookup.canSerializeIn(holderOwner);
+        return this.value.canSerializeIn(holderOwner);
     }
 
     @Override

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -74,6 +74,9 @@
   "net/minecraft/core/Registry": [
     "net/neoforged/neoforge/registries/IRegistryExtension<T>"
   ],
+  "net/minecraft/core/RegistrySetBuilder$UniversalLookup": [
+    "net/minecraft/core/HolderLookup<java.lang.Object>"
+  ],
   "net/minecraft/core/component/DataComponentHolder": [
     "net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension"
   ],


### PR DESCRIPTION
This PR makes the `AnyHolderSet` always return `true` (since the check is quite useless and it is possible to get technically valid registry lookups that are not of the same instance as the one passed in `canSerializeIn` - see #2073 - also, vanilla's own `ListBacked` holderset returns `true` for this check (and not all implementations, `Direct` included, override it); the check is made even more pointless when you consider that the holderset can serialise within any registry as it doesn't serialise any data) and the `NotHolderSet` delegate the check to its `value` to fix #2073

Additionally, in order to fix #1838 `RegistrySetBuilder$UniversalLookup` is patched to implement the remaining trivial methods of `RegistryLookup`. This means that a `RegistryLookup` for a dynamic registry can be acquired from a registry bootstrapper `BootstrapContext`.