### PR TITLE
Add tool stack sensitive overload of `onDestroyedByPlayer`

### DIFF
--- a/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -8,7 +8,7 @@
                      block.playerWillDestroy(level, p_105268_, blockstate, this.minecraft.player);
                      FluidState fluidstate = level.getFluidState(p_105268_);
 -                    boolean flag = level.setBlock(p_105268_, fluidstate.createLegacyBlock(), 11);
-+                    boolean flag = blockstate.onDestroyedByPlayer(level, p_105268_, minecraft.player, false, fluidstate);
++                    boolean flag = blockstate.onDestroyedByPlayer(level, p_105268_, minecraft.player, minecraft.player.getMainHandItem().copy(), false, fluidstate);
                      if (flag) {
 -                        block.destroy(level, p_105268_, blockstate);
 +                        block.destroy(level, p_105268_, removedBlockState);

--- a/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -40,7 +40,7 @@
              return false;
          } else {
              BlockEntity blockentity = this.level.getBlockEntity(p_9281_);
-@@ -268,30 +_,45 @@
+@@ -268,30 +_,46 @@
                  return false;
              } else {
                  BlockState blockstate = block.playerWillDestroy(this.level, p_9281_, blockstate1, this.player);
@@ -54,7 +54,7 @@
 -                }
  
                  if (this.player.preventsBlockDrops()) {
-+                    removeBlock(p_9281_, blockstate, false);
++                    removeBlock(p_9281_, blockstate, false, player.getMainHandItem().copy());
                      return true;
                  } else {
                      ItemStack itemstack = this.player.getMainHandItem();
@@ -62,7 +62,7 @@
 -                    boolean flag = this.player.hasCorrectToolForDrops(blockstate);
 +                    boolean flag1 = blockstate.canHarvestBlock(this.level, p_9281_, this.player); // previously player.hasCorrectToolForDrops(blockstate)
                      itemstack.mineBlock(this.level, blockstate, p_9281_, this.player);
-+                    boolean flag = removeBlock(p_9281_, blockstate, flag1);
++                    boolean flag = removeBlock(p_9281_, blockstate, flag1, itemstack1.copy());
 +
                      if (flag1 && flag) {
                          block.playerDestroy(this.level, this.player, p_9281_, blockstate, blockentity, itemstack1);
@@ -85,10 +85,11 @@
 +     * @param pos The block pos of the destroyed block
 +     * @param state The state of the destroyed block
 +     * @param canHarvest If the player breaking the block can harvest the drops of the block
++     * @param toolStack The players main-hand prior to destroying the block and applying damage to the tool.
 +     * @return If the block was removed, as reported by {@link BlockState#onDestroyedByPlayer}.
 +     */
-+    private boolean removeBlock(BlockPos pos, BlockState state, boolean canHarvest) {
-+        boolean removed = state.onDestroyedByPlayer(this.level, pos, this.player, canHarvest, this.level.getFluidState(pos));
++    private boolean removeBlock(BlockPos pos, BlockState state, boolean canHarvest, ItemStack toolStack) {
++        boolean removed = state.onDestroyedByPlayer(this.level, pos, this.player, toolStack, canHarvest, this.level.getFluidState(pos));
 +        if (removed)
 +            state.getBlock().destroy(this.level, pos, state);
 +        return removed;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -227,13 +227,14 @@ public interface IBlockExtension {
      *
      * @param state       The current state.
      * @param level       The current level
-     * @param player      The player damaging the block, may be null
      * @param pos         Block position in level
+     * @param player      The player damaging the block, may be null
+     * @param toolStack   The players main-hand prior to destroying the block and applying damage to the tool.
      * @param willHarvest The result of {@link #canHarvestBlock}, if called on the server by a non-creative player, otherwise always false.
      * @param fluid       The current fluid state at current position
      * @return True if the block is actually destroyed.
      */
-    default boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) {
+    default boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, ItemStack toolStack, boolean willHarvest, FluidState fluid) {
         if (level.isClientSide()) {
             // On the client, vanilla calls Level#setBlock, per MultiPlayerGameMode#destroyBlock
             return level.setBlock(pos, fluid.createLegacyBlock(), 11);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -136,14 +136,15 @@ public interface IBlockStateExtension {
      * This function is called on both the logical client and logical server.
      *
      * @param level       The current level
-     * @param player      The player damaging the block, may be null
      * @param pos         Block position in level
+     * @param player      The player damaging the block, may be null
+     * @param toolStack   The players main-hand prior to destroying the block and applying damage to the tool.
      * @param willHarvest The result of {@link #canHarvestBlock}, if called on the server by a non-creative player, otherwise always false.
      * @param fluid       The current fluid and block state for the position in the level.
      * @return True if the block is actually destroyed.
      */
-    default boolean onDestroyedByPlayer(Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) {
-        return self().getBlock().onDestroyedByPlayer(self(), level, pos, player, willHarvest, fluid);
+    default boolean onDestroyedByPlayer(Level level, BlockPos pos, Player player, ItemStack toolStack, boolean willHarvest, FluidState fluid) {
+        return self().getBlock().onDestroyedByPlayer(self(), level, pos, player, toolStack, willHarvest, fluid);
     }
 
     /**


### PR DESCRIPTION
On the server, by the time `onDestroyedByPlayer` has been called, the players tool stack (main hand) has already been damaged, and may be empty.

Currently to get the tool stack for custom drops (such as destroying part of the block) in this method, you need to ThreadLocal store it from `canHarvestBlock` which is less than ideal.

This PR adds an overload of `onDestroyedByPlayer` with the players tool stack prior to it being damaged and/or destroyed, on the client and in creative this just provides the players main-hand stack as-is.