### PR TITLE
[1.21.7][B3D][breaking] Add frame transient GpuBuffer usage bit.

### DIFF
--- a/patches/com/mojang/blaze3d/buffers/GpuBuffer.java.patch
+++ b/patches/com/mojang/blaze3d/buffers/GpuBuffer.java.patch
@@ -1,9 +1,15 @@
 --- a/com/mojang/blaze3d/buffers/GpuBuffer.java
 +++ b/com/mojang/blaze3d/buffers/GpuBuffer.java
-@@ -17,6 +_,10 @@
+@@ -17,6 +_,16 @@
      public static final int USAGE_INDEX = 64;
      public static final int USAGE_UNIFORM = 128;
      public static final int USAGE_UNIFORM_TEXEL_BUFFER = 256;
++    /**
++     * Neo: Requires that this buffer be uploaded to before being used for a given frame
++     *      <br>
++     *      Use of a buffer created with this bit without prior upload on a given frame may crash
++     */
++    public static final int USAGE_PERF_FRAME_TRANSIENT = USAGE_UNIFORM_TEXEL_BUFFER << 1;
 +    /**
 +     * Neo: These bits are reserved for alternate backend specific uses
 +     */

--- a/patches/com/mojang/blaze3d/vertex/VertexFormat.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/VertexFormat.java.patch
@@ -1,9 +1,18 @@
 --- a/com/mojang/blaze3d/vertex/VertexFormat.java
 +++ b/com/mojang/blaze3d/vertex/VertexFormat.java
-@@ -238,4 +_,28 @@
+@@ -128,6 +_,7 @@
+     }
+ 
+     private GpuBuffer uploadToBufferWithWorkaround(@Nullable GpuBuffer p_428850_, ByteBuffer p_428822_, int p_428845_, Supplier<String> p_428834_) {
++        p_428845_ |= GpuBuffer.USAGE_PERF_FRAME_TRANSIENT;
+         if (USE_STAGING_BUFFER_WORKAROUND) {
+             GpuDevice gpudevice = RenderSystem.getDevice();
+             if (p_428850_ == null) {
+@@ -237,5 +_,29 @@
+                 default -> 0;
              };
          }
-     }
++    }
 +
 +    public ImmutableMap<String, VertexFormatElement> getElementMapping() {
 +        ImmutableMap.Builder<String, VertexFormatElement> builder = ImmutableMap.builder();
@@ -27,5 +36,5 @@
 +
 +    public boolean hasUV(int which) {
 +        return elements.stream().anyMatch(e -> e.usage() == VertexFormatElement.Usage.UV && e.index() == which);
-+    }
+     }
  }

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/GpuDeviceUsageValidator.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/GpuDeviceUsageValidator.java
@@ -34,7 +34,7 @@ public class GpuDeviceUsageValidator {
         }
         // the reserved bits were already checked, so ignore those
         usage &= ~GpuBuffer.RESERVED_USAGE_BITS;
-        var knownGpuBufferBits = (GpuBuffer.USAGE_UNIFORM_TEXEL_BUFFER << 1) - 1;
+        var knownGpuBufferBits = (GpuBuffer.USAGE_PERF_FRAME_TRANSIENT << 1) - 1;
         if ((usage & ~knownGpuBufferBits) != 0) {
             throw new IllegalArgumentException("Use of undefined GpuBuffer usage bits");
         }


### PR DESCRIPTION
This bit is targeted specifically at usage like the immediate vertex/index buffers used in entity rendering.
This bit was a part of #2359

This will allow backends to make optimizations to how the API buffer(s) backing this GpuBuffer is/are allocated, freed, and uploaded that would otherwise be impossible. 
This is considered a breaking change as it would be a default known bit per #2399.

Backends are free to ignore this bit, as it places a restriction on usage not implementation, and as such no modifications to the default backend are required.