### PR TITLE
Fix villager discount count being invisible

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/MerchantScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/MerchantScreen.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/client/gui/screens/inventory/MerchantScreen.java
 +++ b/net/minecraft/client/gui/screens/inventory/MerchantScreen.java
-@@ -230,7 +_,10 @@
+@@ -230,7 +_,11 @@
              p_281357_.renderItemDecorations(this.font, p_283466_, p_282403_, p_283601_);
          } else {
              p_281357_.renderItemDecorations(this.font, p_282046_, p_282403_, p_283601_, p_282046_.getCount() == 1 ? "1" : null);
 -            p_281357_.renderItemDecorations(this.font, p_283466_, p_282403_ + 14, p_283601_, p_283466_.getCount() == 1 ? "1" : null);
-+            // Forge: fixes Forge-8806, code for count rendering taken from GuiGraphics#renderGuiItemDecorations
++            // NEO: Fixes MCForge#8806: forced item decorations (e.g., ItemStack#isBarVisible() returns true) were rendered for discount count text
++            // Code for count rendering taken from GuiGraphics#renderItemCount
 +            String count = p_283466_.getCount() == 1 ? "1" : String.valueOf(p_283466_.getCount());
 +            p_281357_.drawString(font, count, p_282403_ + 14 + 19 - 2 - font.width(count), p_283601_ + 6 + 3, 0xFFFFFFFF, true);
 +

--- a/patches/net/minecraft/client/gui/screens/inventory/MerchantScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/MerchantScreen.java.patch
@@ -5,7 +5,7 @@
          } else {
              p_281357_.renderItemDecorations(this.font, p_282046_, p_282403_, p_283601_, p_282046_.getCount() == 1 ? "1" : null);
 -            p_281357_.renderItemDecorations(this.font, p_283466_, p_282403_ + 14, p_283601_, p_283466_.getCount() == 1 ? "1" : null);
-+            // NEO: Fixes MCForge#8806: forced item decorations (e.g., ItemStack#isBarVisible() returns true) were rendered for discount count text
++            // Neo: Fixes MCForge#8806: forced item decorations (e.g., ItemStack#isBarVisible() returns true) were rendered for discount count text
 +            // Code for count rendering taken from GuiGraphics#renderItemCount
 +            String count = p_283466_.getCount() == 1 ? "1" : String.valueOf(p_283466_.getCount());
 +            p_281357_.drawString(font, count, p_282403_ + 14 + 19 - 2 - font.width(count), p_283601_ + 6 + 3, 0xFFFFFFFF, true);

--- a/patches/net/minecraft/client/gui/screens/inventory/MerchantScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/MerchantScreen.java.patch
@@ -7,7 +7,7 @@
 -            p_281357_.renderItemDecorations(this.font, p_283466_, p_282403_ + 14, p_283601_, p_283466_.getCount() == 1 ? "1" : null);
 +            // Forge: fixes Forge-8806, code for count rendering taken from GuiGraphics#renderGuiItemDecorations
 +            String count = p_283466_.getCount() == 1 ? "1" : String.valueOf(p_283466_.getCount());
-+            p_281357_.drawString(font, count, p_282403_ + 14 + 19 - 2 - font.width(count), p_283601_ + 6 + 3, 0xFFFFFF, true);
++            p_281357_.drawString(font, count, p_282403_ + 14 + 19 - 2 - font.width(count), p_283601_ + 6 + 3, 0xFFFFFFFF, true);
 +
              p_281357_.blitSprite(RenderPipelines.GUI_TEXTURED, DISCOUNT_STRIKETHRUOGH_SPRITE, p_282403_ + 7, p_283601_ + 12, 9, 2);
          }


### PR DESCRIPTION
This PR fixes #2420 by changing the color used to render the discount count text to include full alpha `FF`. See my comment in the linked issue for additional details on the root cause.

This also includes a cleanup of the comment near that code to be more descriptive of the original bug fix, and splits the comment so the part of the code's origin is on a separate line.

Tested and confirmed to work using the same steps in the linked issue.