### PR TITLE
Add an alternative register method to RegisterRenderPipelinesEvent

### DIFF
--- a/patches/net/minecraft/client/renderer/RenderPipelines.java.patch
+++ b/patches/net/minecraft/client/renderer/RenderPipelines.java.patch
@@ -7,9 +7,9 @@
 +
 +    @org.jetbrains.annotations.ApiStatus.Internal
 +    public static void registerCustomPipelines() {
-+        var event = new net.neoforged.neoforge.client.event.RegisterRenderPipelinesEvent(pipeline -> {
++        var event = new net.neoforged.neoforge.client.event.RegisterRenderPipelinesEvent((pipeline, errorOnRegistered) -> {
 +            if (PIPELINES_BY_LOCATION.putIfAbsent(pipeline.getLocation(), pipeline) != null) {
-+                throw new IllegalStateException("Duplicate RenderPipeline registration for location: " + pipeline.getLocation());
++                if(errorOnRegistered) throw new IllegalStateException("Duplicate RenderPipeline registration for location: " + pipeline.getLocation());
 +            }
 +        });
 +        net.neoforged.fml.ModLoader.postEvent(event);

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterRenderPipelinesEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterRenderPipelinesEvent.java
@@ -6,7 +6,7 @@
 package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
@@ -22,10 +22,10 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RegisterRenderPipelinesEvent extends Event implements IModBusEvent {
-    private final Consumer<RenderPipeline> registrar;
+    private final BiConsumer<RenderPipeline, Boolean> registrar;
 
     @ApiStatus.Internal
-    public RegisterRenderPipelinesEvent(Consumer<RenderPipeline> registrar) {
+    public RegisterRenderPipelinesEvent(BiConsumer<RenderPipeline, Boolean> registrar) {
         this.registrar = registrar;
     }
 
@@ -35,6 +35,15 @@ public class RegisterRenderPipelinesEvent extends Event implements IModBusEvent 
      * @param pipeline a pipeline
      */
     public void registerPipeline(RenderPipeline pipeline) {
-        registrar.accept(pipeline);
+        registrar.accept(pipeline, true);
+    }
+
+    /**
+     * Attempts to register a {@link RenderPipeline}, failing gracefully if the pipeline is already registered.
+     *
+     * @param pipeline a pipeline
+     */
+    public void tryRegisterPipeline(RenderPipeline pipeline) {
+        registrar.accept(pipeline, false);
     }
 }


### PR DESCRIPTION
Less kaboom if a library needs access to registration.

Use-case is something like Gander, which can provide pre-built and common pipelines, would currently be FORCED to either be a mod to claim its namespace (and be a singular event listener) or for the library to provide a supplier-style method to register under another mod's namespace (which sucks for multiple reasons).

This means that the library can provide the pipeline and a simple registration hook, and multiple mods can safely call the hook without worrying about who "won" in the event order.