### PR TITLE
Fix failing attachmentSyncTest game test

### DIFF
--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentSyncTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentSyncTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.attachment;
 
+import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import java.util.List;
 import java.util.Random;
@@ -139,141 +140,140 @@ public class AttachmentSyncTests {
 
         test.onGameTest(TestHelper.class, helper -> {
             var player = helper.makeTickingMockServerPlayerInCorner(GameType.CREATIVE);
+            var feetPos = helper.relativePos(player.blockPosition()).below(1);
 
             player.clearOutboundPackets();
 
-            // Test that players receive updates for changes to their own data
-            {
-                var testValue = helper.randomInt();
-                player.setData(intAttachment, testValue);
+            helper.startSequence()
+                    // Test that players receive updates for changes to their own data
+                    .thenExecute(() -> {
+                        var testValue = helper.randomInt();
+                        player.setData(intAttachment, testValue);
 
-                var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                helper.expectTarget(payload, new SyncAttachmentsPayload.EntityTarget(player.getId()));
+                        var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        helper.expectTarget(payload, new SyncAttachmentsPayload.EntityTarget(player.getId()));
 
-                var holder = helper.holder();
-                holder.readFrom(payload);
-                holder.assertEqual(intAttachment, testValue);
+                        var holder = helper.holder();
+                        holder.readFrom(payload);
+                        holder.assertEqual(intAttachment, testValue);
 
-                player.clearOutboundPackets();
-            }
+                        player.clearOutboundPackets();
+                    })
+                    // Test that players receive updates for changes to the chunk they're in
+                    .thenExecute(() -> {
+                        var chunk = helper.getLevel().getChunkAt(player.blockPosition());
+                        var testValue = helper.randomInt();
+                        chunk.setData(intAttachment, testValue);
 
-            // Test that players receive updates for changes to the chunk they're in
-            {
-                var chunk = helper.getLevel().getChunkAt(player.blockPosition());
-                var testValue = helper.randomInt();
-                chunk.setData(intAttachment, testValue);
+                        var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        helper.expectTarget(payload, new SyncAttachmentsPayload.ChunkTarget(player.chunkPosition()));
 
-                var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                helper.expectTarget(payload, new SyncAttachmentsPayload.ChunkTarget(player.chunkPosition()));
+                        var holder = helper.holder();
+                        holder.readFrom(payload);
+                        holder.assertEqual(intAttachment, testValue);
 
-                var holder = helper.holder();
-                holder.readFrom(payload);
-                holder.assertEqual(intAttachment, testValue);
+                        player.clearOutboundPackets();
+                    })
+                    // Test that players receive updates for changes to block entities in tracked chunks
+                    .thenExecute(() -> {
+                        var testValue = helper.randomInt();
+                        helper.setBlock(feetPos, Blocks.FURNACE);
+                        var be = helper.getBlockEntity(feetPos, FurnaceBlockEntity.class);
+                        be.setData(intAttachment, testValue);
 
-                player.clearOutboundPackets();
-            }
+                        var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        helper.expectTarget(payload, new SyncAttachmentsPayload.BlockEntityTarget(helper.absolutePos(feetPos)));
 
-            var feetPos = helper.relativePos(player.blockPosition()).below(1);
+                        var holder = helper.holder();
+                        holder.readFrom(payload);
+                        holder.assertEqual(intAttachment, testValue);
 
-            // Test that players receive updates for changes to block entities in tracked chunks
-            {
-                var testValue = helper.randomInt();
-                helper.setBlock(feetPos, Blocks.FURNACE);
-                var be = helper.getBlockEntity(feetPos, FurnaceBlockEntity.class);
-                be.setData(intAttachment, testValue);
+                        player.clearOutboundPackets();
+                    })
+                    .thenMap(() -> helper.spawnWithNoFreeWill(EntityType.PIG, helper.relativePos(player.blockPosition())))
+                    // Test that players receive updates for entities in tracked chunks
+                    .thenExecute(entity -> {
+                        var testValue = helper.randomInt();
+                        entity.setData(intAttachment, testValue);
 
-                var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                helper.expectTarget(payload, new SyncAttachmentsPayload.BlockEntityTarget(helper.absolutePos(feetPos)));
+                        var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        helper.expectTarget(payload, new SyncAttachmentsPayload.EntityTarget(entity.getId()));
 
-                var holder = helper.holder();
-                holder.readFrom(payload);
-                holder.assertEqual(intAttachment, testValue);
+                        var holder = helper.holder();
+                        holder.readFrom(payload);
+                        holder.assertEqual(intAttachment, testValue);
 
-                player.clearOutboundPackets();
-            }
+                        player.clearOutboundPackets();
+                    })
+                    // Test that players receive initial login packets
+                    .thenMap(entity -> Pair.of(entity, helper.makeTickingMockServerPlayerInCorner(GameType.CREATIVE)))
+                    // Wait 1 tick to let the player tick so that it starts tracking the other entities
+                    .thenIdle(1)
+                    // Resume flushing after idling else packets won't get sent immediately
+                    .thenExecute(pair -> player.connection.resumeFlushing())
+                    .thenExecute(pair -> {
+                        var entity = pair.getFirst();
+                        var newPlayer = pair.getSecond();
+                        helper.assertTrue(
+                                newPlayer.getOutboundPayloads(SyncAttachmentsPayload.class)
+                                        .map(SyncAttachmentsPayload::target)
+                                        .toList()
+                                        .containsAll(List.of(
+                                                new SyncAttachmentsPayload.BlockEntityTarget(helper.absolutePos(feetPos)),
+                                                new SyncAttachmentsPayload.ChunkTarget(player.chunkPosition()),
+                                                new SyncAttachmentsPayload.EntityTarget(player.getId()),
+                                                new SyncAttachmentsPayload.EntityTarget(entity.getId()))),
+                                "Expected to find that player received all sync payloads");
+                        newPlayer.disconnectGameTest();
+                    })
+                    .thenMap(Pair::getFirst)
+                    // Test that removing data causes players to receive packets
+                    .thenExecute(entity -> {
+                        entity.removeData(intAttachment);
 
-            var entity = helper.spawnWithNoFreeWill(EntityType.PIG, helper.relativePos(player.blockPosition()));
-            // Test that players receive updates for entities in tracked chunks
-            {
-                var testValue = helper.randomInt();
-                entity.setData(intAttachment, testValue);
+                        var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        helper.expectTarget(payload, new SyncAttachmentsPayload.EntityTarget(entity.getId()));
 
-                var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                helper.expectTarget(payload, new SyncAttachmentsPayload.EntityTarget(entity.getId()));
+                        var holder = helper.holder();
+                        holder.setData(intAttachment, 1);
+                        holder.readFrom(payload);
+                        holder.assertEqual(intAttachment, null);
 
-                var holder = helper.holder();
-                holder.readFrom(payload);
-                holder.assertEqual(intAttachment, testValue);
+                        player.clearOutboundPackets();
+                    })
+                    // Test that manual syncs send the packets to players that track the entity
+                    .thenExecute(entity -> {
+                        var attachment = entity.getData(mutableIntAttachment);
+                        var holder = helper.holder();
+                        var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        holder.readFrom(payload);
+                        // Default value is expected to send a packet too
+                        holder.assertEqual(mutableIntAttachment, new MutableInt(23));
 
-                player.clearOutboundPackets();
-            }
+                        player.clearOutboundPackets();
 
-            // Test that players receive initial login packets
-            {
-                var newPlayer = helper.makeTickingMockServerPlayerInCorner(GameType.CREATIVE);
-                helper.assertTrue(
-                        newPlayer.getOutboundPayloads(SyncAttachmentsPayload.class)
-                                .map(SyncAttachmentsPayload::target)
-                                .toList()
-                                .containsAll(List.of(
-                                        new SyncAttachmentsPayload.BlockEntityTarget(helper.absolutePos(feetPos)),
-                                        new SyncAttachmentsPayload.ChunkTarget(player.chunkPosition()),
-                                        new SyncAttachmentsPayload.EntityTarget(player.getId()),
-                                        new SyncAttachmentsPayload.EntityTarget(entity.getId()))),
-                        "Expected to find that player received all sync payloads");
-                newPlayer.disconnectGameTest();
-            }
+                        attachment.setValue(30);
+                        helper.assertTrue(
+                                player.getOutboundPayloads(SyncAttachmentsPayload.class).count() == 0,
+                                "Expected player to receive no sync payloads for mutable attachment having its inner value updated");
 
-            // Test that removing data causes players to receive packets
-            {
-                entity.removeData(intAttachment);
+                        entity.syncData(mutableIntAttachment);
 
-                var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                helper.expectTarget(payload, new SyncAttachmentsPayload.EntityTarget(entity.getId()));
+                        payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
+                        holder.readFrom(payload);
+                        holder.assertEqual(mutableIntAttachment, new MutableInt(30));
 
-                var holder = helper.holder();
-                holder.setData(intAttachment, 1);
-                holder.readFrom(payload);
-                holder.assertEqual(intAttachment, null);
-
-                player.clearOutboundPackets();
-            }
-
-            // Test that manual syncs send the packets to players that track the entity
-            {
-                var attachment = entity.getData(mutableIntAttachment);
-                var holder = helper.holder();
-                var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                holder.readFrom(payload);
-                // Default value is expected to send a packet too
-                holder.assertEqual(mutableIntAttachment, new MutableInt(23));
-
-                player.clearOutboundPackets();
-
-                attachment.setValue(30);
-                helper.assertTrue(
-                        player.getOutboundPayloads(SyncAttachmentsPayload.class).count() == 0,
-                        "Expected player to receive no sync payloads for mutable attachment having its inner value updated");
-
-                entity.syncData(mutableIntAttachment);
-
-                payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
-                holder.readFrom(payload);
-                holder.assertEqual(mutableIntAttachment, new MutableInt(30));
-
-                player.clearOutboundPackets();
-            }
-
-            // Test that values are not synced if the sync predicate returns false
-            {
-                player.setData(blacklistedPlayer, true);
-                entity.setData(mutableIntAttachment, new MutableInt(4));
-                helper.assertTrue(
-                        player.getOutboundPayloads(SyncAttachmentsPayload.class).count() == 0,
-                        "Expected player not to receive a sync payload as the predicate should've returned false");
-            }
-
-            helper.succeed();
+                        player.clearOutboundPackets();
+                    })
+                    // Test that values are not synced if the sync predicate returns false
+                    .thenExecute(entity -> {
+                        player.setData(blacklistedPlayer, true);
+                        entity.setData(mutableIntAttachment, new MutableInt(4));
+                        helper.assertTrue(
+                                player.getOutboundPayloads(SyncAttachmentsPayload.class).count() == 0,
+                                "Expected player not to receive a sync payload as the predicate should've returned false");
+                    })
+                    .thenSucceed();
         });
     }
 }


### PR DESCRIPTION
Basically when the second mock player is made we have to wait 1 tick before checking if the sync packet was received. This required wrapping the entire test in a sequence.

Do also note the `player.connection.resumeFlushing()` after the 1 tick idle which is required to be able to immediately intercept packets.