### PR TITLE
Expand the context of GrindstoneEvent.OnTakeItem

### DIFF
--- a/patches/net/minecraft/world/inventory/GrindstoneMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/GrindstoneMenu.java.patch
@@ -28,7 +28,7 @@
  
              @Override
              public void onTake(Player p_150574_, ItemStack p_150575_) {
-+                if (net.neoforged.neoforge.common.CommonHooks.onGrindstoneTake(GrindstoneMenu.this.repairSlots, p_39568_, this::getExperienceAmount)) return;
++                if (net.neoforged.neoforge.common.CommonHooks.onGrindstoneTake(GrindstoneMenu.this.repairSlots, p_39568_, p_150574_, this::getExperienceAmount)) return;
                  p_39568_.execute((p_39634_, p_39635_) -> {
                      if (p_39634_ instanceof ServerLevel) {
                          ExperienceOrb.award((ServerLevel)p_39634_, Vec3.atCenterOf(p_39635_), this.getExperienceAmount(p_39634_));

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -778,7 +778,7 @@ public class CommonHooks {
         return onGrindstoneTake(inputSlots, access, null, xpFunction);
     }
 
-    public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, Player player, Function<Level, Integer> xpFunction) {
+    public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, @Nullable Player player, Function<Level, Integer> xpFunction) {
         access.execute((l, p) -> {
             int xp = xpFunction.apply(l);
             GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(access, player, inputSlots.getItem(0), inputSlots.getItem(1), xp);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -770,10 +770,10 @@ public class CommonHooks {
         return e.getXp();
     }
 
-    public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, Function<Level, Integer> xpFunction) {
+    public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, Player player, Function<Level, Integer> xpFunction) {
         access.execute((l, p) -> {
             int xp = xpFunction.apply(l);
-            GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(inputSlots.getItem(0), inputSlots.getItem(1), xp);
+            GrindstoneEvent.OnTakeItem e = new GrindstoneEvent.OnTakeItem(access, player, inputSlots.getItem(0), inputSlots.getItem(1), xp);
             if (NeoForge.EVENT_BUS.post(e).isCanceled()) {
                 return;
             }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -770,6 +770,14 @@ public class CommonHooks {
         return e.getXp();
     }
 
+    /**
+     * @deprecated Use {@link #onGrindstoneTake(Container, ContainerLevelAccess, Player, Function) the player version} instead
+     */
+    @Deprecated(forRemoval = true, since = "1.21.8")
+    public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, Function<Level, Integer> xpFunction) {
+        return onGrindstoneTake(inputSlots, access, null, xpFunction);
+    }
+
     public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, Player player, Function<Level, Integer> xpFunction) {
         access.execute((l, p) -> {
             int xp = xpFunction.apply(l);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -778,6 +778,7 @@ public class CommonHooks {
         return onGrindstoneTake(inputSlots, access, null, xpFunction);
     }
 
+    //TODO remove nullable annotation from player once method above is removed
     public static boolean onGrindstoneTake(Container inputSlots, ContainerLevelAccess access, @Nullable Player player, Function<Level, Integer> xpFunction) {
         access.execute((l, p) -> {
             int xp = xpFunction.apply(l);

--- a/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
@@ -127,6 +127,14 @@ public abstract class GrindstoneEvent extends Event {
         }
 
         /**
+         * @deprecated Use {@link #OnTakeItem(ContainerLevelAccess, Player, ItemStack, ItemStack, int) the context-aware version} instead
+         */
+        @Deprecated(forRemoval = true, since = "1.21.8")
+        public OnTakeItem(ItemStack top, ItemStack bottom, int xp) {
+            this(ContainerLevelAccess.NULL, null, top, bottom, xp);
+        }
+
+        /**
          * @return The item in that will be in the top input grindstone slot after the event. <br>
          */
         public ItemStack getNewTopItem() {

--- a/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
@@ -6,6 +6,8 @@
 package net.neoforged.neoforge.event;
 
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.GrindstoneMenu;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.Event;
@@ -115,8 +117,13 @@ public abstract class GrindstoneEvent extends Event {
         private ItemStack newTop = ItemStack.EMPTY;
         private ItemStack newBottom = ItemStack.EMPTY;
 
-        public OnTakeItem(ItemStack top, ItemStack bottom, int xp) {
+        private final ContainerLevelAccess access;
+        private final Player player;
+
+        public OnTakeItem(ContainerLevelAccess access, Player player, ItemStack top, ItemStack bottom, int xp) {
             super(top, bottom, xp);
+            this.access = access;
+            this.player = player;
         }
 
         /**
@@ -158,6 +165,20 @@ public abstract class GrindstoneEvent extends Event {
          */
         public int getXp() {
             return super.getXp();
+        }
+
+        /**
+         * @return access to the grindstone's level and position
+         */
+        public ContainerLevelAccess getContainerAccess() {
+            return this.access;
+        }
+
+        /**
+         * @return the player currently using the grindstone
+         */
+        public Player getPlayer() {
+            return this.player;
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
@@ -131,6 +131,7 @@ public abstract class GrindstoneEvent extends Event {
         /**
          * @deprecated Use {@link #OnTakeItem(ContainerLevelAccess, Player, ItemStack, ItemStack, int) the context-aware version} instead
          */
+        //TODO also remove nullable annotations from player once this is removed
         @Deprecated(forRemoval = true, since = "1.21.8")
         public OnTakeItem(ItemStack top, ItemStack bottom, int xp) {
             this(ContainerLevelAccess.NULL, null, top, bottom, xp);
@@ -178,14 +179,14 @@ public abstract class GrindstoneEvent extends Event {
         }
 
         /**
-         * @return access to the grindstone's level and position
+         * {@return an accessor for the grindstone's level and position}
          */
         public ContainerLevelAccess getContainerAccess() {
             return this.access;
         }
 
         /**
-         * @return the player currently using the grindstone
+         * {@return the player currently using the grindstone}
          */
         @Nullable
         public Player getPlayer() {

--- a/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/GrindstoneEvent.java
@@ -12,6 +12,7 @@ import net.minecraft.world.inventory.GrindstoneMenu;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class GrindstoneEvent extends Event {
     private final ItemStack top;
@@ -118,9 +119,10 @@ public abstract class GrindstoneEvent extends Event {
         private ItemStack newBottom = ItemStack.EMPTY;
 
         private final ContainerLevelAccess access;
+        @Nullable
         private final Player player;
 
-        public OnTakeItem(ContainerLevelAccess access, Player player, ItemStack top, ItemStack bottom, int xp) {
+        public OnTakeItem(ContainerLevelAccess access, @Nullable Player player, ItemStack top, ItemStack bottom, int xp) {
             super(top, bottom, xp);
             this.access = access;
             this.player = player;
@@ -185,6 +187,7 @@ public abstract class GrindstoneEvent extends Event {
         /**
          * @return the player currently using the grindstone
          */
+        @Nullable
         public Player getPlayer() {
             return this.player;
         }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/GrindstoneEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/GrindstoneEventTest.java
@@ -18,7 +18,7 @@ import net.neoforged.neoforge.event.GrindstoneEvent;
 
 @Mod("grindstone_event_test")
 public class GrindstoneEventTest {
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
 
     public GrindstoneEventTest() {
         if (ENABLED) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/GrindstoneEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/misc/GrindstoneEventTest.java
@@ -5,8 +5,12 @@
 
 package net.neoforged.neoforge.oldtest.misc;
 
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
@@ -14,7 +18,7 @@ import net.neoforged.neoforge.event.GrindstoneEvent;
 
 @Mod("grindstone_event_test")
 public class GrindstoneEventTest {
-    private static final boolean ENABLED = false;
+    private static final boolean ENABLED = true;
 
     public GrindstoneEventTest() {
         if (ENABLED) {
@@ -75,6 +79,24 @@ public class GrindstoneEventTest {
             top.shrink(1);
             event.setNewBottomItem(bottom);
             event.setNewTopItem(top);
+        }
+
+        //do some effects when disenchanting a netherite helmet
+        if (topItem.is(Items.NETHERITE_HELMET) && EnchantmentHelper.hasAnyEnchantments(topItem)) {
+            //give the player an enchanted book with the item's enchants
+            ItemStack reward = new ItemStack(Items.ENCHANTED_BOOK);
+            reward.set(DataComponents.STORED_ENCHANTMENTS, topItem.getTagEnchantments());
+            if (!event.getPlayer().getInventory().add(reward)) {
+                event.getPlayer().drop(reward, false);
+            }
+
+            //summon visual lightning above the grindstone
+            event.getContainerAccess().execute((level, pos) -> {
+                LightningBolt bolt = new LightningBolt(EntityType.LIGHTNING_BOLT, level);
+                bolt.setPos(pos.getCenter());
+                bolt.setVisualOnly(true);
+                level.addFreshEntity(bolt);
+            });
         }
     }
 }


### PR DESCRIPTION
Hello!
This is a simple PR to pass the `Player` and `ContainerLevelAccess` into the GrindstoneEvent.OnTakeItem event. The reason for this is so I can make extra things happen after using the grindstone, like giving items back to a player after removing an internal inventory from an item via the grindstone. 
I updated the grindstone tests to show both of these hooks in action. When removing an enchanted netherite helmet from the grindstone, it will give the player an enchanted book with all the old enchants on it, as well as spawn a harmless lightning bolt on the grindstone. Please let me know if anything else needs to be done for this. Thank you!