### PR TITLE
Add `ContextOps` as a general stackable abstraction for context-aware dynamic ops

### DIFF
--- a/patches/net/minecraft/resources/RegistryDataLoader.java.patch
+++ b/patches/net/minecraft/resources/RegistryDataLoader.java.patch
@@ -85,7 +85,7 @@
      ) {
          FileToIdConverter filetoidconverter = FileToIdConverter.registry(p_321557_.key());
 -        RegistryOps<JsonElement> registryops = RegistryOps.create(JsonOps.INSTANCE, p_321612_);
-+        RegistryOps<JsonElement> registryops = new net.neoforged.neoforge.common.conditions.ConditionalOps<>(RegistryOps.create(JsonOps.INSTANCE, p_321612_), net.neoforged.neoforge.common.conditions.ICondition.IContext.TAGS_INVALID);
++        RegistryOps<JsonElement> registryops = net.neoforged.neoforge.common.conditions.ConditionalOps.injectConditionContext(RegistryOps.create(JsonOps.INSTANCE, p_321612_), net.neoforged.neoforge.common.conditions.ICondition.IContext.TAGS_INVALID);
  
          for (Entry<ResourceLocation, Resource> entry : filetoidconverter.listMatchingResources(p_321535_).entrySet()) {
              ResourceLocation resourcelocation = entry.getKey();

--- a/patches/net/minecraft/resources/RegistryOps.java.patch
+++ b/patches/net/minecraft/resources/RegistryOps.java.patch
@@ -1,12 +1,25 @@
 --- a/net/minecraft/resources/RegistryOps.java
 +++ b/net/minecraft/resources/RegistryOps.java
-@@ -35,6 +_,11 @@
+@@ -15,7 +_,7 @@
+ import net.minecraft.core.Registry;
+ import net.minecraft.util.ExtraCodecs;
+ 
+-public class RegistryOps<T> extends DelegatingOps<T> {
++public class RegistryOps<T> extends net.neoforged.neoforge.common.util.dfu.ContextOps<T> {
+     public final RegistryOps.RegistryInfoLookup lookupProvider;
+ 
+     public static <T> RegistryOps<T> create(DynamicOps<T> p_256342_, HolderLookup.Provider p_255950_) {
+@@ -35,6 +_,15 @@
          this.lookupProvider = p_255799_;
      }
  
-+    protected RegistryOps(RegistryOps<T> other) {
-+        super(other);
++    protected RegistryOps(RegistryOps<T> other, Map<net.neoforged.neoforge.common.util.dfu.ContextOps.Key<?>, Object> additionalContext) {
++        super(other, additionalContext);
 +        this.lookupProvider = other.lookupProvider;
++    }
++
++    protected RegistryOps(RegistryOps<T> other) {
++        this(other, Map.of());
 +    }
 +
      public <U> RegistryOps<U> withParent(DynamicOps<U> p_330654_) {

--- a/patches/net/minecraft/resources/RegistryOps.java.patch
+++ b/patches/net/minecraft/resources/RegistryOps.java.patch
@@ -9,7 +9,7 @@
      public final RegistryOps.RegistryInfoLookup lookupProvider;
  
      public static <T> RegistryOps<T> create(DynamicOps<T> p_256342_, HolderLookup.Provider p_255950_) {
-@@ -35,6 +_,15 @@
+@@ -35,8 +_,29 @@
          this.lookupProvider = p_255799_;
      }
  
@@ -22,9 +22,24 @@
 +        this(other, Map.of());
 +    }
 +
++    /** {@inheritDoc} **/
++    @Override
++    public <Z> RegistryOps<T> withContext(net.neoforged.neoforge.common.util.dfu.ContextOps.Key<Z> key, Z value) {
++        return withContext(Map.of(key, value));
++    }
++
++    /** {@inheritDoc} **/
++    @Override
++    public RegistryOps<T> withContext(Map<net.neoforged.neoforge.common.util.dfu.ContextOps.Key<?>, Object> contextMap) {
++        return contextMap.isEmpty() ? this : new RegistryOps<>(this, contextMap);
++    }
++
      public <U> RegistryOps<U> withParent(DynamicOps<U> p_330654_) {
-         return (RegistryOps<U>)(p_330654_ == this.delegate ? this : new RegistryOps<>(p_330654_, this.lookupProvider));
+-        return (RegistryOps<U>)(p_330654_ == this.delegate ? this : new RegistryOps<>(p_330654_, this.lookupProvider));
++        return (RegistryOps<U>)(p_330654_ == this.delegate ? this : new RegistryOps<>(p_330654_, this.lookupProvider).withContext(this.contextObjects));
      }
+ 
+     public <E> Optional<HolderOwner<E>> owner(ResourceKey<? extends Registry<? extends E>> p_255757_) {
 @@ -74,6 +_,20 @@
                      : DataResult.error(() -> "Not a registry ops")
              )

--- a/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
+++ b/patches/net/minecraft/world/item/crafting/RecipeManager.java.patch
@@ -13,7 +13,7 @@
          SortedMap<ResourceLocation, Recipe<?>> sortedmap = new TreeMap<>();
          SimpleJsonResourceReloadListener.scanDirectory(
 -            p_379845_, RECIPE_LISTER, this.registries.createSerializationContext(JsonOps.INSTANCE), Recipe.CODEC, sortedmap
-+            p_379845_, RECIPE_LISTER, new net.neoforged.neoforge.common.conditions.ConditionalOps<>(this.registries.createSerializationContext(JsonOps.INSTANCE), getContext()), Recipe.CODEC, sortedmap // Neo: add condition context
++            p_379845_, RECIPE_LISTER, net.neoforged.neoforge.common.conditions.ConditionalOps.injectConditionContext(this.registries.createSerializationContext(JsonOps.INSTANCE), getContext()), Recipe.CODEC, sortedmap // Neo: add condition context
          );
          List<RecipeHolder<?>> list = new ArrayList<>(sortedmap.size());
          sortedmap.forEach((p_379232_, p_379233_) -> {

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
@@ -13,21 +13,52 @@ import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.Encoder;
 import com.mojang.serialization.MapCodec;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import net.minecraft.resources.RegistryOps;
-import net.minecraft.util.ExtraCodecs;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.common.util.NeoForgeExtraCodecs;
+import net.neoforged.neoforge.common.util.dfu.ContextOps;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
 
 /**
- * Extension of {@link RegistryOps} that also encapsulates a {@link ICondition.IContext}.
- * This allows getting the {@link ICondition.IContext} while decoding an entry from within a codec.
+ * Utility methods that can be used to create wrapper codecs that only decode and return an object if its {@linkplain ICondition conditions} match.
+ * <p>
+ * This class is also an extension of {@link RegistryOps} that also encapsulates a {@link ICondition.IContext}.
+ * Using it this way is <strong>deprecated</strong>, as it will be removed in a future update. Use {@link ContextOps context ops} instances with
+ * {@link #CONDITION_CONTEXT}.
+ *
+ * @see #CONDITION_CONTEXT
+ * @see #injectConditionContext(RegistryOps, ICondition.IContext)
  */
 public class ConditionalOps<T> extends RegistryOps<T> {
+    /**
+     * The context key of the {@link ICondition.IContext condition context} injected into context-aware ops.
+     */
+    public static final ContextOps.Key<ICondition.IContext> CONDITION_CONTEXT = new ContextOps.Key<>(ICondition.IContext.class, ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "condition_context"));
+
     private final ICondition.IContext context;
 
+    /**
+     * @deprecated Use {@link #injectConditionContext(RegistryOps, ICondition.IContext)}
+     */
+    @Deprecated(forRemoval = true, since = "1.21.8")
     public ConditionalOps(RegistryOps<T> ops, ICondition.IContext context) {
-        super(ops);
+        super(ops, Map.of(CONDITION_CONTEXT, context));
         this.context = context;
+    }
+
+    /**
+     * Injects the given {@link ICondition.IContext} into the {@code ops}, creating a new registry ops instance.
+     *
+     * @param ops     the ops to wrap
+     * @param context the condition context to inject
+     * @param <T>     the type of the registry ops
+     * @return the new registry ops instance with additional condition context
+     */
+    public static <T> RegistryOps<T> injectConditionContext(RegistryOps<T> ops, ICondition.IContext context) {
+        // TODO 1.22 - replace with ops.with and make this class an utility class rather than a child of RegistryOps
+        return new ConditionalOps<>(ops, context);
     }
 
     /**
@@ -35,12 +66,7 @@ public class ConditionalOps<T> extends RegistryOps<T> {
      * for example with {@code retrieveContext().decode(ops, ops.emptyMap())}.
      */
     public static MapCodec<ICondition.IContext> retrieveContext() {
-        return ExtraCodecs.retrieveContext(ops -> {
-            if (!(ops instanceof ConditionalOps<?> conditionalOps))
-                return DataResult.success(ICondition.IContext.EMPTY);
-
-            return DataResult.success(conditionalOps.context);
-        });
+        return ContextOps.retrieveOptionalContext(CONDITION_CONTEXT, ICondition.IContext.EMPTY);
     }
 
     /**
@@ -51,7 +77,7 @@ public class ConditionalOps<T> extends RegistryOps<T> {
      * Key used to store the value associated with conditions,
      * when the value is not represented as a map.
      * For example, if we wanted to store the value 2 with some conditions, we could do:
-     * 
+     *
      * <pre>
      * {
      *     "neoforge:conditions": [ ... ],

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionalOps.java
@@ -35,7 +35,7 @@ public class ConditionalOps<T> extends RegistryOps<T> {
     /**
      * The context key of the {@link ICondition.IContext condition context} injected into context-aware ops.
      */
-    public static final ContextOps.Key<ICondition.IContext> CONDITION_CONTEXT = new ContextOps.Key<>(ICondition.IContext.class, ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "condition_context"));
+    public static final ContextOps.Key<ICondition.IContext> CONDITION_CONTEXT = new ContextOps.Key<>(ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "condition_context"));
 
     private final ICondition.IContext context;
 

--- a/src/main/java/net/neoforged/neoforge/common/data/JsonCodecProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/JsonCodecProvider.java
@@ -70,7 +70,7 @@ public abstract class JsonCodecProvider<T> implements DataProvider {
         gather();
 
         return lookupProvider.thenCompose(provider -> {
-            final DynamicOps<JsonElement> dynamicOps = new ConditionalOps<>(RegistryOps.create(JsonOps.INSTANCE, provider), ICondition.IContext.EMPTY);
+            final DynamicOps<JsonElement> dynamicOps = ConditionalOps.injectConditionContext(RegistryOps.create(JsonOps.INSTANCE, provider), ICondition.IContext.EMPTY);
 
             this.conditions.forEach((id, withConditions) -> {
                 final Path path = this.pathProvider.json(id);

--- a/src/main/java/net/neoforged/neoforge/common/util/dfu/ContextOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/dfu/ContextOps.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.util.dfu;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import net.minecraft.resources.DelegatingOps;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.ExtraCodecs;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A {@link DelegatingOps} that can hold additional context, identified by {@linkplain Key}s.
+ * <p>
+ * Context can be injected with {@link #withContext(Key, Object) withContext} and retrieved via {@link #getContext(Key) getContext}.
+ * Utility methods like {@link #retrieveContext(Key)}, {@link #retrieveOptionalContext(Key)} or {@link #retrieveOptionalContext(Key, Object)}
+ * can be used to retrieve the context through a {@linkplain MapCodec}.
+ * <p>
+ * The context map of {@linkplain ContextOps} is immutable, therefore any additional context can only be added by creating a new instance.
+ *
+ * @param <T> the type of the base element the delegate {@linkplain DynamicOps} serialises to and from
+ *
+ * @see Key
+ */
+public class ContextOps<T> extends DelegatingOps<T> {
+    private final Map<Key<?>, Object> contextObjects;
+
+    /**
+     * Create a new context that delegates to the given ops.
+     *
+     * @param delegate the ops to delegate to. If it is an instance of {@link ContextOps}, its context will be copied to this ops.
+     */
+    public ContextOps(DynamicOps<T> delegate) {
+        this(delegate, Map.of());
+    }
+
+    /**
+     * Create a new context that delegates to the given ops, and has the given {@code additionalContext} as context.
+     *
+     * @param delegate          the ops to delegate to. If it is an instance of {@link ContextOps}, its context will be copied to this ops.
+     * @param additionalContext additional context objects to add on top of the ones from the {@code delegate}
+     */
+    public ContextOps(DynamicOps<T> delegate, Map<Key<?>, Object> additionalContext) {
+        super(delegate);
+
+        Map<Key<?>, Object> delegateContext = delegate instanceof ContextOps<?> contextAware ? contextAware.contextObjects : Map.of();
+        if (additionalContext.isEmpty()) {
+            this.contextObjects = delegateContext;
+        } else {
+            var newContext = new HashMap<>(delegateContext);
+            newContext.putAll(additionalContext);
+            this.contextObjects = Collections.unmodifiableMap(newContext);
+        }
+    }
+
+    /**
+     * {@return the context object with the given key, or {@code null} if context of that type is not present}
+     *
+     * @param key the key of the context object to retrieve
+     * @param <Z> the type of the context object
+     */
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <Z> Z getContext(Key<Z> key) {
+        return (Z) contextObjects.get(key);
+    }
+
+    /**
+     * {@return a new context ops instance that has the given {@code value} as additional context}
+     *
+     * @param key   the key of the additional context object
+     * @param value an additional context object to add to the new ops instance
+     * @param <Z>   the type of the context object
+     */
+    public <Z> ContextOps<T> withContext(Key<Z> key, Z value) {
+        return new ContextOps<>(this.delegate, Map.of(key, value));
+    }
+
+    /**
+     * Creates a {@linkplain MapCodec} instance that retrieves the context of the given {@code type}
+     * from the ops that it decodes with, {@linkplain DataResult#error(Supplier, Object) erroring} if
+     * context of the given type is not provided.
+     * <p>
+     * Example method of retrieving context from a given {@code ops}:
+     * {@snippet :
+     * DynamicOps<?> ops;
+     * retrieveContext(SOME_KEY).decode(ops, ops.emptyMap())
+     * }
+     * <p>
+     * This codec can also be used as a field in a {@link RecordCodecBuilder}.
+     *
+     * @param type the key of the context object to retrieve
+     * @param <T>  the type of the context object to retrieve
+     */
+    public static <T> MapCodec<T> retrieveContext(Key<T> type) {
+        return ExtraCodecs.retrieveContext(ops -> {
+            if (!(ops instanceof ContextOps<?> contextOps)) {
+                return DataResult.error(() -> "Dynamic ops " + ops + " is not context-aware");
+            }
+
+            var value = contextOps.getContext(type);
+            if (value == null) {
+                return DataResult.error(() -> "Context ops " + ops + " does not have context with ID " + type.identifier() + " of type " + type.type() + ". Available context: " + contextOps.contextObjects.keySet());
+            }
+
+            return DataResult.success(value);
+        });
+    }
+
+    /**
+     * Creates a {@linkplain MapCodec} instance that retrieves the context of the given {@code type}
+     * from the ops that it decodes with, or an {@linkplain Optional#empty() empty optional} if
+     * context of the given type is not provided.
+     * <p>
+     * Example method of retrieving context from a given {@code ops}:
+     * {@snippet :
+     * DynamicOps<?> ops;
+     * retrieveOptionalContext(SOME_KEY).decode(ops, ops.emptyMap())
+     * }
+     * <p>
+     * This codec can also be used as a field in a {@link RecordCodecBuilder}.
+     *
+     * @param type the key of the context object to retrieve
+     * @param <T>  the type of the context object to retrieve
+     */
+    public static <T> MapCodec<Optional<T>> retrieveOptionalContext(Key<T> type) {
+        return ExtraCodecs.retrieveContext(ops -> {
+            if (!(ops instanceof ContextOps<?> contextOps)) {
+                return DataResult.success(Optional.empty());
+            }
+
+            var value = contextOps.getContext(type);
+            if (value == null) {
+                return DataResult.success(Optional.empty());
+            }
+
+            return DataResult.success(Optional.of(value));
+        });
+    }
+
+    /**
+     * Creates a {@linkplain MapCodec} instance that retrieves the context of the given {@code type}
+     * from the ops that it decodes with, or the given {@code fallback} if
+     * context of the given type is not provided.
+     * <p>
+     * Example method of retrieving context from a given {@code ops}:
+     * {@snippet :
+     * DynamicOps<?> ops;
+     * retrieveOptionalContext(SOME_KEY, fallback).decode(ops, ops.emptyMap())
+     * }
+     * <p>
+     * This codec can also be used as a field in a {@link RecordCodecBuilder}.
+     *
+     * @param type     the key of the context object to retrieve
+     * @param fallback the object to return as context if the ops does not have context of the given {@code type} provided
+     * @param <T>      the type of the context object to retrieve
+     */
+    public static <T> MapCodec<T> retrieveOptionalContext(Key<T> type, T fallback) {
+        return ExtraCodecs.retrieveContext(ops -> {
+            if (!(ops instanceof ContextOps<?> contextOps)) {
+                return DataResult.success(fallback);
+            }
+
+            var value = contextOps.getContext(type);
+            if (value == null) {
+                return DataResult.success(fallback);
+            }
+
+            return DataResult.success(value);
+        });
+    }
+
+    /**
+     * A key for context objects stored within a {@link ContextOps}, that can be retrieved
+     * from the ops to aid in building context-aware {@linkplain Codec}s.
+     *
+     * @param type       the type of the context object this key is for
+     * @param identifier the identifier of the context object this key is for
+     * @param <T>        the generic type of the context object
+     */
+    public record Key<T>(Class<T> type, ResourceLocation identifier) {}
+}

--- a/src/main/java/net/neoforged/neoforge/common/util/dfu/ContextOps.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/dfu/ContextOps.java
@@ -18,30 +18,32 @@ import java.util.function.Supplier;
 import net.minecraft.resources.DelegatingOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A {@link DelegatingOps} that can hold additional context, identified by {@linkplain Key}s.
  * <p>
- * Context can be injected with {@link #withContext(Key, Object) withContext} and retrieved via {@link #getContext(Key) getContext}.
+ * Context can be injected with {@link #withContext(Map) withContext} and retrieved via {@link #getContext(Key) getContext}.
  * Utility methods like {@link #retrieveContext(Key)}, {@link #retrieveOptionalContext(Key)} or {@link #retrieveOptionalContext(Key, Object)}
  * can be used to retrieve the context through a {@linkplain MapCodec}.
  * <p>
  * The context map of {@linkplain ContextOps} is immutable, therefore any additional context can only be added by creating a new instance.
  *
  * @param <T> the type of the base element the delegate {@linkplain DynamicOps} serialises to and from
- *
+ * @apiNote This class should not be extended. Instead, use contexts via {@link #withContext}.
  * @see Key
  */
+@ApiStatus.NonExtendable
 public class ContextOps<T> extends DelegatingOps<T> {
-    private final Map<Key<?>, Object> contextObjects;
+    protected final Map<Key<?>, Object> contextObjects;
 
     /**
      * Create a new context that delegates to the given ops.
      *
      * @param delegate the ops to delegate to. If it is an instance of {@link ContextOps}, its context will be copied to this ops.
      */
-    public ContextOps(DynamicOps<T> delegate) {
+    protected ContextOps(DynamicOps<T> delegate) {
         this(delegate, Map.of());
     }
 
@@ -51,7 +53,7 @@ public class ContextOps<T> extends DelegatingOps<T> {
      * @param delegate          the ops to delegate to. If it is an instance of {@link ContextOps}, its context will be copied to this ops.
      * @param additionalContext additional context objects to add on top of the ones from the {@code delegate}
      */
-    public ContextOps(DynamicOps<T> delegate, Map<Key<?>, Object> additionalContext) {
+    protected ContextOps(DynamicOps<T> delegate, Map<Key<?>, Object> additionalContext) {
         super(delegate);
 
         Map<Key<?>, Object> delegateContext = delegate instanceof ContextOps<?> contextAware ? contextAware.contextObjects : Map.of();
@@ -62,6 +64,15 @@ public class ContextOps<T> extends DelegatingOps<T> {
             newContext.putAll(additionalContext);
             this.contextObjects = Collections.unmodifiableMap(newContext);
         }
+    }
+
+    /**
+     * {@return a context ops instance from the given {@code ops}}
+     *
+     * @param ops the ops to delegate to
+     */
+    public static <T> ContextOps<T> create(DynamicOps<T> ops) {
+        return ops instanceof ContextOps<T> cops ? cops : new ContextOps<>(ops);
     }
 
     /**
@@ -84,7 +95,21 @@ public class ContextOps<T> extends DelegatingOps<T> {
      * @param <Z>   the type of the context object
      */
     public <Z> ContextOps<T> withContext(Key<Z> key, Z value) {
-        return new ContextOps<>(this.delegate, Map.of(key, value));
+        return this.withContext(Map.of(key, value));
+    }
+
+    /**
+     * {@return a new context ops instance that has the given {@code contextMap} as additional context}
+     *
+     * @param contextMap additional context to add to the new context ops
+     */
+    public ContextOps<T> withContext(Map<Key<?>, Object> contextMap) {
+        return contextMap.isEmpty() ? this : new ContextOps<>(this.delegate, contextMap);
+    }
+
+    @Override
+    public String toString() {
+        return "ContextOps[delegate=" + delegate + ", context=" + contextObjects + "]";
     }
 
     /**
@@ -111,7 +136,7 @@ public class ContextOps<T> extends DelegatingOps<T> {
 
             var value = contextOps.getContext(type);
             if (value == null) {
-                return DataResult.error(() -> "Context ops " + ops + " does not have context with ID " + type.identifier() + " of type " + type.type() + ". Available context: " + contextOps.contextObjects.keySet());
+                return DataResult.error(() -> "Context ops " + ops + " does not have context with ID " + type.identifier() + ". Available context: " + contextOps.contextObjects.keySet());
             }
 
             return DataResult.success(value);
@@ -185,9 +210,13 @@ public class ContextOps<T> extends DelegatingOps<T> {
      * A key for context objects stored within a {@link ContextOps}, that can be retrieved
      * from the ops to aid in building context-aware {@linkplain Codec}s.
      *
-     * @param type       the type of the context object this key is for
      * @param identifier the identifier of the context object this key is for
      * @param <T>        the generic type of the context object
      */
-    public record Key<T>(Class<T> type, ResourceLocation identifier) {}
+    public record Key<T>(ResourceLocation identifier) {
+        @Override
+        public String toString() {
+            return identifier.toString();
+        }
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/dfu/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/dfu/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+package net.neoforged.neoforge.common.util.dfu;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.FieldsAreNonnullByDefault;
+import net.minecraft.MethodsReturnNonnullByDefault;

--- a/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
@@ -144,7 +144,7 @@ public class DataMapLoader implements PreparableReloadListener {
     }
 
     private static Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> load(ResourceManager manager, ProfilerFiller profiler, RegistryAccess access, ICondition.IContext context) {
-        final RegistryOps<JsonElement> ops = new ConditionalOps<>(RegistryOps.create(JsonOps.INSTANCE, access), context);
+        final RegistryOps<JsonElement> ops = ConditionalOps.injectConditionContext(RegistryOps.create(JsonOps.INSTANCE, access), context);
 
         final Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> values = new HashMap<>();
         access.registries().forEach(registryEntry -> {

--- a/src/main/java/net/neoforged/neoforge/resource/ContextAwareReloadListener.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ContextAwareReloadListener.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>
  * For children of {@link SimplePreparableReloadListener}, it will be available during both {@link SimplePreparableReloadListener#prepare} prepare()} and {@link SimplePreparableReloadListener#apply apply()}.
  */
+@SuppressWarnings("removal") // TODO 1.22 - makeConditionalOps must return instances of ConditionalOps. Replace with RegistryOps in a breaking changes window
 public abstract class ContextAwareReloadListener implements PreparableReloadListener {
     private ICondition.IContext conditionContext = ICondition.IContext.EMPTY;
 

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ContextOpsTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ContextOpsTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import net.neoforged.neoforge.common.util.dfu.ContextOps;
+import net.neoforged.testframework.junit.EphemeralTestServerProvider;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+public class ContextOpsTests {
+    private static final Gson GSON = new Gson();
+
+    @Test
+    void testRCBContextRetrieval() {
+        class SomeContext {}
+
+        var key = new ContextOps.Key<SomeContext>(ResourceLocation.parse("a:b"));
+
+        var context = new SomeContext();
+
+        var ops = ContextOps.create(JsonOps.INSTANCE)
+                .withContext(key, context);
+
+        record Obj(SomeContext context, int value) {}
+        var codec = RecordCodecBuilder.<Obj>create(in -> in.group(
+                ContextOps.retrieveContext(key).forGetter(Obj::context),
+                Codec.INT.fieldOf("val").forGetter(Obj::value)).apply(in, Obj::new));
+
+        var result = parseJson(ops, codec, "{\"val\": 1}");
+
+        assertThat(result.result())
+                .isPresent()
+                .hasValue(new Obj(context, 1));
+    }
+
+    @Test
+    void testUnavailableContext() {
+        var codec = ContextOps.retrieveContext(new ContextOps.Key<>(ResourceLocation.parse("does_not_exist")));
+
+        var result = parseJson(ContextOps.create(JsonOps.INSTANCE)
+                .withContext(new ContextOps.Key<>(ResourceLocation.parse("abc:d")), "some value"),
+                codec.codec(), "{}");
+
+        assertThat(result.error())
+                .isPresent()
+                .map(DataResult.Error::message)
+                .get(as(STRING))
+                .contains("does not have context with ID minecraft:does_not_exist. Available context: [abc:d]");
+    }
+
+    @Test
+    void testNotContextOps() {
+        var codec = ContextOps.retrieveContext(new ContextOps.Key<>(ResourceLocation.parse("does_not_exist")));
+
+        var result = parseJson(JsonOps.INSTANCE, codec.codec(), "{}");
+
+        assertThat(result.error())
+                .isPresent()
+                .map(DataResult.Error::message)
+                .hasValue("Dynamic ops JSON is not context-aware");
+    }
+
+    @Test
+    @ExtendWith(EphemeralTestServerProvider.class)
+    void testRegistryOps(MinecraftServer server) {
+        var key = new ContextOps.Key<MinecraftServer>(ResourceLocation.parse("server_context"));
+
+        record Obj(MinecraftServer server, Holder<Biome> biome) {}
+        var codec = RecordCodecBuilder.<Obj>create(in -> in.group(
+                ContextOps.retrieveContext(key).forGetter(Obj::server),
+                Biome.CODEC.fieldOf("biome").forGetter(Obj::biome)).apply(in, Obj::new));
+
+        var result = parseJson(ContextOps.create(server.registryAccess().createSerializationContext(JsonOps.INSTANCE))
+                .withContext(key, server), codec, "{\"biome\": \"minecraft:plains\"}");
+
+        assertThat(result.result())
+                .isPresent()
+                .hasValueSatisfying(obj -> {
+                    assertThat(obj.server()).isEqualTo(server);
+                    assertThat(obj.biome().getKey()).isEqualTo(Biomes.PLAINS);
+                });
+    }
+
+    private static <T> DataResult<T> parseJson(DynamicOps<JsonElement> ops, Codec<T> codec, @Language("json") String json) {
+        return codec.decode(ops, GSON.fromJson(json, JsonElement.class)).map(Pair::getFirst);
+    }
+}


### PR DESCRIPTION
Adds a `ContextOps` that can hold arbitrary context objects identified by a `Key` (a `Class` type and a `ResourceLocation` identifier).

The motivation for this is that currently, in order to inject additional context into dynamic ops for use in codecs, one has to create a concrete chain of `DelegatingOps` child classes, knowing exactly what context is provided.

This system is also intended to be used in the future to inject the `AttachmentHolder` into holder-aware but codec-backed data attachments. Another possible use case is a future event that allows mods to inject custom context into vanilla-deserialised objects like datapack registries, recipes, advancements, loot tables, etc. Obviously this system can also be immediately used by mods in their own codec-based deserialisation code.

Unfortunately, the vanilla `RegistryOps` cannot be feasibly patched out to a `ContextOps.Key` due to the amount of references to the class, so it is expected that this ops (which now extends from `ContextOps` itself) sits at the base of any context chain that makes use of registry lookups. The NeoForge-added `ConditionalOps` has however been modified to be backed by context injection. To preserve backwards compatibility, for now the class is still an ops instance. The `ConditionalOps.retrieveContext` method does not on the other hand pose the requirement of a `ConditionalOps` instance, relying instead on context injection.

Tests will be added shortly.