### PR TITLE
Make any holdersets always serialize and the not one delegate the check

### DIFF
--- a/patches/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/patches/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -52,15 +52,51 @@
              p_256495_.forEach(p_256603_ -> builder.put(p_256603_.location(), registrysetbuilder$universallookup));
              return new RegistrySetBuilder.BuildState(
                  registrysetbuilder$universalowner, registrysetbuilder$universallookup, builder.build(), new HashMap<>(), list
-@@ -259,6 +_,11 @@
-                 @Override
+@@ -260,6 +_,11 @@
                  public <S> HolderGetter<S> lookup(ResourceKey<? extends Registry<? extends S>> p_255961_) {
                      return (HolderGetter<S>)BuildState.this.registries.getOrDefault(p_255961_.location(), BuildState.this.lookup);
-+                }
+                 }
 +
 +                @Override
 +                public <S> Optional<HolderLookup.RegistryLookup<S>> registryLookup(ResourceKey<? extends Registry<? extends S>> registry) {
 +                    return Optional.ofNullable((HolderLookup.RegistryLookup<S>) BuildState.this.registries.get(registry.location()));
-                 }
++                }
              };
          }
+ 
+@@ -407,7 +_,7 @@
+         }
+     }
+ 
+-    static class UniversalLookup extends RegistrySetBuilder.EmptyTagLookup<Object> {
++    static class UniversalLookup extends RegistrySetBuilder.EmptyTagLookup<Object> implements HolderLookup<Object> {
+         final Map<ResourceKey<Object>, Holder.Reference<Object>> holders = new HashMap<>();
+ 
+         public UniversalLookup(HolderOwner<Object> p_256629_) {
+@@ -417,6 +_,26 @@
+         @Override
+         public Optional<Holder.Reference<Object>> get(ResourceKey<Object> p_256303_) {
+             return Optional.of(this.getOrCreate(p_256303_));
++        }
++
++        @Override
++        public Stream<Holder.Reference<Object>> listElements() {
++            return holders.values().stream();
++        }
++
++        @Override
++        public Stream<ResourceKey<Object>> listElementIds() {
++            return holders.keySet().stream();
++        }
++
++        @Override
++        public Stream<HolderSet.Named<Object>> listTags() {
++            return Stream.empty();
++        }
++
++        @Override
++        public Stream<TagKey<Object>> listTagIds() {
++            return Stream.empty();
+         }
+ 
+         <T> Holder.Reference<T> getOrCreate(ResourceKey<T> p_256298_) {

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
@@ -85,7 +85,7 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
 
     @Override
     public boolean canSerializeIn(HolderOwner<T> holderOwner) {
-        return this.registryLookup.canSerializeIn(holderOwner);
+        return true;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
@@ -115,7 +115,7 @@ public class NotHolderSet<T> implements ICustomHolderSet<T> {
 
     @Override
     public boolean canSerializeIn(HolderOwner<T> holderOwner) {
-        return this.registryLookup.canSerializeIn(holderOwner);
+        return this.value.canSerializeIn(holderOwner);
     }
 
     @Override


### PR DESCRIPTION
Backport of #2165 to 1.21.3 (this PR will also be the one that 1.21.1 is backported from). Had to be manual because of the lack of interface injection on 1.21.3 and lower.

Fixes #1838 on 1.21.3
Fixes #2073 on 1.21.3