### PR TITLE
[1.21.8] Fix IGuiGraphicsExtension#drawScrollingString() rendering scrolling and static strings at different y levels

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension.java
@@ -43,7 +43,7 @@ public interface IGuiGraphicsExtension {
         if (textWidth <= maxWidth) {
             self().drawString(font, text, minX, y, color);
         } else {
-            AbstractWidget.renderScrollingString(self(), font, text, minX, y, maxX, y + font.lineHeight, color);
+            AbstractWidget.renderScrollingString(self(), font, text, minX, y - 1, maxX, y + font.lineHeight, color);
         }
     }
 


### PR DESCRIPTION
This PR fixes the `IGuiGraphics#drawScrollingString()` helper rendering scrolling strings one pixel lower than static strings.