### PR TITLE
Add displayItems(Collection<Holder>) helper to CreativeModeTab.Builder for use with DeferredRegisters

### DIFF
--- a/patches/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -144,7 +144,7 @@
              return this;
          }
  
-@@ -181,13 +_,108 @@
+@@ -181,13 +_,109 @@
              return this;
          }
  
@@ -232,16 +232,17 @@
 +        }
 +
 +        /**
-+         * Helper to set this tabs contents to everything in the supplied {@link net.neoforged.neoforge.registries.DeferredRegister}.
-+         * Due to the {@link ItemLike} generic, you can pass Item or Block DeferredRegisters into this by default.
-+         * Entries added through this method are filtered out if {@link ItemLike#asItem()} returns {@link Items.AIR}, to account for blocks that do not have items.
++         * Helper to set this tabs contents to everything in the supplied Collection of Holders.
++         * Intended for use with {@link net.neoforged.neoforge.registries.DeferredRegister#getEntries()}, for Item or Block DeferredRegisters.
++         * Entries added through this method are filtered out if {@link ItemLike#asItem()} returns {@link Items.AIR} or if disabled via {@link Item#isEnabled(FeatureFlagSet)}.
 +         * Note that like the vanilla method this overrides any other calls for this tab to {@link #displayItems}.
 +         */
-+        public CreativeModeTab.Builder displayItems(net.neoforged.neoforge.registries.DeferredRegister<? extends ItemLike> register) {
-+            return this.displayItems((p, o) -> register.getEntries().stream()
-+                    .map(net.neoforged.neoforge.registries.DeferredHolder::get)
++        public CreativeModeTab.Builder displayItems(Collection<? extends net.minecraft.core.Holder<? extends ItemLike>> collection) {
++            return this.displayItems((p, o) -> collection.stream()
++                    .map(net.minecraft.core.Holder::value)
 +                    .map(ItemLike::asItem)
 +                    .filter(i -> i != Items.AIR)
++                    .filter(i -> i.isEnabled(p.enabledFeatures()))
 +                    .forEach(o::accept));
 +        }
 +

--- a/patches/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -144,7 +144,7 @@
              return this;
          }
  
-@@ -181,13 +_,94 @@
+@@ -181,13 +_,102 @@
              return this;
          }
  
@@ -229,6 +229,14 @@
 +        public final CreativeModeTab.Builder withTabsAfter(net.minecraft.resources.ResourceKey<CreativeModeTab>... tabs) {
 +            java.util.stream.Stream.of(tabs).map(net.minecraft.resources.ResourceKey::location).forEach(this.tabsAfter::add);
 +            return this;
++        }
++
++        /**
++         * Helper to set this tabs contents to all items in the supplied {@link net.neoforged.neoforge.registries.DeferredRegister<Item>}.
++         * Note that like the vanilla method this overrides any other calls to {@link #displayItems}.
++         */
++        public CreativeModeTab.Builder displayItems(net.neoforged.neoforge.registries.DeferredRegister<Item> register) {
++            return this.displayItems((p, o) -> register.getEntries().forEach(i -> o.accept(i.get())));
 +        }
 +
          public CreativeModeTab build() {

--- a/patches/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -144,7 +144,7 @@
              return this;
          }
  
-@@ -181,13 +_,102 @@
+@@ -181,13 +_,108 @@
              return this;
          }
  
@@ -232,11 +232,17 @@
 +        }
 +
 +        /**
-+         * Helper to set this tabs contents to all items in the supplied {@link net.neoforged.neoforge.registries.DeferredRegister<Item>}.
-+         * Note that like the vanilla method this overrides any other calls to {@link #displayItems}.
++         * Helper to set this tabs contents to everything in the supplied {@link net.neoforged.neoforge.registries.DeferredRegister}.
++         * Due to the {@link ItemLike} generic, you can pass Item or Block DeferredRegisters into this by default.
++         * Entries added through this method are filtered out if {@link ItemLike#asItem()} returns {@link Items.AIR}, to account for blocks that do not have items.
++         * Note that like the vanilla method this overrides any other calls for this tab to {@link #displayItems}.
 +         */
-+        public CreativeModeTab.Builder displayItems(net.neoforged.neoforge.registries.DeferredRegister<Item> register) {
-+            return this.displayItems((p, o) -> register.getEntries().forEach(i -> o.accept(i.get())));
++        public CreativeModeTab.Builder displayItems(net.neoforged.neoforge.registries.DeferredRegister<? extends ItemLike> register) {
++            return this.displayItems((p, o) -> register.getEntries().stream()
++                    .map(net.neoforged.neoforge.registries.DeferredHolder::get)
++                    .map(ItemLike::asItem)
++                    .filter(i -> i != Items.AIR)
++                    .forEach(o::accept));
 +        }
 +
          public CreativeModeTab build() {


### PR DESCRIPTION
A few times in the discord I've found people constructing elaborate registry helper systems (well, a method and a list) to be able to add them all to a creative tab later, unaware that DeferredRegister keeps a collection of all of its items. This adds a method to the creative tab builder that uses that collection to add all of a mods items to a creative tab.

The items will be added in the same order they are added to the deferred register as it is backed by a LinkedHashMap.