### PR TITLE
Fix inversion of dismount location condition

### DIFF
--- a/patches/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
+++ b/patches/net/minecraft/world/entity/animal/horse/AbstractHorse.java.patch
@@ -20,6 +20,15 @@
          if (p_275435_.z > 0.0) {
              float f = Mth.sin(this.getYRot() * (float) (Math.PI / 180.0));
              float f1 = Mth.cos(this.getYRot() * (float) (Math.PI / 180.0));
+@@ -983,7 +_,7 @@
+                 }
+ 
+                 blockpos$mutableblockpos.move(Direction.UP);
+-            } while (!(blockpos$mutableblockpos.getY() < d3));
++            } while (blockpos$mutableblockpos.getY() < d3);
+         }
+ 
+         return null;
 @@ -1020,6 +_,11 @@
  
          this.randomizeAttributes(p_30555_.getRandom());


### PR DESCRIPTION
This pull request fixes the horse dismount location searching condition, the while condition is unexpectedly inversed by VF, which may lead to an infinite loop and halt the server.

To reproduce:
- Summon a horse with command `/summon minecraft:horse ~ ~ ~ {attributes:[{base:0.1,id:"minecraft:scale"}],NoGravity:true,Tame:true,SaddleItem:{id:"minecraft:saddle"}}`
- Dig a 2 block deep hole below it
- Ride the horse and dismount it
- Server halts