### PR TITLE
[1.21.7][B3D][Breaking] Check for USAGE_COPY_SRC instead of USAGE_COPY_DST on copyToBuffer's source buffer.

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/GlCommandEncoder.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlCommandEncoder.java.patch
@@ -34,6 +34,17 @@
      private void verifyColorTexture(GpuTexture p_416690_) {
          if (!p_416690_.getFormat().hasColorAspect()) {
              throw new IllegalStateException("Trying to clear a non-color texture as color");
+@@ -321,8 +_,8 @@
+             GlBuffer glbuffer = (GlBuffer)p_428848_.buffer();
+             if (glbuffer.closed) {
+                 throw new IllegalStateException("Source buffer already closed");
+-            } else if ((glbuffer.usage() & 8) == 0) {
+-                throw new IllegalStateException("Source buffer needs USAGE_COPY_DST to be a destination for a copy");
++            } else if ((glbuffer.usage() & GpuBuffer.USAGE_COPY_SRC) == 0) {
++                throw new IllegalStateException("Source buffer needs USAGE_COPY_SRC to be a source for a copy");
+             } else {
+                 GlBuffer glbuffer1 = (GlBuffer)p_428840_.buffer();
+                 if (glbuffer1.closed) {
 @@ -655,8 +_,19 @@
                  boolean flag = p_410700_.getFormat().hasDepthAspect();
                  int i = ((GlTexture)p_410700_).glId();

--- a/patches/com/mojang/blaze3d/vertex/VertexFormat.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/VertexFormat.java.patch
@@ -1,9 +1,19 @@
 --- a/com/mojang/blaze3d/vertex/VertexFormat.java
 +++ b/com/mojang/blaze3d/vertex/VertexFormat.java
-@@ -238,4 +_,28 @@
+@@ -138,7 +_,7 @@
+                     p_428850_.close();
+                     p_428850_ = gpudevice.createBuffer(p_428834_, p_428845_, p_428822_);
+                 } else {
+-                    UPLOAD_STAGING_BUFFER = uploadToBuffer(UPLOAD_STAGING_BUFFER, p_428822_, p_428845_, p_428834_);
++                    UPLOAD_STAGING_BUFFER = uploadToBuffer(UPLOAD_STAGING_BUFFER, p_428822_, GpuBuffer.USAGE_COPY_SRC | GpuBuffer.USAGE_COPY_DST | GpuBuffer.USAGE_HINT_CLIENT_STORAGE, p_428834_);
+                     commandencoder.copyToBuffer(UPLOAD_STAGING_BUFFER.slice(0, p_428822_.remaining()), p_428850_.slice(0, p_428822_.remaining()));
+                 }
+             }
+@@ -237,5 +_,29 @@
+                 default -> 0;
              };
          }
-     }
++    }
 +
 +    public ImmutableMap<String, VertexFormatElement> getElementMapping() {
 +        ImmutableMap.Builder<String, VertexFormatElement> builder = ImmutableMap.builder();
@@ -27,5 +37,5 @@
 +
 +    public boolean hasUV(int which) {
 +        return elements.stream().anyMatch(e -> e.usage() == VertexFormatElement.Usage.UV && e.index() == which);
-+    }
+     }
  }


### PR DESCRIPTION
This has been flagged to Mojang, though I don't think there is a (public) mojira bug for it.
No other changes to backend required as GL requires no specific flags for on-device (`glCopyBufferSubData`) copies.

This is a breaking change because it changes the usage contract for copyToBuffer.

#2445's PERF_FRAME_TRANSIENT bit should be added to the COPY_SRC and COPY_DST bits that the staging buffer is given. Depending on which PR is merged first the other should be updated to include that.