### PR TITLE
[1.21.5] Include remove entries when copying block tags

### DIFF
--- a/patches/net/minecraft/data/tags/ItemTagsProvider.java.patch
+++ b/patches/net/minecraft/data/tags/ItemTagsProvider.java.patch
@@ -39,3 +39,15 @@
          this.blockTags = p_275634_;
      }
  
+@@ -43,7 +_,10 @@
+             this.tagsToCopy.forEach((p_274763_, p_274764_) -> {
+                 TagBuilder tagbuilder = this.getOrCreateRawBuilder((TagKey<Item>)p_274764_);
+                 Optional<TagBuilder> optional = p_274767_.apply(p_274763_);
+-                optional.orElseThrow(() -> new IllegalStateException("Missing block tag " + p_274764_.location())).build().forEach(tagbuilder::add);
++                // Neo: Copy over the remove entries as well
++                var fromBuilder = optional.orElseThrow(() -> new IllegalStateException("Missing block tag " + p_274764_.location()));
++                fromBuilder.build().forEach(tagbuilder::add);
++                fromBuilder.getRemoveEntries().forEach(tagbuilder::remove);
+             });
+             return (HolderLookup.Provider)p_274766_;
+         });

--- a/tests/src/generated/resources/data/minecraft/tags/item/test_tag.json
+++ b/tests/src/generated/resources/data/minecraft/tags/item/test_tag.json
@@ -1,0 +1,14 @@
+{
+  "remove": [
+    "minecraft:dirt",
+    "minecraft:oak_door",
+    "minecraft:dark_oak_door",
+    "minecraft:anvil",
+    "minecraft:basalt",
+    "minecraft:polished_andesite",
+    "#minecraft:beehives",
+    "#minecraft:banners",
+    "#minecraft:beds"
+  ],
+  "values": []
+}

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/RemoveTagDatagenTest.java
@@ -25,7 +25,8 @@ import net.neoforged.neoforge.data.event.GatherDataEvent;
 @Mod(RemoveTagDatagenTest.MODID)
 public class RemoveTagDatagenTest {
     public static final String MODID = "remove_tag_datagen_test";
-    public static final TagKey<Block> TEST_TAG = BlockTags.create(ResourceLocation.withDefaultNamespace("test_tag"));
+    public static final TagKey<Block> TEST_TAG_BLOCK = BlockTags.create(ResourceLocation.withDefaultNamespace("test_tag"));
+    public static final TagKey<Item> TEST_TAG_ITEM = ItemTags.create(ResourceLocation.withDefaultNamespace("test_tag"));
 
     public RemoveTagDatagenTest(IEventBus modBus) {
         modBus.addListener(this::onGatherData);
@@ -38,7 +39,7 @@ public class RemoveTagDatagenTest {
             @SuppressWarnings("unchecked")
             @Override
             protected void addTags(HolderLookup.Provider provider) {
-                this.tag(TEST_TAG)
+                this.tag(TEST_TAG_BLOCK)
                         .remove(key(Blocks.DIRT))
                         .remove(key(Blocks.OAK_DOOR), key(Blocks.DARK_OAK_DOOR))
                         .remove(key(Blocks.ANVIL))
@@ -59,6 +60,8 @@ public class RemoveTagDatagenTest {
                 // Remove GOLD_ORE from the PIGLIN_LOVED tag, which is added by PIGLIN_LOVED reference to the GOLD_ORES tag
                 // This will make GOLD_ORE unable to be loved by piglins.
                 this.tag(ItemTags.PIGLIN_LOVED).remove(key(Items.GOLD_ORE));
+
+                this.copy(TEST_TAG_BLOCK, TEST_TAG_ITEM);
             }
         });
     }


### PR DESCRIPTION
This PR is a backport of #2607, which fixes #2589 by modifying `ItemTagsProvider` to also include the remove entries when copying a block tag over to an item tag.

This is a manual backport, as noted in the linked PR's description, due to the difference between `ItemTagsProvider` in this version versus `BlockTagCopyingItemTagProvider` in the linked PR.