### PR TITLE
[1.21.6] Add support for custom GUI element render states and PiP renderers

### DIFF
--- a/patches/net/minecraft/client/gui/GuiGraphics.java.patch
+++ b/patches/net/minecraft/client/gui/GuiGraphics.java.patch
@@ -148,3 +148,35 @@
          int j1 = i1;
  
          for (int k1 = 0; k1 < p_371741_.size(); k1++) {
+@@ -1212,6 +_,31 @@
+     public void submitProfilerChartRenderState(List<ResultField> p_415873_, int p_415651_, int p_416392_, int p_415782_, int p_416254_) {
+         this.guiRenderState
+             .submitPicturesInPictureState(new GuiProfilerChartRenderState(p_415873_, p_415651_, p_416392_, p_415782_, p_416254_, this.scissorStack.peek()));
++    }
++
++    /**
++     * Neo: Submit a custom {@link net.minecraft.client.gui.render.state.GuiElementRenderState} for rendering
++     */
++    public void submitGuiElementRenderState(net.minecraft.client.gui.render.state.GuiElementRenderState renderState) {
++        this.guiRenderState.submitGuiElement(renderState);
++    }
++
++    /**
++     * Neo: Submit a custom {@link net.minecraft.client.gui.render.state.pip.PictureInPictureRenderState} for rendering
++     *
++     * @see net.neoforged.neoforge.client.event.RegisterPictureInPictureRenderersEvent
++     */
++    public void submitPictureInPictureRenderState(net.minecraft.client.gui.render.state.pip.PictureInPictureRenderState renderState) {
++        this.guiRenderState.submitPicturesInPictureState(renderState);
++    }
++
++    /**
++     * Neo: Returns the top-most scissor rectangle, if present, for use with custom {@link net.minecraft.client.gui.render.state.GuiElementRenderState}s
++     * and {@link net.minecraft.client.gui.render.state.pip.PictureInPictureRenderState}s
++     */
++    @Nullable
++    public ScreenRectangle peekScissorStack() {
++        return this.scissorStack.peek();
+     }
+ 
+     @OnlyIn(Dist.CLIENT)

--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -1,5 +1,22 @@
 --- a/net/minecraft/client/renderer/GameRenderer.java
 +++ b/net/minecraft/client/renderer/GameRenderer.java
+@@ -140,14 +_,14 @@
+         this.guiRenderer = new GuiRenderer(
+             this.guiRenderState,
+             multibuffersource$buffersource,
+-            List.of(
++            net.neoforged.neoforge.client.ClientHooks.gatherPictureInPictureRenderers(multibuffersource$buffersource, List.of(
+                 new GuiEntityRenderer(multibuffersource$buffersource, p_234219_.getEntityRenderDispatcher()),
+                 new GuiSkinRenderer(multibuffersource$buffersource),
+                 new GuiBookModelRenderer(multibuffersource$buffersource),
+                 new GuiBannerResultRenderer(multibuffersource$buffersource),
+                 new GuiSignRenderer(multibuffersource$buffersource),
+                 new GuiProfilerChartRenderer(multibuffersource$buffersource)
+-            )
++            ))
+         );
+         this.screenEffectRenderer = new ScreenEffectRenderer(p_234219_, multibuffersource$buffersource);
+     }
 @@ -194,6 +_,8 @@
              this.setPostEffect(ResourceLocation.withDefaultNamespace("spider"));
          } else if (p_109107_ instanceof EnderMan) {

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -47,6 +47,7 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.client.gui.components.toasts.Toast;
+import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
 import net.minecraft.client.gui.screens.LoadingOverlay;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Overlay;
@@ -166,6 +167,7 @@ import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.event.RegisterMaterialAtlasesEvent;
 import net.neoforged.neoforge.client.event.RegisterParticleProvidersEvent;
+import net.neoforged.neoforge.client.event.RegisterPictureInPictureRenderersEvent;
 import net.neoforged.neoforge.client.event.RegisterSpriteDefaultMetadataSectionTypesEvent;
 import net.neoforged.neoforge.client.event.RenderArmEvent;
 import net.neoforged.neoforge.client.event.RenderBlockScreenEffectEvent;
@@ -1136,5 +1138,13 @@ public class ClientHooks {
     public static Set<MetadataSectionType<?>> getSpriteDefaultMetadataSectionTypes(Set<MetadataSectionType<?>> vanillaTypes) {
         DEFAULT_METADATA_SECTION_TYPES.addAll(vanillaTypes);
         return Collections.unmodifiableSet(DEFAULT_METADATA_SECTION_TYPES);
+    }
+
+    public static List<PictureInPictureRenderer<?>> gatherPictureInPictureRenderers(
+            MultiBufferSource.BufferSource bufferSource,
+            List<PictureInPictureRenderer<?>> vanillaRenderers) {
+        vanillaRenderers = new ArrayList<>(vanillaRenderers);
+        ModLoader.postEvent(new RegisterPictureInPictureRenderersEvent(vanillaRenderers, bufferSource));
+        return List.copyOf(vanillaRenderers);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterPictureInPictureRenderersEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterPictureInPictureRenderersEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import java.util.List;
+import java.util.function.Function;
+import net.minecraft.client.gui.render.pip.PictureInPictureRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.fml.event.IModBusEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Event to register custom {@link PictureInPictureRenderer}s for specialized rendering in UIs.
+ *
+ * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.
+ */
+public final class RegisterPictureInPictureRenderersEvent extends Event implements IModBusEvent {
+    private final List<PictureInPictureRenderer<?>> renderers;
+    private final MultiBufferSource.BufferSource bufferSource;
+
+    @ApiStatus.Internal
+    public RegisterPictureInPictureRenderersEvent(List<PictureInPictureRenderer<?>> renderers, MultiBufferSource.BufferSource bufferSource) {
+        this.renderers = renderers;
+        this.bufferSource = bufferSource;
+    }
+
+    /**
+     * Register a custom {@link PictureInPictureRenderer}
+     *
+     * @param factory A function to construct a PiP renderer
+     */
+    public void register(Function<MultiBufferSource.BufferSource, PictureInPictureRenderer<?>> factory) {
+        this.renderers.add(factory.apply(this.bufferSource));
+    }
+}


### PR DESCRIPTION
This PR adds support for submitting custom `GuiElementRenderState`s and using `PictureInPictureRenderer`s in UI rendering.
The former is required for relatively simple UI element rendering in cases vanilla doesn't support a specific behaviour. One such case would be a horizontal color gradient as vanilla only supports drawing vertical gradients.
The latter is required for rendering arbitrary geometry in GUIs such as blocks or entities (vanilla uses PiP renderers for the player in the inventory screen, the horse in the horse inventory, the sign in the sign edit screen and a few other cases).