### PR TITLE
[1.21.1] Un-hardcode lightning rods

### DIFF
--- a/patches/net/minecraft/server/level/ServerLevel.java.patch
+++ b/patches/net/minecraft/server/level/ServerLevel.java.patch
@@ -67,6 +67,15 @@
              }
          }
      }
+@@ -477,7 +_,7 @@
+                 DifficultyInstance difficultyinstance = this.getCurrentDifficultyAt(blockpos);
+                 boolean flag1 = this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING)
+                     && this.random.nextDouble() < (double)difficultyinstance.getEffectiveDifficulty() * 0.01
+-                    && !this.getBlockState(blockpos.below()).is(Blocks.LIGHTNING_ROD);
++                        && !(this.getBlockState(blockpos.below()).getBlock() instanceof net.minecraft.world.level.block.LightningRodBlock); // Neo: support custom LightningRodBlocks
+                 if (flag1) {
+                     SkeletonHorse skeletonhorse = EntityType.SKELETON_HORSE.create(this);
+                     if (skeletonhorse != null) {
 @@ -542,6 +_,7 @@
          BlockPos blockpos = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, p_295060_);
          BlockPos blockpos1 = blockpos.below();

--- a/patches/net/minecraft/world/entity/LightningBolt.java.patch
+++ b/patches/net/minecraft/world/entity/LightningBolt.java.patch
@@ -8,7 +8,14 @@
  
      public LightningBolt(EntityType<? extends LightningBolt> p_20865_, Level p_20866_) {
          super(p_20865_, p_20866_);
-@@ -73,6 +_,14 @@
+@@ -68,11 +_,20 @@
+     private void powerLightningRod() {
+         BlockPos blockpos = this.getStrikePosition();
+         BlockState blockstate = this.level().getBlockState(blockpos);
+-        if (blockstate.is(Blocks.LIGHTNING_ROD)) {
++        // Neo: support custom LightningRodBlocks
++        if (blockstate.getBlock() instanceof LightningRodBlock) {
+             ((LightningRodBlock)blockstate.getBlock()).onLightningStrike(blockstate, this.level(), blockpos);
          }
      }
  
@@ -31,3 +38,13 @@
                      entity.thunderHit((ServerLevel)this.level(), this);
                  }
  
+@@ -191,7 +_,8 @@
+         BlockState blockstate = p_147151_.getBlockState(p_147152_);
+         BlockPos blockpos;
+         BlockState blockstate1;
+-        if (blockstate.is(Blocks.LIGHTNING_ROD)) {
++        // Neo: support custom LightningRodBlocks
++        if (blockstate.getBlock() instanceof LightningRodBlock) {
+             blockpos = p_147152_.relative(blockstate.getValue(LightningRodBlock.FACING).getOpposite());
+             blockstate1 = p_147151_.getBlockState(blockpos);
+         } else {


### PR DESCRIPTION
This PR un-hardcodes the checks for `LightningRodBlock` to allow mods to add custom lightning rods.

For the custom lightning rods to actually be targetted by lightning, they also have to be added to the `PoiTypes.LIGHTNING_ROD` PoI. Therefore this PR is blocked by #2504.

Backport of #2485