### PR TITLE
Re-add reading of additional level save data

### DIFF
--- a/patches/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java.patch
+++ b/patches/net/minecraft/client/gui/screens/worldselection/WorldOpenFlows.java.patch
@@ -12,6 +12,14 @@
          }
  
          this.minecraft.setScreen(new BackupConfirmScreen(p_307323_, (p_307085_, p_307086_) -> {
+@@ -272,6 +_,7 @@
+         try {
+             dynamic = p_330608_.getDataTag();
+             levelsummary = p_330608_.getSummary(dynamic);
++            p_330608_.readAdditionalLevelSaveData(false);
+         } catch (NbtException | ReportedNbtException | IOException ioexception) {
+             this.minecraft.setScreen(new RecoverWorldDataScreen(this.minecraft, p_329781_ -> {
+                 if (p_329781_) {
 @@ -381,10 +_,19 @@
          WorldData worlddata = p_330774_.worldData();
          boolean flag = worlddata.worldGenOptions().isOldCustomizedWorld();

--- a/patches/net/minecraft/world/level/storage/LevelStorageSource.java.patch
+++ b/patches/net/minecraft/world/level/storage/LevelStorageSource.java.patch
@@ -1,9 +1,10 @@
 --- a/net/minecraft/world/level/storage/LevelStorageSource.java
 +++ b/net/minecraft/world/level/storage/LevelStorageSource.java
-@@ -462,6 +_,18 @@
+@@ -462,6 +_,19 @@
              }
          }
  
++        // Neo: For reading NeoForge's additional save data (mod list, etc.)
 +        public void readAdditionalLevelSaveData(boolean fallback) {
 +            checkLock();
 +            Path path = fallback ? this.levelDirectory.oldDataFile() : this.levelDirectory.dataFile();


### PR DESCRIPTION
This PR fixes #2608 by re-adding a call to `LevelStorageSource.LevelStorageAccess#readAdditionalLevelSaveData` (a Neo-added method) to `WorldOpenFlows` which is used on the client, meaning ModMismatchEvent will now be fired again on the client.

The same method is already called from the dedicated server's `Main` class.

This also adds a comment to that method, to distinguish it better as a Neo-added method versus the other methods on the class.

