### PR TITLE
[1.21.5] Allow blocks full control over step, fall and hit sounds

### DIFF
--- a/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -60,11 +60,13 @@
                  this.destroyBlock(p_105284_);
                  return new ServerboundPlayerActionPacket(ServerboundPlayerActionPacket.Action.START_DESTROY_BLOCK, p_105284_, p_105285_, p_233753_);
              });
-@@ -219,7 +_,7 @@
+@@ -218,8 +_,8 @@
+                 return false;
              } else {
                  this.destroyProgress = this.destroyProgress + blockstate.getDestroyProgress(this.minecraft.player, this.minecraft.player.level(), p_105284_);
-                 if (this.destroyTicks % 4.0F == 0.0F) {
+-                if (this.destroyTicks % 4.0F == 0.0F) {
 -                    SoundType soundtype = blockstate.getSoundType();
++                if (this.destroyTicks % 4.0F == 0.0F && !net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions.of(blockstate).playHitSound(blockstate, this.minecraft.level, p_105284_, p_105285_, this.minecraft.getSoundManager())) {
 +                    SoundType soundtype = blockstate.getSoundType(this.minecraft.level, p_105284_, this.minecraft.player);
                      this.minecraft
                          .getSoundManager()

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -78,7 +78,7 @@
 -    protected void playMuffledStepSound(BlockState p_283110_) {
 -        SoundType soundtype = p_283110_.getSoundType();
 +    protected void playMuffledStepSound(BlockState p_283110_, BlockPos pos) {
-+        if (p_283110_.playStepSound(this.level, pos, this, .05F, .5F)) return;
++        if (p_283110_.playStepSound(this.level, pos, this, .05F, .8F)) return;
 +        SoundType soundtype = p_283110_.getSoundType(this.level, pos, this);
          this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.05F, soundtype.getPitch() * 0.8F);
      }

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -59,7 +59,7 @@
                      ? blockpos.atY(Mth.floor(this.position.y - p_216987_))
                      : blockpos;
              }
-@@ -1184,19 +_,23 @@
+@@ -1184,20 +_,17 @@
          return !blockstate.is(BlockTags.INSIDE_STEP_SOUND_BLOCKS) && !blockstate.is(BlockTags.COMBINATION_STEP_SOUND_BLOCKS) ? p_278049_ : blockpos;
      }
  
@@ -68,28 +68,24 @@
 -        this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
 -        this.playMuffledStepSound(p_277630_);
 +    protected void playCombinationStepSounds(BlockState p_277472_, BlockState p_277630_, BlockPos primaryPos, BlockPos secondaryPos) {
-+        if (!p_277472_.playStepSound(this.level, primaryPos, this, .15F, 1F)) {
-+            SoundType soundtype = p_277472_.getSoundType(this.level, primaryPos, this);
-+            this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
-+        }
++        p_277472_.playStepSound(this.level, primaryPos, this, .15F, 1F);
 +        this.playMuffledStepSound(p_277630_, secondaryPos);
      }
  
 -    protected void playMuffledStepSound(BlockState p_283110_) {
 -        SoundType soundtype = p_283110_.getSoundType();
+-        this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.05F, soundtype.getPitch() * 0.8F);
 +    protected void playMuffledStepSound(BlockState p_283110_, BlockPos pos) {
-+        if (p_283110_.playStepSound(this.level, pos, this, .05F, .8F)) return;
-+        SoundType soundtype = p_283110_.getSoundType(this.level, pos, this);
-         this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.05F, soundtype.getPitch() * 0.8F);
++        p_283110_.playStepSound(this.level, pos, this, .05F, .8F);
      }
  
      protected void playStepSound(BlockPos p_20135_, BlockState p_20136_) {
 -        SoundType soundtype = p_20136_.getSoundType();
-+        if (p_20136_.playStepSound(this.level(), p_20135_, this, .15F, 1F)) return;
-+        SoundType soundtype = p_20136_.getSoundType(this.level, p_20135_, this);
-         this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
+-        this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
++        p_20136_.playStepSound(this.level(), p_20135_, this, .15F, 1F);
      }
  
+     private boolean shouldPlayAmethystStepSound(BlockState p_278069_) {
 @@ -1351,20 +_,23 @@
  
      public void updateSwimming() {

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -59,28 +59,33 @@
                      ? blockpos.atY(Mth.floor(this.position.y - p_216987_))
                      : blockpos;
              }
-@@ -1184,19 +_,19 @@
+@@ -1184,19 +_,23 @@
          return !blockstate.is(BlockTags.INSIDE_STEP_SOUND_BLOCKS) && !blockstate.is(BlockTags.COMBINATION_STEP_SOUND_BLOCKS) ? p_278049_ : blockpos;
      }
  
 -    protected void playCombinationStepSounds(BlockState p_277472_, BlockState p_277630_) {
 -        SoundType soundtype = p_277472_.getSoundType();
-+    protected void playCombinationStepSounds(BlockState p_277472_, BlockState p_277630_, BlockPos primaryPos, BlockPos secondaryPos) {
-+        SoundType soundtype = p_277472_.getSoundType(this.level, primaryPos, this);
-         this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
+-        this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
 -        this.playMuffledStepSound(p_277630_);
++    protected void playCombinationStepSounds(BlockState p_277472_, BlockState p_277630_, BlockPos primaryPos, BlockPos secondaryPos) {
++        if (!p_277472_.playStepSound(this.level, primaryPos, this, .15F, 1F)) {
++            SoundType soundtype = p_277472_.getSoundType(this.level, primaryPos, this);
++            this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
++        }
 +        this.playMuffledStepSound(p_277630_, secondaryPos);
      }
  
 -    protected void playMuffledStepSound(BlockState p_283110_) {
 -        SoundType soundtype = p_283110_.getSoundType();
 +    protected void playMuffledStepSound(BlockState p_283110_, BlockPos pos) {
++        if (p_283110_.playStepSound(this.level, pos, this, .05F, .5F)) return;
 +        SoundType soundtype = p_283110_.getSoundType(this.level, pos, this);
          this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.05F, soundtype.getPitch() * 0.8F);
      }
  
      protected void playStepSound(BlockPos p_20135_, BlockState p_20136_) {
 -        SoundType soundtype = p_20136_.getSoundType();
++        if (p_20136_.playStepSound(this.level(), p_20135_, this, .15F, 1F)) return;
 +        SoundType soundtype = p_20136_.getSoundType(this.level, p_20135_, this);
          this.playSound(soundtype.getStepSound(), soundtype.getVolume() * 0.15F, soundtype.getPitch());
      }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -385,10 +385,11 @@
              int j = Mth.floor(this.getY() - 0.2F);
              int k = Mth.floor(this.getZ());
 -            BlockState blockstate = this.level().getBlockState(new BlockPos(i, j, k));
+-            if (!blockstate.isAir()) {
+-                SoundType soundtype = blockstate.getSoundType();
 +            BlockPos pos = new BlockPos(i, j, k);
 +            BlockState blockstate = this.level().getBlockState(pos);
-             if (!blockstate.isAir()) {
--                SoundType soundtype = blockstate.getSoundType();
++            if (!blockstate.isAir() && !blockstate.playFallSound(this.level(), pos, this)) {
 +                SoundType soundtype = blockstate.getSoundType(level(), pos, this);
                  this.playSound(soundtype.getFallSound(), soundtype.getVolume() * 0.5F, soundtype.getPitch() * 0.75F);
              }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -380,20 +380,20 @@
          boolean flag = super.causeFallDamage(p_397597_, p_147187_, p_147189_);
          int i = this.calculateFallDamage(p_397597_, p_147187_);
          if (i > 0) {
-@@ -1697,9 +_,10 @@
+@@ -1697,10 +_,10 @@
              int i = Mth.floor(this.getX());
              int j = Mth.floor(this.getY() - 0.2F);
              int k = Mth.floor(this.getZ());
 -            BlockState blockstate = this.level().getBlockState(new BlockPos(i, j, k));
--            if (!blockstate.isAir()) {
--                SoundType soundtype = blockstate.getSoundType();
 +            BlockPos pos = new BlockPos(i, j, k);
 +            BlockState blockstate = this.level().getBlockState(pos);
-+            if (!blockstate.isAir() && !blockstate.playFallSound(this.level(), pos, this)) {
-+                SoundType soundtype = blockstate.getSoundType(level(), pos, this);
-                 this.playSound(soundtype.getFallSound(), soundtype.getVolume() * 0.5F, soundtype.getPitch() * 0.75F);
+             if (!blockstate.isAir()) {
+-                SoundType soundtype = blockstate.getSoundType();
+-                this.playSound(soundtype.getFallSound(), soundtype.getVolume() * 0.5F, soundtype.getPitch() * 0.75F);
++                blockstate.playFallSound(this.level(), pos, this);
              }
          }
+     }
 @@ -1725,6 +_,8 @@
          if (!(p_330394_ <= 0.0F)) {
              int i = (int)Math.max(1.0F, p_330394_ / 4.0F);

--- a/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
@@ -7,7 +7,9 @@ package net.neoforged.neoforge.client.extensions.common;
 
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
@@ -69,6 +71,20 @@ public interface IClientBlockExtensions {
      */
     default boolean addDestroyEffects(BlockState state, Level Level, BlockPos pos, ParticleEngine manager) {
         return !state.shouldSpawnTerrainParticles();
+    }
+
+    /**
+     * Play hit sound(s) when the block is punched.
+     *
+     * @param state        The current state
+     * @param level        The current level
+     * @param pos          The position of the block
+     * @param face         The face of the block that was hit
+     * @param soundManager The sound manager to play the sound(s) through
+     * @return True to prevent vanilla hit sounds from playing
+     */
+    default boolean playHitSound(BlockState state, Level level, BlockPos pos, Direction face, SoundManager soundManager) {
+        return false;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -361,6 +361,39 @@ public interface IBlockExtension {
     }
 
     /**
+     * Allows a block to override the standard fall sound played in {@link LivingEntity#playBlockFallSound()}.
+     *
+     * @param state  The block being fallen onto
+     * @param level  The level which the block is in
+     * @param pos    The position of the block in the level
+     * @param entity The entity falling onto the block
+     */
+    default boolean playFallSound(BlockState state, Level level, BlockPos pos, LivingEntity entity) {
+        return false;
+    }
+
+    /**
+     * Allows a block to override the standard step sound played in:
+     * <ul>
+     * <li>{@link Entity#playCombinationStepSounds(BlockState, BlockState, BlockPos, BlockPos)} (primary step sound only)</li>
+     * <li>{@link Entity#playMuffledStepSound(BlockState, BlockPos)} (usually the secondary sound in a call to the above method)</li>
+     * <li>{@link Entity#playStepSound(BlockPos, BlockState)} (simple step sound)</li>
+     * </ul>
+     * The volume and pitch of any sound played in this method should be multiplied with the provided multipliers to
+     * replicate the behaviour of the callers.
+     *
+     * @param state            The block being stepped on
+     * @param level            The level which the block is in
+     * @param pos              The position of the block in the level
+     * @param entity           The entity stepping on the block
+     * @param volumeMultiplier The volume multiplier to apply to the step sound being played
+     * @param pitchMultiplier  The pitch multiplier to apply to the step sound being played
+     */
+    default boolean playStepSound(BlockState state, Level level, BlockPos pos, Entity entity, float volumeMultiplier, float pitchMultiplier) {
+        return false;
+    }
+
+    /**
      * Determines if this block either force allow or force disallow a plant from being placed on it. (Or pass and let the plant's decision win)
      * This will be called in plant's canSurvive method and/or mayPlace method.
      *

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -368,8 +368,9 @@ public interface IBlockExtension {
      * @param pos    The position of the block in the level
      * @param entity The entity falling onto the block
      */
-    default boolean playFallSound(BlockState state, Level level, BlockPos pos, LivingEntity entity) {
-        return false;
+    default void playFallSound(BlockState state, Level level, BlockPos pos, LivingEntity entity) {
+        SoundType soundType = state.getSoundType(level, pos, entity);
+        entity.playSound(soundType.getFallSound(), soundType.getVolume() * .5F, soundType.getPitch() * .75F);
     }
 
     /**
@@ -389,8 +390,9 @@ public interface IBlockExtension {
      * @param volumeMultiplier The volume multiplier to apply to the step sound being played
      * @param pitchMultiplier  The pitch multiplier to apply to the step sound being played
      */
-    default boolean playStepSound(BlockState state, Level level, BlockPos pos, Entity entity, float volumeMultiplier, float pitchMultiplier) {
-        return false;
+    default void playStepSound(BlockState state, Level level, BlockPos pos, Entity entity, float volumeMultiplier, float pitchMultiplier) {
+        SoundType soundType = state.getSoundType(level, pos, entity);
+        entity.playSound(soundType.getStepSound(), soundType.getVolume() * volumeMultiplier, soundType.getPitch() * pitchMultiplier);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -265,8 +265,8 @@ public interface IBlockStateExtension {
      * @param pos    The position of the block in the level
      * @param entity The entity falling onto the block
      */
-    default boolean playFallSound(Level level, BlockPos pos, LivingEntity entity) {
-        return self().getBlock().playFallSound(self(), level, pos, entity);
+    default void playFallSound(Level level, BlockPos pos, LivingEntity entity) {
+        self().getBlock().playFallSound(self(), level, pos, entity);
     }
 
     /**
@@ -285,8 +285,8 @@ public interface IBlockStateExtension {
      * @param volumeMultiplier The volume multiplier to apply to the step sound being played
      * @param pitchMultiplier  The pitch multiplier to apply to the step sound being played
      */
-    default boolean playStepSound(Level level, BlockPos pos, Entity entity, float volumeMultiplier, float pitchMultiplier) {
-        return self().getBlock().playStepSound(self(), level, pos, entity, volumeMultiplier, pitchMultiplier);
+    default void playStepSound(Level level, BlockPos pos, Entity entity, float volumeMultiplier, float pitchMultiplier) {
+        self().getBlock().playStepSound(self(), level, pos, entity, volumeMultiplier, pitchMultiplier);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -259,6 +259,37 @@ public interface IBlockStateExtension {
     }
 
     /**
+     * Allows a block to override the standard fall sound played in {@link LivingEntity#playBlockFallSound()}.
+     *
+     * @param level  The level which the block is in
+     * @param pos    The position of the block in the level
+     * @param entity The entity falling onto the block
+     */
+    default boolean playFallSound(Level level, BlockPos pos, LivingEntity entity) {
+        return self().getBlock().playFallSound(self(), level, pos, entity);
+    }
+
+    /**
+     * Allows a block to override the standard step sound played in:
+     * <ul>
+     * <li>{@link Entity#playCombinationStepSounds(BlockState, BlockState, BlockPos, BlockPos)} (primary step sound only)</li>
+     * <li>{@link Entity#playMuffledStepSound(BlockState, BlockPos)} (usually the secondary sound in a call to the above method)</li>
+     * <li>{@link Entity#playStepSound(BlockPos, BlockState)} (simple step sound)</li>
+     * </ul>
+     * The volume and pitch of any sound played in this method should be multiplied with the provided multipliers to
+     * replicate the behaviour of the callers.
+     *
+     * @param level            The level which the block is in
+     * @param pos              The position of the block in the level
+     * @param entity           The entity stepping on the block
+     * @param volumeMultiplier The volume multiplier to apply to the step sound being played
+     * @param pitchMultiplier  The pitch multiplier to apply to the step sound being played
+     */
+    default boolean playStepSound(Level level, BlockPos pos, Entity entity, float volumeMultiplier, float pitchMultiplier) {
+        return self().getBlock().playStepSound(self(), level, pos, entity, volumeMultiplier, pitchMultiplier);
+    }
+
+    /**
      * Determines if this block either force allow or force disallow a plant from being placed on it. (Or pass and let the plant's decision win)
      * This will be called in plant's canSurvive method and/or mayPlace method.
      *


### PR DESCRIPTION
This PR adds hooks to allow mods full control over the sound being played when a block is punched, stepped on or fallen onto.
This is useful in cases these sounds cannot be provided as part of a `SoundType` from `IBlockExtension#getSoundType()` or multiple sounds are desired.

- The hit sound hook is the sound-equivalent to the `IClientBlockExtensions#addHitEffects()` particle hook.
- The step sound hook is the sound-equivalent to the `IBlockExtension#addRunningEffects()` particle hook, except not limited to sprinting
- The fall sound hook is the sound-equivalent to the `IBlockExtension#addLandingEffects()` particle hook

My specific use case is a block imitating two other arbitrary blocks, which should both have sounds of the relevant type played, at all times when the block is hit and in cases where both imitated blocks are visible at the top surface when the block is stepped or fallen onto. 