### PR TITLE
Add a Warning when adding Synced Entity Data Accessors to Foreign Entities

### DIFF
--- a/patches/net/minecraft/network/syncher/SynchedEntityData.java.patch
+++ b/patches/net/minecraft/network/syncher/SynchedEntityData.java.patch
@@ -1,18 +1,14 @@
 --- a/net/minecraft/network/syncher/SynchedEntityData.java
 +++ b/net/minecraft/network/syncher/SynchedEntityData.java
-@@ -27,11 +_,13 @@
+@@ -26,8 +_,10 @@
+         this.itemsById = p_326032_;
      }
  
++    private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
      public static <T> EntityDataAccessor<T> defineId(Class<? extends SyncedDataHolder> p_135354_, EntityDataSerializer<T> p_135355_) {
 -        if (LOGGER.isDebugEnabled()) {
-+        if (true || LOGGER.isDebugEnabled()) { // Forge: This is very useful for mods that register keys on classes that are not their own
++        net.neoforged.neoforge.common.CommonHooks.verifyEntityDataAccessorRegistration(STACK_WALKER.getCallerClass(), p_135354_);
++        if (false && LOGGER.isDebugEnabled()) { // Neo: disable this check as we are handling it in the above hook
              try {
                  Class<?> oclass = Class.forName(Thread.currentThread().getStackTrace()[2].getClassName());
                  if (!oclass.equals(p_135354_)) {
--                    LOGGER.debug("defineId called for: {} from {}", p_135354_, oclass, new RuntimeException());
-+                    // Forge: log at warn, mods should not add to classes that they don't own, and only add stacktrace when in debug is enabled as it is mostly not needed and consumes time
-+                    if (LOGGER.isDebugEnabled()) LOGGER.warn("defineId called for: {} from {}", p_135354_, oclass, new RuntimeException());
-+                    else LOGGER.warn("defineId called for: {} from {}", p_135354_, oclass);
-                 }
-             } catch (ClassNotFoundException classnotfoundexception) {
-             }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1728,6 +1728,7 @@ public class CommonHooks {
 
     private static final Set<Class<?>> EDA_CHECKED_CLASSES = ConcurrentHashMap.newKeySet(BuiltInRegistries.ENTITY_TYPE.size());
 
+    @ApiStatus.Internal
     public static void verifyEntityDataAccessorRegistration(final Class<?> callerClass, final Class<? extends SyncedDataHolder> holderClass) {
         if (!EDA_CHECKED_CLASSES.add(callerClass)) return;
 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1765,7 +1765,7 @@ public class CommonHooks {
             message.append("Mixins into entity class: ").append(String.join(", ", mixinsInjectingEda));
         }
 
-        message.append("\nModders should instead use syncable data attachments instead, as they do not suffer from potential ID mismatches.\n");
+        message.append("\nModders should use syncable data attachments instead, as they do not suffer from potential ID mismatches.\n");
         message.append("Please refer to the data attachments documentation available at https://docs.neoforged.net/docs/datastorage/attachments.\n");
         message.append("This message will only be printed once per class");
 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -39,6 +39,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.minecraft.ChatFormatting;
 import net.minecraft.ResourceLocationException;
@@ -1737,17 +1738,17 @@ public class CommonHooks {
         // The check might hold up either because the definition is sound or because someone added a Mixin into the
         // entity class aiming to add their own synced data; this is still an issue as different ordering that might
         // occur due to whatever version might still cause problems down the line.
-        final List<String> mixinsInjectingEda;
+        final Collection<String> mixinsInjectingEda;
         if (isEntityClass) {
             mixinsInjectingEda = Stream.of(callerClass.getDeclaredFields())
                     .filter(it -> EntityDataAccessor.class.isAssignableFrom(it.getType()))
                     .map(it -> it.getAnnotation(MixinMerged.class))
                     .filter(Objects::nonNull)
                     .map(MixinMerged::mixin)
-                    .toList();
+                    .collect(Collectors.toSet());
         } else {
             // We don't care about which mixins exist outside of entities, it's wrong already
-            mixinsInjectingEda = List.of();
+            mixinsInjectingEda = Set.of();
         }
 
         final var isValid = isEntityClass && mixinsInjectingEda.isEmpty();

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -71,7 +71,9 @@ import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
+import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializer;
+import net.minecraft.network.syncher.SyncedDataHolder;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -228,6 +230,7 @@ import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.transformer.meta.MixinMerged;
 
 /**
  * Class for various common (i.e. client and server-side) hooks.
@@ -692,7 +695,7 @@ public class CommonHooks {
      * Called from {@link AnvilMenu#createResult()} after the vanilla result has been computed.
      * <p>
      * If the left input to the anvil is not empty, this method fires the {@link AnvilUpdateEvent} to allow mods to manipulate the result.
-     * 
+     *
      * @param menu       The anvil menu
      * @param leftInput  The left input item
      * @param rightInput The right input item
@@ -724,7 +727,7 @@ public class CommonHooks {
      * This is fired from the head of {@link AnvilMenu#onTake}, before any other logic is run.
      * <p>
      * If this event is cancelled, {@link AnvilMenu#onTake} should return immediately.
-     * 
+     *
      * @param menu   The anvil menu
      * @param player The player who is using the anvil
      * @param output The output item
@@ -741,7 +744,7 @@ public class CommonHooks {
      * Fires the {@link AnvilCraftEvent.Post} when the anvil is used to craft an item.
      * <p>
      * This is fired from the tail of {@link AnvilMenu#onTake}, after all other logic is run.
-     * 
+     *
      * @param menu   The anvil menu
      * @param player The player who is using the anvil
      * @param output The output item
@@ -1719,6 +1722,58 @@ public class CommonHooks {
             var payload = RecipeContentPayload.create(recipeTypesToSend, recipeMap);
             LOGGER.debug("Sending {} recipes of the following types: {}", payload.recipes().size(), payload.recipeTypes());
             PacketDistributor.sendToPlayer(player, payload);
+        }
+    }
+
+    public static void verifyEntityDataAccessorRegistration(final Class<?> callerClass, final Class<? extends SyncedDataHolder> holderClass) {
+        // Replicate Mojang check, which ensures that the defining class is the same as the holder
+        var isValid = callerClass == holderClass;
+        StringBuilder mixinClasses = null;
+
+        // The check might hold up either because the definition is sound or because someone added a Mixin into the
+        // entity class aiming to add their own synced data; this is still an issue as different ordering that might
+        // occur due to whatever version might still cause problems down the line.
+        if (isValid) {
+            for (final var field : callerClass.getDeclaredFields()) {
+                if (!EntityDataAccessor.class.isAssignableFrom(field.getType())) continue;
+
+                final var mixinMerged = field.getAnnotation(MixinMerged.class);
+                if (mixinMerged == null) continue;
+
+                // Identified an EntityDataAccessor merged by a Mixin, this is a problem: we will now append the Mixin
+                // declaration to mixinClasses; do note that we are processing all mixin-merged fields anyway, so we
+                // will report all problematic areas at once.
+                final var mixinName = mixinMerged.mixin();
+
+                isValid = false;
+                if (mixinClasses == null) {
+                    mixinClasses = new StringBuilder(mixinName);
+                } else {
+                    mixinClasses.append(", ").append(mixinName);
+                }
+            }
+        }
+
+        if (isValid) {
+            return;
+        }
+
+        final var message = new StringBuilder();
+        message.append("Identified an attempt to add synced data to a foreign entity: this is highly discouraged.\n");
+        message.append("Entity class: ").append(holderClass.getName()).append('\n');
+        message.append("Declaring class: ").append(callerClass.getName());
+
+        if (mixinClasses != null) {
+            message.append(" (due to the following Mixins: ").append(mixinClasses).append(')');
+        }
+
+        message.append("\nModders should instead use syncable data attachments instead, as they do not suffer from potential ID mismatches.\n");
+        message.append("Please refer to the data attachments documentation available at https://docs.neoforged.net/docs/datastorage/attachments.");
+
+        if (SharedConstants.IS_RUNNING_IN_IDE) {
+            throw new IllegalStateException(message.toString());
+        } else {
+            LOGGER.warn(message);
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1726,7 +1726,7 @@ public class CommonHooks {
         }
     }
 
-    private static final Set<Class<?>> EDA_CHECKED_CLASSES = new HashSet<>(BuiltInRegistries.ENTITY_TYPE.size());
+    private static final Set<Class<?>> EDA_CHECKED_CLASSES = ConcurrentHashMap.newKeySet(BuiltInRegistries.ENTITY_TYPE.size());
 
     public static void verifyEntityDataAccessorRegistration(final Class<?> callerClass, final Class<? extends SyncedDataHolder> holderClass) {
         if (!EDA_CHECKED_CLASSES.add(callerClass)) return;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1732,33 +1732,25 @@ public class CommonHooks {
         if (!EDA_CHECKED_CLASSES.add(callerClass)) return;
 
         // Replicate Mojang check, which ensures that the defining class is the same as the holder
-        var isValid = callerClass == holderClass;
-        StringBuilder mixinClasses = null;
+        final var isEntityClass = callerClass == holderClass;
 
         // The check might hold up either because the definition is sound or because someone added a Mixin into the
         // entity class aiming to add their own synced data; this is still an issue as different ordering that might
         // occur due to whatever version might still cause problems down the line.
-        if (isValid) {
-            for (final var field : callerClass.getDeclaredFields()) {
-                if (!EntityDataAccessor.class.isAssignableFrom(field.getType())) continue;
-
-                final var mixinMerged = field.getAnnotation(MixinMerged.class);
-                if (mixinMerged == null) continue;
-
-                // Identified an EntityDataAccessor merged by a Mixin, this is a problem: we will now append the Mixin
-                // declaration to mixinClasses; do note that we are processing all mixin-merged fields anyway, so we
-                // will report all problematic areas at once.
-                final var mixinName = mixinMerged.mixin();
-
-                isValid = false;
-                if (mixinClasses == null) {
-                    mixinClasses = new StringBuilder(mixinName);
-                } else {
-                    mixinClasses.append(", ").append(mixinName);
-                }
-            }
+        final List<String> mixinsInjectingEda;
+        if (isEntityClass) {
+            mixinsInjectingEda = Stream.of(callerClass.getDeclaredFields())
+                    .filter(it -> EntityDataAccessor.class.isAssignableFrom(it.getType()))
+                    .map(it -> it.getAnnotation(MixinMerged.class))
+                    .filter(Objects::nonNull)
+                    .map(MixinMerged::mixin)
+                    .toList();
+        } else {
+            // We don't care about which mixins exist outside of entities, it's wrong already
+            mixinsInjectingEda = List.of();
         }
 
+        final var isValid = isEntityClass && mixinsInjectingEda.isEmpty();
         if (isValid) {
             return;
         }
@@ -1767,10 +1759,10 @@ public class CommonHooks {
         message.append("Identified an attempt to add synced data to a foreign entity: this is highly discouraged.\n");
         message.append("Entity class: ").append(holderClass.getName()).append('\n');
 
-        if (mixinClasses == null) {
+        if (mixinsInjectingEda.isEmpty()) {
             message.append("Declaring class: ").append(callerClass.getName());
         } else {
-            message.append("Mixins into entity class: ").append(mixinClasses);
+            message.append("Mixins into entity class: ").append(String.join(", ", mixinsInjectingEda));
         }
 
         message.append("\nModders should instead use syncable data attachments instead, as they do not suffer from potential ID mismatches.\n");

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1725,7 +1726,11 @@ public class CommonHooks {
         }
     }
 
+    private static final Set<Class<?>> EDA_CHECKED_CLASSES = new HashSet<>(BuiltInRegistries.ENTITY_TYPE.size());
+
     public static void verifyEntityDataAccessorRegistration(final Class<?> callerClass, final Class<? extends SyncedDataHolder> holderClass) {
+        if (!EDA_CHECKED_CLASSES.add(callerClass)) return;
+
         // Replicate Mojang check, which ensures that the defining class is the same as the holder
         var isValid = callerClass == holderClass;
         StringBuilder mixinClasses = null;
@@ -1761,14 +1766,16 @@ public class CommonHooks {
         final var message = new StringBuilder();
         message.append("Identified an attempt to add synced data to a foreign entity: this is highly discouraged.\n");
         message.append("Entity class: ").append(holderClass.getName()).append('\n');
-        message.append("Declaring class: ").append(callerClass.getName());
 
-        if (mixinClasses != null) {
-            message.append(" (due to the following Mixins: ").append(mixinClasses).append(')');
+        if (mixinClasses == null) {
+            message.append("Declaring class: ").append(callerClass.getName());
+        } else {
+            message.append("Mixins into entity class: ").append(mixinClasses);
         }
 
         message.append("\nModders should instead use syncable data attachments instead, as they do not suffer from potential ID mismatches.\n");
-        message.append("Please refer to the data attachments documentation available at https://docs.neoforged.net/docs/datastorage/attachments.");
+        message.append("Please refer to the data attachments documentation available at https://docs.neoforged.net/docs/datastorage/attachments.\n");
+        message.append("This message will only be printed once per class");
 
         if (SharedConstants.IS_RUNNING_IN_IDE) {
             throw new IllegalStateException(message.toString());

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -60,6 +60,7 @@ junitTest {
     classpath = sourceSets.junit.output + sourceSets.junit.runtimeClasspath
     testClassesDirs = sourceSets.junit.output.classesDirs
     outputs.upToDateWhen { false }
+    exclude("**/mixin/**")
 }
 
 neoDev {

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/EntityDataAccessorTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/EntityDataAccessorTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.SyncedDataHolder;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.neoforged.neoforge.common.CommonHooks;
+import org.junit.jupiter.api.Test;
+
+public final class EntityDataAccessorTests {
+    private static abstract class NoopSyncedDataHolder implements SyncedDataHolder {
+        @Override
+        public final void onSyncedDataUpdated(final EntityDataAccessor<?> p_326288_) {}
+
+        @Override
+        public final void onSyncedDataUpdated(final List<SynchedEntityData.DataValue<?>> p_326334_) {}
+    }
+
+    public static final class NoIssuesHolder extends NoopSyncedDataHolder {
+        static {
+            CommonHooks.verifyEntityDataAccessorRegistration(NoIssuesHolder.class, NoIssuesHolder.class);
+        }
+
+        static void init() {}
+    }
+
+    public static final class CorrectMixinTarget extends NoopSyncedDataHolder {
+        static {
+            CommonHooks.verifyEntityDataAccessorRegistration(CorrectMixinTarget.class, CorrectMixinTarget.class);
+        }
+
+        static void init() {}
+    }
+
+    public static final class WrongMixinTarget extends NoopSyncedDataHolder {
+        static {
+            CommonHooks.verifyEntityDataAccessorRegistration(EntityDataAccessorTests.WrongMixinTarget.class, EntityDataAccessorTests.WrongMixinTarget.class);
+        }
+
+        static void init() {}
+    }
+
+    @Test
+    void testThatNoErrorsAreThrownWhenSafeClassIsInitialized() {
+        assertDoesNotThrow(NoIssuesHolder::init);
+    }
+
+    @Test
+    void testExternalSyncedDataAccessorsAreCorrectlyDetected() {
+        assertThrows(IllegalStateException.class, () -> CommonHooks.verifyEntityDataAccessorRegistration(EntityDataAccessor.class, NoIssuesHolder.class));
+    }
+
+    @Test
+    void testMixinSyncedDataAccessorsAreCorrectlyDetected() {
+        final var throwable = assertThrows(ExceptionInInitializerError.class, WrongMixinTarget::init);
+        final var cause = throwable.getCause();
+        assertNotNull(cause);
+        assertInstanceOf(IllegalStateException.class, cause);
+        assertTrue(() -> cause.getMessage().contains("EntityDataAccessorTestsWrongMixin"));
+    }
+
+    @Test
+    void testOtherInjectedMixinFieldsAreIgnored() {
+        assertDoesNotThrow(CorrectMixinTarget::init);
+    }
+}

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/mixin/EntityDataAccessorTestsCorrectMixin.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/mixin/EntityDataAccessorTestsCorrectMixin.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest.mixin;
+
+import net.neoforged.neoforge.unittest.EntityDataAccessorTests;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntityDataAccessorTests.CorrectMixinTarget.class)
+public abstract class EntityDataAccessorTestsCorrectMixin {
+    private static final Object SHOULD_NOT_BE_DETECTED = null;
+}

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/mixin/EntityDataAccessorTestsWrongMixin.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/mixin/EntityDataAccessorTestsWrongMixin.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest.mixin;
+
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.neoforged.neoforge.unittest.EntityDataAccessorTests;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(EntityDataAccessorTests.WrongMixinTarget.class)
+public abstract class EntityDataAccessorTestsWrongMixin {
+    private static final EntityDataAccessor<Integer> SHOULD_BE_DETECTED = null;
+}

--- a/tests/src/junit/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/junit/resources/META-INF/neoforge.mods.toml
@@ -2,6 +2,9 @@ modLoader="javafml"
 loaderVersion="[1,)"
 license="LGPL v2.1"
 
+[[mixins]]
+config="unittests.mixins.json"
+
 [[mods]]
 modId="block_entity_type_valid_blocks_event_test"
 [[mods]]

--- a/tests/src/junit/resources/unittests.mixins.json
+++ b/tests/src/junit/resources/unittests.mixins.json
@@ -1,0 +1,10 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.neoforged.neoforge.unittest.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/tests/src/junit/resources/unittests.mixins.json
+++ b/tests/src/junit/resources/unittests.mixins.json
@@ -3,7 +3,10 @@
   "minVersion": "0.8",
   "package": "net.neoforged.neoforge.unittest.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [],
+  "mixins": [
+    "EntityDataAccessorTestsCorrectMixin",
+    "EntityDataAccessorTestsWrongMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
## The Problem
Synced `EntityDataAccessor`s (EDAs for short) are synced across the network via numerical IDs which are automatically assigned by the game based on the order of the calls to `SynchedEntityData.defineId`. This in turn makes adding synced EDAs to *foreign entities*[^1] a problem, as different classes may load in different orders (especially due to parallel mod loading) or Mixins may be applied in different orders depending on various factors.

## The PR
This PR adds a check during the definition of synced entity data that verifies attempts to attach EDAs to *foreign entities*, either via Mixins or via calls to the method from outside the targeted entity class. In particular, the class defining the EDA is retrieved and is verified to be the same as the entity for which the EDA is being registered. If this is the case, then the entity class is further verified for the presence of EDAs injected through Mixins (identified through the use of the `@MixinMerged` annotation).
If any violation of the contract is identified, then the faulty situation is signaled through a log message in production and a hard crash in dev, allowing the mod author to promptly identify the issue and fix the problem prior to release.

## The Alternative
Mod developers should prefer using automatically synced data attachments instead (#1823), which allow attaching arbitrary data to *foreign entities* and have it automatically synced between server and client.

For clarity, we will outline an example migration process for a mod adding an EDA to represent Mana to an Evoker.

For the purposes of this discussion, we will assume that the data accessor is currently being created as such:
```java
static final EntityDataAccessor<Integer> MANA = SynchedEntityData.defineId(Evoker.class, EntityDataSerializers.INT); // (1)
```
and it is then being defined on the entity's `SynchedEntityData.Builder` as such:
```java
builder.define(MANA, 100); // (2)
```

The mod should instead register a new data attachment through a `DeferredRegister` like so:
```java
private static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, MOD_ID);

public static final DeferredHolder<AttachmentType<?>, AttachmentType<Integer>> EVOKER_MANA = ATTACHMENT_TYPES.register("evoker_mana", () ->
    AttachmentType.builder(() -> 100) // Define the default value of the data, as pulled from the builder definition call (2)
        .sync(ByteBufCodecs.VAR_INT) // Defines the stream codec that should be used to sync data
                                     // Alternatively, the EntityDataSerializer specified in (1) can be reused via EntityDataSerializers.INT.codec()
        //.serialize(Codec.INT.fieldOf("mana")) // ONLY IF persistence is desired -- note that EDAs do not handle persistence by themselves
                                                // so this is relevant only if the mod is achieving persistence with some other mechanism
        .build()
);

// Call this in the mod constructor
public static void init(final IEventBus modBus) {
    ATTACHMENT_TYPES.register(modBus);
}
```

Usages of the data attachment now won't require going through the entity data, meaning that code such as the following:
```java
static int getMana(Evoker evoker) {
    return evoker.getEntityData().get(MANA);
}

static void setMana(Evoker evoker, int mana) {
    return evoker.getEntityData().set(MANA, mana);
}
```
will have to be replaced as follows:
```java
static int getMana(Evoker evoker) {
    return evoker.getData(MANA);
}

static void setMana(Evoker evoker, int mana) {
    return evoker.setData(MANA, mana);
}
```

[^1]: In this discussion, a *foreign entity* represents an entity whose class is not the same as the one where the EDA is defined, be it a regular class or a Mixin.