### PR TITLE
[1.21.8] Fix AnimationLoader loading too late

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -157,7 +157,10 @@ public class ClientNeoForgeMod {
         event.addDependency(NeoForgeReloadListeners.BRANDING, VanillaClientListeners.FIRST);
 
         event.addListener(NeoForgeReloadListeners.OBJ_LOADER, ObjLoader.INSTANCE);
+
         event.addListener(NeoForgeReloadListeners.ENTITY_ANIMATIONS, AnimationLoader.INSTANCE);
+        // Animations need to be loaded before entity renderers are instantiated
+        event.addDependency(NeoForgeReloadListeners.ENTITY_ANIMATIONS, VanillaClientListeners.ENTITY_RENDERER);
     }
 
     @SubscribeEvent

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.client;
+
+import net.minecraft.client.model.EntityModel;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.neoforge.client.entity.animation.json.AnimationLoader;
+import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+
+@ForEachTest(side = Dist.CLIENT, groups = "client.animation")
+public class AnimationLoaderTests {
+    @TestHolder(description = "Tests that data-driven animations are loaded at the correct time", enabledByDefault = true)
+    static void animLoaderTest(final DynamicTest test) {
+        var entity = test.registrationHelper().entityTypes().registerEntityType("test", TestEntity::new, MobCategory.AMBIENT);
+        test.framework().modEventBus().addListener((EntityRenderersEvent.RegisterLayerDefinitions event) -> {
+            event.registerLayerDefinition(TestEntityModel.LAYER_LOC, TestEntityModel::createLayer);
+        });
+        test.framework().modEventBus().addListener((EntityRenderersEvent.RegisterRenderers event) -> {
+            event.registerEntityRenderer(entity.get(), context -> new TestEntityRenderer(context, test));
+        });
+    }
+
+    private static final class TestEntity extends Entity {
+        private TestEntity(EntityType<? extends Entity> entityType, Level level) {
+            super(entityType, level);
+        }
+
+        @Override
+        protected void defineSynchedData(SynchedEntityData.Builder builder) {}
+
+        @Override
+        protected void readAdditionalSaveData(ValueInput tag) {}
+
+        @Override
+        protected void addAdditionalSaveData(ValueOutput tag) {}
+
+        @Override
+        public boolean hurtServer(ServerLevel level, DamageSource source, float amount) {
+            return false;
+        }
+    }
+
+    private static final class TestEntityModel extends EntityModel<EntityRenderState> {
+        private static final ModelLayerLocation LAYER_LOC = new ModelLayerLocation(ResourceLocation.fromNamespaceAndPath("neotests_anim_loader_test", "test"), "main");
+        private static final ResourceLocation ANIM_LOC = ResourceLocation.fromNamespaceAndPath("neotests_anim_loader_test", "empty_animation");
+
+        private TestEntityModel(ModelPart modelPart, DynamicTest test) {
+            super(modelPart);
+            if (AnimationLoader.INSTANCE.getAnimation(ANIM_LOC) != null) {
+                test.pass();
+            } else {
+                test.fail("Test animation not loaded in time");
+            }
+            test.framework().setEnabled(test, false, null);
+        }
+
+        private static LayerDefinition createLayer() {
+            return LayerDefinition.create(new MeshDefinition(), 0, 0);
+        }
+    }
+
+    private static final class TestEntityRenderer extends EntityRenderer<TestEntity, EntityRenderState> {
+        private TestEntityRenderer(EntityRendererProvider.Context context, DynamicTest test) {
+            super(context);
+            new TestEntityModel(context.bakeLayer(TestEntityModel.LAYER_LOC), test);
+        }
+
+        @Override
+        public EntityRenderState createRenderState() {
+            return new EntityRenderState();
+        }
+    }
+}

--- a/tests/src/main/resources/assets/neotests_anim_loader_test/neoforge/animations/entity/empty_animation.json
+++ b/tests/src/main/resources/assets/neotests_anim_loader_test/neoforge/animations/entity/empty_animation.json
@@ -1,0 +1,4 @@
+{
+    "length": 0,
+    "animations": []
+}


### PR DESCRIPTION
In 1.21.6, the keyframe animation system was changed to bake the keyframe animations in the constructor of the entity model using said animation and these models are instantiated in the constructor of the entity renderer rendering said model.
This PR fixes the animation loader running after the entity renderer instantiation, causing the models to receive empty animations on the first resource reload and potentially outdated animations from the last reload on any subsequent reload.

Fixes #2566