### PR TITLE
Fix ATs in 1.20.4 so validateAccessTransformers works in userdev

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -525,7 +525,6 @@ public net.minecraft.world.level.levelgen.NoiseGeneratorSettings end(Lnet/minecr
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings overworld(Lnet/minecraft/data/worldgen/BootstapContext;ZZ)Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # overworld
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings floatingIslands(Lnet/minecraft/data/worldgen/BootstapContext;)Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # floatingIslands
 public net.minecraft.world.level.levelgen.NoiseGeneratorSettings nether(Lnet/minecraft/data/worldgen/BootstapContext;)Lnet/minecraft/world/level/levelgen/NoiseGeneratorSettings; # nether
-public net.minecraft.world.level.levelgen.NoiseGeneratorSettings lambda$static$0(Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App; # lambda$static$0
 #endgroup
 public net.minecraft.world.level.levelgen.feature.featuresize.FeatureSizeType <init>(Lcom/mojang/serialization/Codec;)V # constructor
 public net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacerType <init>(Lcom/mojang/serialization/Codec;)V # constructor


### PR DESCRIPTION
(To be confirmed using PR publishing).

Is this a breaking change? I hope not...