### PR TITLE
add ability to get attachment data without an optional or creation

### DIFF
--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -53,8 +53,8 @@
 +
 +    @Override
 +    @Nullable
-+    public <T> T getExistingDataNullable(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
-+        return getAttachmentHolder().getExistingDataNullable(type);
++    public <T> T getExistingDataOrNull(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        return getAttachmentHolder().getExistingDataOrNull(type);
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/patches/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -28,7 +28,7 @@
                              }
                          }
                      }
-@@ -490,6 +_,74 @@
+@@ -490,6 +_,75 @@
      public ChunkSkyLightSources getSkyLightSources() {
          return this.skyLightSources;
      }
@@ -52,8 +52,9 @@
 +    }
 +
 +    @Override
-+    public <T> java.util.Optional<T> getExistingData(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
-+        return getAttachmentHolder().getExistingData(type);
++    @Nullable
++    public <T> T getExistingDataNullable(net.neoforged.neoforge.attachment.AttachmentType<T> type) {
++        return getAttachmentHolder().getExistingDataNullable(type);
 +    }
 +
 +    @Override

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -83,7 +83,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
 
     @Override
     @Nullable
-    public <T> T getExistingDataNullable(AttachmentType<T> type) {
+    public <T> T getExistingDataOrNull(AttachmentType<T> type) {
         validateAttachmentType(type);
         if (attachments == null) {
             return null;

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -9,7 +9,6 @@ import com.mojang.logging.LogUtils;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -83,12 +82,13 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
     }
 
     @Override
-    public <T> Optional<T> getExistingData(AttachmentType<T> type) {
+    @Nullable
+    public <T> T getExistingDataNullable(AttachmentType<T> type) {
         validateAttachmentType(type);
         if (attachments == null) {
-            return Optional.empty();
+            return null;
         }
-        return Optional.ofNullable((T) this.attachments.get(type));
+        return (T) this.attachments.get(type);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -53,14 +53,14 @@ public interface IAttachmentHolder {
      * <p>If there is no data attachment of the given type, an empty optional is returned.
      */
     default <T> Optional<T> getExistingData(AttachmentType<T> type) {
-        return Optional.ofNullable(getExistingDataNullable(type));
+        return Optional.ofNullable(getExistingDataOrNull(type));
     }
 
     /**
      * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type
      */
     @Nullable
-    <T> T getExistingDataNullable(AttachmentType<T> type);
+    <T> T getExistingDataOrNull(AttachmentType<T> type);
 
     /**
      * {@return an optional possibly containing a data attachment value of the given type}
@@ -75,8 +75,8 @@ public interface IAttachmentHolder {
      * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type
      */
     @Nullable
-    default <T> T getExistingDataNullable(Supplier<AttachmentType<T>> type) {
-        return getExistingDataNullable(type.get());
+    default <T> T getExistingDataOrNull(Supplier<AttachmentType<T>> type) {
+        return getExistingDataOrNull(type.get());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -52,7 +52,15 @@ public interface IAttachmentHolder {
      *
      * <p>If there is no data attachment of the given type, an empty optional is returned.
      */
-    <T> Optional<T> getExistingData(AttachmentType<T> type);
+    default <T> Optional<T> getExistingData(AttachmentType<T> type) {
+        return Optional.ofNullable(getExistingDataNullable(type));
+    }
+
+    /**
+     * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type
+     */
+    @Nullable
+    <T> T getExistingDataNullable(AttachmentType<T> type);
 
     /**
      * {@return an optional possibly containing a data attachment value of the given type}
@@ -61,6 +69,14 @@ public interface IAttachmentHolder {
      */
     default <T> Optional<T> getExistingData(Supplier<AttachmentType<T>> type) {
         return getExistingData(type.get());
+    }
+
+    /**
+     * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type
+     */
+    @Nullable
+    default <T> T getExistingDataNullable(Supplier<AttachmentType<T>> type) {
+        return getExistingDataNullable(type.get());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/IAttachmentHolder.java
@@ -57,12 +57,6 @@ public interface IAttachmentHolder {
     }
 
     /**
-     * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type
-     */
-    @Nullable
-    <T> T getExistingDataOrNull(AttachmentType<T> type);
-
-    /**
      * {@return an optional possibly containing a data attachment value of the given type}
      *
      * <p>If there is no data attachment of the given type, an empty optional is returned.
@@ -70,6 +64,12 @@ public interface IAttachmentHolder {
     default <T> Optional<T> getExistingData(Supplier<AttachmentType<T>> type) {
         return getExistingData(type.get());
     }
+
+    /**
+     * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type
+     */
+    @Nullable
+    <T> T getExistingDataOrNull(AttachmentType<T> type);
 
     /**
      * @return an existing data attachment value of the given type, or null if there is no data attachment of the given type


### PR DESCRIPTION
Currently the only way to avoid creation of attachment data is to use an optional. This is fine when the data _doesn't_ exist, but creates a useless allocation when there _is_. 
Not great for hot paths, like a BE that uses attachments to store its data.

Limited context on Neocord: https://discord.com/channels/313125603924639766/852298000042164244/1225342963740180553

It'd be great to have this backported to 21.1