### PR TITLE
[1.21.1] Fix the bug that some blocks do not catch fire from lava when they should

### DIFF
--- a/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -80,7 +80,7 @@
      public abstract static class BlockStateBase extends StateHolder<Block, BlockState> {
          private final int lightEmission;
          private final boolean useShapeForLightOcclusion;
-@@ -523,12 +_,14 @@
+@@ -523,14 +_,18 @@
              return this.useShapeForLightOcclusion;
          }
  
@@ -95,7 +95,11 @@
 +            return this.getBlock().isAir((BlockState)this);
          }
  
++        /** @deprecated Neo: Use {@link net.neoforged.neoforge.common.extensions.IBlockStateExtension#ignitedByLava(BlockGetter, BlockPos, Direction)} instead */
++        @Deprecated
          public boolean ignitedByLava() {
+             return this.ignitedByLava;
+         }
 @@ -541,9 +_,11 @@
          }
  

--- a/patches/net/minecraft/world/level/material/LavaFluid.java.patch
+++ b/patches/net/minecraft/world/level/material/LavaFluid.java.patch
@@ -46,7 +46,7 @@
 +            return false;
 +        }
 +        BlockState state = level.getBlockState(pos);
-+        return state.ignitedByLava() && state.isFlammable(level, pos, face);
++        return state.ignitedByLava();
 +    }
 +
      @Nullable

--- a/patches/net/minecraft/world/level/material/LavaFluid.java.patch
+++ b/patches/net/minecraft/world/level/material/LavaFluid.java.patch
@@ -46,7 +46,7 @@
 +            return false;
 +        }
 +        BlockState state = level.getBlockState(pos);
-+        return state.ignitedByLava();
++        return state.ignitedByLava(level, pos, face);
 +    }
 +
      @Nullable

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -157,6 +157,19 @@ public interface IBlockExtension {
     }
 
     /**
+     * Called when lava is updating, checks if a block face can catch fire from lava.
+     *
+     * @param state     The current state
+     * @param level     The current level
+     * @param pos       Block position in level
+     * @param direction The direction that the fire is coming from
+     * @return True if the face can catch fire from lava, false otherwise.
+     */
+    default boolean ignitedByLava(BlockState state, BlockGetter level, BlockPos pos, Direction direction) {
+        return state.ignitedByLava();
+    }
+
+    /**
      * Checks if a player or entity can use this block to 'climb' like a ladder.
      *
      * @param state  The current state

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -92,6 +92,18 @@ public interface IBlockStateExtension {
     }
 
     /**
+     * Called when lava is updating, checks if a block face can catch fire from lava.
+     *
+     * @param level The current level
+     * @param pos   Block position in level
+     * @param face  The face that the fire is coming from
+     * @return True if the face can catch fire from lava, false otherwise.
+     */
+    default boolean ignitedByLava(BlockGetter level, BlockPos pos, Direction face) {
+        return self().getBlock().ignitedByLava(self(), level, pos, face);
+    }
+
+    /**
      * Checks if a player or entity can use this block to 'climb' like a ladder.
      *
      * @param level  The current level


### PR DESCRIPTION
## Summary

Backport of #2627
Resolves #2625 for `1.21.1` branch.

* Introduces new methods:
  * `IBlockExtension.ignitedByLava(BlockState, BlockGetter, BlockPos, Direction)`
  * `IBlockStateExtension.ignitedByLava(BlockGetter, BlockPos, Direction)`
* Patches the `LavaFluid.isFlammable(LevelReader, BlockPos, Direction)` to use the `IBlockStateExtension.ignitedByLava(BlockGetter, BlockPos, Direction)`

All images below are taken with `randomTickSpeed` set to `700`.
Vanilla:
<img width="3840" height="2036" alt="Vanilla" src="https://github.com/user-attachments/assets/37eb0697-4641-48ba-b998-ed9c18425b2f" />

Before patches (NeoForge 21.1.208):
<img width="3840" height="2036" alt="Before" src="https://github.com/user-attachments/assets/9b63dbc7-386a-4781-930a-aa3c49c53ecc" />

After patches (this PR):
<img width="3840" height="2036" alt="After" src="https://github.com/user-attachments/assets/cff7c03a-4fdc-4def-81b0-bce291011d45" />