### PR TITLE
[1.21.7][B3D] Add viewport to RenderPass

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/GlRenderPass.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlRenderPass.java.patch
@@ -17,3 +17,15 @@
          if (this.pipeline == null || this.pipeline.info() != p_409823_) {
              this.dirtyUniforms.addAll(this.uniforms.keySet());
              this.dirtyUniforms.addAll(this.samplers.keySet());
+@@ -103,6 +_,11 @@
+             this.uniforms.put(p_409689_, p_418312_);
+             this.dirtyUniforms.add(p_409689_);
+         }
++    }
++
++    @Override
++    public void setViewport(int x, int y, int width, int height){
++        GlStateManager._viewport(x, y, width, height);
+     }
+ 
+     @Override

--- a/patches/com/mojang/blaze3d/systems/RenderPass.java.patch
+++ b/patches/com/mojang/blaze3d/systems/RenderPass.java.patch
@@ -1,0 +1,11 @@
+--- a/com/mojang/blaze3d/systems/RenderPass.java
++++ b/com/mojang/blaze3d/systems/RenderPass.java
+@@ -28,6 +_,8 @@
+ 
+     void setUniform(String p_410316_, GpuBufferSlice p_418316_);
+ 
++    void setViewport(int x, int y, int width, int height);
++
+     void enableScissor(int p_409956_, int p_410530_, int p_409728_, int p_410747_);
+ 
+     void disableScissor();

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationRenderPass.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationRenderPass.java
@@ -61,6 +61,11 @@ public class ValidationRenderPass implements RenderPass {
     }
 
     @Override
+    public void setViewport(int x, int y, int width, int height) {
+        realRenderPass.setViewport(x, y, width, height);
+    }
+
+    @Override
     public void enableScissor(int x, int y, int width, int height) {
         realRenderPass.enableScissor(x, y, width, height);
     }


### PR DESCRIPTION
Adds the ability to set the viewport on a RenderPass. GL state does not need to be reset as during RenderPass creation viewport is set by Vanilla to the full framebuffer, and as a result is already dirtied state.

ELS overlay will need this to be implemented on top of B3D.

As implemented, this is a breaking change. If this PR misses BC, this can be implemented as a non-breraking change, though NeoForge itself will need the feature making it a semi-breaking change regardless.