### PR TITLE
[1.21.8][B3D] Add ValidationGpuTextureView to validation layer

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationCommandEncoder.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationCommandEncoder.java
@@ -55,7 +55,6 @@ public class ValidationCommandEncoder implements CommandEncoder {
         }
         if (depthTextureView instanceof ValidationGpuTextureView validationDepthTextureView) {
             // TODO 1.21.8: Can't require a validated wrapper since we initially forgot and that'd make it a breaking change
-
             depthTextureView = validationDepthTextureView.getRealTextureView();
         }
 

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationCommandEncoder.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationCommandEncoder.java
@@ -40,11 +40,25 @@ public class ValidationCommandEncoder implements CommandEncoder {
 
     @Override
     public RenderPass createRenderPass(Supplier<String> label, GpuTextureView colorTextureView, OptionalInt clearColor) {
+        if (colorTextureView instanceof ValidationGpuTextureView validationColorTextureView) {
+            // TODO 1.21.8: Can't require a validated wrapper since we initially forgot and that'd make it a breaking change
+            colorTextureView = validationColorTextureView.getRealTextureView();
+        }
         return wrapRenderPass(realCommandEncoder.createRenderPass(label, colorTextureView, clearColor), validator);
     }
 
     @Override
     public RenderPass createRenderPass(Supplier<String> label, GpuTextureView colorTextureView, OptionalInt clearColor, @Nullable GpuTextureView depthTextureView, OptionalDouble clearDepth) {
+        if (colorTextureView instanceof ValidationGpuTextureView validationColorTextureView) {
+            // TODO 1.21.8: Can't require a validated wrapper since we initially forgot and that'd make it a breaking change
+            colorTextureView = validationColorTextureView.getRealTextureView();
+        }
+        if (depthTextureView instanceof ValidationGpuTextureView validationDepthTextureView) {
+            // TODO 1.21.8: Can't require a validated wrapper since we initially forgot and that'd make it a breaking change
+
+            depthTextureView = validationDepthTextureView.getRealTextureView();
+        }
+
         return wrapRenderPass(realCommandEncoder.createRenderPass(label, colorTextureView, clearColor, depthTextureView, clearDepth), validator);
     }
 
@@ -166,8 +180,12 @@ public class ValidationCommandEncoder implements CommandEncoder {
     }
 
     @Override
-    public void presentTexture(GpuTextureView texture) {
-        realCommandEncoder.presentTexture(texture);
+    public void presentTexture(GpuTextureView textureView) {
+        if (textureView instanceof ValidationGpuTextureView validationTextureView) {
+            // TODO 1.21.8: Can't require a validated wrapper since we initially forgot and that'd make it a breaking change
+            textureView = validationTextureView.getRealTextureView();
+        }
+        realCommandEncoder.presentTexture(textureView);
     }
 
     @Override

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationGpuDevice.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationGpuDevice.java
@@ -75,12 +75,16 @@ public class ValidationGpuDevice implements GpuDevice {
         return wrapGpuTexture(realDevice.createTexture(label, usage, format, width, height, depthOrLayers, mipLevels), validator);
     }
 
+    protected ValidationGpuTextureView wrapGpuTextureView(ValidationGpuTexture validationGpuTexture, GpuTextureView gpuTextureView, GpuDeviceUsageValidator validator) {
+        return new ValidationGpuTextureView(validationGpuTexture, gpuTextureView, validator);
+    }
+
     @Override
     public GpuTextureView createTextureView(GpuTexture texture) {
         if (!(texture instanceof ValidationGpuTexture validationTexture)) {
             throw new IllegalArgumentException();
         }
-        return realDevice.createTextureView(validationTexture.getRealTexture());
+        return wrapGpuTextureView(validationTexture, realDevice.createTextureView(validationTexture.getRealTexture()), validator);
     }
 
     @Override
@@ -88,7 +92,7 @@ public class ValidationGpuDevice implements GpuDevice {
         if (!(texture instanceof ValidationGpuTexture validationTexture)) {
             throw new IllegalArgumentException();
         }
-        return realDevice.createTextureView(validationTexture.getRealTexture(), baseMipLevel, mipLevels);
+        return wrapGpuTextureView(validationTexture, realDevice.createTextureView(validationTexture.getRealTexture(), baseMipLevel, mipLevels), validator);
     }
 
     @Override

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationGpuTextureView.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationGpuTextureView.java
@@ -1,0 +1,26 @@
+package net.neoforged.neoforge.client.blaze3d.validation;
+
+import com.mojang.blaze3d.textures.GpuTextureView;
+
+public class ValidationGpuTextureView extends GpuTextureView {
+    private final GpuTextureView realTextureView;
+
+    public ValidationGpuTextureView(ValidationGpuTexture validationGpuTexture, GpuTextureView realTextureView, GpuDeviceUsageValidator validator) {
+        super(validationGpuTexture, realTextureView.baseMipLevel(), realTextureView.mipLevels());
+        this.realTextureView = realTextureView;
+    }
+
+    public GpuTextureView getRealTextureView() {
+        return realTextureView;
+    }
+
+    @Override
+    public void close() {
+        realTextureView.close();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return realTextureView.isClosed();
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationGpuTextureView.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationGpuTextureView.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client.blaze3d.validation;
 
 import com.mojang.blaze3d.textures.GpuTextureView;

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationRenderPass.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationRenderPass.java
@@ -46,8 +46,12 @@ public class ValidationRenderPass implements RenderPass {
     }
 
     @Override
-    public void bindSampler(String name, @Nullable GpuTextureView texture) {
-        realRenderPass.bindSampler(name, texture);
+    public void bindSampler(String name, @Nullable GpuTextureView textureView) {
+        if (textureView instanceof ValidationGpuTextureView validationTextureView) {
+            // TODO 1.21.8: Can't require a validated wrapper since we initially forgot and that'd make it a breaking change
+            textureView = validationTextureView.getRealTextureView();
+        }
+        realRenderPass.bindSampler(name, textureView);
     }
 
     @Override


### PR DESCRIPTION
GpuTextureView.texture() needs to return a ValidationGpuTexture when the layer is enabled.

Because requiring this would be a BC, it is currently optional and the validation layer will unwrap them if it is passed a validation view.

This fixes issues where Vanilla exposes a GpuTextureView, but the GpuTextureView#texture() getter then returns the unwrapped object instead of the validation wrapper.