### PR TITLE
Fix pack.mcmeta not being updated in tests

### DIFF
--- a/tests/src/generated/resources/pack.mcmeta
+++ b/tests/src/generated/resources/pack.mcmeta
@@ -49,7 +49,7 @@
   },
   "pack": {
     "description": "NeoForge tests resource pack",
-    "pack_format": 63,
+    "pack_format": 64,
     "supported_formats": [
       0,
       2147483647


### PR DESCRIPTION
The pack.mcmeta version was not updated in the test sourceset during 1.21.7, making the check local changes check fail for PRs