### PR TITLE
[1.21.6] Fix root transforms with arbitrary rotations creating mangled quads

### DIFF
--- a/patches/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
+++ b/patches/net/minecraft/client/renderer/block/model/FaceBakery.java.patch
@@ -1,6 +1,11 @@
 --- a/net/minecraft/client/renderer/block/model/FaceBakery.java
 +++ b/net/minecraft/client/renderer/block/model/FaceBakery.java
-@@ -72,7 +_,14 @@
+@@ -69,10 +_,19 @@
+         );
+         Direction direction = calculateFacing(aint);
+         if (p_111607_ == null) {
++            // Neo: Suppress winding re-calculation when the quads may not be axis-aligned due to root transforms
++            if (!p_111606_.mayApplyArbitraryRotation())
              recalculateWinding(aint, direction);
          }
  

--- a/src/client/java/net/neoforged/neoforge/client/extensions/ModelStateExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/ModelStateExtension.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions;
+
+import net.minecraft.client.resources.model.BlockModelRotation;
+import net.minecraft.client.resources.model.ModelState;
+
+public interface ModelStateExtension {
+    private ModelState self() {
+        return (ModelState) this;
+    }
+
+    /**
+     * {@return whether this model state may apply a rotation that is not a multiple of 90 degrees}
+     */
+    default boolean mayApplyArbitraryRotation() {
+        ModelState self = self();
+        return !(self instanceof BlockModelRotation || self instanceof BlockModelRotation.WithUvLock);
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/ComposedModelState.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/ComposedModelState.java
@@ -19,12 +19,12 @@ public final class ComposedModelState implements ModelState {
 
     public ComposedModelState(ModelState parent, Transformation transformation) {
         this.parent = parent;
-        this.transformation = transformation;
+        this.transformation = parent.transformation().compose(transformation);
     }
 
     @Override
     public Transformation transformation() {
-        return parent.transformation().compose(transformation);
+        return transformation;
     }
 
     @Override

--- a/src/client/java/net/neoforged/neoforge/client/model/UnbakedElementsHelper.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/UnbakedElementsHelper.java
@@ -182,6 +182,10 @@ public final class UnbakedElementsHelper {
      * {@return a {@link ModelState} that combines the existing model state and the {@linkplain Transformation root transform}}
      */
     public static ModelState composeRootTransformIntoModelState(ModelState modelState, Transformation rootTransform) {
+        if (rootTransform.isIdentity()) {
+            return modelState;
+        }
+
         // Move the origin of the root transform as if the negative corner were the block center to match the way the
         // ModelState transform is applied in the FaceBakery by moving the vertices to be centered on that corner
         rootTransform = rootTransform.applyOrigin(new Vector3f(-.5F, -.5F, -.5F));

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -84,6 +84,8 @@ public net.minecraft.client.renderer.texture.atlas.sources.Unstitcher$Region <in
 public net.minecraft.client.renderer.texture.atlas.sources.Unstitcher$RegionInstance
 public net.minecraft.client.renderer.texture.atlas.sources.Unstitcher$RegionInstance <init>(Lnet/minecraft/client/renderer/texture/atlas/sources/LazyLoadedImage;Lnet/minecraft/client/renderer/texture/atlas/sources/Unstitcher$Region;DD)V # constructor
 public net.minecraft.client.resources.ClientPackSource createVanillaPackSource(Ljava/nio/file/Path;)Lnet/minecraft/server/packs/VanillaPackResources; # createVanillaPackSource
+public net.minecraft.client.resources.model.BlockModelRotation$WithUvLock
+public net.minecraft.client.resources.model.BlockModelRotation$WithUvLock <init>(Lnet.minecraft.client.resources.model.BlockModelRotation;)V
 protected net.minecraft.client.resources.TextureAtlasHolder textureAtlas # textureAtlas
 public net.minecraft.client.sounds.SoundEngine soundManager # soundManager
 public net.minecraft.commands.CommandSourceStack source # source

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -44,6 +44,9 @@
   "net/minecraft/client/resources/model/ModelBaker": [
     "net/neoforged/neoforge/client/extensions/ModelBakerExtension"
   ],
+  "net/minecraft/client/resources/model/ModelState": [
+    "net/neoforged/neoforge/client/extensions/ModelStateExtension"
+  ],
   "net/minecraft/client/resources/model/QuadCollection$Builder": [
     "net/neoforged/neoforge/client/extensions/QuadCollectionBuilderExtension"
   ],


### PR DESCRIPTION
This PR fixes models with root transforms having mangled quads when the root transform applies a rotation that is not a multiple of 90 degrees.

Before fix:
![2025-06-04_01 08 52](https://github.com/user-attachments/assets/009090f7-97be-42eb-8f0d-1836144a652b)

After fix:
![2025-06-04_01 08 36](https://github.com/user-attachments/assets/709f48e8-adcb-40bb-8591-45d45e03f9a4)
