### PR TITLE
Provide debug utilities for class transformation for FML 10

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -5,11 +5,13 @@
 
 package net.neoforged.neoforge.client;
 
+import com.mojang.brigadier.Command;
 import java.util.Optional;
 import net.minecraft.DetectedVersion;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BiomeColors;
 import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
+import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.data.metadata.PackMetadataGenerator;
 import net.minecraft.network.chat.Component;
@@ -17,12 +19,14 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.util.InclusiveRange;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.material.FluidState;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.config.ModConfigs;
@@ -33,6 +37,7 @@ import net.neoforged.neoforge.client.data.internal.NeoForgeSpriteSourceProvider;
 import net.neoforged.neoforge.client.entity.animation.json.AnimationLoader;
 import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientResourceLoadFinishedEvent;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.RegisterBlockStateModels;
 import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
@@ -108,6 +113,25 @@ public class ClientNeoForgeMod {
 
         NeoForge.EVENT_BUS.addListener(RegisterClientCommandsEvent.class, event -> {
             ClientConfigCommand.register(event.getDispatcher());
+        });
+
+        NeoForge.EVENT_BUS.addListener(ClientResourceLoadFinishedEvent.class, event -> {
+            if (event.isInitial()) {
+                ModLoader.logTransformationSummary();
+            }
+        });
+
+        NeoForge.EVENT_BUS.addListener(RegisterClientCommandsEvent.class, event -> {
+            event.getDispatcher().register(
+                    Commands.literal("neoforge")
+                            .then(Commands.literal("debug_class_loading_transformations")
+                                    .executes(ctx -> {
+                                        var entity = ctx.getSource().getEntity();
+                                        if (entity instanceof Player player) {
+                                            player.displayClientMessage(Component.translatable("commands.neoforge.debug_class_loading_transformations.message", ModLoader.getTransformationSummary(), ModLoader.getMixinParsedClassesSummary()), false);
+                                        }
+                                        return Command.SINGLE_SUCCESS;
+                                    })));
         });
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -23,10 +23,12 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.common.crafting.RecipePriorityManager;
 import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.common.util.FakePlayerFactory;
 import net.neoforged.neoforge.event.AddServerReloadListenersEvent;
+import net.neoforged.neoforge.event.GameShuttingDownEvent;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
@@ -175,5 +177,10 @@ public class NeoForgeEventHandler {
         if (event.getEntity() instanceof Mob mob && mob.isSpawnCancelled()) {
             event.setCanceled(true);
         }
+    }
+
+    @SubscribeEvent
+    public void logTransformationsOnGameShutdown(GameShuttingDownEvent event) {
+        ModLoader.logTransformationSummary();
     }
 }

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -127,6 +127,7 @@
   "commands.neoforge.data_components.list.tooltip.deleted": "Component %s with value %s was deleted",
   "commands.neoforge.data_components.list.tooltip.modified": "Component %s was modified from %s to %s",
   "commands.neoforge.data_components.list.tooltip.added": "Component %s was added with value %s",
+  "commands.neoforge.debug_class_loading_transformations.message": "Transformed/total loaded classes: %s and %s parsed for mixin",
 
   "commands.neoforge.vanilla.resource_key.no_recipes_on_client": "Recipe lookup is not possible in client commands",
 


### PR DESCRIPTION
Requires https://github.com/neoforged/FancyModLoader/pull/319; this makes use of debugging information exposed there for inspecting how many classes get `ClassNode`-ed during load.