### PR TITLE
[1.21.6] Fix render fog event not being posted

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -441,7 +441,7 @@ public class ClientHooks {
         if (camera.getPosition().y < (double) ((float) camera.getBlockPosition().getY() + state.getHeight(camera.getEntity().level(), camera.getBlockPosition())))
             IClientFluidTypeExtensions.of(state).modifyFogRender(camera, environment, renderDistance, partialTick, fogData);
 
-        new ViewportEvent.RenderFog(environment, type, camera, partialTick, fogData);
+        NeoForge.EVENT_BUS.post(new ViewportEvent.RenderFog(environment, type, camera, partialTick, fogData));
     }
 
     public static void onModifyBakingResult(ModelBakery.BakingResult bakingResult, Map<ResourceLocation, AtlasSet.StitchResult> stitchResults, ModelBakery modelBakery) {

--- a/src/client/java/net/neoforged/neoforge/client/event/ViewportEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ViewportEvent.java
@@ -67,9 +67,6 @@ public abstract class ViewportEvent extends Event {
     /**
      * Fired for <b>rendering</b> custom fog. The plane distances are based on the player's render distance.
      *
-     * <p>This event is {@linkplain ICancellableEvent cancellable}. <br/>
-     * The event must be cancelled for any changes to the plane distances to take effect.</p>
-     *
      * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */


### PR DESCRIPTION
The `RenderFog` event isn't actually posted to the event bus, so this PR fixes that.

Additionally, it updates the documentation on the event itself. The note about needing to cancel the event to make changes has been removed as the event is no longer cancelable.