### PR TITLE
Update FML to remove the need of a bus in EBS and introduce Early Loading Screen Theming

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ nightconfig_version=3.8.2
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=8.0.4
+fancy_mod_loader_version=8.0.5
 typetools_version=0.6.3
 mixin_extras_version=0.4.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ nightconfig_version=3.8.2
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=7.0.10
+fancy_mod_loader_version=8.0.4
 typetools_version=0.6.3
 mixin_extras_version=0.4.1
 

--- a/src/client/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
+++ b/src/client/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
@@ -26,7 +26,7 @@ import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
-@EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME, modid = NeoForgeVersion.MOD_ID)
+@EventBusSubscriber(value = Dist.CLIENT, modid = NeoForgeVersion.MOD_ID)
 public final class BlockEntityRenderBoundsDebugRenderer {
     private static boolean enabled = false;
 

--- a/src/client/java/net/neoforged/neoforge/client/NeoForgeRenderPipelines.java
+++ b/src/client/java/net/neoforged/neoforge/client/NeoForgeRenderPipelines.java
@@ -15,7 +15,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterRenderPipelinesEvent;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
-@EventBusSubscriber(value = Dist.CLIENT, modid = NeoForgeVersion.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(value = Dist.CLIENT, modid = NeoForgeVersion.MOD_ID)
 public final class NeoForgeRenderPipelines {
     // Duplicate of RenderPipelines.ENTITY_TRANSLUCENT with directional shading and lighting disabled
     public static final RenderPipeline ENTITY_UNLIT_TRANSLUCENT = RenderPipeline.builder(RenderPipelines.ENTITY_SNIPPET)

--- a/src/client/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
+++ b/src/client/java/net/neoforged/neoforge/client/ParticleBoundsDebugRenderer.java
@@ -20,7 +20,7 @@ import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
-@EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.GAME, modid = NeoForgeVersion.MOD_ID)
+@EventBusSubscriber(value = Dist.CLIENT, modid = NeoForgeVersion.MOD_ID)
 public final class ParticleBoundsDebugRenderer {
     private static boolean enabled = false;
 

--- a/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.client.loading;
 
 import com.mojang.blaze3d.opengl.GlDevice;
-import com.mojang.blaze3d.opengl.GlTexture;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuTexture;
 import java.util.Optional;
@@ -27,6 +26,8 @@ import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.earlydisplay.DisplayWindow;
 import net.neoforged.fml.loading.progress.ProgressMeter;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.opengl.GL;
 
 /**
  * This is an implementation of the LoadingOverlay that calls back into the early window rendering, as part of the
@@ -53,8 +54,6 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
         this.reload = reloader;
         this.onFinish = errorConsumer;
         this.displayWindow = displayWindow;
-        var logoGpuTexture = (GlTexture) mc.getTextureManager().getTexture(MOJANG_STUDIOS_LOGO_LOCATION).getTexture();
-        displayWindow.addMojangTexture(logoGpuTexture.glId());
         this.progressMeter = StartupNotificationManager.prependProgressBar("Minecraft Progress", 1000);
         this.framebuffer = ((GlDevice) RenderSystem.getDevice()).createExternalTexture("loading overlay framebuffer", GpuTexture.USAGE_TEXTURE_BINDING, displayWindow.getFramebufferTextureId());
         Minecraft.getInstance().getTextureManager().register(LOADING_OVERLAY_TEXTURE_ID, new ExternalTexture(framebuffer));
@@ -97,6 +96,8 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
             Minecraft.getInstance().schedule(() -> {
                 Minecraft.getInstance().getTextureManager().release(LOADING_OVERLAY_TEXTURE_ID);
                 this.displayWindow.close();
+                GLFW.glfwMakeContextCurrent(this.minecraft.getWindow().getWindow());
+                GL.createCapabilities();
             });
             this.minecraft.setOverlay(null);
         }

--- a/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
@@ -25,8 +25,6 @@ import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.earlydisplay.DisplayWindow;
 import net.neoforged.fml.loading.progress.ProgressMeter;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
-import org.lwjgl.glfw.GLFW;
-import org.lwjgl.opengl.GL;
 
 /**
  * This is an implementation of the LoadingOverlay that calls back into the early window rendering, as part of the
@@ -88,8 +86,6 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
             Minecraft.getInstance().schedule(() -> {
                 Minecraft.getInstance().getTextureManager().release(LOADING_OVERLAY_TEXTURE_ID);
                 this.displayWindow.close();
-                GLFW.glfwMakeContextCurrent(this.minecraft.getWindow().getWindow());
-                GL.createCapabilities();
             });
             this.minecraft.setOverlay(null);
         }

--- a/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
@@ -10,7 +10,6 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.GpuTexture;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -37,6 +36,7 @@ import org.lwjgl.opengl.GL;
  * <p>
  * It is somewhat a copy of the superclass render method.
  */
+@SuppressWarnings("UnstableApiUsage")
 public class NeoForgeLoadingOverlay extends LoadingOverlay {
     public static final ResourceLocation LOADING_OVERLAY_TEXTURE_ID = ResourceLocation.parse("neoforge:loading_overlay");
     private final Minecraft minecraft;
@@ -44,7 +44,6 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
     private final Consumer<Optional<Throwable>> onFinish;
     private final DisplayWindow displayWindow;
     private final ProgressMeter progressMeter;
-    private final GpuTexture framebuffer;
     private float currentProgress;
     private long fadeOutStart = -1L;
 
@@ -55,12 +54,8 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
         this.onFinish = errorConsumer;
         this.displayWindow = displayWindow;
         this.progressMeter = StartupNotificationManager.prependProgressBar("Minecraft Progress", 1000);
-        this.framebuffer = ((GlDevice) RenderSystem.getDevice()).createExternalTexture("loading overlay framebuffer", GpuTexture.USAGE_TEXTURE_BINDING, displayWindow.getFramebufferTextureId());
+        var framebuffer = ((GlDevice) RenderSystem.getDevice()).createExternalTexture("loading overlay framebuffer", GpuTexture.USAGE_TEXTURE_BINDING, displayWindow.getFramebufferTextureId());
         Minecraft.getInstance().getTextureManager().register(LOADING_OVERLAY_TEXTURE_ID, new ExternalTexture(framebuffer));
-    }
-
-    public static Supplier<LoadingOverlay> newInstance(Supplier<Minecraft> mc, Supplier<ReloadInstance> ri, Consumer<Optional<Throwable>> handler, DisplayWindow window) {
-        return () -> new NeoForgeLoadingOverlay(mc.get(), ri.get(), handler, window);
     }
 
     @Override
@@ -69,9 +64,6 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
         float fadeouttimer = this.fadeOutStart > -1L ? (float) (millis - this.fadeOutStart) / 1000.0F : -1.0F;
         this.currentProgress = Mth.clamp(this.currentProgress * 0.95F + this.reload.getActualProgress() * 0.05F, 0.0F, 1.0F);
         progressMeter.setAbsolute(Mth.ceil(this.currentProgress * 1000));
-
-        // TODO porting: check whether this is still needed
-        //graphics.flush(); // Ensure no draws are queued before we go and render externally
 
         // This updates the EarlyDisplay screen in the off-screen framebuffer
         displayWindow.renderToFramebuffer();

--- a/src/main/java/net/neoforged/neoforge/common/MonsterRoomHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/MonsterRoomHooks.java
@@ -17,7 +17,7 @@ import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 import net.neoforged.neoforge.registries.datamaps.DataMapsUpdatedEvent;
 import net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME, modid = NeoForgeVersion.MOD_ID)
+@EventBusSubscriber(modid = NeoForgeVersion.MOD_ID)
 public class MonsterRoomHooks {
     private static WeightedList<EntityType<?>> monsterRoomMobs = WeightedList.of();
 

--- a/src/main/java/net/neoforged/neoforge/model/data/ModelDataManager.java
+++ b/src/main/java/net/neoforged/neoforge/model/data/ModelDataManager.java
@@ -21,7 +21,6 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.common.EventBusSubscriber.Bus;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import org.jetbrains.annotations.UnmodifiableView;
 
@@ -31,7 +30,7 @@ import org.jetbrains.annotations.UnmodifiableView;
  * Users should not instantiate this unless they know what they are doing. The manager is also not thread-safe,
  * it should only be interacted with on the main client thread.
  */
-@EventBusSubscriber(modid = "neoforge", bus = Bus.GAME, value = Dist.CLIENT)
+@EventBusSubscriber(modid = "neoforge", value = Dist.CLIENT)
 public class ModelDataManager {
     private final Thread owningThread = Thread.currentThread();
     private final Level level;

--- a/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigurationInitialization.java
@@ -28,7 +28,7 @@ import net.neoforged.neoforge.network.payload.FrozenRegistrySyncStartPayload;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-@EventBusSubscriber(modid = "neoforge", bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = "neoforge")
 public class ConfigurationInitialization {
     /**
      * Method called to add configuration tasks that should run before all others,

--- a/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
+++ b/src/main/java/net/neoforged/neoforge/network/NetworkInitialization.java
@@ -38,7 +38,7 @@ import net.neoforged.neoforge.registries.RegistryManager;
 import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
-@EventBusSubscriber(modid = NeoForgeVersion.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = NeoForgeVersion.MOD_ID)
 public class NetworkInitialization {
     private static <T extends ClientDispatchPayload> IPayloadHandler<T> clientHandler() {
         return NeoForgeProxy.INSTANCE::handleClientPayload;

--- a/src/main/java/net/neoforged/neoforge/network/filters/GenericPacketSplitter.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/GenericPacketSplitter.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.ApiStatus;
  * A generic packet splitter that can be used to split packets that are too large to be sent in one go.
  */
 @ApiStatus.Internal
-@EventBusSubscriber(modid = NeoForgeVersion.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = NeoForgeVersion.MOD_ID)
 public class GenericPacketSplitter extends MessageToMessageEncoder<Packet<?>> implements DynamicChannelHandler {
     private static final Logger LOGGER = LogManager.getLogger();
 

--- a/testframework/src/main/java/net/neoforged/testframework/Test.java
+++ b/testframework/src/main/java/net/neoforged/testframework/Test.java
@@ -17,7 +17,8 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.testframework.gametest.GameTestData;
 import net.neoforged.testframework.group.Groupable;
 import org.jetbrains.annotations.Nullable;
@@ -104,26 +105,20 @@ public interface Test extends Groupable {
     }
 
     /**
-     * A group of collectors by {@link EventBusSubscriber.Bus bus}.
+     * A group of collectors by bus.
      */
     @ParametersAreNonnullByDefault
     @MethodsReturnNonnullByDefault
     interface EventListenerGroup {
         /**
-         * Gets the collector for a bus.
-         *
-         * @param bus the bus to get the collector for
-         * @return the collector associated with the bus
+         * {@return the listener collector for the {@link ModContainer#getEventBus() mod event bus}}
          */
-        EventListenerCollector getFor(EventBusSubscriber.Bus bus);
+        EventListenerCollector mod();
 
-        default EventListenerCollector mod() {
-            return getFor(EventBusSubscriber.Bus.MOD);
-        }
-
-        default EventListenerCollector forge() {
-            return getFor(EventBusSubscriber.Bus.GAME);
-        }
+        /**
+         * {@return the listener collector for the {@link NeoForge#EVENT_BUS game event bus}}
+         */
+        EventListenerCollector forge();
 
         /**
          * A collector of event listeners which automatically unregisters listeners when a test is disabled.

--- a/testframework/src/main/java/net/neoforged/testframework/impl/EventListenerGroupImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/EventListenerGroupImpl.java
@@ -45,10 +45,10 @@ public class EventListenerGroupImpl implements Test.EventListenerGroup {
 
     public void copyFrom(EventListenerGroupImpl other) {
         this.mod.subscribeActions.addAll(other.mod.subscribeActions);
-        this.mod.subscribers.add(other.mod.subscribers);
+        this.mod.subscribers.addAll(other.mod.subscribers);
 
         this.game.subscribeActions.addAll(other.game.subscribeActions);
-        this.game.subscribers.add(other.game.subscribers);
+        this.game.subscribers.addAll(other.game.subscribers);
     }
 
     private static final class EventListenerCollectorImpl implements EventListenerCollector {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/EventListenerGroupImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/EventListenerGroupImpl.java
@@ -6,16 +6,13 @@
 package net.neoforged.testframework.impl;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.testframework.Test;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -23,27 +20,35 @@ import org.jetbrains.annotations.ApiStatus;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public class EventListenerGroupImpl implements Test.EventListenerGroup {
-    private final Map<EventBusSubscriber.Bus, EventListenerCollectorImpl> collectors = new HashMap<>();
+    private final EventListenerCollectorImpl mod = new EventListenerCollectorImpl(),
+            game = new EventListenerCollectorImpl();
 
     @Override
-    public EventListenerCollectorImpl getFor(EventBusSubscriber.Bus bus) {
-        return collectors.computeIfAbsent(bus, it -> new EventListenerCollectorImpl());
+    public EventListenerCollector mod() {
+        return mod;
     }
 
-    public void unregister(Map<EventBusSubscriber.Bus, IEventBus> buses) {
-        collectors.forEach((bus, col) -> col.unregisterAll(buses.get(bus)));
+    @Override
+    public EventListenerCollector forge() {
+        return game;
     }
 
-    public void register(Map<EventBusSubscriber.Bus, IEventBus> buses) {
-        collectors.forEach((bus, col) -> col.registerAll(buses.get(bus)));
+    public void unregister(BusSet set) {
+        mod.unregisterAll(set.mod);
+        game.unregisterAll(set.game);
+    }
+
+    public void register(BusSet set) {
+        mod.registerAll(set.mod);
+        game.registerAll(set.game);
     }
 
     public void copyFrom(EventListenerGroupImpl other) {
-        other.collectors.forEach((bus, eventListenerCollector) -> {
-            final var ours = getFor(bus);
-            ours.subscribeActions.addAll(eventListenerCollector.subscribeActions);
-            ours.subscribers.addAll(eventListenerCollector.subscribers);
-        });
+        this.mod.subscribeActions.addAll(other.mod.subscribeActions);
+        this.mod.subscribers.add(other.mod.subscribers);
+
+        this.game.subscribeActions.addAll(other.game.subscribeActions);
+        this.game.subscribers.add(other.game.subscribers);
     }
 
     private static final class EventListenerCollectorImpl implements EventListenerCollector {
@@ -80,4 +85,6 @@ public class EventListenerGroupImpl implements Test.EventListenerGroup {
             subscribeActions.forEach(c -> c.accept(bus));
         }
     }
+
+    public record BusSet(IEventBus mod, IEventBus game) {}
 }

--- a/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/TestFrameworkImpl.java
@@ -40,7 +40,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.saveddata.SavedDataType;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.common.NeoForge;
@@ -224,7 +223,7 @@ public class TestFrameworkImpl implements MutableTestFramework {
                 .onInitMethodsWithAnnotation(container);
 
         this.modBus = modBus;
-        tests.buses = Map.of(EventBusSubscriber.Bus.GAME, NeoForge.EVENT_BUS, EventBusSubscriber.Bus.MOD, modBus);
+        tests.buses = new EventListenerGroupImpl.BusSet(modBus, NeoForge.EVENT_BUS);
 
         byStage.get(OnInit.Stage.BEFORE_SETUP).forEach(cons -> cons.accept(this));
 
@@ -373,7 +372,7 @@ public class TestFrameworkImpl implements MutableTestFramework {
         private final Map<String, EventListenerGroupImpl> collectors = new HashMap<>();
         private final Set<String> enabled = Collections.synchronizedSet(new LinkedHashSet<>());
         private final Map<String, Test.Status> statuses = new ConcurrentHashMap<>();
-        private Map<EventBusSubscriber.Bus, IEventBus> buses = Map.of();
+        private EventListenerGroupImpl.BusSet buses;
 
         private final Set<TestListener> globalListeners = new HashSet<>();
 

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/MethodBasedEventTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/MethodBasedEventTest.java
@@ -10,7 +10,6 @@ import java.lang.reflect.Method;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.testframework.Test;
 import net.neoforged.testframework.impl.ReflectionUtils;
@@ -20,7 +19,7 @@ public class MethodBasedEventTest extends AbstractTest.Dynamic {
     private final Method method;
 
     private final Class<? extends Event> eventClass;
-    private final EventBusSubscriber.Bus bus;
+    private final boolean modBus;
     private final EventPriority priority;
     private final boolean receiveCancelled;
 
@@ -30,7 +29,7 @@ public class MethodBasedEventTest extends AbstractTest.Dynamic {
 
         //noinspection unchecked
         this.eventClass = (Class<? extends Event>) method.getParameterTypes()[0];
-        this.bus = IModBusEvent.class.isAssignableFrom(eventClass) ? EventBusSubscriber.Bus.MOD : EventBusSubscriber.Bus.GAME;
+        this.modBus = IModBusEvent.class.isAssignableFrom(eventClass);
 
         final SubscribeEvent seAnnotation = method.getAnnotation(SubscribeEvent.class);
         if (seAnnotation == null) {
@@ -52,7 +51,7 @@ public class MethodBasedEventTest extends AbstractTest.Dynamic {
     @Override
     public void onEnabled(Test.EventListenerGroup buses) {
         super.onEnabled(buses);
-        buses.getFor(bus).addListener(priority, receiveCancelled, eventClass, event -> {
+        (modBus ? buses.mod() : buses.forge()).addListener(priority, receiveCancelled, eventClass, event -> {
             try {
                 handle.invoke(event, this);
             } catch (Throwable throwable) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
@@ -83,7 +83,6 @@ import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.common.EventBusSubscriber.Bus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.data.ParticleDescriptionProvider;
 import net.neoforged.neoforge.common.conditions.NeoForgeConditions;
@@ -104,8 +103,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+@EventBusSubscriber
 @Mod(DataGeneratorTest.MODID)
-@EventBusSubscriber(bus = Bus.MOD)
 public class DataGeneratorTest {
     static final String MODID = "data_gen_test";
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredWorkQueueTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredWorkQueueTest.java
@@ -16,8 +16,8 @@ import org.slf4j.Logger;
  * Tests that the {@link net.neoforged.fml.DeferredWorkQueue} properly executes enqueued tasks and
  * forwards any exceptions thrown by those tasks
  */
+@EventBusSubscriber
 @Mod(DeferredWorkQueueTest.MOD_ID)
-@EventBusSubscriber(modid = DeferredWorkQueueTest.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public class DeferredWorkQueueTest {
     public static final String MOD_ID = "deferred_work_queue_test";
     private static final boolean ENABLE = false;

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomHeadTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomHeadTest.java
@@ -30,7 +30,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.common.EventBusSubscriber.Bus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
@@ -117,7 +116,7 @@ public class CustomHeadTest {
         }
     }
 
-    @EventBusSubscriber(value = Dist.CLIENT, bus = Bus.MOD, modid = MODID)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = MODID)
     private static class ClientEvents {
         static final ModelLayerLocation BLAZE_HEAD_LAYER = new ModelLayerLocation(BLAZE_HEAD.getId(), "main");
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomPlantTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomPlantTypeTest.java
@@ -29,8 +29,8 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
+@EventBusSubscriber
 @Mod(CustomPlantTypeTest.MODID)
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
 public class CustomPlantTypeTest {
     static final String MODID = "custom_plant_type_test";
     private static final String CUSTOM_SOIL_BLOCK = "test_custom_block";

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
@@ -21,8 +21,8 @@ import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
+@EventBusSubscriber
 @Mod(FlowerPotTest.MODID)
-@EventBusSubscriber(modid = FlowerPotTest.MODID, bus = EventBusSubscriber.Bus.MOD)
 public class FlowerPotTest {
     static final String MODID = "flower_pot_test";
     static final String BLOCK_ID = "test_flower_pot";

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
@@ -214,7 +214,7 @@ public class FullPotsAccessorDemo {
         }
     }
 
-    @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
     private static class ClientHandler {
         @SubscribeEvent
         public static void registerBlockStateModelType(final RegisterBlockStateModels event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/HideNeighborFaceTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/HideNeighborFaceTest.java
@@ -79,7 +79,7 @@ public class HideNeighborFaceTest {
         }
     }
 
-    @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID)
     public static class ClientEvents {
         @SubscribeEvent
         public static void onClientSetup(final FMLClientSetupEvent event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/SlipperinessTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/SlipperinessTest.java
@@ -22,8 +22,8 @@ import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
+@EventBusSubscriber
 @Mod(SlipperinessTest.MOD_ID)
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.MOD)
 public class SlipperinessTest {
     static final String MOD_ID = "slipperiness_test";
     static final String BLOCK_ID = "test_block";

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomColorResolverTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomColorResolverTest.java
@@ -41,7 +41,7 @@ public class CustomColorResolverTest {
         ITEMS.registerSimpleBlockItem(BLOCK);
     }
 
-    @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID)
     private static class ClientHandler {
         private static final ColorResolver COLOR_RESOLVER = (biome, x, z) -> biome.getPrecipitationAt(BlockPos.containing(x, 0, z), Minecraft.getInstance().level.getSeaLevel()) == Biome.Precipitation.NONE ? 0xFF0000 : 0x0000FF;
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomPresetEditorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomPresetEditorTest.java
@@ -48,7 +48,7 @@ public class CustomPresetEditorTest {
     public static final String MODID = "custom_preset_editor_test";
     public static final ResourceKey<WorldPreset> WORLD_PRESET_KEY = ResourceKey.create(Registries.WORLD_PRESET, ResourceLocation.fromNamespaceAndPath(MODID, MODID));
 
-    @EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(modid = MODID)
     public static class CommonModEvents {
         @SubscribeEvent
         public static void onGatherData(GatherDataEvent.Client event) {
@@ -81,7 +81,7 @@ public class CustomPresetEditorTest {
         }
     }
 
-    @EventBusSubscriber(modid = MODID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(modid = MODID, value = Dist.CLIENT)
     public static class ClientModEvents {
         @SubscribeEvent
         public static void onRegisterPresetEditors(RegisterPresetEditorsEvent event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CustomItemDisplayContextTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CustomItemDisplayContextTest.java
@@ -77,7 +77,7 @@ import org.jetbrains.annotations.Nullable;
 public class CustomItemDisplayContextTest {
     public static final String MODID = "custom_transformtype_test";
 
-    @EventBusSubscriber(value = Dist.CLIENT, modid = MODID, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = MODID)
     private static class RendererEvents {
         public static final ItemDisplayContext HANGING = ItemDisplayContext.valueOf("NEOTESTS_HANGING");
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
@@ -96,7 +96,7 @@ public class MegaModelTest {
             event.accept(TEST_BLOCK_ITEM);
     }
 
-    @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = MOD_ID)
     public static class ClientEvents {
         @SubscribeEvent
         public static void onModelBakingCompleted(ModelEvent.ModifyBakingResult event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/CustomItemDecorationsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/CustomItemDecorationsTest.java
@@ -24,7 +24,7 @@ public class CustomItemDecorationsTest {
 
     public CustomItemDecorationsTest() {}
 
-    @EventBusSubscriber(modid = CustomItemDecorationsTest.MOD_ID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
+    @EventBusSubscriber(modid = CustomItemDecorationsTest.MOD_ID, value = Dist.CLIENT)
     public static class ClientEvents {
         @SubscribeEvent
         public static void onRegisterItemDecorations(final RegisterItemDecorationsEvent event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/CustomParticleTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/CustomParticleTypeTest.java
@@ -26,7 +26,7 @@ public class CustomParticleTypeTest {
 
     public CustomParticleTypeTest() {}
 
-    @EventBusSubscriber(modid = CustomParticleTypeTest.MOD_ID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+    @EventBusSubscriber(modid = CustomParticleTypeTest.MOD_ID, value = Dist.CLIENT)
     public static class ClientEvents {
         private static final ParticleRenderType CUSTOM_TYPE = new ParticleRenderType("CUSTOM_TYPE", RenderType.translucentParticle(TextureAtlas.LOCATION_BLOCKS));
         private static final ParticleRenderType CUSTOM_TYPE_TWO = new ParticleRenderType("CUSTOM_TYPE_TWO", RenderType.translucentParticle(TextureAtlas.LOCATION_BLOCKS));

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/EntityRendererEventsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/rendering/EntityRendererEventsTest.java
@@ -44,8 +44,8 @@ import net.neoforged.neoforge.event.entity.EntityAttributeCreationEvent;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
+@EventBusSubscriber
 @Mod("entity_renderer_events_test")
-@EventBusSubscriber(modid = "entity_renderer_events_test", bus = EventBusSubscriber.Bus.MOD)
 public class EntityRendererEventsTest {
     private static final ResourceLocation MY_ENTITY = ResourceLocation.fromNamespaceAndPath("entity_renderer_events_test", "test_entity");
 
@@ -63,7 +63,7 @@ public class EntityRendererEventsTest {
         event.put(MY_ENTITY_TYPE.get(), Monster.createMonsterAttributes().add(Attributes.MAX_HEALTH, 1.0D).build());
     }
 
-    @EventBusSubscriber(value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(value = Dist.CLIENT, modid = "entity_renderer_events_test")
     private static class EntityRenderEventsTestClientModStuff {
         private static final ModelLayerLocation MAIN_LAYER = new ModelLayerLocation(MY_ENTITY, "main");
         private static final ModelLayerLocation OUTER_LAYER = new ModelLayerLocation(MY_ENTITY, "main");

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/PartEntityTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/PartEntityTest.java
@@ -57,7 +57,7 @@ public class PartEntityTest {
         event.put(TEST_ENTITY.get(), Pig.createAttributes().build());
     }
 
-    @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
     private static class ClientEvents {
         @SubscribeEvent
         public static void onRegisterRenderers(final EntityRenderersEvent.RegisterRenderers event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/StopUsingItemTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/StopUsingItemTest.java
@@ -19,7 +19,6 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.common.EventBusSubscriber.Bus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
 import net.neoforged.neoforge.common.NeoForge;
@@ -126,7 +125,7 @@ public class StopUsingItemTest {
         }
     }
 
-    @EventBusSubscriber(modid = MODID, value = Dist.CLIENT, bus = Bus.GAME)
+    @EventBusSubscriber(modid = MODID, value = Dist.CLIENT)
     public static class ClientEvents {
         @SubscribeEvent
         static void computeFovModifier(ComputeFovModifierEvent event) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/recipebook/RecipeBookExtensionTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/recipebook/RecipeBookExtensionTest.java
@@ -77,7 +77,7 @@ public class RecipeBookExtensionTest {
         return ResourceLocation.fromNamespaceAndPath(MOD_ID, name);
     }
 
-    @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT, bus = EventBusSubscriber.Bus.MOD)
+    @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
     public static class ClientHandler {
         @SubscribeEvent
         public static void clientSetup(RegisterMenuScreensEvent event) {


### PR DESCRIPTION
This PR updates FML to latest to remove the bus parameter from `@EventBusSubscriber`, allowing mods to even mix listeners, completely hiding the bus from users of EBS.

This FML update also introduces support for [custom loading screen themes](https://github.com/neoforged/FancyModLoader/blob/main/earlydisplay/THEMING.md).