### PR TITLE
Use `IItemHandler#getSlotLimit` in `SlotItemHandler#getMaxStackSize`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java
@@ -58,29 +58,7 @@ public class SlotItemHandler extends Slot {
 
     @Override
     public int getMaxStackSize(ItemStack stack) {
-        ItemStack maxAdd = stack.copy();
-        int maxInput = stack.getMaxStackSize();
-        maxAdd.setCount(maxInput);
-
-        IItemHandler handler = this.getItemHandler();
-        ItemStack currentStack = handler.getStackInSlot(index);
-        if (handler instanceof IItemHandlerModifiable) {
-            IItemHandlerModifiable handlerModifiable = (IItemHandlerModifiable) handler;
-
-            handlerModifiable.setStackInSlot(index, ItemStack.EMPTY);
-
-            ItemStack remainder = handlerModifiable.insertItem(index, maxAdd, true);
-
-            handlerModifiable.setStackInSlot(index, currentStack);
-
-            return maxInput - remainder.getCount();
-        } else {
-            ItemStack remainder = handler.insertItem(index, maxAdd, true);
-
-            int current = currentStack.getCount();
-            int added = maxInput - remainder.getCount();
-            return current + added;
-        }
+        return Math.min(stack.getMaxStackSize(), this.itemHandler.getSlotLimit(this.index));
     }
 
     @Override


### PR DESCRIPTION
The current implementation of `SlotItemHandler#getMaxStackSize(ItemStack)` attempts to insert the stack's max size into the handler and based on the current count in the slot, and the remainder of that operation, calculates the max stack size. However, as pointed out in #1896, this causes needless slot modifications which can have unexpected side effects. Therefore this PR changes it to use the minimum between `IItemHandler#getSlotLimit`, and the item's max stack size.

As for *why* the current code looks like this, it seems like it was changed to swap the stack in the slot while calculating in https://github.com/neoforged/NeoForge/commit/a1bbcf8a0b840df9af1b01163d12af36eaf972bf, a whopping 9 years ago, when `IItemHandler` did not have a `#getSlotLimit` method. Ironically, just a month later, in https://github.com/neoforged/NeoForge/commit/c17b40790b616a59277ca00cff97fbb336c1369e, `IItemHandler#getSlotLimit` was introduced but `SlotItemHandler` was not modified to use it.

Fixes #1896