### PR TITLE
Add item hand information to `LivingEntityUseItemEvent`s

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -619,7 +619,7 @@
      public void startUsingItem(InteractionHand p_21159_) {
          ItemStack itemstack = this.getItemInHand(p_21159_);
          if (!itemstack.isEmpty() && !this.isUsingItem()) {
-+            int duration = net.neoforged.neoforge.event.EventHooks.onItemUseStart(this, itemstack, itemstack.getUseDuration(this));
++            int duration = net.neoforged.neoforge.event.EventHooks.onItemUseStart(this, itemstack, p_21159_, itemstack.getUseDuration(this));
 +            if (duration < 0) return; // Neo: Early return for negative values, as that indicates event cancellation.
              this.useItem = itemstack;
 -            this.useItemRemaining = itemstack.getUseDuration(this);

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -445,8 +445,17 @@ public class EventHooks {
         return NeoForge.EVENT_BUS.post(new EntityStruckByLightningEvent(entity, bolt)).isCanceled();
     }
 
+    /**
+     * @deprecated Use {@link #onItemUseStart(LivingEntity, ItemStack, InteractionHand, int) the hand sensitive version} as this version provides wrong hand information
+     */
+    @Deprecated(forRemoval = true)
     public static int onItemUseStart(LivingEntity entity, ItemStack item, int duration) {
         var event = new LivingEntityUseItemEvent.Start(entity, item, duration);
+        return NeoForge.EVENT_BUS.post(event).isCanceled() ? -1 : event.getDuration();
+    }
+
+    public static int onItemUseStart(LivingEntity entity, ItemStack item, InteractionHand hand, int duration) {
+        var event = new LivingEntityUseItemEvent.Start(entity, item, hand, duration);
         return NeoForge.EVENT_BUS.post(event).isCanceled() ? -1 : event.getDuration();
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -448,7 +448,7 @@ public class EventHooks {
     /**
      * @deprecated Use {@link #onItemUseStart(LivingEntity, ItemStack, InteractionHand, int) the hand sensitive version} as this version provides wrong hand information
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "1.21.5", forRemoval = true)
     public static int onItemUseStart(LivingEntity entity, ItemStack item, int duration) {
         return onItemUseStart(entity, item, entity.getItemInHand(InteractionHand.MAIN_HAND) == item ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, duration);
     }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -450,8 +450,7 @@ public class EventHooks {
      */
     @Deprecated(forRemoval = true)
     public static int onItemUseStart(LivingEntity entity, ItemStack item, int duration) {
-        var event = new LivingEntityUseItemEvent.Start(entity, item, duration);
-        return NeoForge.EVENT_BUS.post(event).isCanceled() ? -1 : event.getDuration();
+        return onItemUseStart(entity, item, entity.getItemInHand(InteractionHand.MAIN_HAND) == item ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, duration);
     }
 
     public static int onItemUseStart(LivingEntity entity, ItemStack item, InteractionHand hand, int duration) {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -5,17 +5,24 @@
 
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.ICancellableEvent;
 
 public class LivingEntityUseItemEvent extends LivingEvent {
     private final ItemStack item;
+    private final InteractionHand hand;
     private int duration;
 
     private LivingEntityUseItemEvent(LivingEntity entity, ItemStack item, int duration) {
+        this(entity, item, entity.getUsedItemHand(), duration);
+    }
+
+    private LivingEntityUseItemEvent(LivingEntity entity, ItemStack item, InteractionHand hand, int duration) {
         super(entity);
         this.item = item;
+        this.hand = hand;
         this.setDuration(duration);
     }
 
@@ -32,6 +39,13 @@ public class LivingEntityUseItemEvent extends LivingEvent {
     }
 
     /**
+     * {@return the hand the entity is using the item in}
+     */
+    public InteractionHand getHand() {
+        return hand;
+    }
+
+    /**
      * Fired when a player starts 'using' an item, typically when they hold right mouse.
      * Examples:
      * Drawing a bow
@@ -43,8 +57,16 @@ public class LivingEntityUseItemEvent extends LivingEvent {
      *
      */
     public static class Start extends LivingEntityUseItemEvent implements ICancellableEvent {
+        /**
+         * @deprecated Use {@link Start#Start(LivingEntity, ItemStack, InteractionHand, int) the hand sensitive version} as this version provides wrong hand information
+         */
+        @Deprecated(forRemoval = true)
         public Start(LivingEntity entity, ItemStack item, int duration) {
-            super(entity, item, duration);
+            super(entity, item, entity.getItemInHand(InteractionHand.MAIN_HAND) == item ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, duration);
+        }
+
+        public Start(LivingEntity entity, ItemStack item, InteractionHand hand, int duration) {
+            super(entity, item, hand, duration);
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -60,7 +60,7 @@ public class LivingEntityUseItemEvent extends LivingEvent {
         /**
          * @deprecated Use {@link Start#Start(LivingEntity, ItemStack, InteractionHand, int) the hand sensitive version} as this version provides wrong hand information
          */
-        @Deprecated(forRemoval = true)
+        @Deprecated(since = "1.21.5", forRemoval = true)
         public Start(LivingEntity entity, ItemStack item, int duration) {
             super(entity, item, entity.getItemInHand(InteractionHand.MAIN_HAND) == item ? InteractionHand.MAIN_HAND : InteractionHand.OFF_HAND, duration);
         }


### PR DESCRIPTION
This PR adds a `#getHand` method to `LivingEntityUseItemEvent`, representing the hand the stack is being used in. This will return `LivingEntity#getUsedItemHand` by default, which works for all events but the `Start` subclass since that event is fired before the used hand flag is set. Therefore, the `Start` event is modified to accept the hand explicitly.

I did not cause a breaking change right now, and decided to deprecate the old constructor for removal to ease backporting.

Fixes #1859