### PR TITLE
[1.21.8] Add stack-aware overload of Item#canFitInsideContainerItems()

### DIFF
--- a/patches/net/minecraft/world/inventory/ShulkerBoxSlot.java.patch
+++ b/patches/net/minecraft/world/inventory/ShulkerBoxSlot.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/inventory/ShulkerBoxSlot.java
++++ b/net/minecraft/world/inventory/ShulkerBoxSlot.java
+@@ -10,6 +_,7 @@
+ 
+     @Override
+     public boolean mayPlace(ItemStack p_40207_) {
+-        return p_40207_.getItem().canFitInsideContainerItems();
++        // Neo: stack-aware placeability check
++        return p_40207_.canFitInsideContainerItems();
+     }
+ }

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -57,7 +57,7 @@
      public final ItemStack getCraftingRemainder() {
          return this.craftingRemainingItem == null ? ItemStack.EMPTY : new ItemStack(this.craftingRemainingItem);
      }
-@@ -338,7 +_,14 @@
+@@ -338,13 +_,26 @@
      }
  
      public boolean useOnRelease(ItemStack p_41464_) {
@@ -73,6 +73,18 @@
      }
  
      public ItemStack getDefaultInstance() {
+         return new ItemStack(this);
+     }
+ 
++    /**
++     * @deprecated Neo: call {@link net.neoforged.neoforge.common.extensions.IItemStackExtension#canFitInsideContainerItems()} instead,
++     *             prefer overriding {@link net.neoforged.neoforge.common.extensions.IItemExtension#canFitInsideContainerItems(ItemStack)}
++     * @implNote It is recommended to still override this to ensure mods calling this instead of the extension still behave safely.
++     */
++    @Deprecated
+     public boolean canFitInsideContainerItems() {
+         return true;
+     }
 @@ -369,6 +_,12 @@
          private ResourceKey<Item> id;
          private DependantName<Item, String> descriptionId = ITEM_DESCRIPTION_ID;

--- a/patches/net/minecraft/world/item/component/BundleContents.java.patch
+++ b/patches/net/minecraft/world/item/component/BundleContents.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/world/item/component/BundleContents.java
++++ b/net/minecraft/world/item/component/BundleContents.java
+@@ -73,7 +_,8 @@
+     }
+ 
+     public static boolean canItemBeInBundle(ItemStack p_362945_) {
+-        return !p_362945_.isEmpty() && p_362945_.getItem().canFitInsideContainerItems();
++        // Neo: stack-aware placeability check
++        return !p_362945_.isEmpty() && p_362945_.canFitInsideContainerItems();
+     }
+ 
+     public int getNumberOfItemsToShow() {

--- a/patches/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/ShulkerBoxBlockEntity.java
-@@ -236,7 +_,7 @@
+@@ -236,7 +_,8 @@
  
      @Override
      public boolean canPlaceItemThroughFace(int p_59663_, ItemStack p_59664_, @Nullable Direction p_59665_) {
 -        return !(Block.byItem(p_59664_.getItem()) instanceof ShulkerBoxBlock);
-+        return !(Block.byItem(p_59664_.getItem()) instanceof ShulkerBoxBlock) && p_59664_.getItem().canFitInsideContainerItems(); // FORGE: Make shulker boxes respect Item#canFitInsideContainerItems
++        // Neo: Make shulker boxes respect IItemStackExtension#canFitInsideContainerItems
++        return !(Block.byItem(p_59664_.getItem()) instanceof ShulkerBoxBlock) && p_59664_.canFitInsideContainerItems();
      }
  
      @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemExtension.java
@@ -662,4 +662,15 @@ public interface IItemExtension {
 
         return stack;
     }
+
+    /**
+     * Determines whether this item can be safely stored inside another container item, optionally taking the provided
+     * stack's data into account.
+     *
+     * @param stack The stack holding this item
+     * @return whether this item can fit inside a container item
+     */
+    default boolean canFitInsideContainerItems(ItemStack stack) {
+        return self().canFitInsideContainerItems();
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -413,4 +413,14 @@ public interface IItemStackExtension {
 
         return CommonHooks.computeModifiedAttributes(self(), defaultModifiers);
     }
+
+    /**
+     * Determines whether the item held by this stack can be safely stored inside another container item, optionally
+     * taking this stack's data into account.
+     *
+     * @return whether the item held by this stack can fit inside a container item
+     */
+    default boolean canFitInsideContainerItems() {
+        return self().getItem().canFitInsideContainerItems(self());
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/items/ComponentItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/items/ComponentItemHandler.java
@@ -140,7 +140,7 @@ public class ComponentItemHandler implements IItemHandlerModifiable {
 
     @Override
     public boolean isItemValid(int slot, ItemStack stack) {
-        return stack.getItem().canFitInsideContainerItems();
+        return stack.canFitInsideContainerItems();
     }
 
     /**


### PR DESCRIPTION
This PR adds a stack-aware overload of `Item#canFitInsideContainerItems()`. This is useful to allow storing container items inside other container items of the "inner" ones are empty.