### PR TITLE
Add method to wrap gui layers

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterGuiLayersEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterGuiLayersEvent.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.client.event;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.UnaryOperator;
 import java.util.stream.IntStream;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
@@ -79,6 +80,45 @@ public class RegisterGuiLayersEvent extends Event implements IModBusEvent {
      */
     public void registerAboveAll(ResourceLocation id, GuiLayer layer) {
         register(Ordering.AFTER, null, id, layer);
+    }
+
+    /**
+     * Replace the layer with the given {@code id} with a new one.
+     *
+     * @param id          the id of the layer to replace
+     * @param replacement the layer to replace it with
+     * @throws IllegalArgumentException if a layer with the given {@code id} is not yet registered
+     * @see #wrapLayer(ResourceLocation, UnaryOperator) use {@code wrapLayer} if you'd like to
+     *      wrap the layer to apply pose stack transformations
+     */
+    public void replaceLayer(ResourceLocation id, GuiLayer replacement) {
+        wrapLayer(id, old -> replacement);
+    }
+
+    /**
+     * Wrap the layer with the given {@code id} in a new layer.
+     * <p>
+     * This can be used, for instance, to apply pose stack transformations to move the layer or resize it.
+     *
+     * @param id      the id of the layer to wrap
+     * @param wrapper an unary operator which takes in the old layer and returns the new layer that wraps the old one
+     * @throws IllegalArgumentException if a layer with the given {@code id} is not yet registered
+     */
+    public void wrapLayer(ResourceLocation id, UnaryOperator<GuiLayer> wrapper) {
+        Objects.requireNonNull(id);
+        Objects.requireNonNull(wrapper);
+
+        for (int i = 0; i < layers.size(); i++) {
+            var layer = layers.get(i);
+            if (layer.name().equals(id)) {
+                var wrapped = wrapper.apply(layer.layer());
+                Objects.requireNonNull(wrapped, "wrapping layer must not be null");
+                layers.set(i, new GuiLayerManager.NamedLayer(id, wrapped));
+                return;
+            }
+        }
+
+        throw new IllegalArgumentException("Attempted to wrap layer with id '" + id + "', which does not exist!");
     }
 
     private void register(Ordering ordering, @Nullable ResourceLocation other, ResourceLocation key, GuiLayer layer) {

--- a/testframework/src/main/java/net/neoforged/testframework/impl/test/AbstractTest.java
+++ b/testframework/src/main/java/net/neoforged/testframework/impl/test/AbstractTest.java
@@ -26,7 +26,6 @@ import net.minecraft.gametest.framework.GameTestRunner;
 import net.minecraft.gametest.framework.StructureUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Blocks;
@@ -202,15 +201,16 @@ public abstract class AbstractTest implements Test {
     }
 
     public final void requestConfirmation(Player player, Component message) {
-        if (framework instanceof MutableTestFramework internal && player instanceof ServerPlayer serverPlayer) {
-            serverPlayer.sendSystemMessage(message.copy().append(" ").append(
+        if (framework instanceof MutableTestFramework internal) {
+            player.displayClientMessage(message.copy().append(" ").append(
                     Component.literal("Yes").withStyle(style -> style.withColor(ChatFormatting.GREEN).withBold(true)
                             .withClickEvent(internal.setStatusCommand(
                                     id(), Result.PASSED, "")))
                             .append(" ").append(
                                     Component.literal("No").withStyle(style -> style.withColor(ChatFormatting.RED).withBold(true)
                                             .withClickEvent(internal.setStatusCommand(
-                                                    id(), Result.FAILED, player.getGameProfile().getName() + " denied seeing the effects of the test"))))));
+                                                    id(), Result.FAILED, player.getGameProfile().getName() + " denied seeing the effects of the test"))))),
+                    false);
         }
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
@@ -17,6 +17,8 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.RegisterGuiLayersEvent;
@@ -26,8 +28,12 @@ import net.neoforged.neoforge.client.gui.VanillaGuiLayers;
 import net.neoforged.neoforge.client.gui.widget.ExtendedButton;
 import net.neoforged.neoforge.client.gui.widget.ExtendedSlider;
 import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.Test;
+import net.neoforged.testframework.TestFramework;
+import net.neoforged.testframework.TestListener;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
+import org.jetbrains.annotations.Nullable;
 
 @ForEachTest(groups = "client.gui", side = Dist.CLIENT)
 public class GuiTests {
@@ -166,6 +172,31 @@ public class GuiTests {
                     color);
             gui.leftHeight += height + 1;
         };
+    }
+
+    @TestHolder(description = "Tests if gui layers can be wrapped to apply pose stack transformations")
+    static void testGuiLayerWrapping(DynamicTest test) {
+        test.framework().modEventBus().addListener((RegisterGuiLayersEvent event) -> {
+            event.wrapLayer(VanillaGuiLayers.FOOD_LEVEL, guiLayer -> (guiGraphics, deltaTracker) -> {
+                if (test.framework().tests().isEnabled(test.id())) {
+                    guiGraphics.pose().pushMatrix();
+                    guiGraphics.pose().translate(-91 / 2f, -11);
+                    guiLayer.render(guiGraphics, deltaTracker);
+                    guiGraphics.pose().popMatrix();
+                } else {
+                    guiLayer.render(guiGraphics, deltaTracker);
+                }
+            });
+        });
+
+        test.framework().tests().addListener(new TestListener() {
+            @Override
+            public void onEnabled(TestFramework framework, Test enabledTest, @Nullable Entity changer) {
+                if (test == enabledTest && changer instanceof Player player) {
+                    test.requestConfirmation(player, Component.literal("Is the food bar rendering above the health bar, in the centre of the screen?"));
+                }
+            }
+        });
     }
 
     @TestHolder(description = "Checks that the depth budget for GUI layers gets adjusted as necessary")


### PR DESCRIPTION
This PR adds a new `RegisterGuiLayersEvent#wrapLayer` method which can be used to wrap a gui layer with an unary operator, allowing mods to, for instance, translate the location of the layer, thereby closing #2214.

~~I am however aware of the fact that the same can be achieved by listening to both the `RenderGuiLayerEvent.Pre` and the `RenderGuiLayerEvent.Post` events in order to correctly match the pose stacks. I do think though, that doing so is more harder and requires more care to ensure there is no mismatch present, so that's why I'm making this PR. If others feel like there is no need for these methods, feel free to comment as such.~~
Scratch the above, you should **not** do these modifications using the Pre/Post events as, if you push to the stack during the Pre event and the event is subsequently cancelled, the Post event will not fire, leaving the stack in a corrupted state that will crash the game with a non-descript message. This is the only safe way to do it.