### PR TITLE
Disable syncing registries to client in singleplayer

### DIFF
--- a/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
@@ -37,7 +37,8 @@ public class ConfigurationInitialization {
     public static void configureEarlyTasks(ServerConfigurationPacketListener listener, Consumer<ConfigurationTask> tasks) {
         if (listener.hasChannel(FrozenRegistrySyncStartPayload.TYPE) &&
                 listener.hasChannel(FrozenRegistryPayload.TYPE) &&
-                listener.hasChannel(FrozenRegistrySyncCompletedPayload.TYPE)) {
+                listener.hasChannel(FrozenRegistrySyncCompletedPayload.TYPE) &&
+                !listener.getConnection().isMemoryConnection()) {
             tasks.accept(new SyncRegistries());
         }
     }


### PR DESCRIPTION
This should fix #2254, and the fix for that issue should be backported to 1.21.1. The registry sync packets are no longer sent in singleplayer. Syncing built-in (non-data-driven) registries is redundant as the client uses the same objects as the server.