### PR TITLE
Fix dry foliage color being dropped during biome modification

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/world/BiomeSpecialEffectsBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/BiomeSpecialEffectsBuilder.java
@@ -24,6 +24,7 @@ public class BiomeSpecialEffectsBuilder extends BiomeSpecialEffects.Builder {
         BiomeSpecialEffectsBuilder builder = BiomeSpecialEffectsBuilder.create(baseEffects.getFogColor(), baseEffects.getWaterColor(), baseEffects.getWaterFogColor(), baseEffects.getSkyColor());
         builder.grassColorModifier = baseEffects.getGrassColorModifier();
         baseEffects.getFoliageColorOverride().ifPresent(builder::foliageColorOverride);
+        baseEffects.getDryFoliageColorOverride().ifPresent(builder::dryFoliageColorOverride);
         baseEffects.getGrassColorOverride().ifPresent(builder::grassColorOverride);
         baseEffects.getAmbientParticleSettings().ifPresent(builder::ambientParticle);
         baseEffects.getAmbientLoopSoundEvent().ifPresent(builder::ambientLoopSound);
@@ -68,6 +69,10 @@ public class BiomeSpecialEffectsBuilder extends BiomeSpecialEffects.Builder {
 
     public Optional<Integer> getFoliageColorOverride() {
         return this.foliageColorOverride;
+    }
+
+    public Optional<Integer> getDryFoliageColorOverride() {
+        return this.dryFoliageColorOverride;
     }
 
     public Optional<Integer> getGrassColorOverride() {


### PR DESCRIPTION
Fixes #2238 

The new `dry_foliage_color` field was not being preserved when copying an existing biome for the purposes of modifying it.

This fixes the dry foliage color tint not using the biome override for it:
![image](https://github.com/user-attachments/assets/e5ce5712-53d4-4229-8ca5-ffa7089fef92)
