### PR TITLE
Reduce collisions in PatchedDataComponentMap hashCode

### DIFF
--- a/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
@@ -19,7 +19,7 @@
      public DataComponentPatch asPatch() {
          if (this.patch.isEmpty()) {
              return DataComponentPatch.EMPTY;
-@@ -232,7 +_,25 @@
+@@ -232,7 +_,26 @@
  
      @Override
      public int hashCode() {
@@ -39,7 +39,8 @@
 +        while (n-- != 0) {
 +            var entry = iterator.next();
 +            int componentId = net.minecraft.core.registries.BuiltInRegistries.DATA_COMPONENT_TYPE.getId(entry.getKey());
-+            int entryHash = com.google.common.math.IntMath.pow(31, componentId) * entry.getValue().hashCode();
++            // If the component is not registered in this registry (could be a different component registry), fall back to default strategy
++            int entryHash = componentId == -1 ? entry.hashCode() : com.google.common.math.IntMath.pow(31, componentId) * entry.getValue().hashCode();
 +            h += entryHash;
 +        }
 +        return h;

--- a/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
@@ -19,7 +19,7 @@
      public DataComponentPatch asPatch() {
          if (this.patch.isEmpty()) {
              return DataComponentPatch.EMPTY;
-@@ -232,7 +_,26 @@
+@@ -232,7 +_,23 @@
  
      @Override
      public int hashCode() {
@@ -29,18 +29,15 @@
 +
 +    // Neo: Change implementation of hashCode to reduce collisions.
 +    // For a map, hashCode is specified as the sum of the hash codes of its entries.
-+    // We do that, but change the entry hash code to 31^<id> * <value hash>,
-+    // where <id> is the ID of the DataComponentType in the registry.
-+    // Note: This assumes that stacks are not reused across different servers on the client,
-+    // else the ID and thus the hash code might change.
++    // We do that, but change the entry hash code to 31^<key hash> * <value hash>,
++    // where <key hash> is the lower bits of the identity hash code of the key.
 +    private static int hashPatch(Reference2ObjectMap<DataComponentType<?>, Optional<?>> patch) {
 +        int h = 0, n = patch.size();
 +        var iterator = it.unimi.dsi.fastutil.objects.Reference2ObjectMaps.fastIterator(patch);
 +        while (n-- != 0) {
 +            var entry = iterator.next();
-+            int componentId = net.minecraft.core.registries.BuiltInRegistries.DATA_COMPONENT_TYPE.getId(entry.getKey());
-+            // If the component is not registered in this registry (could be a different component registry), fall back to default strategy
-+            int entryHash = componentId == -1 ? entry.hashCode() : com.google.common.math.IntMath.pow(31, componentId) * entry.getValue().hashCode();
++            int exponent = System.identityHashCode(entry.getKey()) & 0xff;
++            int entryHash = com.google.common.math.IntMath.pow(31, exponent) * entry.getValue().hashCode();
 +            h += entryHash;
 +        }
 +        return h;

--- a/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/PatchedDataComponentMap.java.patch
@@ -8,14 +8,41 @@
          this.ensureMapOwnership();
          T t = this.prototype.get(p_330791_);
          Optional<T> optional;
-@@ -201,6 +_,10 @@
-         }
- 
+@@ -203,6 +_,10 @@
          return i;
-+    }
-+
-+    public boolean isPatchEmpty() {
-+        return this.patch.isEmpty();
      }
  
++    public boolean isPatchEmpty() {
++        return this.patch.isEmpty();
++    }
++
      public DataComponentPatch asPatch() {
+         if (this.patch.isEmpty()) {
+             return DataComponentPatch.EMPTY;
+@@ -232,7 +_,25 @@
+ 
+     @Override
+     public int hashCode() {
+-        return this.prototype.hashCode() + this.patch.hashCode() * 31;
++        return this.prototype.hashCode() + hashPatch(this.patch) * 31;
++    }
++
++    // Neo: Change implementation of hashCode to reduce collisions.
++    // For a map, hashCode is specified as the sum of the hash codes of its entries.
++    // We do that, but change the entry hash code to 31^<id> * <value hash>,
++    // where <id> is the ID of the DataComponentType in the registry.
++    // Note: This assumes that stacks are not reused across different servers on the client,
++    // else the ID and thus the hash code might change.
++    private static int hashPatch(Reference2ObjectMap<DataComponentType<?>, Optional<?>> patch) {
++        int h = 0, n = patch.size();
++        var iterator = it.unimi.dsi.fastutil.objects.Reference2ObjectMaps.fastIterator(patch);
++        while (n-- != 0) {
++            var entry = iterator.next();
++            int componentId = net.minecraft.core.registries.BuiltInRegistries.DATA_COMPONENT_TYPE.getId(entry.getKey());
++            int entryHash = com.google.common.math.IntMath.pow(31, componentId) * entry.getValue().hashCode();
++            h += entryHash;
++        }
++        return h;
+     }
+ 
+     @Override

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.Test;
+
+public class ComponentHashingTest {
+    @Test
+    void testHashCodeCollisions() {
+        int MAX_DAMAGE = 1000;
+        int MAX_REPAIR_COST = 100;
+
+        Map<Integer, List<ItemStack>> hashCodeToStacks = new HashMap<>();
+
+        for (int damage = 1; damage <= MAX_DAMAGE; ++damage) {
+            for (int repairCost = 1; repairCost <= MAX_REPAIR_COST; ++repairCost) {
+                ItemStack stack = new ItemStack(Items.NETHERITE_PICKAXE);
+                stack.set(DataComponents.DAMAGE, damage);
+                stack.set(DataComponents.REPAIR_COST, repairCost);
+
+                int hashCode = ItemStack.hashItemAndComponents(stack);
+                hashCodeToStacks.computeIfAbsent(hashCode, hc -> new ArrayList<>()).add(stack);
+            }
+        }
+
+        // Collisions should be rare, say less than 1%
+        double collisionRate = 1 - (double) hashCodeToStacks.size() / MAX_DAMAGE / MAX_REPAIR_COST;
+        if (collisionRate > 0.01) {
+            throw new AssertionError("Too many hash code collisions detected: " + collisionRate);
+        }
+    }
+}

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
@@ -5,6 +5,8 @@
 
 package net.neoforged.neoforge.unittest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,8 +18,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ComponentHashingTest {
     @Test

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
@@ -5,18 +5,13 @@
 
 package net.neoforged.neoforge.unittest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.core.component.PatchedDataComponentMap;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import org.junit.jupiter.api.Test;
 
 public class ComponentHashingTest {
@@ -43,20 +38,5 @@ public class ComponentHashingTest {
         if (collisionRate > 0.01) {
             throw new AssertionError("Too many hash code collisions detected: " + collisionRate);
         }
-    }
-
-    @Test
-    void testUnregisteredComponent() {
-        var map = new PatchedDataComponentMap(DataComponentMap.EMPTY);
-
-        map.set(EnchantmentEffectComponents.ARMOR_EFFECTIVENESS, List.of());
-        int hashCode1 = map.hashCode();
-
-        map.remove(EnchantmentEffectComponents.ARMOR_EFFECTIVENESS);
-        map.set(EnchantmentEffectComponents.AMMO_USE, List.of());
-        int hashCode2 = map.hashCode();
-
-        assertThat(hashCode1)
-                .isNotEqualTo(hashCode2);
     }
 }

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentHashingTest.java
@@ -9,10 +9,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.component.PatchedDataComponentMap;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ComponentHashingTest {
     @Test
@@ -38,5 +43,20 @@ public class ComponentHashingTest {
         if (collisionRate > 0.01) {
             throw new AssertionError("Too many hash code collisions detected: " + collisionRate);
         }
+    }
+
+    @Test
+    void testUnregisteredComponent() {
+        var map = new PatchedDataComponentMap(DataComponentMap.EMPTY);
+
+        map.set(EnchantmentEffectComponents.ARMOR_EFFECTIVENESS, List.of());
+        int hashCode1 = map.hashCode();
+
+        map.remove(EnchantmentEffectComponents.ARMOR_EFFECTIVENESS);
+        map.set(EnchantmentEffectComponents.AMMO_USE, List.of());
+        int hashCode2 = map.hashCode();
+
+        assertThat(hashCode1)
+                .isNotEqualTo(hashCode2);
     }
 }


### PR DESCRIPTION
Issue originally reported to me on https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/8539. I made a first attempt at the fix in https://github.com/AppliedEnergistics/Applied-Energistics-2/pull/8561, but from discussions on Discord it would be better to patch this at the source here such that all modders can benefit from this patch.

The change is in how each entry of the `patch` map is hashed.

This PR also comes with a test that hashes 100'000 different stacks. Before the patch, the test fails with **99.8 % collision rate**. After the patch, the test passes with **0 % collision rate**.
