### PR TITLE
[1.21.5] Properly intern full-cube face occlusion shapes generated from shapes with multiple boxes

### DIFF
--- a/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -62,7 +62,7 @@
 -                    this.occlusionShapesByFace[direction.ordinal()] = this.occlusionShape.getFaceShape(direction);
 +                    // Neo: properly intern full-cube face shapes generated from shapes with multiple boxes
 +                    VoxelShape faceOcclusionShape = this.occlusionShape.getFaceShape(direction);
-+                    if (faceOcclusionShape != Shapes.block() && Block.isShapeFullBlock(faceOcclusionShape)) {
++                    if (faceOcclusionShape != Shapes.empty() && faceOcclusionShape != Shapes.block() && Block.isShapeFullBlock(faceOcclusionShape)) {
 +                        faceOcclusionShape = Shapes.block();
 +                    }
 +                    this.occlusionShapesByFace[direction.ordinal()] = faceOcclusionShape;

--- a/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -55,6 +55,20 @@
      public abstract static class BlockStateBase extends StateHolder<Block, BlockState> {
          private static final Direction[] DIRECTIONS = Direction.values();
          private static final VoxelShape[] EMPTY_OCCLUSION_SHAPES = Util.make(
+@@ -508,7 +_,12 @@
+                 this.occlusionShapesByFace = new VoxelShape[DIRECTIONS.length];
+ 
+                 for (Direction direction : DIRECTIONS) {
+-                    this.occlusionShapesByFace[direction.ordinal()] = this.occlusionShape.getFaceShape(direction);
++                    // Neo: properly intern full-cube face shapes generated from shapes with multiple boxes
++                    VoxelShape faceOcclusionShape = this.occlusionShape.getFaceShape(direction);
++                    if (faceOcclusionShape != Shapes.block() && Block.isShapeFullBlock(faceOcclusionShape)) {
++                        faceOcclusionShape = Shapes.block();
++                    }
++                    this.occlusionShapesByFace[direction.ordinal()] = faceOcclusionShape;
+                 }
+             }
+ 
 @@ -563,12 +_,14 @@
              return this.useShapeForLightOcclusion;
          }


### PR DESCRIPTION
This PR fixes full-cube face occlusion shapes generated from shapes with multiple boxes not being replaced with the `Shapes.BLOCK` singleton.

Since 1.21.2, face occlusion checks in `Block.shouldRenderFace()` perform reference equality checks against the `Shapes.BLOCK` and `Shapes.EMPTY` singletons in multiple places, the one relevant for this case being the first early exit when the occluding block has a full-cube face occlusion shape on the side opposite to the face being occluded.
When the face occlusion shapes are computed, they are checked for `VoxelShape#isEmpty()` and `VoxelShape#isCubeLike()` in order to replace them with the aforementioned singletons. The latter check however relies on the original shape only consisting of a single box. This means that blocks like stairs for example which have an occlusion shape with two or three boxes do not have their face occlusion shape on the full faces turned into the `Shapes.BLOCK` singleton.

In vanilla this only manifests itself as an efficiency hit during chunk rendering (both during meshing and actual rendering) due to the unnecessary shape comparisons during occlusion checks and due to unnecessary quads being rendered when this bug causes the occlusion check to incorrectly consider the face visible. The latter can be reproduced by placing a glass block behind or below a straight stair block and flying into the stair block in spectator mode.
In mods this can cause more severe issues. An example of such a case is a connected textures system checking whether a connection should be prevented by an adjacent occluding block.