### PR TITLE
[1.21.6] Fix air meter rendering below vehicle health

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -76,7 +76,7 @@
 +                .add(PLAYER_HEALTH, (guiGraphics, partialTick) -> renderHealthLevel(guiGraphics))
 +                .add(ARMOR_LEVEL, (guiGraphics, partialTick) -> renderArmorLevel(guiGraphics))
 +                .add(FOOD_LEVEL, (guiGraphics, partialTick) -> renderFoodLevel(guiGraphics))
-+                .add(VEHICLE_HEALTH, (guiGraphics, deltaTracker) -> renderVehicleHealth(guiGraphics), guiVisible)
++                .add(VEHICLE_HEALTH, (guiGraphics, partialTick) -> renderVehicleHealth(guiGraphics), guiVisible)
 +                .add(AIR_LEVEL, (guiGraphics, partialTick) -> renderAirLevel(guiGraphics));
 +        layerManager.add(playerHealthComponents, () -> this.minecraft.gameMode.canHurtPlayer() && guiVisible.getAsBoolean());
 +        layerManager.add(CONTEXTUAL_INFO_BAR_BACKGROUND, this::renderContextualInfoBarBackground, guiVisible);

--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -76,9 +76,9 @@
 +                .add(PLAYER_HEALTH, (guiGraphics, partialTick) -> renderHealthLevel(guiGraphics))
 +                .add(ARMOR_LEVEL, (guiGraphics, partialTick) -> renderArmorLevel(guiGraphics))
 +                .add(FOOD_LEVEL, (guiGraphics, partialTick) -> renderFoodLevel(guiGraphics))
++                .add(VEHICLE_HEALTH, (guiGraphics, deltaTracker) -> renderVehicleHealth(guiGraphics), guiVisible)
 +                .add(AIR_LEVEL, (guiGraphics, partialTick) -> renderAirLevel(guiGraphics));
 +        layerManager.add(playerHealthComponents, () -> this.minecraft.gameMode.canHurtPlayer() && guiVisible.getAsBoolean());
-+        layerManager.add(VEHICLE_HEALTH, this::renderVehicleHealth, guiVisible);
 +        layerManager.add(CONTEXTUAL_INFO_BAR_BACKGROUND, this::renderContextualInfoBarBackground, guiVisible);
 +        layerManager.add(EXPERIENCE_LEVEL, this::renderExperienceLevel, guiVisible);
 +        layerManager.add(CONTEXTUAL_INFO_BAR, this::renderContextualInfoBar, guiVisible);


### PR DESCRIPTION
The solution was to append the vehicle health to `playerHealthComponents` before adding the `AIR_LEVEL`, allowing `VEHICLE_HEALTH` to be rendered before the `AIR_LEVEL` is. Fixes #2380.
Vanilla (from @Fuzss):
![image](https://github.com/user-attachments/assets/41879180-3fdc-4749-8597-ee6efb40416a)
Neoforged BUGGED(from @Fuzss):
![image](https://github.com/user-attachments/assets/3e7827c1-1167-4ce5-b45b-cd2598a90907)
Neoforge:
![image](https://github.com/user-attachments/assets/e8779d7a-ced8-46af-83f3-5bda66fe80e4)

