### PR TITLE
Allow client-side commands to run chat components

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -138,6 +138,15 @@
          SignableCommand<SharedSuggestionProvider> signablecommand = SignableCommand.of(this.parseCommand(p_250092_));
          if (signablecommand.arguments().isEmpty()) {
              this.send(new ServerboundChatCommandPacket(p_250092_));
+@@ -2432,6 +_,8 @@
+     }
+ 
+     public boolean sendUnsignedCommand(String p_251509_) {
++        // Neo: Dispatch client commands for text component click actions.
++        if (net.neoforged.neoforge.client.ClientCommandHandler.runCommand(p_251509_)) return true;
+         if (!SignableCommand.hasSignableArguments(this.parseCommand(p_251509_))) {
+             this.send(new ServerboundChatCommandPacket(p_251509_));
+             return true;
 @@ -2490,6 +_,10 @@
  
      public Scoreboard scoreboard() {


### PR DESCRIPTION
Backporting #554 from 1.21.x to 1.21.1. While the patch is usable on 1.21.x branch it does not on 1.21.1 branch