### PR TITLE
[1.21.6] Fix links in mod list crashing when accessed from the main menu

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -30,6 +30,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.locale.Language;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
@@ -461,5 +462,10 @@ public class ModListScreen extends Screen {
     @Override
     public void onClose() {
         this.minecraft.setScreen(this.parentScreen);
+    }
+
+    @Override
+    protected void handleClickEvent(Minecraft minecraft, ClickEvent clickEvent) {
+        defaultHandleClickEvent(clickEvent, minecraft, this);
     }
 }


### PR DESCRIPTION
This PR fixes clicking on links in the mod list screen crashing when the mod list screen is accessed from the main menu. This is fixed by preventing Minecraft from trying to handle the `ClickEvent` as a type which requires access to a player.

Fixes #2378 