### PR TITLE
[1.21.8][B3D] Make ValidationRenderPass and ValidationCommandEncoder constructors protected

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationCommandEncoder.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationCommandEncoder.java
@@ -29,7 +29,7 @@ public class ValidationCommandEncoder implements CommandEncoder {
     private final CommandEncoder realCommandEncoder;
     private final GpuDeviceUsageValidator validator;
 
-    ValidationCommandEncoder(CommandEncoder realCommandEncoder, GpuDeviceUsageValidator validator) {
+    protected ValidationCommandEncoder(CommandEncoder realCommandEncoder, GpuDeviceUsageValidator validator) {
         this.realCommandEncoder = realCommandEncoder;
         this.validator = validator;
     }

--- a/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationRenderPass.java
+++ b/src/client/java/net/neoforged/neoforge/client/blaze3d/validation/ValidationRenderPass.java
@@ -24,7 +24,7 @@ public class ValidationRenderPass implements RenderPass {
     private final RenderPass realRenderPass;
     private final GpuDeviceUsageValidator validator;
 
-    ValidationRenderPass(RenderPass realRenderPass, GpuDeviceUsageValidator validator) {
+    protected ValidationRenderPass(RenderPass realRenderPass, GpuDeviceUsageValidator validator) {
         this.realRenderPass = realRenderPass;
         this.validator = validator;
     }


### PR DESCRIPTION
These were supposed to be extendable classes, with backends extending them for any extended features they add.

Related #2515