### PR TITLE
Add `CompoundTag`/`ListTag` constructors with initial size

### DIFF
--- a/patches/net/minecraft/nbt/CompoundTag.java.patch
+++ b/patches/net/minecraft/nbt/CompoundTag.java.patch
@@ -22,6 +22,24 @@
                  Tag tag = CompoundTag.readNamedTagData(TagTypes.getType(b0), s, p_302338_, p_302362_);
                  if (map.put(s, tag) == null) {
                      p_302362_.accountBytes(36L);
+@@ -173,6 +_,17 @@
+         this(new HashMap<>());
+     }
+ 
++    /**
++     * Neo: create a compound tag that is generally suitable to hold the given amount of mappings
++     * without needing to resize the internal map.
++     *
++     * @param numMappings the expected number of mappings that the compound tag will have
++     * @see HashMap#newHashMap(int)
++     */
++    public CompoundTag(int numMappings) {
++        this(HashMap.newHashMap(numMappings));
++    }
++
+     @Override
+     public void write(DataOutput p_128341_) throws IOException {
+         for (String s : this.tags.keySet()) {
 @@ -228,6 +_,7 @@
  
      @Nullable

--- a/patches/net/minecraft/nbt/CompoundTag.java.patch
+++ b/patches/net/minecraft/nbt/CompoundTag.java.patch
@@ -27,14 +27,14 @@
      }
  
 +    /**
-+     * Neo: create a compound tag that is generally suitable to hold the given amount of mappings
++     * Neo: create a compound tag that is generally suitable to hold the given amount of entries
 +     * without needing to resize the internal map.
 +     *
-+     * @param numMappings the expected number of mappings that the compound tag will have
++     * @param expectedEntries the expected number of entries that the compound tag will have
 +     * @see HashMap#newHashMap(int)
 +     */
-+    public CompoundTag(int numMappings) {
-+        this(HashMap.newHashMap(numMappings));
++    public CompoundTag(int expectedEntries) {
++        this(HashMap.newHashMap(expectedEntries));
 +    }
 +
      @Override

--- a/patches/net/minecraft/nbt/ListTag.java.patch
+++ b/patches/net/minecraft/nbt/ListTag.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/nbt/ListTag.java
++++ b/net/minecraft/nbt/ListTag.java
+@@ -153,6 +_,15 @@
+         this(new ArrayList<>());
+     }
+ 
++    /**
++     * Neo: create a list tag with the given initial capacity.
++     *
++     * @param initialCapacity the initial capacity of the list tag
++     */
++    public ListTag(int initialCapacity) {
++        this(new ArrayList<>(initialCapacity));
++    }
++
+     ListTag(List<Tag> p_128721_) {
+         this.list = p_128721_;
+     }


### PR DESCRIPTION
Adds a `ListTag` constructor with an int parameter specifying the initial size of the array list so that it does not need to be resized when the amount of expected elements is known. A similar `CompoundTag` constructor is also added, though it uses `HashMap#newHashMap` which accounts for the default 0.75 map load factor.