### PR TITLE
Backport to 1.21.1: Add source entity to MobEffectEvent.Applicable

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -117,7 +117,7 @@
  
      public boolean addEffect(MobEffectInstance p_147208_, @Nullable Entity p_147209_) {
 -        if (!this.canBeAffected(p_147208_)) {
-+        if (!net.neoforged.neoforge.common.CommonHooks.canMobEffectBeApplied(this, p_147208_)) {
++        if (!net.neoforged.neoforge.common.CommonHooks.canMobEffectBeApplied(this, p_147208_, p_147209_)) {
              return false;
          } else {
              MobEffectInstance mobeffectinstance = this.activeEffects.get(p_147208_.getEffect());
@@ -131,7 +131,7 @@
      }
  
 +    /**
-+     * Neo: Override-Only. Call via {@link net.neoforged.neoforge.common.CommonHooks#canMobEffectBeApplied(LivingEntity, MobEffectInstance)}
++     * Neo: Override-Only. Call via {@link net.neoforged.neoforge.common.CommonHooks#canMobEffectBeApplied(LivingEntity, MobEffectInstance,Entity)}
 +     *
 +     * @param p_21197_ A mob effect instance
 +     * @return If the mob effect instance can be applied to this entity
@@ -146,7 +146,7 @@
  
      public void forceAddEffect(MobEffectInstance p_147216_, @Nullable Entity p_147217_) {
 -        if (this.canBeAffected(p_147216_)) {
-+        if (net.neoforged.neoforge.common.CommonHooks.canMobEffectBeApplied(this, p_147216_)) {
++        if (net.neoforged.neoforge.common.CommonHooks.canMobEffectBeApplied(this, p_147216_, p_147217_)) {
              MobEffectInstance mobeffectinstance = this.activeEffects.put(p_147216_.getEffect(), p_147216_);
              if (mobeffectinstance == null) {
                  this.onEffectAdded(p_147216_, p_147217_);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1511,6 +1511,8 @@ public class CommonHooks {
      * @param entity The target entity the mob effect is being applied to.
      * @param effect The mob effect being applied.
      * @return True if the mob effect can be applied, otherwise false.
+     *
+     * @deprecated Use {@link CommonHooks#canMobEffectBeApplied(LivingEntity, MobEffectInstance, Entity)} instead.
      */
     @Deprecated(forRemoval = true)
     public static boolean canMobEffectBeApplied(LivingEntity entity, MobEffectInstance effect) {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1512,8 +1512,21 @@ public class CommonHooks {
      * @param effect The mob effect being applied.
      * @return True if the mob effect can be applied, otherwise false.
      */
+    @Deprecated(forRemoval = true)
     public static boolean canMobEffectBeApplied(LivingEntity entity, MobEffectInstance effect) {
-        var event = new MobEffectEvent.Applicable(entity, effect);
+        return canMobEffectBeApplied(entity, effect, null);
+    }
+
+    /**
+     * Checks if a mob effect can be applied to an entity by firing {@link MobEffectEvent.Applicable}.
+     *
+     * @param entity The target entity the mob effect is being applied to.
+     * @param effect The mob effect being applied.
+     * @param source The source entity who is applying the mob effect, or {@code null} if none exists.
+     * @return True if the mob effect can be applied, otherwise false.
+     */
+    public static boolean canMobEffectBeApplied(LivingEntity entity, MobEffectInstance effect, @Nullable Entity source) {
+        var event = new MobEffectEvent.Applicable(entity, effect, source);
         return NeoForge.EVENT_BUS.post(event).getApplicationResult();
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/MobEffectEvent.java
@@ -93,10 +93,19 @@ public abstract class MobEffectEvent extends LivingEvent {
      */
     public static class Applicable extends MobEffectEvent {
         protected Result result = Result.DEFAULT;
+        @Nullable
+        private final Entity source;
 
+        @Deprecated(forRemoval = true)
         @ApiStatus.Internal
         public Applicable(LivingEntity living, MobEffectInstance effectInstance) {
+            this(living, effectInstance, null);
+        }
+
+        @ApiStatus.Internal
+        public Applicable(LivingEntity living, MobEffectInstance effectInstance, @Nullable Entity source) {
             super(living, effectInstance);
+            this.source = source;
         }
 
         @Override
@@ -118,6 +127,14 @@ public abstract class MobEffectEvent extends LivingEvent {
          */
         public Result getResult() {
             return this.result;
+        }
+
+        /**
+         * @return the entity source of the effect, or {@code null} if none exists
+         */
+        @Nullable
+        public Entity getEffectSource() {
+            return source;
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/MobEffectEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/MobEffectEvent.java
@@ -96,12 +96,6 @@ public abstract class MobEffectEvent extends LivingEvent {
         @Nullable
         private final Entity source;
 
-        @Deprecated(forRemoval = true)
-        @ApiStatus.Internal
-        public Applicable(LivingEntity living, MobEffectInstance effectInstance) {
-            this(living, effectInstance, null);
-        }
-
         @ApiStatus.Internal
         public Applicable(LivingEntity living, MobEffectInstance effectInstance, @Nullable Entity source) {
             super(living, effectInstance);
@@ -130,7 +124,7 @@ public abstract class MobEffectEvent extends LivingEvent {
         }
 
         /**
-         * @return the entity source of the effect, or {@code null} if none exists
+         * {@return the entity source of the effect, or {@code null} if none exists}
          */
         @Nullable
         public Entity getEffectSource() {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/PotionEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/PotionEventTest.java
@@ -37,7 +37,10 @@ public class PotionEventTest {
     public static void isPotionApplicable(MobEffectEvent.Applicable event) {
         if (!event.getEntity().getCommandSenderWorld().isClientSide) {
             event.setResult(Applicable.Result.APPLY);
-            LOGGER.info("Allowed Potion {} for Entity {}", event.getEffectInstance(), event.getEntity());
+            if (event.getEffectSource() != null)
+                LOGGER.info("Allowed Potion {} for Entity {} from Source Entity {}", event.getEffectInstance(), event.getEntity(), event.getEffectSource());
+            else
+                LOGGER.info("Allowed Potion {} for Entity {}", event.getEffectInstance(), event.getEntity());
         }
     }
 


### PR DESCRIPTION
Manually backported #2276 to 1.21.1.
I kept 2 of the old method signatures to avoid breaking changes, just marked them for removal to reflect the 1.21.5 change.