### PR TITLE
[1.21.5] Add sysprop to disable Blaze3D validation

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/GlRenderPass.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlRenderPass.java.patch
@@ -1,5 +1,14 @@
 --- a/com/mojang/blaze3d/opengl/GlRenderPass.java
 +++ b/com/mojang/blaze3d/opengl/GlRenderPass.java
+@@ -19,7 +_,7 @@
+ @OnlyIn(Dist.CLIENT)
+ public class GlRenderPass implements RenderPass {
+     protected static final int MAX_VERTEX_BUFFERS = 1;
+-    public static final boolean VALIDATION = SharedConstants.IS_RUNNING_IN_IDE;
++    public static final boolean VALIDATION = SharedConstants.IS_RUNNING_IN_IDE && !Boolean.parseBoolean(System.getProperty("neoforge.disableGlValidation", "false"));
+     private final GlCommandEncoder encoder;
+     private final boolean hasDepthTexture;
+     private boolean closed;
 @@ -34,6 +_,8 @@
      protected final HashMap<String, GpuTexture> samplers = new HashMap<>();
      protected final Set<String> dirtyUniforms = new HashSet<>();

--- a/patches/com/mojang/blaze3d/opengl/GlRenderPass.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlRenderPass.java.patch
@@ -5,7 +5,7 @@
  public class GlRenderPass implements RenderPass {
      protected static final int MAX_VERTEX_BUFFERS = 1;
 -    public static final boolean VALIDATION = SharedConstants.IS_RUNNING_IN_IDE;
-+    public static final boolean VALIDATION = SharedConstants.IS_RUNNING_IN_IDE && !Boolean.parseBoolean(System.getProperty("neoforge.disableGlValidation", "false"));
++    public static final boolean VALIDATION = SharedConstants.IS_RUNNING_IN_IDE && !Boolean.getBoolean("neoforge.disableGlValidation");
      private final GlCommandEncoder encoder;
      private final boolean hasDepthTexture;
      private boolean closed;


### PR DESCRIPTION
This PR adds a system property to allow disabling the validation in Blaze3D without setting `SharedConstants.IS_RUNNING_IN_IDE` to false and therefore disabling all other features associated with it.

The primary use case is to prevent crashes in the validation when the shader compiler does not behave the way the validator expects it to. The main known case of this is related to the `entity.vsh`/`entity.fsh` shaders with `RenderPipeline`s declaring the `EMISSIVE` define where some GPU drivers don't perform dead code elimination in the way the validator expects (the mechanism is identical to the one described [here](https://github.com/neoforged/NeoForge/issues/2046#issuecomment-2746646042) except that the cause lies in the shader compiler not eliminating the technically unused `Sampler2` instead of the shader itself using that sampler when it shouldn't). This is reproducable with certain GPUs (appears to primarily affect AMD GPUs) in an empty mod dev environment by spawning a Warden.