### PR TITLE
Make all removal entries optional at runtime

### DIFF
--- a/patches/net/minecraft/tags/TagEntry.java.patch
+++ b/patches/net/minecraft/tags/TagEntry.java.patch
@@ -1,5 +1,21 @@
 --- a/net/minecraft/tags/TagEntry.java
 +++ b/net/minecraft/tags/TagEntry.java
+@@ -44,6 +_,15 @@
+         return new ExtraCodecs.TagOrElementLocation(this.id, this.tag);
+     }
+ 
++    /**
++     * {@return a copy of this entry with the required flag set to the given parameter}
++     *
++     * @param required whether the new entry is required
++     */
++    TagEntry withRequired(boolean required) {
++        return new TagEntry(this.id, this.tag, required);
++    }
++
+     public static TagEntry element(ResourceLocation p_215926_) {
+         return new TagEntry(p_215926_, false, true);
+     }
 @@ -111,11 +_,21 @@
          return stringbuilder.toString();
      }

--- a/patches/net/minecraft/tags/TagLoader.java.patch
+++ b/patches/net/minecraft/tags/TagLoader.java.patch
@@ -4,17 +4,16 @@
  
                      String s = resource.sourcePackId();
                      tagfile.entries().forEach(p_215997_ -> list.add(new TagLoader.EntryWithSource(p_215997_, s)));
-+                    tagfile.remove().forEach(e -> list.add(new TagLoader.EntryWithSource(e, s, true)));
++                    tagfile.remove().forEach(e -> list.add(new TagLoader.EntryWithSource(e.withRequired(false), s, true))); // Make all removal entries optional at runtime to avoid them creating intrusive holders - see NeoForge#2319
                  } catch (Exception exception) {
                      LOGGER.error("Couldn't read tag list {} from {} in data pack {}", resourcelocation1, resourcelocation, resource.sourcePackId(), exception);
                  }
-@@ -78,7 +_,8 @@
+@@ -78,7 +_,7 @@
          List<TagLoader.EntryWithSource> list = new ArrayList<>();
  
          for (TagLoader.EntryWithSource tagloader$entrywithsource : p_215980_) {
 -            if (!tagloader$entrywithsource.entry().build(p_215979_, sequencedset::add)) {
 +            if (!tagloader$entrywithsource.entry().build(p_215979_, tagloader$entrywithsource.remove() ? sequencedset::remove : sequencedset::add)) {
-+                if (!tagloader$entrywithsource.remove()) // Treat all removals as optional at runtime. If it was missing, then it could of never been added.
                  list.add(tagloader$entrywithsource);
              }
          }

--- a/patches/net/minecraft/tags/TagLoader.java.patch
+++ b/patches/net/minecraft/tags/TagLoader.java.patch
@@ -1,10 +1,11 @@
 --- a/net/minecraft/tags/TagLoader.java
 +++ b/net/minecraft/tags/TagLoader.java
-@@ -64,6 +_,7 @@
+@@ -64,6 +_,8 @@
  
                      String s = resource.sourcePackId();
                      tagfile.entries().forEach(p_215997_ -> list.add(new TagLoader.EntryWithSource(p_215997_, s)));
-+                    tagfile.remove().forEach(e -> list.add(new TagLoader.EntryWithSource(e.withRequired(false), s, true))); // Make all removal entries optional at runtime to avoid them creating intrusive holders - see NeoForge#2319
++                    // Make all removal entries optional at runtime to avoid them creating intrusive holders - see NeoForge#2319
++                    tagfile.remove().forEach(e -> list.add(new TagLoader.EntryWithSource(e.withRequired(false), s, true)));
                  } catch (Exception exception) {
                      LOGGER.error("Couldn't read tag list {} from {} in data pack {}", resourcelocation1, resourcelocation, resource.sourcePackId(), exception);
                  }


### PR DESCRIPTION
The issue detailed in #2319 is caused by reloadable registries using a different method in `TagLoader`: `loadTagsForRegistry`, which is operated on writable registries. This method uses a `ElementLookup#fromWritableRegistry` element lookup, which uses either the registry directly if the tag entry is not marked as required or, if the tag entry is marked as required, it uses the `WritableRegistry#createRegistrationLookup` - and this lookup always uses `getOrCreateHolderOrThrow`, creating pending intrusive holders for all looked-up required elements.

The fix I implemented is to create copies of all `TagEntry`s used for removal that have the `required` flag always set to `false`. I also removed the patched-in removal check in `tryBuildTag` as it is no longer necessary if all removal entries are optional.

Fixes #2319