### PR TITLE
[1.21.8] Protect B3D validation against reading an unloaded config in case of game loading errors

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -140,6 +140,7 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.earlydisplay.DisplayWindow;
 import net.neoforged.fml.loading.EarlyLoadingScreenController;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.blaze3d.validation.ValidationGpuDevice;
 import net.neoforged.neoforge.client.config.NeoForgeClientConfig;
 import net.neoforged.neoforge.client.entity.animation.json.AnimationTypeManager;
@@ -1136,7 +1137,14 @@ public class ClientHooks {
 
     public static GpuDevice createGpuDevice(long window, int debugLevel, boolean syncDebug, BiFunction<ResourceLocation, ShaderType, String> defaultShaderSource, boolean enableDebugLabels) {
         final var glDevice = new GlDevice(window, debugLevel, syncDebug, defaultShaderSource, enableDebugLabels);
-        if (NeoForgeClientConfig.INSTANCE.enableB3DValidationLayer.getAsBoolean()) {
+        boolean enableValidation;
+        try {
+            enableValidation = NeoForgeClientConfig.INSTANCE.enableB3DValidationLayer.getAsBoolean();
+        } catch (NullPointerException | IllegalStateException e) {
+            // We're in an early error state, config is not available. Assume environment default.
+            enableValidation = NeoForgeClientConfig.INSTANCE.enableB3DValidationLayer.getDefault();
+        }
+        if (enableValidation) {
             return new ValidationGpuDevice(glDevice, true);
         }
         return glDevice;

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -140,7 +140,6 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.earlydisplay.DisplayWindow;
 import net.neoforged.fml.loading.EarlyLoadingScreenController;
-import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.client.blaze3d.validation.ValidationGpuDevice;
 import net.neoforged.neoforge.client.config.NeoForgeClientConfig;
 import net.neoforged.neoforge.client.entity.animation.json.AnimationTypeManager;


### PR DESCRIPTION
This PR adds a guard to the validation config check in `ClientHooks.createGpuDevice()` to prevent a crash when an early loading error occured and configs were therefore not loaded. An identical check exists in `ClientModLoader.completeModLoading()` to fix the same issue with the `showLoadWarnings` config.