### PR TITLE
Fix crash when defeating the ender dragon if there is no player reference

### DIFF
--- a/patches/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java.patch
+++ b/patches/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java.patch
@@ -50,7 +50,7 @@
          if (this.level() instanceof ServerLevel serverlevel) {
              if (this.dragonDeathTime > 150 && this.dragonDeathTime % 5 == 0 && serverlevel.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
 -                ExperienceOrb.award(serverlevel, this.position(), Mth.floor(i * 0.08F));
-+                int award = net.neoforged.neoforge.event.EventHooks.getExperienceDrop(this, this.unlimitedLastHurtByPlayer.getEntity(serverlevel, Player.class), Mth.floor((float)i * 0.08F));
++                int award = net.neoforged.neoforge.event.EventHooks.getExperienceDrop(this, net.minecraft.world.entity.EntityReference.get(this.unlimitedLastHurtByPlayer, serverlevel, Player.class), Mth.floor((float)i * 0.08F));
 +                ExperienceOrb.award((ServerLevel) this.level(), this.position(), award);
              }
  
@@ -60,7 +60,7 @@
          if (this.dragonDeathTime == 200 && this.level() instanceof ServerLevel serverlevel1) {
              if (serverlevel1.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
 -                ExperienceOrb.award(serverlevel1, this.position(), Mth.floor(i * 0.2F));
-+                int award = net.neoforged.neoforge.event.EventHooks.getExperienceDrop(this, this.unlimitedLastHurtByPlayer.getEntity(serverlevel1, Player.class), Mth.floor((float)i * 0.2F));
++                int award = net.neoforged.neoforge.event.EventHooks.getExperienceDrop(this, net.minecraft.world.entity.EntityReference.get(this.unlimitedLastHurtByPlayer, serverlevel1, Player.class), Mth.floor((float)i * 0.2F));
 +                ExperienceOrb.award((ServerLevel) this.level(), this.position(), award);
              }
  


### PR DESCRIPTION
Fixes a crash when trying to fire the `LivingExperienceDropEvent` where if the ender dragon is defeated without damage being done by a player or after the ender dragon was ticked while the last player that did damage isn't in the end dimension.