### PR TITLE
Fix Eclipse formatter putting blank lines in the wrong place within `record`s

### DIFF
--- a/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
+++ b/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
@@ -48,7 +48,7 @@ immaculate {
         toggleOff = 'spotless:off'
         toggleOn = 'spotless:on'
         eclipse {
-            version '3.37.0'
+            version '3.42.0'
             config = rootProject.file('codeformat/formatter-config.xml')
         }
 

--- a/src/client/java/net/neoforged/neoforge/client/entity/animation/AnimationTarget.java
+++ b/src/client/java/net/neoforged/neoforge/client/entity/animation/AnimationTarget.java
@@ -22,7 +22,6 @@ public record AnimationTarget(
         AnimationChannel.Target channelTarget,
         AnimationKeyframeTarget keyframeTarget,
         AnimationKeyframeTarget inverseKeyframeTarget) {
-
     public static final AnimationTarget POSITION = new AnimationTarget(
             AnimationChannel.Targets.POSITION,
             KeyframeAnimations::posVec,
@@ -36,6 +35,7 @@ public record AnimationTarget(
             AnimationChannel.Targets.SCALE,
             KeyframeAnimations::scaleVec,
             AnimationTarget::inverseScaleVec);
+
     private static Vector3f inverseDegreeVec(float x, float y, float z) {
         return new Vector3f(
                 x / (float) (Math.PI / 180.0),

--- a/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
@@ -741,7 +741,6 @@ public final class ConfigurationScreen extends OptionsSubScreen {
          * A custom variant of OptionsInstance.Enum that doesn't show the key on the button, just the value
          */
         public record Custom<T>(List<T> values) implements OptionInstance.ValueSet<T> {
-
             @Override
             public Function<OptionInstance<T>, AbstractWidget> createButton(OptionInstance.TooltipSupplier<T> tooltip, Options options, int x, int y, int width, Consumer<T> target) {
                 return optionsInstance -> CycleButton.builder(optionsInstance.toString)
@@ -765,6 +764,7 @@ public final class ConfigurationScreen extends OptionsSubScreen {
             public Codec<T> codec() {
                 return null;
             }
+
             public static final Custom<Boolean> BOOLEAN_VALUES_NO_PREFIX = new Custom<>(ImmutableList.of(Boolean.TRUE, Boolean.FALSE));
         }
 

--- a/src/client/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/ExtraFaceData.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Nullable;
  * @param ambientOcclusion If this face has AO
  */
 public record ExtraFaceData(int color, int blockLight, int skyLight, boolean ambientOcclusion) {
-
     public static final ExtraFaceData DEFAULT = new ExtraFaceData(0xFFFFFFFF, 0, 0, true);
 
     public static final Codec<Integer> COLOR = Codec.either(Codec.INT, Codec.STRING).xmap(
@@ -41,6 +40,7 @@ public record ExtraFaceData(int color, int blockLight, int skyLight, boolean amb
                             Codec.intRange(0, 15).optionalFieldOf("sky_light", 0).forGetter(ExtraFaceData::skyLight),
                             Codec.BOOL.optionalFieldOf("ambient_occlusion", true).forGetter(ExtraFaceData::ambientOcclusion))
                     .apply(builder, ExtraFaceData::new));
+
     /**
      * Parses an ExtraFaceData from JSON
      * 

--- a/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java
@@ -177,7 +177,6 @@ public class DynamicFluidContainerModel implements ItemModel {
     }
 
     public record Unbaked(Textures textures, Fluid fluid, boolean flipGas, boolean coverIsMask, boolean applyFluidLuminosity) implements ItemModel.Unbaked {
-
         public static final MapCodec<Unbaked> MAP_CODEC = RecordCodecBuilder.mapCodec(
                 instance -> instance
                         .group(
@@ -187,6 +186,7 @@ public class DynamicFluidContainerModel implements ItemModel {
                                 Codec.BOOL.optionalFieldOf("cover_is_mask", true).forGetter(Unbaked::coverIsMask),
                                 Codec.BOOL.optionalFieldOf("apply_fluid_luminosity", true).forGetter(Unbaked::applyFluidLuminosity))
                         .apply(instance, Unbaked::new));
+
         @Override
         public MapCodec<? extends ItemModel.Unbaked> type() {
             return MAP_CODEC;

--- a/src/client/java/net/neoforged/neoforge/client/stencil/StencilTest.java
+++ b/src/client/java/net/neoforged/neoforge/client/stencil/StencilTest.java
@@ -21,10 +21,10 @@ public record StencilTest(
         int readMask,
         int writeMask,
         int referenceValue) {
-
     public static int DEFAULT_READ_MASK = -1;
     public static int DEFAULT_WRITE_MASK = -1;
     public static int DEFAULT_REFERENCE_VALUE = 0;
+
     public StencilTest(StencilPerFaceTest test, int readMask, int writeMask, int referenceValue) {
         this(test, test, readMask, writeMask, referenceValue);
     }

--- a/src/client/java/net/neoforged/neoforge/client/textures/NamespacedDirectoryLister.java
+++ b/src/client/java/net/neoforged/neoforge/client/textures/NamespacedDirectoryLister.java
@@ -21,12 +21,12 @@ import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
  * stitched to this atlas
  */
 public record NamespacedDirectoryLister(String namespace, String sourcePath, String idPrefix) implements SpriteSource {
-
     public static final MapCodec<NamespacedDirectoryLister> CODEC = RecordCodecBuilder.mapCodec(inst -> inst.group(
             Codec.STRING.fieldOf("namespace").forGetter(lister -> lister.namespace),
             Codec.STRING.fieldOf("source").forGetter(lister -> lister.sourcePath),
             Codec.STRING.fieldOf("prefix").forGetter(lister -> lister.idPrefix)).apply(inst, NamespacedDirectoryLister::new));
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "namespaced_directory");
+
     @Override
     public void run(ResourceManager resourceManager, Output output) {
         FileToIdConverter converter = new FileToIdConverter("textures/" + this.sourcePath, ".png");

--- a/src/main/java/net/neoforged/neoforge/common/conditions/WithConditions.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/WithConditions.java
@@ -11,7 +11,6 @@ import java.util.List;
 import org.apache.commons.lang3.Validate;
 
 public record WithConditions<A>(List<ICondition> conditions, A carrier) {
-
     public WithConditions(A carrier, ICondition... conditions) {
         this(List.of(conditions), carrier);
     }
@@ -23,6 +22,7 @@ public record WithConditions<A>(List<ICondition> conditions, A carrier) {
     public static <A> Builder<A> builder(A carrier) {
         return new Builder<A>().withCarrier(carrier);
     }
+
     public static class Builder<T> {
         private final List<ICondition> conditions = new ArrayList<>();
         private T carrier;

--- a/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/CompoundIngredient.java
@@ -18,13 +18,13 @@ import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
 
 /** Ingredient that matches if any of the child ingredients match */
 public record CompoundIngredient(List<Ingredient> children) implements ICustomIngredient {
-
     public CompoundIngredient {
         if (children.isEmpty()) {
             // Empty ingredients are always represented as Ingredient.EMPTY.
             throw new IllegalArgumentException("Compound ingredient must have at least one child.");
         }
     }
+
     public static final MapCodec<CompoundIngredient> CODEC = NeoForgeExtraCodecs.aliasedFieldOf(Ingredient.CODEC.listOf(1, Integer.MAX_VALUE), "children", "ingredients").xmap(CompoundIngredient::new, CompoundIngredient::children);
 
     /** Creates a compound ingredient from the given list of ingredients */

--- a/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/common/crafting/IntersectionIngredient.java
@@ -18,12 +18,12 @@ import net.neoforged.neoforge.common.NeoForgeMod;
 
 /** Ingredient that matches if all child ingredients match */
 public record IntersectionIngredient(List<Ingredient> children) implements ICustomIngredient {
-
     public IntersectionIngredient {
         if (children.isEmpty()) {
             throw new IllegalArgumentException("Intersection ingredient must have at least one child.");
         }
     }
+
     public static final MapCodec<IntersectionIngredient> CODEC = RecordCodecBuilder.mapCodec(
             builder -> builder
                     .group(

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -28,17 +28,17 @@ import org.jetbrains.annotations.ApiStatus;
  * import net.minecraft.world.item.Items;
  *
  * public void modifyComponents(ModifyDefaultComponentsEvent event) {
- *    event.modify(Items.MELON_SEEDS, builder -> builder
- *         .set(DataComponents.MAX_STACK_SIZE, 16)); // Stack melon seeds to at most 16 items
+ *     event.modify(Items.MELON_SEEDS, builder -> builder
+ *             .set(DataComponents.MAX_STACK_SIZE, 16)); // Stack melon seeds to at most 16 items
  *
- *    event.modify(Items.APPLE, builder -> builder
- *         .remove(DataComponents.FOOD)); // Remove the ability of eating apples
+ *     event.modify(Items.APPLE, builder -> builder
+ *             .remove(DataComponents.FOOD)); // Remove the ability of eating apples
  * }
  *
  * // Lowest priority listener
  * public void modifyComponentsLow(ModifyDefaultComponentsEvent event) {
- *    event.modifyMatching(item -> item.components().has(DataComponents.FIRE_RESISTANT), builder -> builder
- *         .set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)); // Make all fire resistant items have a glint
+ *     event.modifyMatching(item -> item.components().has(DataComponents.FIRE_RESISTANT), builder -> builder
+ *             .set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)); // Make all fire resistant items have a glint
  * }
  * }
  */

--- a/src/main/java/net/neoforged/neoforge/network/configuration/CheckExtensibleEnums.java
+++ b/src/main/java/net/neoforged/neoforge/network/configuration/CheckExtensibleEnums.java
@@ -231,7 +231,6 @@ public record CheckExtensibleEnums(ServerConfigurationPacketListener listener) i
     }
 
     public record EnumEntry(String className, NetworkedEnum.NetworkCheck networkCheck, Optional<ExtensionData> data) {
-
         public static final StreamCodec<ByteBuf, EnumEntry> STREAM_CODEC = StreamCodec.composite(
                 ByteBufCodecs.STRING_UTF8,
                 EnumEntry::className,
@@ -240,6 +239,7 @@ public record CheckExtensibleEnums(ServerConfigurationPacketListener listener) i
                 ByteBufCodecs.optional(ExtensionData.STREAM_CODEC),
                 EnumEntry::data,
                 EnumEntry::new);
+
         public boolean isClientbound() {
             return networkCheck == NetworkedEnum.NetworkCheck.CLIENTBOUND || networkCheck == NetworkedEnum.NetworkCheck.BIDIRECTIONAL;
         }

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedContainerSetDataPayload.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record AdvancedContainerSetDataPayload(byte containerId, short dataId, int value) implements CustomPacketPayload {
-
     public static final Type<AdvancedContainerSetDataPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "advanced_container_set_data"));
     public static final StreamCodec<RegistryFriendlyByteBuf, AdvancedContainerSetDataPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.BYTE,
@@ -33,6 +32,7 @@ public record AdvancedContainerSetDataPayload(byte containerId, short dataId, in
             ByteBufCodecs.VAR_INT,
             AdvancedContainerSetDataPayload::value,
             AdvancedContainerSetDataPayload::new);
+
     @Override
     public Type<AdvancedContainerSetDataPayload> type() {
         return TYPE;

--- a/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/AdvancedOpenScreenPayload.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Component name, byte[] additionalData) implements CustomPacketPayload {
-
     public static final Type<AdvancedOpenScreenPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "advanced_open_screen"));
     public static final StreamCodec<RegistryFriendlyByteBuf, AdvancedOpenScreenPayload> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.VAR_INT,
@@ -40,6 +39,7 @@ public record AdvancedOpenScreenPayload(int windowId, MenuType<?> menuType, Comp
             NeoForgeStreamCodecs.UNBOUNDED_BYTE_ARRAY,
             AdvancedOpenScreenPayload::additionalData,
             AdvancedOpenScreenPayload::new);
+
     @Override
     public Type<AdvancedOpenScreenPayload> type() {
         return TYPE;

--- a/src/main/java/net/neoforged/neoforge/network/payload/ClientboundCustomSetTimePayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ClientboundCustomSetTimePayload.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public record ClientboundCustomSetTimePayload(long gameTime, long dayTime, boolean gameRule, float dayTimeFraction, float dayTimePerTick) implements CustomPacketPayload {
-
     public static final Type<ClientboundCustomSetTimePayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "custom_time_packet"));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundCustomSetTimePayload> STREAM_CODEC = StreamCodec.composite(
@@ -25,6 +24,7 @@ public record ClientboundCustomSetTimePayload(long gameTime, long dayTime, boole
             ByteBufCodecs.FLOAT, ClientboundCustomSetTimePayload::dayTimeFraction,
             ByteBufCodecs.FLOAT, ClientboundCustomSetTimePayload::dayTimePerTick,
             ClientboundCustomSetTimePayload::new);
+
     @Override
     public Type<ClientboundCustomSetTimePayload> type() {
         return TYPE;

--- a/src/main/java/net/neoforged/neoforge/network/payload/CommonRegisterPayload.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/CommonRegisterPayload.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
  */
 @ApiStatus.Internal
 public record CommonRegisterPayload(int version, ConnectionProtocol protocol, Set<ResourceLocation> channels) implements CustomPacketPayload {
-
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath("c", "register");
     public static final CustomPacketPayload.Type<CommonRegisterPayload> TYPE = new CustomPacketPayload.Type<>(ID);
     public static final StreamCodec<FriendlyByteBuf, CommonRegisterPayload> STREAM_CODEC = StreamCodec.composite(
@@ -33,6 +32,7 @@ public record CommonRegisterPayload(int version, ConnectionProtocol protocol, Se
             ByteBufCodecs.STRING_UTF8.map(CommonRegisterPayload::protocolById, ConnectionProtocol::id), CommonRegisterPayload::protocol,
             ByteBufCodecs.collection(HashSet::new, ResourceLocation.STREAM_CODEC), CommonRegisterPayload::channels,
             CommonRegisterPayload::new);
+
     @Override
     public Type<CommonRegisterPayload> type() {
         return TYPE;

--- a/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryComponent.java
+++ b/src/main/java/net/neoforged/neoforge/network/payload/ModdedNetworkQueryComponent.java
@@ -25,13 +25,13 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public record ModdedNetworkQueryComponent(ResourceLocation id, String version, Optional<PacketFlow> flow, boolean optional) {
-
     public static final StreamCodec<FriendlyByteBuf, ModdedNetworkQueryComponent> STREAM_CODEC = StreamCodec.composite(
             ResourceLocation.STREAM_CODEC, ModdedNetworkQueryComponent::id,
             ByteBufCodecs.STRING_UTF8, ModdedNetworkQueryComponent::version,
             ByteBufCodecs.optional(NeoForgeStreamCodecs.enumCodec(PacketFlow.class)), ModdedNetworkQueryComponent::flow,
             ByteBufCodecs.BOOL, ModdedNetworkQueryComponent::optional,
             ModdedNetworkQueryComponent::new);
+
     public ModdedNetworkQueryComponent(PayloadRegistration<?> reg) {
         this(reg.id(), reg.version(), reg.flow(), reg.optional());
     }

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapEntry.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/DataMapEntry.java
@@ -14,7 +14,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 
 public record DataMapEntry<T>(T value, boolean replace) {
-
     private DataMapEntry(T value) {
         this(value, false);
     }
@@ -26,6 +25,7 @@ public record DataMapEntry<T>(T value, boolean replace) {
                         Codec.BOOL.optionalFieldOf("replace", false).forGetter(DataMapEntry::replace)).apply(i, DataMapEntry::new)),
                 type.codec()).xmap(e -> e.map(Function.identity(), DataMapEntry::new), entry -> entry.replace() ? Either.left(entry) : Either.right(entry.value()));
     }
+
     public record Removal<T, R>(Either<TagKey<R>, ResourceKey<R>> key,
             Optional<DataMapValueRemover<R, T>> remover) {
         private Removal(Either<TagKey<R>, ResourceKey<R>> key) {

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
@@ -37,7 +37,6 @@ import net.neoforged.neoforge.common.NeoForgeMod;
  * </pre>
  */
 public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) implements ICustomHolderSet<T> {
-
     @Override
     public HolderSetType type() {
         return NeoForgeMod.ANY_HOLDER_SET.value();
@@ -103,6 +102,7 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
     public String toString() {
         return "AnySet(" + this.registryLookup.key() + ")";
     }
+
     public static class Type implements HolderSetType {
         @Override
         public <T> MapCodec<? extends ICustomHolderSet<T>> makeCodec(ResourceKey<? extends Registry<T>> registryKey, Codec<Holder<T>> holderCodec, boolean forceList) {

--- a/testframework/src/main/java/net/neoforged/testframework/condition/TestEnabledIngredient.java
+++ b/testframework/src/main/java/net/neoforged/testframework/condition/TestEnabledIngredient.java
@@ -21,7 +21,6 @@ import net.neoforged.testframework.impl.MutableTestFramework;
 import net.neoforged.testframework.impl.TestFrameworkMod;
 
 public record TestEnabledIngredient(Ingredient base, TestFramework framework, String testId) implements ICustomIngredient {
-
     public static final MapCodec<TestEnabledIngredient> CODEC = RecordCodecBuilder.mapCodec(
             builder -> builder
                     .group(
@@ -29,6 +28,7 @@ public record TestEnabledIngredient(Ingredient base, TestFramework framework, St
                             MutableTestFramework.REFERENCE_CODEC.fieldOf("framework").forGetter(i -> i.framework),
                             Codec.STRING.fieldOf("testId").forGetter(i -> i.testId))
                     .apply(builder, TestEnabledIngredient::new));
+
     @Override
     public boolean test(ItemStack stack) {
         return base.test(stack) && framework.tests().isEnabled(testId);

--- a/testframework/src/main/java/net/neoforged/testframework/conf/ClientConfiguration.java
+++ b/testframework/src/main/java/net/neoforged/testframework/conf/ClientConfiguration.java
@@ -11,10 +11,10 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public record ClientConfiguration(int toggleOverlayKey, int openManagerKey) {
-
     public static Builder builder() {
         return new Builder();
     }
+
     public static final class Builder {
         private int toggleOverlayKey;
         private int openManagerKey;

--- a/testframework/src/main/java/net/neoforged/testframework/conf/FrameworkConfiguration.java
+++ b/testframework/src/main/java/net/neoforged/testframework/conf/FrameworkConfiguration.java
@@ -31,7 +31,6 @@ public record FrameworkConfiguration(
         @Nullable Supplier<ClientConfiguration> clientConfiguration,
         List<SummaryDumper> dumpers,
         MissingDescriptionAction onMissingDescription) {
-
     public static Builder builder(ResourceLocation id) {
         return new Builder(id);
     }
@@ -43,6 +42,7 @@ public record FrameworkConfiguration(
     public MutableTestFramework create() {
         return new TestFrameworkImpl(this);
     }
+
     public static final class Builder {
         private final ResourceLocation id;
         private final Collection<Feature> features = EnumSet.noneOf(Feature.class);

--- a/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeEnabledPayload.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeEnabledPayload.java
@@ -16,8 +16,8 @@ import net.neoforged.testframework.conf.Feature;
 import net.neoforged.testframework.impl.MutableTestFramework;
 
 public record ChangeEnabledPayload(MutableTestFramework framework, String testId, boolean enabled) implements CustomPacketPayload {
-
     public static final CustomPacketPayload.Type<ChangeEnabledPayload> ID = new Type<>(ResourceLocation.fromNamespaceAndPath("neoforge", "tf_change_enabled"));
+
     public void handle(IPayloadContext context) {
         switch (context.flow().getReceptionSide()) {
             case CLIENT -> {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeStatusPayload.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/packet/ChangeStatusPayload.java
@@ -16,8 +16,8 @@ import net.neoforged.testframework.conf.Feature;
 import net.neoforged.testframework.impl.MutableTestFramework;
 
 public record ChangeStatusPayload(MutableTestFramework framework, String testId, Test.Status status) implements CustomPacketPayload {
-
     public static final CustomPacketPayload.Type<ChangeStatusPayload> ID = new Type<>(ResourceLocation.fromNamespaceAndPath("neoforge", "tf_change_status"));
+
     public void write(FriendlyByteBuf buf) {
         buf.writeUtf(testId);
         buf.writeEnum(status.result());

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/StructureModifierTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/StructureModifierTest.java
@@ -84,8 +84,8 @@ generator.addProvider(event.includeServer(), structureModifierProvider);*/
 
     public record TestModifier(HolderSet<Structure> structures, MobCategory category, MobSpawnSettings.SpawnerData spawn)
             implements StructureModifier {
-
         private static final DeferredHolder<MapCodec<? extends StructureModifier>, MapCodec<? extends StructureModifier>> SERIALIZER = DeferredHolder.create(NeoForgeRegistries.Keys.STRUCTURE_MODIFIER_SERIALIZERS, ADD_SPAWNS_TO_STRUCTURE_RL);
+
         @Override
         public void modify(Holder<Structure> structure, Phase phase, Builder builder) {
             if (phase == Phase.ADD && this.structures.contains(structure)) {


### PR DESCRIPTION
This PR updates Eclipse JDT Core version (3.37.0 -> 3.42.0). I ran the formatter and included the fixed formatting in the commit as well. There's a sister PR to add JDT Core version discoverability to Renovate #2409.