### PR TITLE
[1.21.5] Prevent BlockCapabilityCache keeping capability references for too long.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/BlockCapabilityCache.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/BlockCapabilityCache.java
@@ -100,6 +100,8 @@ public final class BlockCapabilityCache<T, C extends @Nullable Object> {
             canQuery = false;
             // mark cached cap as invalid
             cacheValid = false;
+            // clear cached cap
+            cachedCap = null;
 
             if (isValid.getAsBoolean()) {
                 // notify


### PR DESCRIPTION
I noticed that `BlockCapabilityCache` will hold a reference to the previously cached capability if it is not queried again (for example if the caller knows no block exists at that side anymore).
This PR clears the cached capability immediately to allow the garbage collector to tidy the capability.