### PR TITLE
Fix issues with binding function keys on Mac systems

### DIFF
--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
@@ -46,7 +46,7 @@
 +        // We ignore events from keys with the scan code 63 as they're emitted
 +        // (only as RELEASE, not PRESS) by Mac systems to indicate that "Fn" is being pressed
 +        // See https://github.com/neoforged/NeoForge/issues/1683
-+        if (this.selectedKey != null && (net.minecraft.Util.getPlatform() != net.minecraft.Util.OS.OSX || p_94716_ != 63)) {
++        if (this.selectedKey != null && (!net.minecraft.client.Minecraft.ON_OSX || p_94716_ != 63)) {
 +            if (p_94715_ == 256) {
 +                this.selectedKey.setKeyModifierAndCode(net.neoforged.neoforge.client.settings.KeyModifier.NONE, InputConstants.UNKNOWN);
                  this.selectedKey.setKey(InputConstants.UNKNOWN);

--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
@@ -21,7 +21,7 @@
              }
  
              this.keyBindsList.resetMappingAndUpdateButtons();
-@@ -72,18 +_,65 @@
+@@ -72,18 +_,68 @@
      @Override
      public boolean keyPressed(int p_345810_, int p_345447_, int p_344981_) {
          if (this.selectedKey != null) {
@@ -40,10 +40,13 @@
 +        }
 +    }
 +
-+    // Neo: This method is override to more easily handle modifier keys
++    // Neo: This method is overridden to more easily handle modifier keys
 +    @Override
 +    public boolean keyReleased(int p_94715_, int p_94716_, int p_94717_) {
-+        if (this.selectedKey != null) {
++        // We ignore events from keys with the scan code 63 as they're emitted
++        // (only as RELEASE, not PRESS) by Mac systems to indicate that "Fn" is being pressed
++        // See https://github.com/neoforged/NeoForge/issues/1683
++        if (this.selectedKey != null && p_94716_ != 63) {
 +            if (p_94715_ == 256) {
 +                this.selectedKey.setKeyModifierAndCode(net.neoforged.neoforge.client.settings.KeyModifier.NONE, InputConstants.UNKNOWN);
                  this.selectedKey.setKey(InputConstants.UNKNOWN);

--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
@@ -46,7 +46,7 @@
 +        // We ignore events from keys with the scan code 63 as they're emitted
 +        // (only as RELEASE, not PRESS) by Mac systems to indicate that "Fn" is being pressed
 +        // See https://github.com/neoforged/NeoForge/issues/1683
-+        if (this.selectedKey != null && p_94716_ != 63) {
++        if (this.selectedKey != null && (net.minecraft.Util.getPlatform() != net.minecraft.Util.OS.OSX || p_94716_ != 63)) {
 +            if (p_94715_ == 256) {
 +                this.selectedKey.setKeyModifierAndCode(net.neoforged.neoforge.client.settings.KeyModifier.NONE, InputConstants.UNKNOWN);
                  this.selectedKey.setKey(InputConstants.UNKNOWN);


### PR DESCRIPTION
With the help of @codexadrian I was able to find the cause of this issue. With the following simple listeners added to a mod
```java
@SubscribeEvent
static void onPress(ScreenEvent.KeyPressed.Pre event) {
	if (event.getScreen() instanceof KeyBindsScreen) {
		var key = InputConstants.getKey(event.getKeyCode(), event.getScanCode());
		Ihatekeybinds.LOGGER.error("Pressed key {} with code {}, modifiers {}, scan code {}", key, event.getKeyCode(), event.getModifiers(), event.getScanCode());
	}
}

@SubscribeEvent
static void onRelease(ScreenEvent.KeyReleased.Pre event) {
	if (event.getScreen() instanceof KeyBindsScreen) {
		var key = InputConstants.getKey(event.getKeyCode(), event.getScanCode());
		Ihatekeybinds.LOGGER.error("Released key {} with code {}, modifiers {}, scan code {}", key, event.getKeyCode(), event.getModifiers(), event.getScanCode());
	}
}
```
we can notice that attempting to press `Fn` + any function key when the option to `Use F keys as standard function keys` is turned off will cause the following log lines to be printed
```
[10Jul2025 17:25:41.591] [Render thread/ERROR] [com.matyrobbrt.keybinds.Ihatekeybinds/]: Released key scancode.63 with code -1, modifiers 0, scan code 63
[10Jul2025 17:25:42.116] [Render thread/ERROR] [com.matyrobbrt.keybinds.Ihatekeybinds/]: Pressed key key.keyboard.f1 with code 290, modifiers 0, scan code 122
[10Jul2025 17:25:42.196] [Render thread/ERROR] [com.matyrobbrt.keybinds.Ihatekeybinds/]: Released key key.keyboard.f1 with code 290, modifiers 0, scan code 122
[10Jul2025 17:25:42.274] [Render thread/ERROR] [com.matyrobbrt.keybinds.Ihatekeybinds/]: Released key scancode.63 with code -1, modifiers 0, scan code 63
```
As it would seem, Mac systems fire the `RELEASE` event for a special key with the scan code 63 before pressing the function key, and after releasing it. For this issue, only the first part is relevant. By firing a `RELEASE` event before even pressing the function key, our patch in `KeyBindsScreen` detects the `keyReleased` event, sets the `selectedKey`'s value to `UNKNOWN` (as this key event has the code -1) and then sets the `selectedKey` to null, resetting the keybind and preventing the game from further picking up the press/release combination of the real function key.  
The fix is rather naive but unfortunately I was not able to come up with something better than simply hardcoding the patch to ignore scancode 63 events.

Fixes #1683

P.S.: this does not affect vanilla as they only listen for `keyPressed` which as we have determined above does not fire for the special `Fn` key

~~**PENDING TESTING**~~ Testing has confirmed the issue to no longer be present with this PR.