### PR TITLE
LivingEntity Freeze event

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -589,6 +589,23 @@
              }
          } else {
              this.noJumpDelay = 0;
+@@ -2837,6 +_,8 @@
+         profilerfiller.pop();
+         if (this.level() instanceof ServerLevel serverlevel) {
+             profilerfiller.push("freezing");
++            net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, serverlevel);
++            if (false) { // Neo: Handled in CommonHooks#onLivingFreeze(LivingEntity, int, int)
+             if (!this.isInPowderSnow || !this.canFreeze()) {
+                 this.setTicksFrozen(Math.max(0, this.getTicksFrozen() - 2));
+             }
+@@ -2846,6 +_,7 @@
+             if (this.tickCount % 40 == 0 && this.isFullyFrozen() && this.canFreeze()) {
+                 this.hurtServer(serverlevel, this.damageSources().freeze(), 1.0F);
+             }
++            }
+ 
+             profilerfiller.pop();
+         }
 @@ -3121,8 +_,11 @@
  
      private void updatingUsingItem() {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1503,7 +1503,9 @@ public class CommonHooks {
 
             if (!frozenEvent.isCanceled()) {
                 if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
-                    entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                    if (frozenEvent.getDamageAmount() > 0) {
+                        entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                    }
                 }
             }
         }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1466,10 +1466,6 @@ public class CommonHooks {
         LivingFreezeEvent freezeEvent = new LivingFreezeEvent(entity, isFreezing);
         NeoForge.EVENT_BUS.post(freezeEvent);
 
-        if (freezeEvent.isCanceled()) { // Do not freeze if canceled
-            return;
-        }
-
         if (!freezeEvent.isFreezing()) {
             entity.setTicksFrozen(Math.max(0, entity.getTicksFrozen() - 2));
         }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -98,7 +98,10 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -195,6 +198,7 @@ import net.neoforged.neoforge.event.entity.living.LivingDropsEvent;
 import net.neoforged.neoforge.event.entity.living.LivingDrownEvent;
 import net.neoforged.neoforge.event.entity.living.LivingEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFallEvent;
+import net.neoforged.neoforge.event.entity.living.LivingFreezeEvent;
 import net.neoforged.neoforge.event.entity.living.LivingGetProjectileEvent;
 import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 import net.neoforged.neoforge.event.entity.living.LivingKnockBackEvent;
@@ -1453,6 +1457,54 @@ public class CommonHooks {
 
         if (!isAir && !entity.level().isClientSide && entity.isPassenger() && entity.getVehicle() != null && !entity.getVehicle().canBeRiddenUnderFluidType(entity.getEyeInFluidType(), entity)) {
             entity.stopRiding();
+        }
+    }
+
+    public static void onLivingFreeze(LivingEntity entity, ServerLevel serverLevel) {
+        boolean isFreezing = entity.isInPowderSnow && entity.canFreeze();
+
+        LivingFreezeEvent freezeEvent = new LivingFreezeEvent(entity, isFreezing);
+        NeoForge.EVENT_BUS.post(freezeEvent);
+
+        if (freezeEvent.isCanceled()) { // Do not freeze if canceled
+            return;
+        }
+
+        if (!freezeEvent.isFreezing()) {
+            entity.setTicksFrozen(Math.max(0, entity.getTicksFrozen() - 2));
+        }
+
+        ResourceLocation speedModifierPowderSnowId = ResourceLocation.withDefaultNamespace("powder_snow");
+        // LivingEntity#removeFrost
+        {
+            AttributeInstance attributeinstance = entity.getAttribute(Attributes.MOVEMENT_SPEED);
+            if (attributeinstance != null) {
+                if (attributeinstance.getModifier(speedModifierPowderSnowId) != null) {
+                    attributeinstance.removeModifier(speedModifierPowderSnowId);
+                }
+            }
+        }
+
+        // LivingEntity#tryAddFrost
+        {
+            BlockState blockStateOnLegacy = entity.level().getBlockState(entity.getOnPosLegacy());
+            if (!blockStateOnLegacy.isAir()) {
+                int i = entity.getTicksFrozen();
+                if (i > 0) {
+                    AttributeInstance attributeinstance = entity.getAttribute(Attributes.MOVEMENT_SPEED);
+                    if (attributeinstance != null) {
+                        int required = freezeEvent.getTicksRequiredToFreeze();
+                        float percent = (float) Math.min(entity.getTicksFrozen(), required) / required;
+                        float f = freezeEvent.getSlowAmount() * percent;
+                        attributeinstance.addTransientModifier(new AttributeModifier(speedModifierPowderSnowId, f, AttributeModifier.Operation.ADD_VALUE));
+                    }
+                }
+            }
+        }
+
+        boolean isFullyFrozen = entity.getTicksFrozen() >= freezeEvent.getTicksRequiredToFreeze();
+        if (entity.tickCount % freezeEvent.getDamageTickRate() == 0 && isFullyFrozen && entity.canFreeze()) {
+            entity.hurtServer(serverLevel, entity.damageSources().freeze(), freezeEvent.getDamageAmount());
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -199,6 +199,7 @@ import net.neoforged.neoforge.event.entity.living.LivingDrownEvent;
 import net.neoforged.neoforge.event.entity.living.LivingEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFallEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFreezeEvent;
+import net.neoforged.neoforge.event.entity.living.LivingFrozenEvent;
 import net.neoforged.neoforge.event.entity.living.LivingGetProjectileEvent;
 import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 import net.neoforged.neoforge.event.entity.living.LivingKnockBackEvent;
@@ -1489,18 +1490,22 @@ public class CommonHooks {
                 if (i > 0) {
                     AttributeInstance attributeinstance = entity.getAttribute(Attributes.MOVEMENT_SPEED);
                     if (attributeinstance != null) {
-                        int required = freezeEvent.getTicksRequiredToFreeze();
-                        float percent = (float) Math.min(entity.getTicksFrozen(), required) / required;
-                        float f = freezeEvent.getSlowAmount() * percent;
+                        float f = freezeEvent.getSlowAmount() * entity.getPercentFrozen();
                         attributeinstance.addTransientModifier(new AttributeModifier(speedModifierPowderSnowId, f, AttributeModifier.Operation.ADD_VALUE));
                     }
                 }
             }
         }
 
-        boolean isFullyFrozen = entity.getTicksFrozen() >= freezeEvent.getTicksRequiredToFreeze();
-        if (entity.tickCount % freezeEvent.getDamageTickRate() == 0 && isFullyFrozen && entity.canFreeze()) {
-            entity.hurtServer(serverLevel, entity.damageSources().freeze(), freezeEvent.getDamageAmount());
+        if (entity.isFullyFrozen() && entity.canFreeze()) {
+            LivingFrozenEvent frozenEvent = new LivingFrozenEvent(entity);
+            NeoForge.EVENT_BUS.post(frozenEvent);
+
+            if (!frozenEvent.isCanceled()) {
+                if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
+                    entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                }
+            }
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -22,23 +22,17 @@ import net.neoforged.neoforge.common.NeoForge;
  */
 public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
-    private int ticksRequiredToFreeze;
     private float slowAmount;
-    private float damageAmount;
-    private int damageTickRate; // In ticks
 
     public LivingFreezeEvent(LivingEntity entity, boolean isFreezing) {
         super(entity);
         this.isFreezing = isFreezing;
-        this.ticksRequiredToFreeze = entity.getTicksRequiredToFreeze();
         this.slowAmount = -0.05F;
-        this.damageAmount = 1.0F;
-        this.damageTickRate = 40;
     }
 
     /**
      * If the entity is freezing, its freezing counter will be increased. If it's over the
-     * {@link #getTicksRequiredToFreeze()} threshold, the entity will take damage.<br>
+     * {@link LivingEntity#getTicksRequiredToFreeze()} threshold, the entity will take damage.<br>
      * If the entity is not freezing, its freezing counter will be decreased.
      *
      * @return True if the entity is freezing
@@ -56,38 +50,11 @@ public class LivingFreezeEvent extends LivingEvent {
         isFreezing = freezing;
     }
 
-    /**
-     * @return The number of ticks needed to fully freeze (start applying damage) while freezing.
-     */
-    public int getTicksRequiredToFreeze() {
-        return ticksRequiredToFreeze;
-    }
-
-    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
-        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
-    }
-
     public float getSlowAmount() {
         return slowAmount;
     }
 
     public void setSlowAmount(float slowAmount) {
         this.slowAmount = slowAmount;
-    }
-
-    public float getDamageAmount() {
-        return damageAmount;
-    }
-
-    public void setDamageAmount(float damageAmount) {
-        this.damageAmount = damageAmount;
-    }
-
-    public int getDamageTickRate() {
-        return damageTickRate;
-    }
-
-    public void setDamageTickRate(int damageTickRate) {
-        this.damageTickRate = damageTickRate;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -53,6 +53,7 @@ public class LivingFreezeEvent extends LivingEvent {
 
     /**
      * Get the slow attribute value applied to the entity as it's freezing. It's applied as {@link AttributeModifier.Operation#ADD_VALUE}.
+     * 
      * @return The current value
      */
     public float getSlowAmount() {
@@ -61,6 +62,7 @@ public class LivingFreezeEvent extends LivingEvent {
 
     /**
      * Sets the slow attribute value that will be applied to the entity as it's freezing.
+     * 
      * @param slowAmount The new value.
      */
     public void setSlowAmount(float slowAmount) {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -8,7 +8,7 @@ package net.neoforged.neoforge.event.entity.living;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
 
-public class LivingFreezeEvent extends LivingEvent implements ICancellableEvent {
+public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
     private int ticksRequiredToFreeze;
     private float slowAmount;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -5,9 +5,21 @@
 
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.common.NeoForge;
 
+/**
+ * LivingFreezeEvent is fired whenever a living entity ticks.<br>
+ * <br>
+ * This event is fired via {@link CommonHooks#onLivingFreeze(LivingEntity, ServerLevel)}.<br>
+ * <br>
+ * This event is {@link ICancellableEvent}.<br>
+ * <br>
+ * This event is fired on {@link NeoForge#EVENT_BUS}, on the logical server only.
+ */
 public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
     private int ticksRequiredToFreeze;
@@ -24,14 +36,29 @@ public class LivingFreezeEvent extends LivingEvent {
         this.damageTickRate = 40;
     }
 
+    /**
+     * If the entity is freezing, its freezing counter will be increased. If it's over the
+     * {@link #getTicksRequiredToFreeze()} threshold, the entity will take damage.<br>
+     * If the entity is not freezing, its freezing counter will be decreased.
+     *
+     * @return True if the entity is freezing
+     */
     public boolean isFreezing() {
         return isFreezing;
     }
 
+    /**
+     * Sets if the entity is freezing or not.
+     *
+     * @param freezing The new value.
+     */
     public void setFreezing(boolean freezing) {
         isFreezing = freezing;
     }
 
+    /**
+     * @return The number of ticks needed to fully freeze (start applying damage) while freezing.
+     */
     public int getTicksRequiredToFreeze() {
         return ticksRequiredToFreeze;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.event.entity.living;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
@@ -50,10 +51,18 @@ public class LivingFreezeEvent extends LivingEvent {
         isFreezing = freezing;
     }
 
+    /**
+     * Get the slow attribute value applied to the entity as it's freezing. It's applied as {@link AttributeModifier.Operation#ADD_VALUE}.
+     * @return The current value
+     */
     public float getSlowAmount() {
         return slowAmount;
     }
 
+    /**
+     * Sets the slow attribute value that will be applied to the entity as it's freezing.
+     * @param slowAmount The new value.
+     */
     public void setSlowAmount(float slowAmount) {
         this.slowAmount = slowAmount;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.living;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.ICancellableEvent;
+
+public class LivingFreezeEvent extends LivingEvent implements ICancellableEvent {
+    private boolean isFreezing;
+    private int ticksRequiredToFreeze;
+    private float slowAmount;
+    private float damageAmount;
+    private int damageTickRate; // In ticks
+
+    public LivingFreezeEvent(LivingEntity entity, boolean isFreezing) {
+        super(entity);
+        this.isFreezing = isFreezing;
+        this.ticksRequiredToFreeze = entity.getTicksRequiredToFreeze();
+        this.slowAmount = -0.05F;
+        this.damageAmount = 1.0F;
+        this.damageTickRate = 40;
+    }
+
+    public boolean isFreezing() {
+        return isFreezing;
+    }
+
+    public void setFreezing(boolean freezing) {
+        isFreezing = freezing;
+    }
+
+    public int getTicksRequiredToFreeze() {
+        return ticksRequiredToFreeze;
+    }
+
+    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
+        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
+    }
+
+    public float getSlowAmount() {
+        return slowAmount;
+    }
+
+    public void setSlowAmount(float slowAmount) {
+        this.slowAmount = slowAmount;
+    }
+
+    public float getDamageAmount() {
+        return damageAmount;
+    }
+
+    public void setDamageAmount(float damageAmount) {
+        this.damageAmount = damageAmount;
+    }
+
+    public int getDamageTickRate() {
+        return damageTickRate;
+    }
+
+    public void setDamageTickRate(int damageTickRate) {
+        this.damageTickRate = damageTickRate;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -1,5 +1,7 @@
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.world.damagesource.DamageSources;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
@@ -26,18 +28,40 @@ public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent 
         this.damageTickRate = 40;
     }
 
+    /**
+     * Gets the amount of {@linkplain DamageSources#freeze() drowning damage} the entity would take.<br>
+     * For vanilla entities, the default amount of damage is 1 (half a heart).
+     * <p>
+     * If the damage amount is less than or equal to zero, {@link Entity#hurtServer} will not be called.
+     *
+     * @return The amount of damage that will be dealt to the entity when actively drowning.
+     */
     public float getDamageAmount() {
         return damageAmount;
     }
 
+    /**
+     * Sets the amount of freezing damage that may be inflicted.
+     *
+     * @param damageAmount The new value.
+     * @see #getDamageAmount()
+     */
     public void setDamageAmount(float damageAmount) {
         this.damageAmount = damageAmount;
     }
 
+    /**
+     * @return The amount of ticks between two damages instances.
+     */
     public int getDamageTickRate() {
         return damageTickRate;
     }
 
+    /**
+     * Sets the amount of ticks between two damages instances.
+     *
+     * @param damageTickRate The new value.
+     */
     public void setDamageTickRate(int damageTickRate) {
         this.damageTickRate = damageTickRate;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -1,0 +1,53 @@
+package net.neoforged.neoforge.event.entity.living;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.common.NeoForge;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * LivingDrownEvent is fired whenever a living entity is fully frozen and is taking damage.
+ * <p>
+ * This event is fired via {@link CommonHooks#onLivingFreeze(LivingEntity, ServerLevel)}.
+ * <p>
+ * This event is {@link ICancellableEvent}. Effects of cancellation are noted in {@link #setCanceled(boolean)}.
+ * <p>
+ * This event does not {@linkplain HasResult have a result}.
+ * This event is fired on {@link NeoForge#EVENT_BUS}
+ **/
+public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent {
+    private float damageAmount;
+    private int damageTickRate;
+
+    public LivingFrozenEvent(LivingEntity entity) {
+        super(entity);
+        this.damageAmount = 1.0F;
+        this.damageTickRate = 40;
+    }
+
+    public float getDamageAmount() {
+        return damageAmount;
+    }
+
+    public void setDamageAmount(float damageAmount) {
+        this.damageAmount = damageAmount;
+    }
+
+    public int getDamageTickRate() {
+        return damageTickRate;
+    }
+
+    public void setDamageTickRate(int damageTickRate) {
+        this.damageTickRate = damageTickRate;
+    }
+
+    /**
+     * Cancelling the event will cancel the damage to the entity.
+     * @param canceled
+     */
+    @Override
+    public void setCanceled(boolean canceled) {
+        ICancellableEvent.super.setCanceled(canceled);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -1,12 +1,17 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.damagesource.DamageSources;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
-import net.minecraft.server.level.ServerLevel;
 
 /**
  * LivingDrownEvent is fired whenever a living entity is fully frozen and is taking damage.
@@ -68,6 +73,7 @@ public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent 
 
     /**
      * Cancelling the event will cancel the damage to the entity.
+     * 
      * @param canceled
      */
     @Override


### PR DESCRIPTION
This pull request adds a `LivingFreezeEvent` analogous to the existing `LivingBreatheEvent`. It allows control (and query) on:
- if a living entity is freezing or not
- the amount of slow applied when freezing

There is also the `LivingFrozenEvent` which is analogous to `LivingDrownEvent`. It allows control (and query) on:
- the damage amount per tick
- and the tick rate of the damage (period between instances of damage)

This is my first Neo PR, so there is still work to do about it (mainly documentation), but I would be happy to have feedback!

TODO:
- [X] Document properly `LivingFreezeEvent`
- [ ] Test (mods? gametests?)