### PR TITLE
Allow Renovate to update formatter

### DIFF
--- a/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
+++ b/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
@@ -48,7 +48,7 @@ immaculate {
         toggleOff = 'spotless:off'
         toggleOn = 'spotless:on'
         eclipse {
-            version '3.37.0'
+            version project.jdt_core_version
             config = rootProject.file('codeformat/formatter-config.xml')
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,4 +49,7 @@ jupiter_api_version=5.10.2
 vintage_engine_version=5.+
 assertj_core=3.25.1
 
+# renovate: org.eclipse.jdt:org.eclipse.jdt.core
+jdt_core_version=3.42.0
+
 neogradle.runtime.platform.installer.debug=true


### PR DESCRIPTION
Adds the JDT Core version to `gradle.properties` and uses that in the formatting buildscript. This should be merged after #2408.