### PR TITLE
Remove `RuntimeDistCleaner` and neo uses of `@OnlyIn` and add warnings screen and logging for uses of `@OnlyIn` in mods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.debug=false
 #org.gradle.warning.mode=fail
 
 # renovate: net.neoforged:moddev-gradle
-moddevgradle_plugin_version=2.0.48-beta
+moddevgradle_plugin_version=2.0.96
 # renovate: io.codechicken:DiffPatch
 diffpatch_version=2.0.0.35
 
@@ -41,7 +41,7 @@ nightconfig_version=3.8.2
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=9.0.2
+fancy_mod_loader_version=9.0.5
 typetools_version=0.6.3
 mixin_extras_version=0.4.1
 

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -46,7 +46,6 @@ import org.lwjgl.glfw.GLFW;
  * @see MouseInput
  * @see KeyInput
  */
-@OnlyIn(Dist.CLIENT)
 public abstract class ScreenEvent extends Event {
     private final Screen screen;
 

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -16,7 +16,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.EffectsInInventory;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;

--- a/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
@@ -20,8 +20,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ReloadInstance;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.fml.earlydisplay.DisplayWindow;
 import net.neoforged.fml.loading.progress.ProgressMeter;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;

--- a/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/NeoForgeLoadingOverlay.java
@@ -105,7 +105,6 @@ public class NeoForgeLoadingOverlay extends LoadingOverlay {
         }
     }
 
-    @OnlyIn(Dist.CLIENT)
     static class ExternalTexture extends AbstractTexture {
         public ExternalTexture(GpuTexture texture) {
             this.texture = texture;

--- a/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
@@ -1,0 +1,36 @@
+package net.neoforged.neoforge.common;
+
+import com.mojang.logging.LogUtils;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.fml.ModLoadingIssue;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+import org.jetbrains.annotations.ApiStatus;
+import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+
+@ApiStatus.Internal
+@SuppressWarnings("unused")
+@Mod(NeoForgeVersion.MOD_ID)
+public class OnlyInWarningsHandler {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
+    public OnlyInWarningsHandler(ModContainer container) {
+        if (!FMLEnvironment.production) {
+            ModList.get().forEachModFile(file -> {
+                if (file.getModInfos().stream().anyMatch(info -> info.getModId().equals("minecraft") || info.getModId().equals(NeoForgeVersion.MOD_ID))) {
+                    return;
+                }
+                Type anType = Type.getType(OnlyIn.class);
+                if (file.getScanResult().getAnnotations().stream().anyMatch(ad -> ad.annotationType().equals(anType))) {
+                    LOGGER.warn("The mod {} uses the @OnlyIn annotation; the runtime member-stripping behaviour of this annotation is no longer present, which may lead to issues if that behaviour was relied upon", file.getModInfos().getFirst().getModId());
+                    ModLoader.addLoadingIssue(ModLoadingIssue.warning("loadwarning.neoforge.onlyin", file.getModInfos().getFirst().getModId()).withAffectedModFile(file));
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.common;
 
 import com.mojang.logging.LogUtils;
@@ -18,7 +23,7 @@ import org.slf4j.Logger;
 @Mod(NeoForgeVersion.MOD_ID)
 public class OnlyInWarningsHandler {
     private static final Logger LOGGER = LogUtils.getLogger();
-    
+
     public OnlyInWarningsHandler(ModContainer container) {
         if (!FMLEnvironment.production) {
             ModList.get().forEachModFile(file -> {

--- a/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
@@ -27,7 +27,7 @@ public class OnlyInWarningsHandler {
     public OnlyInWarningsHandler(ModContainer container) {
         if (!FMLEnvironment.production) {
             ModList.get().forEachModFile(file -> {
-                if (file.getModInfos().stream().anyMatch(info -> info.getModId().equals("minecraft") || info.getModId().equals(NeoForgeVersion.MOD_ID))) {
+                if (file.getModInfos().stream().anyMatch(info -> info.getModId().equals("minecraft"))) {
                     return;
                 }
                 Type anType = Type.getType(OnlyIn.class);

--- a/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
@@ -31,9 +31,20 @@ public class OnlyInWarningsHandler {
                     return;
                 }
                 Type anType = Type.getType(OnlyIn.class);
-                if (file.getScanResult().getAnnotations().stream().anyMatch(ad -> ad.annotationType().equals(anType))) {
-                    LOGGER.warn("The mod {} uses the @OnlyIn annotation; the runtime member-stripping behaviour of this annotation is no longer present, which may lead to issues if that behaviour was relied upon", file.getModInfos().getFirst().getModId());
+                var onlyInUsages = file.getScanResult().getAnnotations().stream().filter(ad -> ad.annotationType().equals(anType)).toList();
+                if (!onlyInUsages.isEmpty()) {
                     ModLoader.addLoadingIssue(ModLoadingIssue.warning("loadwarning.neoforge.onlyin", file.getModInfos().getFirst().getModId()).withAffectedModFile(file));
+                    LOGGER.error("The mod {} uses the @OnlyIn annotation; the runtime member-stripping behaviour of this annotation is no longer present, which may lead to issues if that behaviour was relied upon", file.getModInfos().getFirst().getModId());
+                    for (var annData : onlyInUsages) {
+                        switch (annData.targetType()) {
+                            case TYPE -> LOGGER.error("@OnlyIn used on class {}", annData.clazz().getClassName());
+                            case FIELD -> LOGGER.error("@OnlyIn used on field {}.{}", annData.clazz().getClassName(), annData.memberName());
+                            case METHOD -> LOGGER.error("@OnlyIn used on method {}.{}", annData.clazz().getClassName(), annData.memberName());
+                            case CONSTRUCTOR -> LOGGER.error("@OnlyIn used on constructor for {}", annData.clazz().getClassName());
+                            case ANNOTATION_TYPE -> LOGGER.error("@OnlyIn used on annotation {}", annData.clazz().getClassName());
+                            case PACKAGE -> LOGGER.error("@OnlyIn used on package {}", annData.clazz().getClassName());
+                        }
+                    }
                 }
             });
         }

--- a/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/OnlyInWarningsHandler.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 @Mod(NeoForgeVersion.MOD_ID)
 public class OnlyInWarningsHandler {
     private static final Logger LOGGER = LogUtils.getLogger();
+    private static final boolean HIDE_WARNING_SCREEN = Boolean.getBoolean("neoforge.warnings.onlyin.hide");
 
     public OnlyInWarningsHandler(ModContainer container) {
         if (!FMLEnvironment.production) {
@@ -33,7 +34,9 @@ public class OnlyInWarningsHandler {
                 Type anType = Type.getType(OnlyIn.class);
                 var onlyInUsages = file.getScanResult().getAnnotations().stream().filter(ad -> ad.annotationType().equals(anType)).toList();
                 if (!onlyInUsages.isEmpty()) {
-                    ModLoader.addLoadingIssue(ModLoadingIssue.warning("loadwarning.neoforge.onlyin", file.getModInfos().getFirst().getModId()).withAffectedModFile(file));
+                    if (!HIDE_WARNING_SCREEN) {
+                        ModLoader.addLoadingIssue(ModLoadingIssue.warning("loadwarning.neoforge.onlyin", file.getModInfos().getFirst().getModId()).withAffectedModFile(file));
+                    }
                     LOGGER.error("The mod {} uses the @OnlyIn annotation; the runtime member-stripping behaviour of this annotation is no longer present, which may lead to issues if that behaviour was relied upon", file.getModInfos().getFirst().getModId());
                     for (var annData : onlyInUsages) {
                         switch (annData.targetType()) {

--- a/src/main/java/net/neoforged/neoforge/junit/JUnitMain.java
+++ b/src/main/java/net/neoforged/neoforge/junit/JUnitMain.java
@@ -5,8 +5,12 @@
 
 package net.neoforged.neoforge.junit;
 
+import cpw.mods.modlauncher.Launcher;
+import java.lang.invoke.MethodHandles;
+import java.util.Set;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
+import net.neoforged.fml.loading.moddiscovery.locators.NeoForgeDevDistCleaner;
 
 public class JUnitMain {
     public static void main(String[] args) {
@@ -15,5 +19,16 @@ public class JUnitMain {
 
         // Load mods
         net.neoforged.neoforge.server.loading.ServerModLoader.load();
+
+        // We launch as a server, but we want client classes available.
+        // So we explicitly clear the list of masked classes.
+        try {
+            var distCleaner = (NeoForgeDevDistCleaner) Launcher.INSTANCE.environment().findLaunchPlugin("neoforgedevdistcleaner").orElseThrow();
+            var maskedClassesGetter = MethodHandles.privateLookupIn(NeoForgeDevDistCleaner.class, MethodHandles.lookup()).findGetter(NeoForgeDevDistCleaner.class, "maskedClasses", Set.class);
+            var maskedClasses = (Set<String>) maskedClassesGetter.invoke(distCleaner);
+            maskedClasses.clear();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/junit/JUnitMain.java
+++ b/src/main/java/net/neoforged/neoforge/junit/JUnitMain.java
@@ -5,10 +5,8 @@
 
 package net.neoforged.neoforge.junit;
 
-import cpw.mods.modlauncher.Launcher;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
-import net.neoforged.fml.common.asm.RuntimeDistCleaner;
 
 public class JUnitMain {
     public static void main(String[] args) {
@@ -17,10 +15,5 @@ public class JUnitMain {
 
         // Load mods
         net.neoforged.neoforge.server.loading.ServerModLoader.load();
-
-        // We launch as a server, but we want client classes available.
-        // Passing null disables dist-cleaning.
-        var distCleaner = (RuntimeDistCleaner) Launcher.INSTANCE.environment().findLaunchPlugin("runtimedistcleaner").orElseThrow();
-        distCleaner.setDistribution(null);
     }
 }

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -68,6 +68,7 @@
   "fml.modloadingissue.feature_flags.loading_error": "Failed to load FeatureFlag data at {0} in mod {100,modinfo,id}: {102,exc,msg}",
 
   "loadwarning.neoforge.prbuild": "This build of NeoForge was created by a community member and is thus §c§lUNSUPPORTED§r",
+  "loadwarning.neoforge.onlyin": "The mod {0} uses the @OnlyIn annotation; the runtime member-stripping behaviour of this annotation is no longer present, which may lead to issues if that behaviour was relied upon",
 
   "commands.neoforge.arguments.enum.invalid": "Enum constant must be one of %1$s, found %2$s",
   "commands.neoforge.dimensions.list": "Currently registered dimensions by type:",


### PR DESCRIPTION
This accompanies neoforged/FancyModLoader#293, which removes `RuntimeDistCleaner`, with a system that, in dev, (a) adds a log warning for uses of `@OnlyIn` in mods and (b) shows a warning screen informing modders of the same. This should make it much more difficult to rely on the (now nonexistent) runtime ASM stripping behaviour of `@OnlyIn`.

The warning screen and logging implementation are contained within one class (except translations), so that they may be easily removed some time down the road if this is no longer necessary.

![Screenshot_20250701_181656](https://github.com/user-attachments/assets/cca396a0-d5e6-4291-ba09-19e9a2c574e2)

This PR also bumps FML and MDG to pull in the accompanying RuntimeDistCleaner changes, fixes the JUnit entry point to work with the FML change, and removes neo uses of `@OnlyIn`.

If the warning screen must be disabled (say, an external dependency has an unnecessary `@OnlyIn` usage causing it to pop up), the `neoforge.warnings.onlyin.hide` system property may be set to `true`.