### PR TITLE
Disable natural mob spawning and weather in the game test server to prevent random interference of slimes with tests

### DIFF
--- a/patches/net/minecraft/gametest/framework/GameTestServer.java.patch
+++ b/patches/net/minecraft/gametest/framework/GameTestServer.java.patch
@@ -1,5 +1,26 @@
 --- a/net/minecraft/gametest/framework/GameTestServer.java
 +++ b/net/minecraft/gametest/framework/GameTestServer.java
+@@ -75,6 +_,11 @@
+     private static final WorldOptions WORLD_OPTIONS = new WorldOptions(0L, false, false);
+     @Nullable
+     private MultipleTestTracker testTracker;
++    // Neo: disable mob spawning and weather cycling when running game tests, same as for the ephemeral test server
++    private static final GameRules TEST_GAME_RULES = Util.make(new GameRules(ENABLED_FEATURES), rules -> {
++        rules.getRule(GameRules.RULE_DOMOBSPAWNING).set(false, null);
++        rules.getRule(GameRules.RULE_WEATHER_CYCLE).set(false, null);
++    });
+ 
+     public static GameTestServer create(
+         Thread p_206607_, LevelStorageSource.LevelStorageAccess p_206608_, PackRepository p_206609_, Optional<String> p_397118_, boolean p_397698_
+@@ -85,7 +_,7 @@
+         arraylist.addFirst("vanilla");
+         WorldDataConfiguration worlddataconfiguration = new WorldDataConfiguration(new DataPackConfig(arraylist, List.of()), ENABLED_FEATURES);
+         LevelSettings levelsettings = new LevelSettings(
+-            "Test Level", GameType.CREATIVE, false, Difficulty.NORMAL, true, new GameRules(ENABLED_FEATURES), worlddataconfiguration
++            "Test Level", GameType.CREATIVE, false, Difficulty.NORMAL, true, TEST_GAME_RULES, worlddataconfiguration
+         );
+         WorldLoader.PackConfig worldloader$packconfig = new WorldLoader.PackConfig(p_206609_, worlddataconfiguration, false, true);
+         WorldLoader.InitConfig worldloader$initconfig = new WorldLoader.InitConfig(worldloader$packconfig, Commands.CommandSelection.DEDICATED, 4);
 @@ -152,10 +_,12 @@
      @Override
      public boolean initServer() {


### PR DESCRIPTION
We were already doing this in the ephemeral test server, so I copied over the game rules.
Weather is disabled due to the possible lightning strikes or rain damage interfering with tests.

Fixes #2132 