### PR TITLE
[1.21.x] Fix ECJ issue with inner public class

### DIFF
--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentSyncTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentSyncTests.java
@@ -119,7 +119,7 @@ public class AttachmentSyncTests {
                 return new Holder();
             }
 
-            public class Holder extends AttachmentHolder {
+            class Holder extends AttachmentHolder {
                 public void readFrom(SyncAttachmentsPayload payload) {
                     AttachmentSync.receiveSyncedDataAttachments(
                             this,


### PR DESCRIPTION
ECJ fails to compile the method-local double-innerclass `testAttachmentSync()$TestHelper$Holder` because it has a `public` access modifier. Removing it fixes the issue.