### PR TITLE
Remove incorrect server-extra jar from server launch arguments

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateArgsFile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateArgsFile.java
@@ -71,9 +71,7 @@ public abstract class CreateArgsFile extends DefaultTask {
     protected abstract ArchiveOperations getArchiveOperations();
 
     private String resolveClasspath() throws IOException {
-        var ourClasspath = getClasspath().get() + getPathSeparator().get()
-                + "libraries/net/minecraft/server/%s/server-%s-extra.jar".formatted(
-                        getRawNeoFormVersion().get(), getRawNeoFormVersion().get());
+        var ourClasspath = getClasspath().get();
 
         // The raw server jar also contains its own classpath.
         // We want to make sure that our versions of the libraries are used when there is a conflict.


### PR DESCRIPTION
The server-extra jar we currently put on the classpath is actually not used, as is evident by the fact it's path is incorrect.

FML builds the path to this jar on its own here: https://github.com/neoforged/FancyModLoader/blob/1ff4fe8529f9da61024cce7e3e89590a52cec984/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/ProductionServerProvider.java#L45