### PR TITLE
Fix Vanilla clients crashing the server due to updated server config sync

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/network/handlers/ClientPayloadHandler.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/handlers/ClientPayloadHandler.java
@@ -111,7 +111,7 @@ public final class ClientPayloadHandler {
     }
 
     private static void handle(ConfigFilePayload payload, IPayloadContext context) {
-        if (!Minecraft.getInstance().isLocalServer()) {
+        if (!context.connection().isMemoryConnection()) {
             ConfigSync.receiveSyncedConfig(payload.contents(), payload.fileName());
         }
     }

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -78,9 +78,14 @@ public final class ConfigSync {
                         return;
                     }
 
+                    var configFormat = loadedConfig.config().configFormat();
+                    if (configFormat.isInMemory()) {
+                        return; // An in-memory format indicates that we received this config from a server and shouldn't try to sync it
+                    }
+
                     // Write config bytes and queue for syncing to all connected players.
                     // This is harmless client-side, as the configsToSync map is either empty or full of stale connections.
-                    var bytes = loadedConfig.config().configFormat().createWriter().writeToString(loadedConfig.config()).getBytes(StandardCharsets.UTF_8);
+                    var bytes = configFormat.createWriter().writeToString(loadedConfig.config()).getBytes(StandardCharsets.UTF_8);
                     synchronized (lock) {
                         for (var toSync : configsToSync.values()) {
                             toSync.put(config.getFileName(), bytes);

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -94,6 +94,10 @@ public final class ConfigSync {
     public static void syncPendingConfigs(MinecraftServer server) {
         synchronized (lock) {
             for (var player : server.getPlayerList().getPlayers()) {
+                if (!player.connection.hasChannel(ConfigFilePayload.TYPE)) {
+                    continue; // Only sync configs to NeoForge clients supporting config sync
+                }
+
                 var toSync = configsToSync.get(player.connection.getConnection());
                 if (toSync == null) {
                     // null for GameTestPlayer. Should not happen for normal players though.

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -84,7 +84,6 @@ public final class ConfigSync {
                     }
 
                     // Write config bytes and queue for syncing to all connected players.
-                    // This is harmless client-side, as the configsToSync map is either empty or full of stale connections.
                     var bytes = configFormat.createWriter().writeToString(loadedConfig.config()).getBytes(StandardCharsets.UTF_8);
                     synchronized (lock) {
                         for (var toSync : configsToSync.values()) {

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -43,8 +43,13 @@ public final class ConfigSync {
     private ConfigSync() {}
 
     public static void syncAllConfigs(ServerConfigurationPacketListener listener) {
+        var connection = listener.getConnection();
+        if (connection.isMemoryConnection()) {
+            return; // Do not sync server configs with ourselves
+        }
+
         synchronized (lock) {
-            configsToSync.put(listener.getConnection(), new LinkedHashMap<>());
+            configsToSync.put(connection, new LinkedHashMap<>());
         }
 
         final Map<String, byte[]> configData = ModConfigs.getConfigSet(ModConfig.Type.SERVER).stream().collect(Collectors.toMap(ModConfig::getFileName, mc -> {
@@ -100,6 +105,10 @@ public final class ConfigSync {
             for (var player : server.getPlayerList().getPlayers()) {
                 if (!player.connection.hasChannel(ConfigFilePayload.TYPE)) {
                     continue; // Only sync configs to NeoForge clients supporting config sync
+                }
+
+                if (player.connection.getConnection().isMemoryConnection()) {
+                    continue; // Do not sync server configs with ourselves
                 }
 
                 var toSync = configsToSync.get(player.connection.getConnection());


### PR DESCRIPTION
Also skips re-syncing configs that are in-memory which prevents logging pointless exceptions on a client receiving synchronized configs.

Fixes #2221
Fixes #2223