### PR TITLE
[1.21.x] Fix the bug that some blocks do not catch fire from lava when they should

### DIFF
--- a/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
+++ b/patches/net/minecraft/world/level/block/state/BlockBehaviour.java.patch
@@ -69,7 +69,7 @@
                  }
              }
  
-@@ -563,12 +_,14 @@
+@@ -563,14 +_,18 @@
              return this.useShapeForLightOcclusion;
          }
  
@@ -84,7 +84,11 @@
 +            return this.getBlock().isAir((BlockState)this);
          }
  
++        /** @deprecated Neo: Use {@link net.neoforged.neoforge.common.extensions.IBlockStateExtension#ignitedByLava(BlockGetter, BlockPos, Direction)} instead */
++        @Deprecated
          public boolean ignitedByLava() {
+             return this.ignitedByLava;
+         }
 @@ -581,9 +_,11 @@
          }
  

--- a/patches/net/minecraft/world/level/material/LavaFluid.java.patch
+++ b/patches/net/minecraft/world/level/material/LavaFluid.java.patch
@@ -44,7 +44,7 @@
 +            return false;
 +        }
 +        BlockState state = level.getBlockState(pos);
-+        return state.ignitedByLava();
++        return state.ignitedByLava(level, pos, face);
 +    }
 +
      @Nullable

--- a/patches/net/minecraft/world/level/material/LavaFluid.java.patch
+++ b/patches/net/minecraft/world/level/material/LavaFluid.java.patch
@@ -44,7 +44,7 @@
 +            return false;
 +        }
 +        BlockState state = level.getBlockState(pos);
-+        return state.ignitedByLava() && state.isFlammable(level, pos, face);
++        return state.ignitedByLava();
 +    }
 +
      @Nullable

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -153,6 +153,19 @@ public interface IBlockExtension {
     }
 
     /**
+     * Called when lava is updating, checks if a block face can catch fire from lava.
+     *
+     * @param state     The current state
+     * @param level     The current level
+     * @param pos       Block position in level
+     * @param direction The direction that the fire is coming from
+     * @return True if the face can catch fire from lava, false otherwise.
+     */
+    default boolean ignitedByLava(BlockState state, BlockGetter level, BlockPos pos, Direction direction) {
+        return state.ignitedByLava();
+    }
+
+    /**
      * Checks if a player or entity can use this block to 'climb' like a ladder.
      *
      * @param state  The current state

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -90,6 +90,18 @@ public interface IBlockStateExtension {
     }
 
     /**
+     * Called when lava is updating, checks if a block face can catch fire from lava.
+     *
+     * @param level The current level
+     * @param pos   Block position in level
+     * @param face  The face that the fire is coming from
+     * @return True if the face can catch fire from lava, false otherwise.
+     */
+    default boolean ignitedByLava(BlockGetter level, BlockPos pos, Direction face) {
+        return self().getBlock().ignitedByLava(self(), level, pos, face);
+    }
+
+    /**
      * Checks if a player or entity can use this block to 'climb' like a ladder.
      *
      * @param level  The current level


### PR DESCRIPTION
## Summary

Resolves #2625 .

* Introduces new methods:
  * `IBlockExtension.ignitedByLava(BlockState, BlockGetter, BlockPos, Direction)`
  * `IBlockStateExtension.ignitedByLava(BlockGetter, BlockPos, Direction)`
* Patches the `LavaFluid.isFlammable(LevelReader, BlockPos, Direction)` to use the `IBlockStateExtension.ignitedByLava(BlockGetter, BlockPos, Direction)`

All images below are taken with `randomTickSpeed` set to `700`.
Vanilla:
<img width="3840" height="2036" alt="Vanilla" src="https://github.com/user-attachments/assets/584e3e03-5775-4198-a282-80f1dd80fc90" />

Before patches (NeoForge 21.8.45):
<img width="3840" height="2036" alt="Before" src="https://github.com/user-attachments/assets/9b4530e0-2812-4e02-b9b1-d2ec77854f75" />

After patches (this PR):
<img width="3840" height="2036" alt="After" src="https://github.com/user-attachments/assets/b04b8280-6cae-4c36-a4f9-5d3960ec087d" />