### PR TITLE
[1.21.8] Allow adding additional states to foreign PoiTypes

### DIFF
--- a/patches/net/minecraft/world/entity/ai/village/poi/PoiType.java.patch
+++ b/patches/net/minecraft/world/entity/ai/village/poi/PoiType.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/village/poi/PoiType.java
++++ b/net/minecraft/world/entity/ai/village/poi/PoiType.java
+@@ -9,7 +_,7 @@
+     public static final Predicate<Holder<PoiType>> NONE = p_218041_ -> false;
+ 
+     public PoiType(Set<BlockState> matchingStates, int maxTickets, int validRange) {
+-        matchingStates = Set.copyOf(matchingStates);
++        matchingStates = new net.neoforged.neoforge.common.world.poi.PoiStateSet(matchingStates);
+         this.matchingStates = matchingStates;
+         this.maxTickets = maxTickets;
+         this.validRange = validRange;

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/ExtendPoiTypesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/ExtendPoiTypesEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world.poi;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.event.IModBusEvent;
+
+/**
+ * Fired in order to add additional {@link BlockState}s to foreign {@link PoiType}s.
+ * <p>
+ * This event is fired on the mod-specific event bus.
+ */
+public final class ExtendPoiTypesEvent extends Event implements IModBusEvent {
+    private final BiConsumer<Holder<PoiType>, Set<BlockState>> registrar;
+
+    ExtendPoiTypesEvent(BiConsumer<Holder<PoiType>, Set<BlockState>> registrar) {
+        this.registrar = registrar;
+    }
+
+    /**
+     * Add the provided {@link Block}'s {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param typeKey The {@link ResourceKey} of the {@link PoiType} to append the states to
+     * @param block   The {@link Block} whose {@link BlockState}s to append to the PoI type
+     */
+    public void addBlockToPoi(ResourceKey<PoiType> typeKey, Block block) {
+        this.addStatesToPoi(typeKey, Set.copyOf(block.getStateDefinition().getPossibleStates()));
+    }
+
+    /**
+     * Add the provided {@link Block}'s {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param type  The {@link PoiType} to append the states to
+     * @param block The {@link Block} whose {@link BlockState}s to append to the PoI type
+     */
+    public void addBlockToPoi(PoiType type, Block block) {
+        this.addStatesToPoi(type, Set.copyOf(block.getStateDefinition().getPossibleStates()));
+    }
+
+    /**
+     * Add the provided {@link Block}'s {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param type  The {@link PoiType} to append the states to
+     * @param block The {@link Block} whose {@link BlockState}s to append to the PoI type
+     */
+    public void addBlockToPoi(Holder<PoiType> type, Block block) {
+        this.addStatesToPoi(type, Set.copyOf(block.getStateDefinition().getPossibleStates()));
+    }
+
+    /**
+     * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param typeKey The {@link ResourceKey} of the {@link PoiType} to append the states to
+     * @param states  The {@link BlockState}s to append to the PoI type
+     */
+    public void addStatesToPoi(ResourceKey<PoiType> typeKey, Set<BlockState> states) {
+        this.addStatesToPoi(BuiltInRegistries.POINT_OF_INTEREST_TYPE.getOrThrow(typeKey), states);
+    }
+
+    /**
+     * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param type   The {@link PoiType} to append the states to
+     * @param states The {@link BlockState}s to append to the PoI type
+     */
+    public void addStatesToPoi(PoiType type, Set<BlockState> states) {
+        Holder<PoiType> typeHolder = BuiltInRegistries.POINT_OF_INTEREST_TYPE.wrapAsHolder(type);
+        if (!(typeHolder.getDelegate() instanceof Holder.Reference)) {
+            throw new IllegalArgumentException("Unregistered PoiType: " + type);
+        }
+        this.addStatesToPoi(typeHolder, states);
+    }
+
+    /**
+     * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param type   The {@link PoiType} to append the states to
+     * @param states The {@link BlockState}s to append to the PoI type
+     */
+    public void addStatesToPoi(Holder<PoiType> type, Set<BlockState> states) {
+        this.registrar.accept(type.getDelegate(), states);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/ExtendPoiTypesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/ExtendPoiTypesEvent.java
@@ -7,8 +7,6 @@ package net.neoforged.neoforge.common.world.poi;
 
 import java.util.Set;
 import java.util.function.BiConsumer;
-import net.minecraft.core.Holder;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.ai.village.poi.PoiType;
 import net.minecraft.world.level.block.Block;
@@ -22,9 +20,9 @@ import net.neoforged.fml.event.IModBusEvent;
  * This event is fired on the mod-specific event bus.
  */
 public final class ExtendPoiTypesEvent extends Event implements IModBusEvent {
-    private final BiConsumer<Holder<PoiType>, Set<BlockState>> registrar;
+    private final BiConsumer<ResourceKey<PoiType>, Set<BlockState>> registrar;
 
-    ExtendPoiTypesEvent(BiConsumer<Holder<PoiType>, Set<BlockState>> registrar) {
+    ExtendPoiTypesEvent(BiConsumer<ResourceKey<PoiType>, Set<BlockState>> registrar) {
         this.registrar = registrar;
     }
 
@@ -39,56 +37,12 @@ public final class ExtendPoiTypesEvent extends Event implements IModBusEvent {
     }
 
     /**
-     * Add the provided {@link Block}'s {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
-     *
-     * @param type  The {@link PoiType} to append the states to
-     * @param block The {@link Block} whose {@link BlockState}s to append to the PoI type
-     */
-    public void addBlockToPoi(PoiType type, Block block) {
-        this.addStatesToPoi(type, Set.copyOf(block.getStateDefinition().getPossibleStates()));
-    }
-
-    /**
-     * Add the provided {@link Block}'s {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
-     *
-     * @param type  The {@link PoiType} to append the states to
-     * @param block The {@link Block} whose {@link BlockState}s to append to the PoI type
-     */
-    public void addBlockToPoi(Holder<PoiType> type, Block block) {
-        this.addStatesToPoi(type, Set.copyOf(block.getStateDefinition().getPossibleStates()));
-    }
-
-    /**
      * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
      *
      * @param typeKey The {@link ResourceKey} of the {@link PoiType} to append the states to
      * @param states  The {@link BlockState}s to append to the PoI type
      */
     public void addStatesToPoi(ResourceKey<PoiType> typeKey, Set<BlockState> states) {
-        this.addStatesToPoi(BuiltInRegistries.POINT_OF_INTEREST_TYPE.getOrThrow(typeKey), states);
-    }
-
-    /**
-     * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
-     *
-     * @param type   The {@link PoiType} to append the states to
-     * @param states The {@link BlockState}s to append to the PoI type
-     */
-    public void addStatesToPoi(PoiType type, Set<BlockState> states) {
-        Holder<PoiType> typeHolder = BuiltInRegistries.POINT_OF_INTEREST_TYPE.wrapAsHolder(type);
-        if (!(typeHolder.getDelegate() instanceof Holder.Reference)) {
-            throw new IllegalArgumentException("Unregistered PoiType: " + type);
-        }
-        this.addStatesToPoi(typeHolder, states);
-    }
-
-    /**
-     * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
-     *
-     * @param type   The {@link PoiType} to append the states to
-     * @param states The {@link BlockState}s to append to the PoI type
-     */
-    public void addStatesToPoi(Holder<PoiType> type, Set<BlockState> states) {
-        this.registrar.accept(type.getDelegate(), states);
+        this.registrar.accept(typeKey, states);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world.poi;
+
+import com.google.common.collect.Iterators;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Predicate;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class PoiStateSet implements Set<BlockState> {
+    private final Set<BlockState> backingSet = new ReferenceOpenHashSet<>();
+
+    public PoiStateSet(Set<BlockState> states) {
+        this.backingSet.addAll(states);
+    }
+
+    @Override
+    public int size() {
+        return this.backingSet.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.backingSet.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return this.backingSet.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return this.backingSet.containsAll(c);
+    }
+
+    @Override
+    public Iterator<BlockState> iterator() {
+        return Iterators.unmodifiableIterator(this.backingSet.iterator());
+    }
+
+    @Override
+    public Object[] toArray() {
+        return this.backingSet.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return this.backingSet.toArray(a);
+    }
+
+    @Override
+    public boolean add(BlockState state) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends BlockState> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super BlockState> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    void addCustomStates(Set<BlockState> states) {
+        this.backingSet.addAll(states);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.ai.village.poi.PoiType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.ModLoader;
@@ -26,8 +28,9 @@ public final class PoiTypeExtender {
         ModLoader.postEvent(new ExtendPoiTypesEvent(PoiTypeExtender::register));
     }
 
-    private static void register(Holder<PoiType> type, Set<BlockState> states) {
+    private static void register(ResourceKey<PoiType> typeKey, Set<BlockState> states) {
         Map<BlockState, Holder<PoiType>> statePoiMap = GameData.getBlockStatePointOfInterestTypeMap();
+        Holder<PoiType> type = BuiltInRegistries.POINT_OF_INTEREST_TYPE.getOrThrow(typeKey);
         for (BlockState state : states) {
             Holder<PoiType> prevType = statePoiMap.putIfAbsent(state, type);
             if (prevType != null) {

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world.poi;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import net.minecraft.core.Holder;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.registries.GameData;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class PoiTypeExtender {
+    public static void extendPoiTypes() {
+        ModLoader.postEvent(new ExtendPoiTypesEvent(PoiTypeExtender::register));
+    }
+
+    private static void register(Holder<PoiType> type, Set<BlockState> states) {
+        Map<BlockState, Holder<PoiType>> statePoiMap = GameData.getBlockStatePointOfInterestTypeMap();
+        for (BlockState state : states) {
+            Holder<PoiType> prevType = statePoiMap.putIfAbsent(state, type);
+            if (prevType != null) {
+                throw new IllegalStateException(String.format(
+                        Locale.ROOT,
+                        "%s is defined in more than one PoI type (old: %s, new: %s)",
+                        state,
+                        prevType.value(),
+                        type.value()));
+            }
+        }
+        ((PoiStateSet) type.value().matchingStates()).addCustomStates(states);
+    }
+
+    private PoiTypeExtender() {}
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
@@ -5,8 +5,11 @@
 
 package net.neoforged.neoforge.common.world.poi;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import net.minecraft.core.Holder;
 import net.minecraft.world.entity.ai.village.poi.PoiType;
@@ -14,6 +17,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.registries.GameData;
 import org.jetbrains.annotations.ApiStatus;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.transformer.meta.MixinMerged;
 
 @ApiStatus.Internal
 public final class PoiTypeExtender {
@@ -34,7 +39,42 @@ public final class PoiTypeExtender {
                         type.value()));
             }
         }
-        ((PoiStateSet) type.value().matchingStates()).addCustomStates(states);
+
+        if (type.value().matchingStates() instanceof PoiStateSet poiStateSet) {
+            poiStateSet.addCustomStates(states);
+        } else {
+            List<String> accessors = Arrays.stream(PoiType.class.getDeclaredMethods())
+                    .filter(method -> method.isSynthetic() &&
+                            method.isAnnotationPresent(Accessor.class) &&
+                            method.getReturnType() == void.class &&
+                            method.getParameterCount() == 1 &&
+                            method.getParameterTypes()[0] == Set.class)
+                    .map(mth -> mth.getAnnotation(MixinMerged.class))
+                    .filter(Objects::nonNull)
+                    .map(MixinMerged::mixin)
+                    .toList();
+
+            String message;
+            if (accessors.isEmpty()) {
+                message = String.format(
+                        Locale.ROOT,
+                        "The matchingStates set of PoiType %s was replaced after construction",
+                        Objects.requireNonNull(type.getKey()).location()
+                );
+            } else {
+                StringBuilder accessorList = new StringBuilder();
+                for (String accessor : accessors) {
+                    accessorList.append("\n").append(accessor);
+                }
+                message = String.format(
+                        Locale.ROOT,
+                        "The matchingStates set of PoiType %s was replaced after construction. Accessor mixins for mutating the set were found:%s",
+                        Objects.requireNonNull(type.getKey()).location(),
+                        accessorList
+                );
+            }
+            throw new IllegalStateException(message);
+        }
     }
 
     private PoiTypeExtender() {}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
@@ -59,8 +59,7 @@ public final class PoiTypeExtender {
                 message = String.format(
                         Locale.ROOT,
                         "The matchingStates set of PoiType %s was replaced after construction",
-                        Objects.requireNonNull(type.getKey()).location()
-                );
+                        Objects.requireNonNull(type.getKey()).location());
             } else {
                 StringBuilder accessorList = new StringBuilder();
                 for (String accessor : accessors) {
@@ -70,8 +69,7 @@ public final class PoiTypeExtender {
                         Locale.ROOT,
                         "The matchingStates set of PoiType %s was replaced after construction. Accessor mixins for mutating the set were found:%s",
                         Objects.requireNonNull(type.getKey()).location(),
-                        accessorList
-                );
+                        accessorList);
             }
             throw new IllegalStateException(message);
         }

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
@@ -46,6 +46,7 @@ public final class PoiTypeExtender {
         if (type.value().matchingStates() instanceof PoiStateSet poiStateSet) {
             poiStateSet.addCustomStates(states);
         } else {
+            // Detect accessor mixins which may have replaced the set to add additional BlockStates after the PoiType's construction
             List<String> accessors = Arrays.stream(PoiType.class.getDeclaredMethods())
                     .filter(method -> method.isSynthetic() &&
                             method.isAnnotationPresent(Accessor.class) &&

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.common.world.poi;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.internal;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
 import net.neoforged.neoforge.common.world.chunk.ForcedChunkManager;
+import net.neoforged.neoforge.common.world.poi.PoiTypeExtender;
 import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.registries.RegistryManager;
@@ -19,6 +20,7 @@ public class RegistrationEvents {
         ForcedChunkManager.init();
         RegistryManager.initDataMaps();
         modifyComponents();
+        PoiTypeExtender.extendPoiTypes();
     }
 
     private static boolean canModifyComponents;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.block;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import java.util.stream.Stream;
 import net.minecraft.client.data.models.BlockModelGenerators;
@@ -13,6 +14,7 @@ import net.minecraft.client.data.models.ModelProvider;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.BlockFamily;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
@@ -26,6 +28,8 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.entity.ai.village.poi.PoiTypes;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -42,7 +46,10 @@ import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
+import net.neoforged.neoforge.common.world.poi.ExtendPoiTypesEvent;
+import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
@@ -222,5 +229,33 @@ public class BlockTests {
         public BubbleColumnDirection getBubbleColumnDirection(BlockState state) {
             return bubbleColumnDirection;
         }
+    }
+
+    @TestHolder(description = "Adds a block whose states are added to the PoiTypes.MEETING PoI type", enabledByDefault = true)
+    static void extendPoiTypeTest(final DynamicTest test, final RegistrationHelper reg) {
+        DeferredBlock<Block> block = reg.blocks().registerSimpleBlock("test_meeting_point");
+        test.eventListeners().mod().addListener((ExtendPoiTypesEvent event) -> {
+            try {
+                event.addBlockToPoi(PoiTypes.MEETING, block.value());
+            } catch (Throwable e) {
+                test.fail("PoiType extension failed with exception: " + e.getMessage());
+            }
+        });
+        test.eventListeners().mod().addListener((FMLLoadCompleteEvent event) -> {
+            PoiType poiType = BuiltInRegistries.POINT_OF_INTEREST_TYPE.getValueOrThrow(PoiTypes.MEETING);
+            ImmutableList<BlockState> states = block.value().getStateDefinition().getPossibleStates();
+            if (!poiType.matchingStates().containsAll(states)) {
+                test.fail("Test block's states were not added to PoiType's matchingStates");
+                return;
+            }
+            for (BlockState state : states) {
+                Optional<Holder<PoiType>> type = PoiTypes.forState(state);
+                if (type.isEmpty() || type.get().getKey() != PoiTypes.MEETING) {
+                    test.fail("A state of the test block is missing from or assigned to the wrong PoI in PoiTypes.TYPE_BY_STATE");
+                    return;
+                }
+            }
+            test.pass();
+        });
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -52,6 +52,7 @@ import net.neoforged.neoforge.common.world.poi.ExtendPoiTypesEvent;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.Test;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
@@ -234,14 +235,18 @@ public class BlockTests {
     @TestHolder(description = "Adds a block whose states are added to the PoiTypes.MEETING PoI type", enabledByDefault = true)
     static void extendPoiTypeTest(final DynamicTest test, final RegistrationHelper reg) {
         DeferredBlock<Block> block = reg.blocks().registerSimpleBlock("test_meeting_point");
+        boolean[] failedEarly = new boolean[1];
         test.eventListeners().mod().addListener((ExtendPoiTypesEvent event) -> {
             try {
                 event.addBlockToPoi(PoiTypes.MEETING, block.value());
-            } catch (Throwable e) {
-                test.fail("PoiType extension failed with exception: " + e.getMessage());
+            } catch (Exception e) {
+                test.updateStatus(Test.Status.failed("PoiType extension failed with exception", e), null);
+                failedEarly[0] = true;
             }
         });
         test.eventListeners().mod().addListener((FMLLoadCompleteEvent event) -> {
+            if (failedEarly[0]) return;
+
             PoiType poiType = BuiltInRegistries.POINT_OF_INTEREST_TYPE.getValueOrThrow(PoiTypes.MEETING);
             ImmutableList<BlockState> states = block.value().getStateDefinition().getPossibleStates();
             if (!poiType.matchingStates().containsAll(states)) {


### PR DESCRIPTION
This PR adds an event for appending additional `BlockState`s to a foreign (primarily vanilla) `PoiType`. This has been a point of major frustration ever since `PoiType` became a record.

~~The event currently provides overloads for every representation of a `PoiType` one might realistically encounter. It would probably be good to reduce this to only the most necessary ones. The `ResourceKey` overload is basically required as that's what vanilla exposes its `PoiType`s as and is also how one checks for `PoiType`s in the world.~~ Reduced to the `ResourceKey` overloads.