### PR TITLE
Fix non-compostables being insertable through null side

### DIFF
--- a/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
+++ b/src/main/java/net/neoforged/neoforge/capabilities/CapabilityHooks.java
@@ -65,11 +65,7 @@ public class CapabilityHooks {
             // Invalidation is taken care of by the patches to ComposterBlock
 
             // Note: re-query the block state everytime instead of using `state` because the state can change at any time!
-            if (side == null) {
-                return new ForwardingItemHandler(() -> new InvWrapper(composterBlock.getContainer(level.getBlockState(pos), level, pos)));
-            } else {
-                return new ForwardingItemHandler(() -> new SidedInvWrapper(composterBlock.getContainer(level.getBlockState(pos), level, pos), side));
-            }
+            return new ForwardingItemHandler(() -> new SidedInvWrapper(composterBlock.getContainer(level.getBlockState(pos), level, pos), side));
         }, Blocks.COMPOSTER);
 
         event.registerBlock(Capabilities.ItemHandler.BLOCK, (level, pos, state, blockEntity, side) -> {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
@@ -11,7 +11,9 @@ import static net.neoforged.neoforge.fluids.capability.IFluidHandler.FluidAction
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraft.world.level.block.LayeredCauldronBlock;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
@@ -23,6 +25,7 @@ import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.gametest.GameTest;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.Nullable;
 
 @ForEachTest(groups = "capabilities.vanillahandlers")
 public class VanillaHandlersTests {
@@ -74,6 +77,35 @@ public class VanillaHandlersTests {
             helper.fail("Should have invalidated a second time");
         if (capCache.getCapability() != null)
             helper.fail("Expected no capability", composterPos);
+
+        helper.succeed();
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that non-compostable items cannot be inserted into a composter")
+    public static void testComposterCannotAcceptNonCompostables(ExtendedGameTestHelper helper) {
+        var composterPos = new BlockPos(1, 1, 1);
+
+        helper.setBlock(composterPos, Blocks.COMPOSTER.defaultBlockState());
+
+        var nonCompostable = new ItemStack(Blocks.BARRIER, 1);
+        if (ComposterBlock.getValue(nonCompostable) > 0)
+            helper.fail("Assumption failed: expected " + nonCompostable + " to be non-compostable");
+
+        var sides = new Direction[] { null, Direction.UP, Direction.DOWN, Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST };
+
+        for (@Nullable
+        Direction side : sides) {
+            var capability = helper.getLevel().getCapability(Capabilities.ItemHandler.BLOCK, helper.absolutePos(composterPos), side);
+            if (capability == null)
+                helper.fail("Expected composter to have a block item handler capability for side " + side);
+
+            assert capability != null; // The helper#fail call above ensures this is not null
+            var result = capability.insertItem(0, nonCompostable, false);
+            if (result.isEmpty())
+                helper.fail("Expected failure to insert non-compostable item for side " + side);
+        }
 
         helper.succeed();
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
@@ -25,7 +25,6 @@ import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.gametest.GameTest;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.jetbrains.annotations.Nullable;
 
 @ForEachTest(groups = "capabilities.vanillahandlers")
 public class VanillaHandlersTests {
@@ -95,8 +94,7 @@ public class VanillaHandlersTests {
 
         var sides = new Direction[] { null, Direction.UP, Direction.DOWN, Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST };
 
-        for (@Nullable
-        Direction side : sides) {
+        for (Direction side : sides) {
             var capability = helper.getLevel().getCapability(Capabilities.ItemHandler.BLOCK, helper.absolutePos(composterPos), side);
             if (capability == null)
                 helper.fail("Expected composter to have a block item handler capability for side " + side);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
@@ -92,6 +92,8 @@ public class VanillaHandlersTests {
         if (ComposterBlock.getValue(nonCompostable) > 0)
             helper.fail("Assumption failed: expected " + nonCompostable + " to be non-compostable");
 
+        // Of particular note to be tested here is the 'null' side; see #2572
+        // "IItemHandler for null side of Composter allows items without compost value to be inserted"
         var sides = new Direction[] { null, Direction.UP, Direction.DOWN, Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST };
 
         for (Direction side : sides) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/VanillaHandlersTests.java
@@ -97,11 +97,7 @@ public class VanillaHandlersTests {
         var sides = new Direction[] { null, Direction.UP, Direction.DOWN, Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST };
 
         for (Direction side : sides) {
-            var capability = helper.getLevel().getCapability(Capabilities.ItemHandler.BLOCK, helper.absolutePos(composterPos), side);
-            if (capability == null)
-                helper.fail("Expected composter to have a block item handler capability for side " + side);
-
-            assert capability != null; // The helper#fail call above ensures this is not null
+            var capability = helper.requireCapability(Capabilities.ItemHandler.BLOCK, composterPos, side);
             var result = capability.insertItem(0, nonCompostable, false);
             if (result.isEmpty())
                 helper.fail("Expected failure to insert non-compostable item for side " + side);


### PR DESCRIPTION
This PR fixes #2572 by changing the capability registration for `ComposterBlock` to always use `SidedInvWrapper`.

`InvWrapper` does not do an on-insertion check using `WorldlyContainer`'s `canPlaceItemThroughFace`, which composters use to restrict inserted stacks to compostable ones. `SidedInvWrapper` does this check, and it accepts `null` sides, so it's simpler to always use it.

This PR also adds a corresponding game test for this behavior. Without the fix, it errors as expected.

---

I'm unsure what our current policy is on mentioning the issue number in game tests for that issue, so I've left it out. If it's wanted, I can insert it quickly in. (Perhaps as a comment within the game test body?)

The game test assumes that the barrier item is always non-compostable, with a corresponding check to fail the game test if that assumption is wrong just in case.

The game test could be expanded to cover also ensuring that the appropriate sides will accept compostable items, but I think that's a bit too out-of-scope for the fix I'm implementing.