### PR TITLE
Add additional info to contributing file

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,6 +37,14 @@ If you are interested in how NeoForge is ported to new Minecraft versions, see [
 Please note that currently  only maintainers can use all the needed tools.
 Please do not open a porting PR without prior coordination.
 
+## Addition Policies
+
+- `c` tags are to be a standard between loaders with Fabric being our main partner in this effort. This means that `c` tags in 1.21+ NeoForge should be kept in sync with Fabric's `c` tags as close as possible. New `c` tags or changes to existing `c` tag should by ran by Fabric to ensure they will agree to make the same changes. This can be done by opening an issue report or PR on Fabric repository and link the NeoForge issue or PR to it. Only when Fabric agrees to merge the change, the corresponding NeoForge PR can then be merged.
+- PRs that had requested changes from a maintainer or has another maintainer assigned to the PR, these maintainer(s) should be contacted first before merging the PR to ensure they are ok with the final form of the PR and that their concerns were properly addressed. Along these lines, a maintainer's review should not be "dismissed" without checking with the maintainer.
+- Breaking change window for the NeoForge project will generally aim to last about 1 month after a significant Minecraft version.
+    - Hotfix Minecraft versions or very small Minecraft versions will not reset the breaking change window.
+    - This window is flexible and may be longer if there is significant breaking change PRs that need to be released for that Minecraft version but not yet ready. The 1 month timeframe is just a goal we would like to achieve, but we understand it is not always possible or optimal.
+
 Contributor License Agreement
 =============================
 - You grant NeoForged a license to use your code contributed to the primary codebase (everything **not** under patches) in NeoForge, under the LGPLv2.1 license.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,29 +31,9 @@ Contributing to NeoForge
 13. Commit & Push
 14. Make PR
 
-## Porting
-
-If you are interested in how NeoForge is ported to new Minecraft versions, see [the porting workflow][Porting].
-Please note that currently only maintainers can use all the needed tools.
-Please do not open a porting PR without prior coordination.
-
-## Porting Labels
-
-PRs can be backported automatically to a specific minecraft version by having maintainers add the `backport to x.xx.x` label to the PR.
-A bot will generate a new PR and handle backporting to the best of its abilities but the PR may need manual fixing if it runs into issues.
-It is a good idea to test the backport PRs before merging in case the PR functionality is impacted by the older codebase.
-
 ## Addition Policies
 
 - `c` tags are to be a standard between loaders with Fabric being our main partner in this effort. This means that `c` tags in 1.21+ NeoForge should be kept in sync with Fabric's `c` tags as close as possible. New `c` tags or changes to existing `c` tag should by ran by Fabric to ensure they will agree to make the same changes. This can be done by opening an issue report or PR on Fabric repository and link the NeoForge issue or PR to it. Only when Fabric agrees to merge the change, the corresponding NeoForge PR can then be merged.
-- PRs that had requested changes from a maintainer or has another maintainer assigned to the PR, these maintainer(s) should be contacted first before merging the PR to ensure they are ok with the final form of the PR and that their concerns were properly addressed. Along these lines, a maintainer's review should not be "dismissed" without checking with the maintainer.
-- Breaking change window for the NeoForge project will generally aim to last about 1 month after a significant Minecraft version.
-    - Hotfix Minecraft versions or very small Minecraft versions will not reset the breaking change window.
-    - This window is flexible and may be longer if there is significant breaking change PRs that need to be released for that Minecraft version but not yet ready. The 1 month timeframe is just a goal we would like to achieve, but we understand it is not always possible or optimal.
-
-## Releases
-
-If a PR needs to be merged without triggering the workflow to generate a NeoForge release, follow [the documentation here](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs) for how to skip workflow runs. Essentially adding `[skip ci]` to the PR merge commit message will suffice.
 
 Contributor License Agreement
 =============================
@@ -63,3 +43,4 @@ Contributor License Agreement
 This is intended as a **legally binding copyright assignment** to the NeoForged project for contributions under the patches codebase. However you retain your copyright for all other contributions.
 
 [Porting]: ../docs/PORTING.md
+[Maintainers]: ../docs/MAINTAINERS.md

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,8 +34,14 @@ Contributing to NeoForge
 ## Porting
 
 If you are interested in how NeoForge is ported to new Minecraft versions, see [the porting workflow][Porting].
-Please note that currently  only maintainers can use all the needed tools.
+Please note that currently only maintainers can use all the needed tools.
 Please do not open a porting PR without prior coordination.
+
+## Porting Labels
+
+PRs can be backported automatically to a specific minecraft version by having maintainers add the `backport to x.xx.x` label to the PR.
+A bot will generate a new PR and handle backporting to the best of its abilities but the PR may need manual fixing if it runs into issues.
+It is a good idea to test the backport PRs before merging in case the PR functionality is impacted by the older codebase.
 
 ## Addition Policies
 
@@ -44,6 +50,10 @@ Please do not open a porting PR without prior coordination.
 - Breaking change window for the NeoForge project will generally aim to last about 1 month after a significant Minecraft version.
     - Hotfix Minecraft versions or very small Minecraft versions will not reset the breaking change window.
     - This window is flexible and may be longer if there is significant breaking change PRs that need to be released for that Minecraft version but not yet ready. The 1 month timeframe is just a goal we would like to achieve, but we understand it is not always possible or optimal.
+
+## Releases
+
+If a PR needs to be merged without triggering the workflow to generate a NeoForge release, follow [the documentation here](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs) for how to skip workflow runs. Essentially adding `[skip ci]` to the PR merge commit message will suffice.
 
 Contributor License Agreement
 =============================

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,0 +1,32 @@
+MAINTAINERS INFO
+==========================================
+
+## Contributing
+
+For general PR creation and workflow, see [the contributing document][Contributing].
+
+## Porting
+
+For coordinating and porting NeoForge to new Minecraft versions, see [the porting workflow][Porting].
+Non-maintainers are not able to run all the required tooling for this.
+
+## Porting Labels
+
+PRs can be backported automatically to a specific minecraft version by having maintainers add the `backport to x.xx.x` label to the PR.
+A bot will generate a new PR and handle backporting to the best of its abilities but the PR may need manual fixing if it runs into issues.
+It is a good idea to test the backport PRs before merging in case the PR functionality is impacted by the older codebase.
+
+## Releases
+
+If a PR needs to be merged without triggering the workflow to generate a NeoForge release, follow [the documentation here](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs) for how to skip workflow runs. Essentially adding `[skip ci]` to the PR merge commit message will suffice.
+
+## Addition Policies
+
+- `c` tags are to be a standard between loaders with Fabric being our main partner in this effort. This means that `c` tags in 1.21+ NeoForge should be kept in sync with Fabric's `c` tags as close as possible. New `c` tags or changes to existing `c` tag should by ran by Fabric to ensure they will agree to make the same changes. This can be done by opening an issue report or PR on Fabric repository and link the NeoForge issue or PR to it. Only when Fabric agrees to merge the change, the corresponding NeoForge PR can then be merged.
+- PRs that had requested changes from a maintainer or has another maintainer assigned to the PR, these maintainer(s) should be contacted first before merging the PR to ensure they are ok with the final form of the PR and that their concerns were properly addressed. Along these lines, a maintainer's review should not be "dismissed" without checking with the maintainer.
+- Breaking change window for the NeoForge project will generally aim to last about 1 month after a significant Minecraft version.
+    - Hotfix Minecraft versions or very small Minecraft versions will not reset the breaking change window.
+    - This window is flexible and may be longer if there is significant breaking change PRs that need to be released for that Minecraft version but not yet ready. The 1 month timeframe is just a goal we would like to achieve, but we understand it is not always possible or optimal.
+
+[Contributing]: ../docs/CONTRIBUTING.md
+[Porting]: ../docs/PORTING.md

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -20,9 +20,8 @@ It is a good idea to test the backport PRs before merging in case the PR functio
 
 If a PR needs to be merged without triggering the workflow to generate a NeoForge release, follow [the documentation here](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs) for how to skip workflow runs. Essentially adding `[skip ci]` to the PR merge commit message will suffice.
 
-## Addition Policies
+## Notes
 
-- `c` tags are to be a standard between loaders with Fabric being our main partner in this effort. This means that `c` tags in 1.21+ NeoForge should be kept in sync with Fabric's `c` tags as close as possible. New `c` tags or changes to existing `c` tag should by ran by Fabric to ensure they will agree to make the same changes. This can be done by opening an issue report or PR on Fabric repository and link the NeoForge issue or PR to it. Only when Fabric agrees to merge the change, the corresponding NeoForge PR can then be merged.
 - PRs that had requested changes from a maintainer or has another maintainer assigned to the PR, these maintainer(s) should be contacted first before merging the PR to ensure they are ok with the final form of the PR and that their concerns were properly addressed. Along these lines, a maintainer's review should not be "dismissed" without checking with the maintainer.
 - Breaking change window for the NeoForge project will generally aim to last about 1 month after a significant Minecraft version.
     - Hotfix Minecraft versions or very small Minecraft versions will not reset the breaking change window.


### PR DESCRIPTION
Slicing up this original governance PR:
https://github.com/neoforged/governance/pull/20

The parts that made it to this PR while being NeoForge project specific are:

- the rules on `c` tags
- respecting maintainer request change comments on PRs
- our breaking change timeframe we hope to achieve are a target goal but understand it cannot always be met.

Additional info added:

- How to skip triggering neoforge releases on pr merges
- What backport labels do

This will help contributors and new maintainers to get up to speed on NeoForge a bit faster now