### PR TITLE
Add ScreenEvent.Render.Background

### DIFF
--- a/patches/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/Screen.java.patch
@@ -4,7 +4,7 @@
      public final void renderWithTooltip(GuiGraphics p_282345_, int p_283456_, int p_283586_, float p_282339_) {
          p_282345_.nextStratum();
          this.renderBackground(p_282345_, p_283456_, p_283586_, p_282339_);
-+        // Neo: We cannot post these events in the renderBackground method, since many screens override it and don't call super.
++        // Neo: We cannot post this event in the renderBackground method, since many screens override it and don't call super.
 +        if (this instanceof net.minecraft.client.gui.screens.inventory.AbstractContainerScreen<?> containerScreen) {
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ContainerScreenEvent.Render.Background(containerScreen, p_282345_, p_283456_, p_283586_));
 +        }

--- a/patches/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/Screen.java.patch
@@ -1,13 +1,14 @@
 --- a/net/minecraft/client/gui/screens/Screen.java
 +++ b/net/minecraft/client/gui/screens/Screen.java
-@@ -103,6 +_,10 @@
+@@ -103,6 +_,11 @@
      public final void renderWithTooltip(GuiGraphics p_282345_, int p_283456_, int p_283586_, float p_282339_) {
          p_282345_.nextStratum();
          this.renderBackground(p_282345_, p_283456_, p_283586_, p_282339_);
-+        // Neo: We cannot post this event in the renderBackground method, since many screens override it and don't call super.
++        // Neo: We cannot post these events in the renderBackground method, since many screens override it and don't call super.
 +        if (this instanceof net.minecraft.client.gui.screens.inventory.AbstractContainerScreen<?> containerScreen) {
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ContainerScreenEvent.Render.Background(containerScreen, p_282345_, p_283456_, p_283586_));
 +        }
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.ScreenEvent.Render.Background(this, p_282345_, p_283456_, p_283586_, p_282339_));
          p_282345_.nextStratum();
          this.render(p_282345_, p_283456_, p_283586_, p_282339_);
          p_282345_.renderDeferredTooltip();

--- a/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
@@ -112,7 +112,7 @@ public abstract class ContainerScreenEvent extends Event {
          * @deprecated use the new {@link ScreenEvent.Render.Background} event
          */
         @SuppressWarnings("DeprecatedIsStillUsed")
-        @Deprecated(forRemoval = true)
+        @Deprecated(forRemoval = true, since = "1.21.7")
         public static class Background extends Render {
             @ApiStatus.Internal
             public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {

--- a/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
@@ -108,7 +108,11 @@ public abstract class ContainerScreenEvent extends Event {
          *
          * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         *
+         * @deprecated use the new {@link ScreenEvent.Render.Background} event
          */
+        @SuppressWarnings("DeprecatedIsStillUsed")
+		@Deprecated(forRemoval = true)
         public static class Background extends Render {
             @ApiStatus.Internal
             public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {

--- a/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
@@ -112,7 +112,7 @@ public abstract class ContainerScreenEvent extends Event {
          * @deprecated use the new {@link ScreenEvent.Render.Background} event
          */
         @SuppressWarnings("DeprecatedIsStillUsed")
-		@Deprecated(forRemoval = true)
+        @Deprecated(forRemoval = true)
         public static class Background extends Render {
             @ApiStatus.Internal
             public Background(AbstractContainerScreen<?> guiContainer, GuiGraphics guiGraphics, int mouseX, int mouseY) {

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -217,7 +217,7 @@ public abstract class ScreenEvent extends Event {
          *
          * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Background extends ScreenEvent.Render {

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -210,7 +210,7 @@ public abstract class ScreenEvent extends Event {
         }
 
         /**
-         * Fired after the screen's background layer and elements are drawn.
+         * Fired after the screen's renderBackground and before its render method.
          *
          * <p>This can be used for rendering elements that must be below tooltips and the dragged stack,
          * such as slot or item stack specific overlays.</p>

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -215,7 +215,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This can be used for rendering elements that must be below tooltips and the dragged stack,
          * such as slot or item stack specific overlays.</p>
          *
-         * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
+         * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
          *
          * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -41,7 +41,6 @@ import org.lwjgl.glfw.GLFW;
  *
  * @see Init
  * @see Render
- * @see BackgroundRendered
  * @see MouseInput
  * @see KeyInput
  */
@@ -148,6 +147,7 @@ public abstract class ScreenEvent extends Event {
      * See the two subclasses for listening before and after drawing.
      *
      * @see Render.Pre
+     * @see Render.Background
      * @see Render.Post
      */
     public static abstract class Render extends ScreenEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -210,7 +210,7 @@ public abstract class ScreenEvent extends Event {
         }
 
         /**
-         * Fired after the screen's renderBackground and before its render method.
+         * Fired <b>after</b> the screen's renderBackground and <b>before</b> its render method.
          *
          * <p>This can be used for rendering elements that must be below tooltips and the dragged stack,
          * such as slot or item stack specific overlays.</p>

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -210,6 +210,24 @@ public abstract class ScreenEvent extends Event {
         }
 
         /**
+         * Fired after the screen's background layer and elements are drawn.
+         *
+         * <p>This can be used for rendering elements that must be below tooltips and the dragged stack,
+         * such as slot or item stack specific overlays.</p>
+         *
+         * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
+         *
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         */
+        public static class Background extends ScreenEvent.Render {
+            @ApiStatus.Internal
+            public Background(Screen screen, GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+                super(screen, guiGraphics, mouseX, mouseY, partialTick);
+            }
+        }
+
+        /**
          * Fired <b>after</b> the screen is drawn.
          *
          * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>


### PR DESCRIPTION
## Description

This event is necessary since Minecraft 1.21.6 in order to draw next to `Screen`s that have tooltips, because of the `renderDeferredTooltip` call that is done at the end of `Screen#renderWithTooltip`.
None of the currently available events allow for rendering after the background is drawn, but before tooltip is drawn.

Here's a screenshot of the best I can do currently, using `ScreenEvent.Render.Post`, which is after the tooltip is drawn.
![2025-07-07_23 03 37](https://github.com/user-attachments/assets/2101f528-6df7-45fa-8546-13a88c38b735)

## Context

Follow up to:
* https://github.com/neoforged/NeoForge/pull/1500

Created after the old `ScreenEvent.BackgroundRendered` was removed in:
* https://github.com/neoforged/NeoForge/pull/2122

## Considerations

This event is modeled after `ContainerScreenEvent.Render.Background` and is fired from the same exact place, but it is more general because it is for every `Screen` and not just `ContainerScreen`s.