### PR TITLE
[1.21.8][B3D] Remove TextureFormat.DEPTH24_STENCIL8

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/GlConst.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlConst.java.patch
@@ -1,30 +1,27 @@
 --- a/com/mojang/blaze3d/opengl/GlConst.java
 +++ b/com/mojang/blaze3d/opengl/GlConst.java
-@@ -251,6 +_,8 @@
+@@ -251,6 +_,7 @@
              case RED8 -> 33321;
              case RED8I -> 33329;
              case DEPTH32 -> 33191;
-+            case DEPTH24_STENCIL8 -> org.lwjgl.opengl.GL32.GL_DEPTH24_STENCIL8;
 +            case DEPTH32_STENCIL8 -> org.lwjgl.opengl.GL32.GL_DEPTH32F_STENCIL8;
          };
      }
  
-@@ -260,6 +_,10 @@
+@@ -260,6 +_,9 @@
              case RED8 -> 6403;
              case RED8I -> 6403;
              case DEPTH32 -> 6402;
 +            // As long as null data will be passed to texImage2D, the external format does not matter as long as it matches the internalFormat.
 +            // So the usage, for depth, of unsigned int in one case and float in the other case, is not a problem.
-+            case DEPTH24_STENCIL8 -> org.lwjgl.opengl.GL32.GL_DEPTH_STENCIL;
 +            case DEPTH32_STENCIL8 -> org.lwjgl.opengl.GL32.GL_DEPTH_STENCIL;
          };
      }
  
-@@ -269,6 +_,8 @@
+@@ -269,6 +_,7 @@
              case RED8 -> 5121;
              case RED8I -> 5121;
              case DEPTH32 -> 5126;
-+            case DEPTH24_STENCIL8 -> org.lwjgl.opengl.GL32.GL_UNSIGNED_INT_24_8;
 +            case DEPTH32_STENCIL8 -> org.lwjgl.opengl.GL32.GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
          };
      }

--- a/patches/com/mojang/blaze3d/pipeline/MainTarget.java.patch
+++ b/patches/com/mojang/blaze3d/pipeline/MainTarget.java.patch
@@ -18,7 +18,7 @@
      private GpuTexture allocateDepthAttachment(MainTarget.Dimension p_166145_) {
          try {
 -            return RenderSystem.getDevice().createTexture(() -> this.label + " / Depth", 15, TextureFormat.DEPTH32, p_166145_.width, p_166145_.height, 1, 1);
-+            var format = this.useStencil ? net.neoforged.neoforge.client.ClientHooks.getStencilFormat() : TextureFormat.DEPTH32;
++            var format = this.useStencil ? TextureFormat.DEPTH32_STENCIL8 : TextureFormat.DEPTH32;
 +            return RenderSystem.getDevice().createTexture(() -> this.label + " / Depth", 15, format, p_166145_.width, p_166145_.height, 1, 1);
          } catch (GpuOutOfMemoryException gpuoutofmemoryexception) {
              return null;

--- a/patches/com/mojang/blaze3d/pipeline/RenderTarget.java.patch
+++ b/patches/com/mojang/blaze3d/pipeline/RenderTarget.java.patch
@@ -30,7 +30,7 @@
              this.height = p_83952_;
              if (this.useDepth) {
 -                this.depthTexture = gpudevice.createTexture(() -> this.label + " / Depth", 15, TextureFormat.DEPTH32, p_83951_, p_83952_, 1, 1);
-+                var format = this.useStencil ? net.neoforged.neoforge.client.ClientHooks.getStencilFormat() : TextureFormat.DEPTH32;
++                var format = this.useStencil ? TextureFormat.DEPTH32_STENCIL8 : TextureFormat.DEPTH32;
 +                this.depthTexture = gpudevice.createTexture(() -> this.label + " / Depth", 15, format, p_83951_, p_83952_, 1, 1);
                  this.depthTextureView = gpudevice.createTextureView(this.depthTexture);
                  this.depthTexture.setTextureFilter(FilterMode.NEAREST, false);

--- a/patches/com/mojang/blaze3d/textures/TextureFormat.java.patch
+++ b/patches/com/mojang/blaze3d/textures/TextureFormat.java.patch
@@ -1,6 +1,6 @@
 --- a/com/mojang/blaze3d/textures/TextureFormat.java
 +++ b/com/mojang/blaze3d/textures/TextureFormat.java
-@@ -6,16 +_,20 @@
+@@ -6,16 +_,19 @@
  
  @OnlyIn(Dist.CLIENT)
  @DontObfuscate
@@ -11,8 +11,7 @@
      RED8I(1),
 -    DEPTH32(4);
 +    DEPTH32(4),
-+    // Neo: Add depth+stencil formats
-+    DEPTH24_STENCIL8(4),
++    // Neo: Add depth+stencil format
 +    DEPTH32_STENCIL8(8);
  
      private final int pixelSize;
@@ -29,10 +28,10 @@
  
      public boolean hasDepthAspect() {
 -        return this == DEPTH32;
-+        return this == DEPTH32 || this == DEPTH24_STENCIL8 || this == DEPTH32_STENCIL8;
++        return this == DEPTH32 || this == DEPTH32_STENCIL8;
 +    }
 +
 +    public boolean hasStencilAspect() {
-+        return this == DEPTH24_STENCIL8 || this == DEPTH32_STENCIL8;
++        return this == DEPTH32_STENCIL8;
      }
  }

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -15,7 +15,6 @@ import com.mojang.blaze3d.resource.RenderTargetDescriptor;
 import com.mojang.blaze3d.shaders.ShaderType;
 import com.mojang.blaze3d.systems.GpuDevice;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.textures.TextureFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.datafixers.util.Either;
@@ -1101,12 +1100,6 @@ public class ClientHooks {
     public static MainTarget instantiateMainTarget(int width, int height) {
         var e = ModLoader.postEventWithReturn(new ConfigureMainRenderTargetEvent());
         return new MainTarget(width, height, e.isStencilEnabled());
-    }
-
-    @ApiStatus.Internal
-    public static TextureFormat getStencilFormat() {
-        var reducedPrecision = NeoForgeClientConfig.INSTANCE.reducedDepthStencilFormat.getAsBoolean();
-        return reducedPrecision ? TextureFormat.DEPTH24_STENCIL8 : TextureFormat.DEPTH32_STENCIL8;
     }
 
     @ApiStatus.Internal

--- a/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
+++ b/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
@@ -29,8 +29,6 @@ public final class NeoForgeClientConfig {
 
     public final ModConfigSpec.BooleanValue logUntranslatedConfigurationWarnings;
 
-    public final ModConfigSpec.BooleanValue reducedDepthStencilFormat;
-
     public final ModConfigSpec.BooleanValue handleAmbientOcclusionPerPart;
     boolean perPartAoActive;
 
@@ -51,11 +49,6 @@ public final class NeoForgeClientConfig {
                 .comment("A config option mainly for developers. Logs out configuration values that do not have translations when running a client in a development environment.")
                 .translation("neoforge.configgui.logUntranslatedConfigurationWarnings")
                 .define("logUntranslatedConfigurationWarnings", true);
-
-        reducedDepthStencilFormat = builder
-                .comment("Configures how many bits are used for the depth buffer when stenciling has been enabled by a mod. Set to true for 24+8 bits and to false for 32+8 bits. Setting to true will slightly reduce VRAM usage, but risks introducing visual artifacts.")
-                .translation("neoforge.configgui.reducedDepthStencilFormat")
-                .define("reducedDepthStencilFormat", false);
 
         handleAmbientOcclusionPerPart = builder
                 .comment("When enabled, AO will be handled per BlockModelPart instead of using the first part's AO setting")


### PR DESCRIPTION
The D24S8 format's only purpose is vram reduction. If/when other texture formats are added (see #2359), a reduced count (including only one depth-stencil format) at the cost of vram usage was seen as net beneficial. As a removal must be done during a BC window, this is being done stand alone ahead of other format additions.