### PR TITLE
Add permanent registry alias for always/never conditions

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -375,6 +375,12 @@ public class NeoForgeMod {
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<TagEmptyCondition<?>>> TAG_EMPTY_CONDITION = CONDITION_CODECS.register("tag_empty", () -> TagEmptyCondition.CODEC);
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<AlwaysCondition>> ALWAYS_CONDITION = CONDITION_CODECS.register("always", () -> AlwaysCondition.CODEC);
     public static final DeferredHolder<MapCodec<? extends ICondition>, MapCodec<FeatureFlagsEnabledCondition>> FEATURE_FLAGS_ENABLED_CONDITION = CONDITION_CODECS.register("feature_flags_enabled", () -> FeatureFlagsEnabledCondition.CODEC);
+    static {
+        // Allows older json still using `neoforge:true` and `neoforge:false` in mods and datapacks to continue to work as expected.
+        // No plans to remove this alias in the future. Though try and use `neoforge:always` and `neoforge:never` going forward.
+        CONDITION_CODECS.addAlias(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "false"), ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "never"));
+        CONDITION_CODECS.addAlias(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "true"), ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "always"));
+    }
 
     private static final DeferredRegister<MapCodec<? extends EntitySubPredicate>> ENTITY_PREDICATE_CODECS = DeferredRegister.create(Registries.ENTITY_SUB_PREDICATE_TYPE, NeoForgeVersion.MOD_ID);
     public static final DeferredHolder<MapCodec<? extends EntitySubPredicate>, MapCodec<PiglinNeutralArmorEntityPredicate>> PIGLIN_NEUTRAL_ARMOR_PREDICATE = ENTITY_PREDICATE_CODECS.register("piglin_neutral_armor", () -> PiglinNeutralArmorEntityPredicate.CODEC);


### PR DESCRIPTION
When this other PR was done in 1.21.4:
https://github.com/neoforged/NeoForge/pull/1716

It had to rename the true/false conditions to always/never in the code because true/false were reserved Java keywords. The JSON was changed to match the new code name.

However, this does mean any older mod or datapack still using `neoforge:true`/`neoforge:false`, they will now break when trying to be used on newer versions. It seems like an unneeded breaking change that we can easily help stop.

I would like us to add a permanent registry alias for `neoforge:true`/`neoforge:false` to `neoforge:always`/`neoforge:never`. And then back port it to 1.21.4 as well.

This incurs 0 maintenance cost because we will never need to touch this again. It also will not cause confusion because if serializing or parsing through codecs, the end result will always be using always/never. Thus the true/false is hidden away and only to help load older JSON. And true vs always and false vs never are easily understood as equivalent.

As for any slippery slope arguments, those are well, not very strong arguments. Most of what we do is handled on a case-by-case basis on pros/cons/maintenance cost/time spent/etc. This alias gives a nice small benefit to ease modders and datapack devs so we don't cause them more work that wasn't needed to be thrust upon them while also costing us like 0 effort to add and keep. Therefore, it seems good to add it and not remove it going forward. Doesn't seem like tech debt to me.