### PR TITLE
[1.21.9] Handle key mapping category registration and sorting

### DIFF
--- a/patches/net/minecraft/client/KeyMapping.java.patch
+++ b/patches/net/minecraft/client/KeyMapping.java.patch
@@ -167,3 +167,14 @@
      }
  
      @Nullable
+@@ -206,6 +_,10 @@
+             return register(ResourceLocation.withDefaultNamespace(p_449101_));
+         }
+ 
++        /**
++         * @deprecated Neo: use {@link net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent#registerCategory(Category)} instead
++         */
++        @Deprecated
+         public static KeyMapping.Category register(ResourceLocation p_449977_) {
+             KeyMapping.Category keymapping$category = new KeyMapping.Category(p_449977_);
+             if (SORT_ORDER.contains(keymapping$category)) {

--- a/patches/net/minecraft/client/Options.java.patch
+++ b/patches/net/minecraft/client/Options.java.patch
@@ -33,7 +33,7 @@
              p_426141_ -> {}
          );
          this.syncWrites = Util.getPlatform() == Util.OS.WINDOWS;
-+        net.neoforged.neoforge.client.ClientHooks.onRegisterKeyMappings(this);
++        net.neoforged.neoforge.client.ClientHooks.onRegisterKeyMappings(this, KeyMapping.Category.SORT_ORDER);
          this.load();
      }
  

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -719,9 +719,9 @@ public class ClientHooks {
     }
 
     public static void onRegisterKeyMappings(Options options, List<KeyMapping.Category> categories) {
-        RegisterKeyMappingsEvent event = new RegisterKeyMappingsEvent(options, categories);
+        RegisterKeyMappingsEvent event = new RegisterKeyMappingsEvent(options);
         ModLoader.postEvent(event);
-        event.sortAndStoreCategories();
+        event.sortAndStoreCategories(categories);
     }
 
     @Nullable

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -718,8 +718,10 @@ public class ClientHooks {
         ModLoader.postEvent(new RegisterParticleProvidersEvent(particleResources));
     }
 
-    public static void onRegisterKeyMappings(Options options) {
-        ModLoader.postEvent(new RegisterKeyMappingsEvent(options));
+    public static void onRegisterKeyMappings(Options options, List<KeyMapping.Category> categories) {
+        RegisterKeyMappingsEvent event = new RegisterKeyMappingsEvent(options, categories);
+        ModLoader.postEvent(event);
+        event.sortAndStoreCategories();
     }
 
     @Nullable

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -718,6 +718,7 @@ public class ClientHooks {
         ModLoader.postEvent(new RegisterParticleProvidersEvent(particleResources));
     }
 
+    @ApiStatus.Internal
     public static void onRegisterKeyMappings(Options options, List<KeyMapping.Category> categories) {
         RegisterKeyMappingsEvent event = new RegisterKeyMappingsEvent(options);
         ModLoader.postEvent(event);

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
@@ -5,19 +5,11 @@
 
 package net.neoforged.neoforge.client.event;
 
-import com.google.common.graph.ElementOrder;
-import com.google.common.graph.GraphBuilder;
-import com.google.common.graph.Graphs;
-import com.google.common.graph.MutableGraph;
-import com.google.common.graph.Traverser;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
 import net.minecraft.resources.ResourceLocation;
@@ -25,8 +17,6 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.event.IModBusEvent;
-import net.neoforged.fml.loading.toposort.CyclePresentException;
-import net.neoforged.fml.loading.toposort.TopologicalSort;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -37,27 +27,15 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-@SuppressWarnings("UnstableApiUsage")
 public class RegisterKeyMappingsEvent extends Event implements IModBusEvent {
     private final Options options;
     private final List<KeyMapping.Category> categories;
-    private final Set<KeyMapping.Category> vanillaCategories;
-    private final Map<ResourceLocation, KeyMapping.Category> categoriesById = new HashMap<>();
-    private final MutableGraph<KeyMapping.Category> graph = GraphBuilder.directed().nodeOrder(ElementOrder.insertion()).build();
+    private final Map<ResourceLocation, KeyMapping.Category> moddedCategories = new HashMap<>();
 
     @ApiStatus.Internal
     public RegisterKeyMappingsEvent(Options options, List<KeyMapping.Category> categories) {
         this.options = options;
         this.categories = categories;
-        this.vanillaCategories = Set.copyOf(categories);
-        for (KeyMapping.Category category : categories) {
-            this.categoriesById.put(category.id(), category);
-            this.graph.addNode(category);
-        }
-        for (int i = 1; i < categories.size(); i++) {
-            KeyMapping.Category category = categories.get(i);
-            this.graph.putEdge(categories.get(i - 1), category);
-        }
     }
 
     /**
@@ -71,108 +49,15 @@ public class RegisterKeyMappingsEvent extends Event implements IModBusEvent {
      * Register a new key mapping category.
      */
     public void registerCategory(KeyMapping.Category category) {
-        if (this.categoriesById.putIfAbsent(category.id(), category) != null) {
+        if (this.moddedCategories.putIfAbsent(category.id(), category) != null) {
             throw new IllegalArgumentException(String.format(Locale.ROOT, "KeyMapping.Category '%s' is already registered.", category.id()));
         }
-        this.graph.addNode(category);
-    }
-
-    /**
-     * Adds a new dependency entry, such that {@code first} must be placed before {@code second} in the controls screen.
-     * <p>
-     * Introduction of dependency cycles (first->second->first) will cause an error when the event is finished.
-     *
-     * @param first  The key of the category that must be placed first.
-     * @param second The key of the category that must be placed after {@code first}.
-     *
-     * @throws IllegalArgumentException if either {@code first} or {@code second} has not been registered via {@link #registerCategory}.
-     */
-    public void addCategoryDependency(ResourceLocation first, ResourceLocation second) {
-        KeyMapping.Category firstCat = this.categoriesById.get(first);
-        if (firstCat == null) {
-            throw new IllegalArgumentException("Unknown KeyMapping.Category: " + first);
-        }
-        KeyMapping.Category secondCat = this.categoriesById.get(second);
-        if (secondCat == null) {
-            throw new IllegalArgumentException("Unknown KeyMapping.Category: " + second);
-        }
-
-        this.graph.putEdge(firstCat, secondCat);
     }
 
     @ApiStatus.Internal
     public void sortAndStoreCategories() {
-        if (this.categoriesById.size() == this.categories.size()) {
-            return;
-        }
-
-        // For any entries without a dependency, ensure they depend on the last vanilla category.
-        KeyMapping.Category lastVanilla = this.categories.getLast();
-        for (KeyMapping.Category category : this.categoriesById.values()) {
-            if (needsToBeLinkedToVanilla(category)) {
-                this.graph.putEdge(lastVanilla, category);
-            }
-        }
-
-        // Then do the sort.
-        try {
-            List<KeyMapping.Category> sorted = TopologicalSort.topologicalSort(
-                    this.graph,
-                    Comparator.comparing(KeyMapping.Category::id, ResourceLocation::compareNamespaced));
-            this.categories.clear();
-            this.categories.addAll(sorted);
-        } catch (CyclePresentException e) {
-            // If a cycle is found, we have to transform the information in the exception back into the registered keys.
-            Set<Set<KeyMapping.Category>> cycles = e.getCycles();
-            Set<Set<ResourceLocation>> keyedCycles = cycles.stream().map(set -> {
-                return set.stream().map(KeyMapping.Category::id).collect(Collectors.toCollection(LinkedHashSet::new));
-            }).collect(Collectors.toSet());
-
-            // Finally, build a real error message and re-throw.
-            StringBuilder sb = new StringBuilder();
-            sb.append("Cycles were detected during key mapping category sorting:").append('\n');
-
-            int idx = 0;
-            for (Set<ResourceLocation> cycle : keyedCycles) {
-                StringBuilder msg = new StringBuilder();
-
-                msg.append(idx++).append(": ");
-
-                for (ResourceLocation key : cycle) {
-                    msg.append(key).append("->");
-                }
-
-                msg.append(cycle.iterator().next());
-
-                sb.append(msg);
-                sb.append('\n');
-            }
-
-            throw new IllegalArgumentException(sb.toString());
-        }
-    }
-
-    private boolean needsToBeLinkedToVanilla(KeyMapping.Category category) {
-        if (isVanilla(category)) {
-            return false;
-        }
-
-        for (KeyMapping.Category node : Traverser.forGraph(graph).depthFirstPreOrder(category)) {
-            if (isVanilla(node)) {
-                return false;
-            }
-        }
-
-        for (KeyMapping.Category node : Traverser.forGraph(Graphs.transpose(graph)).depthFirstPreOrder(category)) {
-            if (isVanilla(node)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private boolean isVanilla(KeyMapping.Category category) {
-        return this.vanillaCategories.contains(category);
+        List<KeyMapping.Category> custom = new ArrayList<>(this.moddedCategories.values());
+        custom.sort((c1, c2) -> c1.id().compareNamespaced(c2.id()));
+        this.categories.addAll(custom);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
@@ -54,10 +54,9 @@ public class RegisterKeyMappingsEvent extends Event implements IModBusEvent {
             this.categoriesById.put(category.id(), category);
             this.graph.addNode(category);
         }
-        for (int i = 1; i < categories.size() - 1; i++) {
+        for (int i = 1; i < categories.size(); i++) {
             KeyMapping.Category category = categories.get(i);
             this.graph.putEdge(categories.get(i - 1), category);
-            this.graph.putEdge(category, categories.get(i + 1));
         }
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
@@ -29,13 +29,11 @@ import org.jetbrains.annotations.ApiStatus;
  */
 public class RegisterKeyMappingsEvent extends Event implements IModBusEvent {
     private final Options options;
-    private final List<KeyMapping.Category> categories;
     private final Map<ResourceLocation, KeyMapping.Category> moddedCategories = new HashMap<>();
 
     @ApiStatus.Internal
-    public RegisterKeyMappingsEvent(Options options, List<KeyMapping.Category> categories) {
+    public RegisterKeyMappingsEvent(Options options) {
         this.options = options;
-        this.categories = categories;
     }
 
     /**
@@ -55,9 +53,9 @@ public class RegisterKeyMappingsEvent extends Event implements IModBusEvent {
     }
 
     @ApiStatus.Internal
-    public void sortAndStoreCategories() {
+    public void sortAndStoreCategories(List<KeyMapping.Category> categories) {
         List<KeyMapping.Category> custom = new ArrayList<>(this.moddedCategories.values());
         custom.sort((c1, c2) -> c1.id().compareNamespaced(c2.id()));
-        this.categories.addAll(custom);
+        categories.addAll(custom);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterKeyMappingsEvent.java
@@ -5,34 +5,175 @@
 
 package net.neoforged.neoforge.client.event;
 
+import com.google.common.graph.ElementOrder;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.Graphs;
+import com.google.common.graph.MutableGraph;
+import com.google.common.graph.Traverser;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Options;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.fml.loading.toposort.CyclePresentException;
+import net.neoforged.fml.loading.toposort.TopologicalSort;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * Allows users to register custom {@link net.minecraft.client.KeyMapping key mappings}.
+ * Allows users to register custom {@link KeyMapping key mappings} and {@link KeyMapping.Category key mapping categories}.
  *
- * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}.
  *
  * <p>This event is fired on the mod-specific event bus, only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
+@SuppressWarnings("UnstableApiUsage")
 public class RegisterKeyMappingsEvent extends Event implements IModBusEvent {
     private final Options options;
+    private final List<KeyMapping.Category> categories;
+    private final Set<KeyMapping.Category> vanillaCategories;
+    private final Map<ResourceLocation, KeyMapping.Category> categoriesById = new HashMap<>();
+    private final MutableGraph<KeyMapping.Category> graph = GraphBuilder.directed().nodeOrder(ElementOrder.insertion()).build();
 
     @ApiStatus.Internal
-    public RegisterKeyMappingsEvent(Options options) {
+    public RegisterKeyMappingsEvent(Options options, List<KeyMapping.Category> categories) {
         this.options = options;
+        this.categories = categories;
+        this.vanillaCategories = Set.copyOf(categories);
+        for (KeyMapping.Category category : categories) {
+            this.categoriesById.put(category.id(), category);
+            this.graph.addNode(category);
+        }
+        for (int i = 1; i < categories.size() - 1; i++) {
+            KeyMapping.Category category = categories.get(i);
+            this.graph.putEdge(categories.get(i - 1), category);
+            this.graph.putEdge(category, categories.get(i + 1));
+        }
     }
 
     /**
-     * Registers a new key mapping.
+     * Register a new key mapping.
      */
     public void register(KeyMapping key) {
         options.keyMappings = ArrayUtils.add(options.keyMappings, key);
+    }
+
+    /**
+     * Register a new key mapping category.
+     */
+    public void registerCategory(KeyMapping.Category category) {
+        if (this.categoriesById.putIfAbsent(category.id(), category) != null) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT, "KeyMapping.Category '%s' is already registered.", category.id()));
+        }
+        this.graph.addNode(category);
+    }
+
+    /**
+     * Adds a new dependency entry, such that {@code first} must be placed before {@code second} in the controls screen.
+     * <p>
+     * Introduction of dependency cycles (first->second->first) will cause an error when the event is finished.
+     *
+     * @param first  The key of the category that must be placed first.
+     * @param second The key of the category that must be placed after {@code first}.
+     *
+     * @throws IllegalArgumentException if either {@code first} or {@code second} has not been registered via {@link #registerCategory}.
+     */
+    public void addCategoryDependency(ResourceLocation first, ResourceLocation second) {
+        KeyMapping.Category firstCat = this.categoriesById.get(first);
+        if (firstCat == null) {
+            throw new IllegalArgumentException("Unknown KeyMapping.Category: " + first);
+        }
+        KeyMapping.Category secondCat = this.categoriesById.get(second);
+        if (secondCat == null) {
+            throw new IllegalArgumentException("Unknown KeyMapping.Category: " + second);
+        }
+
+        this.graph.putEdge(firstCat, secondCat);
+    }
+
+    @ApiStatus.Internal
+    public void sortAndStoreCategories() {
+        if (this.categoriesById.size() == this.categories.size()) {
+            return;
+        }
+
+        // For any entries without a dependency, ensure they depend on the last vanilla category.
+        KeyMapping.Category lastVanilla = this.categories.getLast();
+        for (KeyMapping.Category category : this.categoriesById.values()) {
+            if (needsToBeLinkedToVanilla(category)) {
+                this.graph.putEdge(lastVanilla, category);
+            }
+        }
+
+        // Then do the sort.
+        try {
+            List<KeyMapping.Category> sorted = TopologicalSort.topologicalSort(
+                    this.graph,
+                    Comparator.comparing(KeyMapping.Category::id, ResourceLocation::compareNamespaced));
+            this.categories.clear();
+            this.categories.addAll(sorted);
+        } catch (CyclePresentException e) {
+            // If a cycle is found, we have to transform the information in the exception back into the registered keys.
+            Set<Set<KeyMapping.Category>> cycles = e.getCycles();
+            Set<Set<ResourceLocation>> keyedCycles = cycles.stream().map(set -> {
+                return set.stream().map(KeyMapping.Category::id).collect(Collectors.toCollection(LinkedHashSet::new));
+            }).collect(Collectors.toSet());
+
+            // Finally, build a real error message and re-throw.
+            StringBuilder sb = new StringBuilder();
+            sb.append("Cycles were detected during key mapping category sorting:").append('\n');
+
+            int idx = 0;
+            for (Set<ResourceLocation> cycle : keyedCycles) {
+                StringBuilder msg = new StringBuilder();
+
+                msg.append(idx++).append(": ");
+
+                for (ResourceLocation key : cycle) {
+                    msg.append(key).append("->");
+                }
+
+                msg.append(cycle.iterator().next());
+
+                sb.append(msg);
+                sb.append('\n');
+            }
+
+            throw new IllegalArgumentException(sb.toString());
+        }
+    }
+
+    private boolean needsToBeLinkedToVanilla(KeyMapping.Category category) {
+        if (isVanilla(category)) {
+            return false;
+        }
+
+        for (KeyMapping.Category node : Traverser.forGraph(graph).depthFirstPreOrder(category)) {
+            if (isVanilla(node)) {
+                return false;
+            }
+        }
+
+        for (KeyMapping.Category node : Traverser.forGraph(Graphs.transpose(graph)).depthFirstPreOrder(category)) {
+            if (isVanilla(node)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isVanilla(KeyMapping.Category category) {
+        return this.vanillaCategories.contains(category);
     }
 }

--- a/testframework/src/main/java/net/neoforged/testframework/client/FrameworkClientImpl.java
+++ b/testframework/src/main/java/net/neoforged/testframework/client/FrameworkClientImpl.java
@@ -34,13 +34,15 @@ public class FrameworkClientImpl implements FrameworkClient {
 
     @Override
     public void init(IEventBus modBus, ModContainer container) {
-        // TODO Porting: make KeyMapping.Category extensible or get mojang to make it not an enum
-        final KeyMapping.Category keyCategory = KeyMapping.Category.MISC;//"key.categories." + impl.id().getNamespace() + "." + impl.id().getPath();
+        final KeyMapping.Category keyCategory = new KeyMapping.Category(impl.id());
 
         final BooleanSupplier overlayEnabled;
         if (configuration.toggleOverlayKey() != 0) {
             final ToggleKeyMapping overlayKey = new ToggleKeyMapping("key.testframework.toggleoverlay", configuration.toggleOverlayKey(), keyCategory, () -> true, true);
-            modBus.addListener((final RegisterKeyMappingsEvent event) -> event.register(overlayKey));
+            modBus.addListener((final RegisterKeyMappingsEvent event) -> {
+                event.register(overlayKey);
+                event.registerCategory(keyCategory);
+            });
             overlayEnabled = () -> !overlayKey.isDown();
         } else {
             overlayEnabled = () -> true;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientTests.java
@@ -112,7 +112,6 @@ public class ClientTests {
 
         test.framework().modEventBus().addListener((final RegisterKeyMappingsEvent event) -> {
             event.registerCategory(categoryOne);
-            event.addCategoryDependency(categoryOne.id(), KeyMapping.Category.INVENTORY.id());
             event.registerCategory(categoryThree);
             event.registerCategory(categoryTwo);
         });
@@ -126,8 +125,8 @@ public class ClientTests {
                 return;
             }
 
-            if (categories.indexOf(categoryOne) > categories.indexOf(KeyMapping.Category.INVENTORY)) {
-                test.fail("Expected 'test_category_1' before 'inventory' category due to explicit dependency");
+            if (categories.indexOf(categoryOne) < categories.indexOf(KeyMapping.Category.SPECTATOR)) {
+                test.fail("Expected custom categories after vanilla categories");
                 return;
             }
             if (categories.indexOf(categoryTwo) > categories.indexOf(categoryThree)) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientTests.java
@@ -7,6 +7,8 @@ package net.neoforged.neoforge.debug.client;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import javax.sound.sampled.AudioFormat;
 import net.minecraft.client.DeltaTracker;
@@ -32,11 +34,13 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.util.ObfuscationReflectionHelper;
 import net.neoforged.neoforge.client.event.ClientChatEvent;
 import net.neoforged.neoforge.client.event.ClientResourceLoadFinishedEvent;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
+import net.neoforged.neoforge.client.event.lifecycle.ClientStartedEvent;
 import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
 import net.neoforged.neoforge.common.data.LanguageProvider;
@@ -92,6 +96,45 @@ public class ClientTests {
                     test.pass();
                 }
             }
+        });
+    }
+
+    @TestHolder(description = "Tests that custom key mapping categories and their sorting works correctly", enabledByDefault = true)
+    static void keyMappingCategoriesTest(final DynamicTest test) {
+        KeyMapping.Category categoryOne = new KeyMapping.Category(ResourceLocation.fromNamespaceAndPath(test.createModId(), "test_category_1"));
+        KeyMapping.Category categoryTwo = new KeyMapping.Category(ResourceLocation.fromNamespaceAndPath(test.createModId(), "test_category_2"));
+        KeyMapping.Category categoryThree = new KeyMapping.Category(ResourceLocation.fromNamespaceAndPath(test.createModId(), "test_category_3"));
+
+        List<KeyMapping.Category> categories = ObfuscationReflectionHelper.getPrivateValue(KeyMapping.Category.class, null, "SORT_ORDER");
+        Objects.requireNonNull(categories);
+
+        List<KeyMapping.Category> vanillaCategories = List.copyOf(categories);
+
+        test.framework().modEventBus().addListener((final RegisterKeyMappingsEvent event) -> {
+            event.registerCategory(categoryOne);
+            event.addCategoryDependency(categoryOne.id(), KeyMapping.Category.INVENTORY.id());
+            event.registerCategory(categoryThree);
+            event.registerCategory(categoryTwo);
+        });
+
+        test.eventListeners().forge().addListener((final ClientStartedEvent event) -> {
+            List<KeyMapping.Category> sortedVanillaCategories = categories.stream()
+                    .filter(cat -> cat.id().getNamespace().equals("minecraft"))
+                    .toList();
+            if (!sortedVanillaCategories.equals(vanillaCategories)) {
+                test.fail("Expected vanilla category order to be retained through sorting");
+                return;
+            }
+
+            if (categories.indexOf(categoryOne) > categories.indexOf(KeyMapping.Category.INVENTORY)) {
+                test.fail("Expected 'test_category_1' before 'inventory' category due to explicit dependency");
+                return;
+            }
+            if (categories.indexOf(categoryTwo) > categories.indexOf(categoryThree)) {
+                test.fail("Expected 'test_category_2' before 'test_category_3' due to lexicographical sorting");
+                return;
+            }
+            test.pass();
         });
     }
 


### PR DESCRIPTION
This PR adds functionality for registering custom `KeyMapping.Category`s to the `RegisterKeyMappingsEvent`. The registered categories are sorted by namespace and path before adding them to the vanilla category list.