### PR TITLE
Backport to 1.21.1: Prevent BlockCapabilityCache keeping capability references for too long.

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/BlockCapabilityCache.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/BlockCapabilityCache.java
@@ -100,6 +100,8 @@ public final class BlockCapabilityCache<T, C extends @Nullable Object> {
             canQuery = false;
             // mark cached cap as invalid
             cacheValid = false;
+            // clear cached cap
+            cachedCap = null;
 
             if (isValid.getAsBoolean()) {
                 // notify


### PR DESCRIPTION
Backport of #2255 to 1.21.1.