### PR TITLE
[1.21.6] Fix recovery on initial resource reload causing mod loading to run twice

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -78,14 +78,22 @@
          this.window.updateVsync(this.options.enableVsync().get());
          this.window.updateRawMouseInput(this.options.rawMouseInput().get());
          this.window.setDefaultErrorCallback();
-@@ -655,9 +_,9 @@
+@@ -655,9 +_,16 @@
          GameLoadTimesEvent.INSTANCE.beginStep(TelemetryProperty.LOAD_TIME_LOADING_OVERLAY_MS);
          Minecraft.GameLoadCookie minecraft$gameloadcookie = new Minecraft.GameLoadCookie(realmsclient, p_91084_.quickPlay);
          this.setOverlay(
 -            new LoadingOverlay(
-+            net.neoforged.neoforge.client.ClientHooks.createLoadingOverlay(
-                 this, reloadinstance, p_299779_ -> Util.ifElse(p_299779_, p_299772_ -> this.rollbackResourcePacks(p_299772_, minecraft$gameloadcookie), () -> {
+-                this, reloadinstance, p_299779_ -> Util.ifElse(p_299779_, p_299772_ -> this.rollbackResourcePacks(p_299772_, minecraft$gameloadcookie), () -> {
 -                    if (SharedConstants.IS_RUNNING_IN_IDE) {
++            net.neoforged.neoforge.client.ClientHooks.createLoadingOverlay(
++                this, reloadinstance, p_299779_ -> Util.ifElse(p_299779_, p_299772_ -> {
++                    if (p_299772_.getCause() instanceof net.neoforged.fml.ModLoadingException mle) {
++                        // Hard-crash if the reload failed due to a modloading error to prevent spurious errors during the recovery reload
++                        // TODO: replace with call to MC-independent error screen
++                        throw mle;
++                    }
++                    this.rollbackResourcePacks(p_299772_, minecraft$gameloadcookie);
++                }, () -> {
 +                    if (SharedConstants.IS_RUNNING_IN_IDE && false /* Neo: Disable self-test */) {
                          this.selfTest();
                      }
@@ -116,12 +124,13 @@
          }
  
          stringbuilder.append(" ");
-@@ -797,7 +_,7 @@
+@@ -797,7 +_,8 @@
      }
  
      private void rollbackResourcePacks(Throwable p_91240_, @Nullable Minecraft.GameLoadCookie p_299846_) {
 -        if (this.resourcePackRepository.getSelectedIds().size() > 1) {
-+        if (this.resourcePackRepository.getSelectedPacks().stream().anyMatch(e -> !e.isRequired())) { //Forge: This caused infinite loop if any resource packs are forced. Such as mod resources. So check if we can disable any.
++        //Neo: Checking for size>1 causes an infinite loop if any packs such as mod resources are forced or hidden
++        if (this.resourcePackRepository.getSelectedPacks().stream().anyMatch(e -> !e.isRequired() && !e.isHidden())) {
              this.clearResourcePacksOnError(p_91240_, null, p_299846_);
          } else {
              Util.throwAsRuntime(p_91240_);

--- a/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 public class ClientModLoader extends CommonModLoader {
     private static final Logger LOGGER = LogManager.getLogger();
     private static boolean loading;
-    private static boolean loadingComplete;
+    private static boolean loadingStarted;
     @Nullable
     private static ModLoadingException error;
 
@@ -74,14 +74,18 @@ public class ClientModLoader extends CommonModLoader {
      * It is used as the entrypoint for client mod loading, which starts when {@link Minecraft} triggers the first resource reload.
      */
     public static CompletableFuture<Void> onResourceReload(final PreparableReloadListener.PreparationBarrier stage, final ResourceManager resourceManager, final Executor asyncExecutor, final Executor syncExecutor) {
+        // Don't load again on subsequent reloads
+        if (loadingStarted) {
+            return stage.wait(null);// The barrier must be notified, otherwise the reload will deadlock
+        }
+
+        loadingStarted = true;
         return CompletableFuture.runAsync(() -> startModLoading(syncExecutor, asyncExecutor), ModWorkManager.parallelExecutor())
                 .thenCompose(stage::wait)
                 .thenRunAsync(() -> finishModLoading(syncExecutor, asyncExecutor), ModWorkManager.parallelExecutor());
     }
 
     private static void catchLoadingException(Runnable r) {
-        // Don't load again on subsequent reloads
-        if (loadingComplete) return;
         // If the mod loading state is invalid, skip further mod initialization
         if (ModLoader.hasErrors()) return;
 
@@ -99,7 +103,6 @@ public class ClientModLoader extends CommonModLoader {
     private static void finishModLoading(Executor syncExecutor, Executor parallelExecutor) {
         catchLoadingException(() -> finish(syncExecutor, parallelExecutor));
         loading = false;
-        loadingComplete = true;
     }
 
     public static VersionChecker.Status checkForUpdates() {


### PR DESCRIPTION
This PR fixes a bug where certain loading errors during the initial resource reload would cause parts of client mod loading to run twice due to vanilla cancelling the active reload, unloading all resource packs and starting a second resource reload to recover from resource loading errors. This causes irrelevant additional errors that mask the actual error in the crash report.

While this fixes the underlying bug, it also uncovers another issue where the recovery reload appears to overwrite Neo's loading error screen and instead causes the game to go to the main menu while rendering only the loading overlay background (1.21.1 behaves very similar, except that it also shows the Mojang logo and the progress bar at ~70%).