### PR TITLE
Fire `InputEvent.MouseButton.Post` after screen handles click

### DIFF
--- a/patches/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/net/minecraft/client/MouseHandler.java.patch
@@ -1,45 +1,62 @@
 --- a/net/minecraft/client/MouseHandler.java
 +++ b/net/minecraft/client/MouseHandler.java
-@@ -90,6 +_,7 @@
+@@ -90,6 +_,8 @@
                  this.activeButton = -1;
              }
  
 +            if (net.neoforged.neoforge.client.ClientHooks.onMouseButtonPre(p_91532_, p_91533_, p_91534_)) return;
++            boolean screenHandled = false;
              if (this.minecraft.getOverlay() == null) {
                  if (this.minecraft.screen == null) {
                      if (!this.mouseGrabbed && flag) {
-@@ -103,7 +_,12 @@
+@@ -103,8 +_,13 @@
                          screen.afterMouseAction();
  
                          try {
 -                            if (screen.mouseClicked(d0, d1, i)) {
+-                                return;
 +                            boolean flag2;
 +                            if (
 +                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseClickedPre(screen, d0, d1, i) ||
 +                                (flag2 = screen.mouseClicked(d0, d1, i)) |
 +                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseClickedPost(screen, d0, d1, i, flag2)
 +                            ) {
-                                 return;
++                                screenHandled = true;
                              }
                          } catch (Throwable throwable1) {
-@@ -116,7 +_,12 @@
+                             CrashReport crashreport = CrashReport.forThrowable(throwable1, "mouseClicked event handler");
+@@ -116,8 +_,13 @@
                          }
                      } else {
                          try {
 -                            if (screen.mouseReleased(d0, d1, i)) {
+-                                return;
 +                            boolean flag2;
 +                            if (
 +                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseReleasedPre(screen, d0, d1, i) ||
 +                                (flag2 = screen.mouseReleased(d0, d1, i)) |
 +                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseReleasedPost(screen, d0, d1, i, flag2)
 +                            ) {
-                                 return;
++                                screenHandled = true;
                              }
                          } catch (Throwable throwable) {
-@@ -149,6 +_,7 @@
+                             CrashReport crashreport1 = CrashReport.forThrowable(throwable, "mouseReleased event handler");
+@@ -131,6 +_,10 @@
+                 }
+             }
+ 
++            // Neo: we patch out the returns in the screen handler code to fire the mouse button post event
++            // therefore we add a boolean to check whether the screen handled the click and if not we let
++            // vanilla's fallback handle it
++            if (!screenHandled) {
+             if (this.minecraft.screen == null && this.minecraft.getOverlay() == null) {
+                 if (p_91532_ == 0) {
+                     this.isLeftPressed = flag;
+@@ -149,6 +_,8 @@
                      }
                  }
              }
++            }
 +            net.neoforged.neoforge.client.ClientHooks.onMouseButtonPost(p_91532_, p_91533_, p_91534_);
          }
      }

--- a/patches/net/minecraft/client/MouseHandler.java.patch
+++ b/patches/net/minecraft/client/MouseHandler.java.patch
@@ -9,35 +9,29 @@
              if (this.minecraft.getOverlay() == null) {
                  if (this.minecraft.screen == null) {
                      if (!this.mouseGrabbed && flag) {
-@@ -103,8 +_,13 @@
+@@ -103,8 +_,10 @@
                          screen.afterMouseAction();
  
                          try {
 -                            if (screen.mouseClicked(d0, d1, i)) {
 -                                return;
-+                            boolean flag2;
-+                            if (
-+                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseClickedPre(screen, d0, d1, i) ||
-+                                (flag2 = screen.mouseClicked(d0, d1, i)) |
-+                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseClickedPost(screen, d0, d1, i, flag2)
-+                            ) {
-+                                screenHandled = true;
++                            screenHandled = net.neoforged.neoforge.client.ClientHooks.onScreenMouseClickedPre(screen, d0, d1, i);
++                            if (!screenHandled) {
++                                screenHandled = screen.mouseClicked(d0, d1, i);
++                                screenHandled = net.neoforged.neoforge.client.ClientHooks.onScreenMouseClickedPost(screen, d0, d1, i, screenHandled);
                              }
                          } catch (Throwable throwable1) {
                              CrashReport crashreport = CrashReport.forThrowable(throwable1, "mouseClicked event handler");
-@@ -116,8 +_,13 @@
+@@ -116,8 +_,10 @@
                          }
                      } else {
                          try {
 -                            if (screen.mouseReleased(d0, d1, i)) {
 -                                return;
-+                            boolean flag2;
-+                            if (
-+                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseReleasedPre(screen, d0, d1, i) ||
-+                                (flag2 = screen.mouseReleased(d0, d1, i)) |
-+                                net.neoforged.neoforge.client.ClientHooks.onScreenMouseReleasedPost(screen, d0, d1, i, flag2)
-+                            ) {
-+                                screenHandled = true;
++                            screenHandled = net.neoforged.neoforge.client.ClientHooks.onScreenMouseReleasedPre(screen, d0, d1, i);
++                            if (!screenHandled) {
++                                screenHandled = screen.mouseReleased(d0, d1, i);
++                                screenHandled = net.neoforged.neoforge.client.ClientHooks.onScreenMouseReleasedPost(screen, d0, d1, i, screenHandled);
                              }
                          } catch (Throwable throwable) {
                              CrashReport crashreport1 = CrashReport.forThrowable(throwable, "mouseReleased event handler");


### PR DESCRIPTION
Fixes #1945 by replacing the `return`s if the screen handled the click with a boolean that will prevent the vanilla code path for non-handled clicks from executing while still firing the post event