### PR TITLE
Account for integrated servers in `NeoForgeClientProxy#resolveLookup`

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/internal/NeoForgeClientProxy.java
+++ b/src/client/java/net/neoforged/neoforge/client/internal/NeoForgeClientProxy.java
@@ -38,6 +38,6 @@ public class NeoForgeClientProxy extends NeoForgeProxy {
                 return level.registryAccess().lookup(key).orElse(null);
             }
         }
-        return null;
+        return lookup;
     }
 }


### PR DESCRIPTION
In
https://github.com/neoforged/NeoForge/blob/6817f07ae45775e512830adaf174c5e1e72b98d9/src/client/java/net/neoforged/neoforge/client/internal/NeoForgeClientProxy.java#L33-L41 the last return statement should return the `lookup`, not `null` to handle the cases where there is an integrated server running (which is what the super method does).

Fixes #2488