### PR TITLE
Fix NeoForge#2032

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -143,9 +143,12 @@
      }
  
      void updateInWaterStateAndDoWaterCurrentPushing() {
-@@ -1279,6 +_,7 @@
+@@ -1278,7 +_,10 @@
+ 
      private void updateFluidOnEyes() {
          this.wasEyeInWater = this.isEyeInFluid(FluidTags.WATER);
++        this.wasTouchingWater = this.wasEyeInWater;
++
          this.fluidOnEyes.clear();
 +        this.forgeFluidTypeOnEyes = net.neoforged.neoforge.common.NeoForgeMod.EMPTY_TYPE.value();
          double d0 = this.getEyeY();
@@ -193,7 +196,7 @@
  
      public boolean isInLava() {
 -        return !this.firstTick && this.fluidHeight.getDouble(FluidTags.LAVA) > 0.0;
-+        return !this.firstTick && this.forgeFluidTypeHeight.getDouble(net.neoforged.neoforge.common.NeoForgeMod.LAVA_TYPE.value()) > 0.0D;
++        return !this.firstTick && (this.forgeFluidTypeHeight.getDouble(net.neoforged.neoforge.common.NeoForgeMod.LAVA_TYPE.value()) > 0.0D || this.forgeFluidTypeOnEyes == net.neoforged.neoforge.common.NeoForgeMod.LAVA_TYPE.value());
      }
  
      public void moveRelative(float p_19921_, Vec3 p_19922_) {


### PR DESCRIPTION
Fixes #2032.  Fixes this by adding check to see if the entity's eyes are in lava and updates `wasTouchingWater` to also be updated when `wasEyeInWater`  is updated.