### PR TITLE
Use SingleThreadedRandomSource for compiling sections

### DIFF
--- a/patches/net/minecraft/client/renderer/chunk/SectionCompiler.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionCompiler.java.patch
@@ -11,9 +11,13 @@
          SectionCompiler.Results sectioncompiler$results = new SectionCompiler.Results();
          BlockPos blockpos = p_350790_.origin();
          BlockPos blockpos1 = blockpos.offset(15, 15, 15);
-@@ -51,6 +_,7 @@
+@@ -49,8 +_,10 @@
+         PoseStack posestack = new PoseStack();
+         ModelBlockRenderer.enableCaching();
          Map<ChunkSectionLayer, BufferBuilder> map = new EnumMap<>(ChunkSectionLayer.class);
-         RandomSource randomsource = RandomSource.create();
+-        RandomSource randomsource = RandomSource.create();
++        // Neo: use a SingleThreadedRandomSource to avoid overhead of atomics
++        RandomSource randomsource = new net.minecraft.world.level.levelgen.SingleThreadedRandomSource(net.minecraft.world.level.levelgen.RandomSupport.generateUniqueSeed());
          List<BlockModelPart> list = new ObjectArrayList<>();
 +        java.util.function.Function<ChunkSectionLayer, com.mojang.blaze3d.vertex.VertexConsumer> bufferLookup = renderType -> this.getOrBeginLayer(map, p_350612_, renderType);
  


### PR DESCRIPTION
The default `RandomSource` returned by `RandomSource.create` uses atomics to store the RNG state. Since chunk meshing takes place on an isolated thread, we can use `SingleThreadedRandomSource` instead to get a bit more performance for free.