### PR TITLE
[1.21.8] Only call IBlockEntityExtension#onLoad() on BEs that were properly added to the level

### DIFF
--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -77,7 +77,7 @@
      }
  
      public void updateNeighborsAtExceptFromFacing(BlockPos p_46591_, Block p_46592_, Direction p_46593_, @Nullable Orientation p_362952_) {
-@@ -505,10 +_,26 @@
+@@ -505,10 +_,32 @@
          (this.tickingBlockEntities ? this.pendingBlockEntityTickers : this.blockEntityTickers).add(p_151526_);
      }
  
@@ -98,7 +98,13 @@
 +        }
          this.tickingBlockEntities = true;
 +        if (!this.freshBlockEntities.isEmpty()) {
-+            this.freshBlockEntities.forEach(BlockEntity::onLoad);
++            this.freshBlockEntities.forEach(blockEntity -> {
++                // Only call onLoad() on BEs which have been fully added to the level, prevents crashes with BEs that
++                // were discarded due to incompatibility with the BlockState at their position
++                if (!blockEntity.isRemoved() && blockEntity.hasLevel()) {
++                    blockEntity.onLoad();
++                }
++            });
 +            this.freshBlockEntities.clear();
 +        }
          if (!this.pendingBlockEntityTickers.isEmpty()) {


### PR DESCRIPTION
This PR guards the `IBlockEntityExtension#onLoad()` call in `Level#tickBlockEntities()` behind a check for the BE having a `Level` and being marked as not removed. This prevents crashes when something attempted to place a BE at a position where a `BlockState` not compatible with the BE is present (i.e. a `BlockState` whose `Block` is not in the `BlockEntityType#validBlocks` set), causing the BE to be discarded. `LevelChunk.BoundTickingBlockEntity#tick()` has an identical check to prevent similar issues during BE ticking.