### PR TITLE
[1.21.1] Allow adding additional states to foreign PoiTypes

### DIFF
--- a/patches/net/minecraft/world/entity/ai/village/poi/PoiType.java.patch
+++ b/patches/net/minecraft/world/entity/ai/village/poi/PoiType.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ai/village/poi/PoiType.java
++++ b/net/minecraft/world/entity/ai/village/poi/PoiType.java
+@@ -9,7 +_,7 @@
+     public static final Predicate<Holder<PoiType>> NONE = p_218041_ -> false;
+ 
+     public PoiType(Set<BlockState> matchingStates, int maxTickets, int validRange) {
+-        matchingStates = Set.copyOf(matchingStates);
++        matchingStates = new net.neoforged.neoforge.common.world.poi.PoiStateSet(matchingStates);
+         this.matchingStates = matchingStates;
+         this.maxTickets = maxTickets;
+         this.validRange = validRange;

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/ExtendPoiTypesEvent.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/ExtendPoiTypesEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world.poi;
+
+import java.util.Set;
+import java.util.function.BiConsumer;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.event.IModBusEvent;
+
+/**
+ * Fired in order to add additional {@link BlockState}s to foreign {@link PoiType}s.
+ * <p>
+ * This event is fired on the mod-specific event bus.
+ */
+public final class ExtendPoiTypesEvent extends Event implements IModBusEvent {
+    private final BiConsumer<ResourceKey<PoiType>, Set<BlockState>> registrar;
+
+    ExtendPoiTypesEvent(BiConsumer<ResourceKey<PoiType>, Set<BlockState>> registrar) {
+        this.registrar = registrar;
+    }
+
+    /**
+     * Add the provided {@link Block}'s {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param typeKey The {@link ResourceKey} of the {@link PoiType} to append the states to
+     * @param block   The {@link Block} whose {@link BlockState}s to append to the PoI type
+     */
+    public void addBlockToPoi(ResourceKey<PoiType> typeKey, Block block) {
+        this.addStatesToPoi(typeKey, Set.copyOf(block.getStateDefinition().getPossibleStates()));
+    }
+
+    /**
+     * Add the provided {@link BlockState}s to the {@link PoiType#matchingStates} of the provided {@link PoiType}
+     *
+     * @param typeKey The {@link ResourceKey} of the {@link PoiType} to append the states to
+     * @param states  The {@link BlockState}s to append to the PoI type
+     */
+    public void addStatesToPoi(ResourceKey<PoiType> typeKey, Set<BlockState> states) {
+        this.registrar.accept(typeKey, states);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world.poi;
+
+import com.google.common.collect.Iterators;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Predicate;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public final class PoiStateSet implements Set<BlockState> {
+    private final Set<BlockState> backingSet = new ReferenceOpenHashSet<>();
+
+    public PoiStateSet(Set<BlockState> states) {
+        this.backingSet.addAll(states);
+    }
+
+    @Override
+    public int size() {
+        return this.backingSet.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.backingSet.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return this.backingSet.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return this.backingSet.containsAll(c);
+    }
+
+    @Override
+    public Iterator<BlockState> iterator() {
+        return Iterators.unmodifiableIterator(this.backingSet.iterator());
+    }
+
+    @Override
+    public Object[] toArray() {
+        return this.backingSet.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return this.backingSet.toArray(a);
+    }
+
+    @Override
+    public boolean add(BlockState state) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends BlockState> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super BlockState> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    void addCustomStates(Set<BlockState> states) {
+        this.backingSet.addAll(states);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiTypeExtender.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.world.poi;
+
+import com.mojang.logging.LogUtils;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.registries.GameData;
+import org.jetbrains.annotations.ApiStatus;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.transformer.meta.MixinMerged;
+
+@ApiStatus.Internal
+public final class PoiTypeExtender {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    public static void extendPoiTypes() {
+        ModLoader.postEvent(new ExtendPoiTypesEvent(PoiTypeExtender::register));
+    }
+
+    private static void register(ResourceKey<PoiType> typeKey, Set<BlockState> states) {
+        Map<BlockState, Holder<PoiType>> statePoiMap = GameData.getBlockStatePointOfInterestTypeMap();
+        Holder<PoiType> type = BuiltInRegistries.POINT_OF_INTEREST_TYPE.getHolderOrThrow(typeKey);
+        for (BlockState state : states) {
+            Holder<PoiType> prevType = statePoiMap.putIfAbsent(state, type);
+            if (prevType != null) {
+                throw new IllegalStateException(String.format(
+                        Locale.ROOT,
+                        "%s is defined in more than one PoI type (old: %s, new: %s)",
+                        state,
+                        prevType.value(),
+                        type.value()));
+            }
+        }
+
+        if (type.value().matchingStates() instanceof PoiStateSet poiStateSet) {
+            poiStateSet.addCustomStates(states);
+        } else {
+            // Detect accessor mixins which may have replaced the set to add additional BlockStates after the PoiType's construction
+            List<String> accessors = Arrays.stream(PoiType.class.getDeclaredMethods())
+                    .filter(method -> method.isSynthetic() &&
+                            method.isAnnotationPresent(Accessor.class) &&
+                            method.getReturnType() == void.class &&
+                            method.getParameterCount() == 1 &&
+                            method.getParameterTypes()[0] == Set.class)
+                    .map(mth -> mth.getAnnotation(MixinMerged.class))
+                    .filter(Objects::nonNull)
+                    .map(MixinMerged::mixin)
+                    .toList();
+
+            String message;
+            if (accessors.isEmpty()) {
+                message = String.format(
+                        Locale.ROOT,
+                        "The matchingStates set of PoiType %s was replaced after construction, PoiType cannot be extended",
+                        Objects.requireNonNull(type.getKey()).location());
+            } else {
+                StringBuilder accessorList = new StringBuilder();
+                for (String accessor : accessors) {
+                    accessorList.append("\n").append(accessor);
+                }
+                message = String.format(
+                        Locale.ROOT,
+                        "The matchingStates set of PoiType %s was replaced after construction, PoiType cannot be extended. Accessor mixins for mutating the set were found:%s",
+                        Objects.requireNonNull(type.getKey()).location(),
+                        accessorList);
+            }
+            LOGGER.error(message);
+        }
+    }
+
+    private PoiTypeExtender() {}
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.common.world.poi;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.internal;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
 import net.neoforged.neoforge.common.world.chunk.ForcedChunkManager;
+import net.neoforged.neoforge.common.world.poi.PoiTypeExtender;
 import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.registries.RegistryManager;
@@ -19,6 +20,7 @@ public class RegistrationEvents {
         ForcedChunkManager.init();
         RegistryManager.initDataMaps();
         modifyComponents();
+        PoiTypeExtender.extendPoiTypes();
     }
 
     private static boolean canModifyComponents;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -5,9 +5,12 @@
 
 package net.neoforged.neoforge.debug.block;
 
+import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
 import net.minecraft.resources.ResourceLocation;
@@ -19,6 +22,8 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraft.world.entity.ai.village.poi.PoiTypes;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -34,8 +39,11 @@ import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.neoforge.client.model.generators.BlockStateProvider;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
+import net.neoforged.neoforge.common.world.poi.ExtendPoiTypesEvent;
+import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -190,5 +198,37 @@ public class BlockTests {
         public BubbleColumnDirection getBubbleColumnDirection(BlockState state) {
             return bubbleColumnDirection;
         }
+    }
+
+    @TestHolder(description = "Adds a block whose states are added to the PoiTypes.MEETING PoI type", enabledByDefault = true)
+    static void extendPoiTypeTest(final DynamicTest test, final RegistrationHelper reg) {
+        DeferredBlock<Block> block = reg.blocks().registerSimpleBlock("test_meeting_point");
+        boolean[] failedEarly = new boolean[1];
+        test.eventListeners().mod().addListener((ExtendPoiTypesEvent event) -> {
+            try {
+                event.addBlockToPoi(PoiTypes.MEETING, block.value());
+            } catch (Exception e) {
+                test.fail("PoiType extension failed with exception");
+                failedEarly[0] = true;
+            }
+        });
+        test.eventListeners().mod().addListener((FMLLoadCompleteEvent event) -> {
+            if (failedEarly[0]) return;
+
+            PoiType poiType = BuiltInRegistries.POINT_OF_INTEREST_TYPE.getOrThrow(PoiTypes.MEETING);
+            ImmutableList<BlockState> states = block.value().getStateDefinition().getPossibleStates();
+            if (!poiType.matchingStates().containsAll(states)) {
+                test.fail("Test block's states were not added to PoiType's matchingStates");
+                return;
+            }
+            for (BlockState state : states) {
+                Optional<Holder<PoiType>> type = PoiTypes.forState(state);
+                if (type.isEmpty() || type.get().getKey() != PoiTypes.MEETING) {
+                    test.fail("A state of the test block is missing from or assigned to the wrong PoI in PoiTypes.TYPE_BY_STATE");
+                    return;
+                }
+            }
+            test.pass();
+        });
     }
 }


### PR DESCRIPTION
This PR adds an event for appending additional `BlockState`s to a foreign (primarily vanilla) `PoiType`. This has been a point of major frustration ever since `PoiType` became a record.
To prevent this from being a breaking change, the exception in the mixin check performed by `PoiTypeExtender.register()` is replaced with an error log.

Backport of #2484