### PR TITLE
Bump ASM to 9.7.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,9 @@ art_version=2.0.3
 # renovate: net.neoforged.installertools:installertools
 installertools_version=3.0.5
 
+# renovate: org.ow2.asm:asm
+asm_version=9.7.1
+
 mergetool_version=2.0.0
 accesstransformers_version=11.0.1
 coremods_version=6.0.4
@@ -36,7 +39,6 @@ eventbus_version=8.0.2
 modlauncher_version=11.0.5
 securejarhandler_version=3.0.8
 bootstraplauncher_version=2.0.2
-asm_version=9.7
 mixin_version=0.15.2+mixin.0.8.7
 terminalconsoleappender_version=1.3.0
 nightconfig_version=3.8.2


### PR DESCRIPTION
Adds Java 24 support. Also adds a comment for renovate with the dep coordinates since after the buildSrc plugin renovate cannot pick up the asm version automatically as it is not simply added as a normal dependency (see https://github.com/neoforged/NeoForge/blob/a8be0be657ade617e7231aeaaf786d52efc8c958/projects/neoforge/build.gradle#L110)