### PR TITLE
Enhanced AO: Clamp vertex coordinates to [0, 1] in corner weight computation

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/ao/AoFace.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/ao/AoFace.java
@@ -63,6 +63,12 @@ enum AoFace {
      * and we don't want that.
      */
     void computeCornerWeights(float[] out, float x, float y, float z) {
+        // Clamp the coordinates to [0, 1] to avoid negative weights for vertices outside the cube,
+        // which could lead to very bright vertices due to underflow. E.g. lectern above magma block.
+        x = Math.clamp(x, 0, 1);
+        y = Math.clamp(y, 0, 1);
+        z = Math.clamp(z, 0, 1);
+
         // The mapping can be obtained by looking at ModelBlockRenderer.AdjacencyInfo.
         // Take on of the vert weights, and turn EAST/WEST -> x and FLIP_EAST/FLIP_WEST -> 1-x.
         // And same for the other axis.


### PR DESCRIPTION
Lecterns have quads that go outside of the block, and if we don't clamp we end up with negative weights when computing the corresponding partial faces. The negative weights can lead to an underflow in `ModelBlockRenderer.AmbientOcclusionRenderStorage#blend`, which can make the outside vertex very bright. The images below speak for themselves.

| ![image](https://github.com/user-attachments/assets/50951b6f-1191-4fe9-ba5d-b87c835b7e41) | ![image](https://github.com/user-attachments/assets/32200cf9-d7e4-4b3f-8655-457be68d3553) | ![image](https://github.com/user-attachments/assets/8e3a7487-acb3-4e7a-b46f-183e75e06a56) |
|:--:|:--:|:--:|
| *Vanilla.* | *Enhanced AO before this PR.* | *Enhanced AO after this PR.* |
