### PR TITLE
[1.21.1] Fix root transforms with arbitrary rotations creating mangled quads

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/client/renderer/block/model/FaceBakery.java
 +++ b/net/minecraft/client/renderer/block/model/FaceBakery.java
-@@ -57,7 +_,14 @@
+@@ -54,10 +_,19 @@
+         Direction direction = calculateFacing(aint);
+         System.arraycopy(afloat, 0, blockfaceuv.uvs, 0, afloat.length);
+         if (p_111607_ == null) {
++            // Neo: Suppress winding re-calculation when the quads may not be axis-aligned due to root transforms
++            if (!p_111606_.mayApplyArbitraryRotation())
              this.recalculateWinding(aint, direction);
          }
  

--- a/src/main/java/net/neoforged/neoforge/client/extensions/ModelStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/ModelStateExtension.java
@@ -1,0 +1,19 @@
+package net.neoforged.neoforge.client.extensions;
+
+import net.minecraft.client.renderer.block.model.Variant;
+import net.minecraft.client.resources.model.BlockModelRotation;
+import net.minecraft.client.resources.model.ModelState;
+
+public interface ModelStateExtension {
+    private ModelState self() {
+        return (ModelState) this;
+    }
+
+    /**
+     * {@return whether this model state may apply a rotation that is not a multiple of 90 degrees}
+     */
+    default boolean mayApplyArbitraryRotation() {
+        ModelState self = self();
+        return !(self instanceof BlockModelRotation || self instanceof Variant);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/extensions/ModelStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/client/extensions/ModelStateExtension.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client.extensions;
 
 import net.minecraft.client.renderer.block.model.Variant;

--- a/src/main/java/net/neoforged/neoforge/client/model/geometry/UnbakedGeometryHelper.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/geometry/UnbakedGeometryHelper.java
@@ -262,6 +262,10 @@ public class UnbakedGeometryHelper {
      * {@return a {@link ModelState} that combines the existing model state and the {@linkplain Transformation root transform}}
      */
     public static ModelState composeRootTransformIntoModelState(ModelState modelState, Transformation rootTransform) {
+        if (rootTransform.isIdentity()) {
+            return modelState;
+        }
+
         // Move the origin of the root transform as if the negative corner were the block center to match the way the
         // ModelState transform is applied in the FaceBakery by moving the vertices to be centered on that corner
         rootTransform = rootTransform.applyOrigin(new Vector3f(-.5F, -.5F, -.5F));

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -38,6 +38,9 @@
     "net/minecraft/client/resources/model/ModelBaker": [
         "net/neoforged/neoforge/client/extensions/IModelBakerExtension"
     ],
+    "net/minecraft/client/resources/model/ModelState": [
+        "net/neoforged/neoforge/client/extensions/ModelStateExtension"
+    ],
     "net/minecraft/client/resources/model/MultiPartBakedModel": [
         "net/neoforged/neoforge/client/model/IDynamicBakedModel"
     ],


### PR DESCRIPTION
This PR fixes models with root transforms having mangled quads when the root transform applies a rotation that is not a multiple of 90 degrees.

Before fix:
![2025-06-04_01 08 52](https://github.com/user-attachments/assets/009090f7-97be-42eb-8f0d-1836144a652b)

After fix:
![2025-06-04_01 08 36](https://github.com/user-attachments/assets/709f48e8-adcb-40bb-8591-45d45e03f9a4)
