### PR TITLE
[1.21.9] Make data-driven keyframe animations accessible to custom ItemModels and SpecialModelRenderers

### DIFF
--- a/patches/net/minecraft/client/renderer/item/ItemModel.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemModel.java.patch
@@ -4,7 +4,7 @@
          PlayerSkinRenderCache playerSkinRenderCache,
          ItemModel missingItemModel,
          @Nullable RegistryContextSwapper contextSwapper
-+        , @Nullable net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
++        , net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
      ) implements SpecialModelRenderer.BakingContext {
 +        /**
 +         * @deprecated Neo: use {@link #BakingContext(ModelBaker, EntityModelSet, MaterialSet, PlayerSkinRenderCache, ItemModel, RegistryContextSwapper, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations)} instead
@@ -18,7 +18,7 @@
 +                ItemModel missingItemModel,
 +                @Nullable RegistryContextSwapper contextSwapper
 +        ) {
-+            this(blockModelBaker, entityModelSet, materials, playerSkinRenderCache, missingItemModel, contextSwapper, null);
++            this(blockModelBaker, entityModelSet, materials, playerSkinRenderCache, missingItemModel, contextSwapper, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations.EMPTY);
 +        }
      }
  

--- a/patches/net/minecraft/client/renderer/item/ItemModel.java.patch
+++ b/patches/net/minecraft/client/renderer/item/ItemModel.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/client/renderer/item/ItemModel.java
++++ b/net/minecraft/client/renderer/item/ItemModel.java
+@@ -36,7 +_,22 @@
+         PlayerSkinRenderCache playerSkinRenderCache,
+         ItemModel missingItemModel,
+         @Nullable RegistryContextSwapper contextSwapper
++        , @Nullable net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
+     ) implements SpecialModelRenderer.BakingContext {
++        /**
++         * @deprecated Neo: use {@link #BakingContext(ModelBaker, EntityModelSet, MaterialSet, PlayerSkinRenderCache, ItemModel, RegistryContextSwapper, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations)} instead
++         */
++        @Deprecated
++        public BakingContext(
++                ModelBaker blockModelBaker,
++                EntityModelSet entityModelSet,
++                MaterialSet materials,
++                PlayerSkinRenderCache playerSkinRenderCache,
++                ItemModel missingItemModel,
++                @Nullable RegistryContextSwapper contextSwapper
++        ) {
++            this(blockModelBaker, entityModelSet, materials, playerSkinRenderCache, missingItemModel, contextSwapper, null);
++        }
+     }
+ 
+     @OnlyIn(Dist.CLIENT)

--- a/patches/net/minecraft/client/renderer/special/SpecialModelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/special/SpecialModelRenderer.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/client/renderer/special/SpecialModelRenderer.java
++++ b/net/minecraft/client/renderer/special/SpecialModelRenderer.java
+@@ -39,9 +_,25 @@
+ 
+         PlayerSkinRenderCache playerSkinRenderCache();
+ 
++        /**
++         * Provides access to the data-driven keyframe animations being loaded by the {@code AnimationLoader}
++         */
++        @Nullable
++        default net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations() {
++            return null;
++        }
++
+         @OnlyIn(Dist.CLIENT)
+-        public record Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache)
++        public record Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache, @Nullable net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations)
+             implements SpecialModelRenderer.BakingContext {
++
++            /**
++             * @deprecated Neo: use {@link #Simple(EntityModelSet, MaterialSet, PlayerSkinRenderCache, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations)} instead
++             */
++            @Deprecated
++            public Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache) {
++                this(entityModelSet, materials, playerSkinRenderCache, null);
++            }
+         }
+     }
+ 

--- a/patches/net/minecraft/client/renderer/special/SpecialModelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/special/SpecialModelRenderer.java.patch
@@ -1,20 +1,19 @@
 --- a/net/minecraft/client/renderer/special/SpecialModelRenderer.java
 +++ b/net/minecraft/client/renderer/special/SpecialModelRenderer.java
-@@ -39,9 +_,25 @@
+@@ -39,9 +_,24 @@
  
          PlayerSkinRenderCache playerSkinRenderCache();
  
 +        /**
 +         * Provides access to the data-driven keyframe animations being loaded by the {@code AnimationLoader}
 +         */
-+        @Nullable
 +        default net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations() {
-+            return null;
++            return net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations.EMPTY;
 +        }
 +
          @OnlyIn(Dist.CLIENT)
 -        public record Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache)
-+        public record Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache, @Nullable net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations)
++        public record Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations)
              implements SpecialModelRenderer.BakingContext {
 +
 +            /**
@@ -22,7 +21,7 @@
 +             */
 +            @Deprecated
 +            public Simple(EntityModelSet entityModelSet, MaterialSet materials, PlayerSkinRenderCache playerSkinRenderCache) {
-+                this(entityModelSet, materials, playerSkinRenderCache, null);
++                this(entityModelSet, materials, playerSkinRenderCache, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations.EMPTY);
 +            }
          }
      }

--- a/patches/net/minecraft/client/renderer/special/SpecialModelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/special/SpecialModelRenderer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/special/SpecialModelRenderer.java
 +++ b/net/minecraft/client/renderer/special/SpecialModelRenderer.java
-@@ -39,9 +_,24 @@
+@@ -40,9 +_,24 @@
  
          PlayerSkinRenderCache playerSkinRenderCache();
  

--- a/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/client/resources/model/ModelBakery.java
 +++ b/net/minecraft/client/resources/model/ModelBakery.java
-@@ -57,7 +_,14 @@
+@@ -57,7 +_,13 @@
      private final Map<ResourceLocation, ClientItem> clientInfos;
      final Map<ResourceLocation, ResolvedModel> resolvedModels;
      final ResolvedModel missingModel;
 +    private final net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels;
-+    @org.jetbrains.annotations.Nullable
 +    private final net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations;
  
 +    /**
@@ -19,7 +18,7 @@
          Map<ResourceLocation, ResolvedModel> p_388404_,
          ResolvedModel p_404940_
      ) {
-+        this(p_388903_, p_434703_, p_440085_, p_251087_, p_250416_, p_388404_, p_404940_, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels.EMPTY, null);
++        this(p_388903_, p_434703_, p_440085_, p_251087_, p_250416_, p_388404_, p_404940_, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels.EMPTY, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations.EMPTY);
 +    }
 +
 +    public ModelBakery(
@@ -31,7 +30,7 @@
 +        Map<ResourceLocation, ResolvedModel> p_388404_,
 +        ResolvedModel p_404940_,
 +        net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels,
-+        @org.jetbrains.annotations.Nullable net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
++        net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
 +    ) {
          this.entityModelSet = p_388903_;
          this.materials = p_434703_;

--- a/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,23 +1,25 @@
 --- a/net/minecraft/client/resources/model/ModelBakery.java
 +++ b/net/minecraft/client/resources/model/ModelBakery.java
-@@ -57,7 +_,12 @@
+@@ -57,7 +_,14 @@
      private final Map<ResourceLocation, ClientItem> clientInfos;
      final Map<ResourceLocation, ResolvedModel> resolvedModels;
      final ResolvedModel missingModel;
 +    private final net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels;
++    @org.jetbrains.annotations.Nullable
++    private final net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations;
  
 +    /**
-+     * @deprecated Neo: use {@link #ModelBakery(EntityModelSet, MaterialSet, PlayerSkinRenderCache, Map, Map, Map, ResolvedModel, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels)} instead
++     * @deprecated Neo: use {@link #ModelBakery(EntityModelSet, MaterialSet, PlayerSkinRenderCache, Map, Map, Map, ResolvedModel, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels, net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations)} instead
 +     */
 +    @Deprecated
      public ModelBakery(
          EntityModelSet p_388903_,
          MaterialSet p_434703_,
-@@ -67,6 +_,19 @@
+@@ -67,6 +_,20 @@
          Map<ResourceLocation, ResolvedModel> p_388404_,
          ResolvedModel p_404940_
      ) {
-+        this(p_388903_, p_434703_, p_440085_, p_251087_, p_250416_, p_388404_, p_404940_, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels.EMPTY);
++        this(p_388903_, p_434703_, p_440085_, p_251087_, p_250416_, p_388404_, p_404940_, net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels.EMPTY, null);
 +    }
 +
 +    public ModelBakery(
@@ -28,19 +30,29 @@
 +        Map<ResourceLocation, ClientItem> p_250416_,
 +        Map<ResourceLocation, ResolvedModel> p_388404_,
 +        ResolvedModel p_404940_,
-+        net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels
++        net.neoforged.neoforge.client.model.standalone.StandaloneModelLoader.LoadedModels standaloneModels,
++        @org.jetbrains.annotations.Nullable net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.PendingAnimations pendingAnimations
 +    ) {
          this.entityModelSet = p_388903_;
          this.materials = p_434703_;
          this.playerSkinRenderCache = p_440085_;
-@@ -74,6 +_,7 @@
+@@ -74,6 +_,8 @@
          this.clientInfos = p_250416_;
          this.resolvedModels = p_388404_;
          this.missingModel = p_404940_;
 +        this.standaloneModels = standaloneModels;
++        this.pendingAnimations = pendingAnimations;
      }
  
      public CompletableFuture<ModelBakery.BakingResult> bakeModels(SpriteGetter p_404922_, Executor p_405407_) {
+@@ -102,6 +_,7 @@
+                                 this.playerSkinRenderCache,
+                                 modelbakery$missingmodels.item,
+                                 p_438822_.registrySwapper()
++                                , this.pendingAnimations
+                             )
+                         );
+                 } catch (Exception exception) {
 @@ -111,6 +_,8 @@
              },
              p_405407_

--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -26,7 +26,18 @@
      }
  
      public ClientItem.Properties getItemProperties(ResourceLocation p_390438_) {
-@@ -105,8 +_,10 @@
+@@ -96,17 +_,20 @@
+     ) {
+         ResourceManager resourcemanager = p_433049_.resourceManager();
+         CompletableFuture<EntityModelSet> completablefuture = CompletableFuture.supplyAsync(EntityModelSet::vanilla, p_250550_);
++        var pendingAnimations = p_433049_.get(net.neoforged.neoforge.client.entity.animation.json.AnimationLoader.STATE_KEY);
+         CompletableFuture<SpecialBlockModelRenderer> completablefuture1 = completablefuture.thenApplyAsync(
+             p_438833_ -> SpecialBlockModelRenderer.vanilla(
+-                new SpecialModelRenderer.BakingContext.Simple(p_438833_, this.atlasManager, this.playerSkinRenderCache)
++                new SpecialModelRenderer.BakingContext.Simple(p_438833_, this.atlasManager, this.playerSkinRenderCache, pendingAnimations)
+             ),
+             p_250550_
+         );
          CompletableFuture<Map<ResourceLocation, UnbakedModel>> completablefuture2 = loadBlockModels(resourcemanager, p_250550_);
          CompletableFuture<BlockStateModelLoader.LoadedModels> completablefuture3 = BlockStateModelLoader.loadBlockStates(resourcemanager, p_250550_);
          CompletableFuture<ClientItemInfoLoader.LoadedClientInfos> completablefuture4 = ClientItemInfoLoader.scheduleLoad(resourcemanager, p_250550_);
@@ -47,11 +58,12 @@
              )
              .thenComposeAsync(
                  p_438832_ -> {
-@@ -139,7 +_,9 @@
+@@ -139,7 +_,10 @@
                          completablefuture4.join().contents(),
                          modelmanager$resolvedmodels.models(),
                          modelmanager$resolvedmodels.missing()
-+                        , standaloneModelsFuture.join()
++                        , standaloneModelsFuture.join(),
++                        pendingAnimations
                      );
 +                    this.modelBakery.set(modelbakery);
                      return loadModels(spriteloader$preparations, modelbakery, object2intmap, completablefuture.join(), completablefuture1.join(), p_250550_);

--- a/src/client/java/net/neoforged/neoforge/client/entity/animation/json/AnimationLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/entity/animation/json/AnimationLoader.java
@@ -7,33 +7,38 @@ package net.neoforged.neoforge.client.entity.animation.json;
 
 import com.google.common.collect.MapMaker;
 import com.mojang.logging.LogUtils;
+import com.mojang.serialization.JsonOps;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import net.minecraft.client.animation.AnimationDefinition;
 import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
-import net.minecraft.util.profiling.ProfilerFiller;
+import net.neoforged.neoforge.resource.ContextAwareReloadListener;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 /**
  * A loader for entity animations written in JSON. You can also get parsed animations from this class.
  */
-public final class AnimationLoader extends SimpleJsonResourceReloadListener<AnimationDefinition> {
+public final class AnimationLoader extends ContextAwareReloadListener implements PreparableReloadListener {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     public static final AnimationLoader INSTANCE = new AnimationLoader();
+    public static final StateKey<PendingAnimations> STATE_KEY = new StateKey<>();
+    private static final FileToIdConverter LISTER = FileToIdConverter.json("neoforge/animations/entity");
 
     private final Map<ResourceLocation, AnimationHolder> animations = new MapMaker().weakValues().concurrencyLevel(1).makeMap();
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     private final List<AnimationHolder> strongHolderReferences = new ArrayList<>();
 
-    private AnimationLoader() {
-        super(AnimationParser.CODEC, FileToIdConverter.json("neoforge/animations/entity"));
-    }
+    private AnimationLoader() {}
 
     /**
      * Gets a loaded {@link AnimationDefinition} with the specified {@code key}.
@@ -53,7 +58,33 @@ public final class AnimationLoader extends SimpleJsonResourceReloadListener<Anim
     }
 
     @Override
-    protected void apply(Map<ResourceLocation, AnimationDefinition> animationJsons, ResourceManager resourceManager, ProfilerFiller profiler) {
+    public void prepareSharedState(SharedState sharedState) {
+        sharedState.set(STATE_KEY, new PendingAnimations());
+    }
+
+    @Override
+    public CompletableFuture<Void> reload(SharedState sharedState, Executor prepareExecutor, PreparationBarrier barrier, Executor applyExecutor) {
+        ResourceManager resourceManager = sharedState.resourceManager();
+        PendingAnimations pending = sharedState.get(STATE_KEY);
+        return CompletableFuture.supplyAsync(() -> this.prepare(resourceManager), prepareExecutor)
+                .whenComplete((map, error) -> {
+                    if (map != null) {
+                        pending.future.complete(map);
+                    } else {
+                        pending.future.completeExceptionally(error);
+                    }
+                })
+                .thenCompose(barrier::wait)
+                .thenAcceptAsync(this::apply, applyExecutor);
+    }
+
+    private Map<ResourceLocation, AnimationDefinition> prepare(ResourceManager resourceManager) {
+        Map<ResourceLocation, AnimationDefinition> map = new HashMap<>();
+        SimpleJsonResourceReloadListener.scanDirectory(resourceManager, LISTER, makeConditionalOps(JsonOps.INSTANCE), AnimationParser.CODEC, map);
+        return map;
+    }
+
+    private void apply(Map<ResourceLocation, AnimationDefinition> animationJsons) {
         animations.values().forEach(AnimationHolder::unbind);
         strongHolderReferences.clear();
         int loaded = 0;
@@ -64,5 +95,18 @@ public final class AnimationLoader extends SimpleJsonResourceReloadListener<Anim
             loaded++;
         }
         LOGGER.info("Loaded {} entity animations", loaded);
+    }
+
+    public static final class PendingAnimations {
+        private final CompletableFuture<Map<ResourceLocation, AnimationDefinition>> future;
+
+        private PendingAnimations() {
+            this.future = new CompletableFuture<>();
+        }
+
+        @Nullable
+        public AnimationDefinition get(ResourceLocation id) {
+            return this.future.join().get(id);
+        }
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/entity/animation/json/AnimationLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/entity/animation/json/AnimationLoader.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import net.minecraft.Util;
 import net.minecraft.client.animation.AnimationDefinition;
 import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceLocation;
@@ -98,6 +99,8 @@ public final class AnimationLoader extends ContextAwareReloadListener implements
     }
 
     public static final class PendingAnimations {
+        public static final PendingAnimations EMPTY = Util.make(new PendingAnimations(), pending -> pending.future.complete(Map.of()));
+
         private final CompletableFuture<Map<ResourceLocation, AnimationDefinition>> future;
 
         private PendingAnimations() {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.debug.client;
 
+import com.mojang.serialization.MapCodec;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.ModelPart;
@@ -13,6 +14,7 @@ import net.minecraft.client.model.geom.builders.MeshDefinition;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.item.ItemModel;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -26,6 +28,7 @@ import net.minecraft.world.level.storage.ValueOutput;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.neoforge.client.entity.animation.json.AnimationLoader;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.RegisterItemModelsEvent;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -35,11 +38,16 @@ public class AnimationLoaderTests {
     @TestHolder(description = "Tests that data-driven animations are loaded at the correct time", enabledByDefault = true)
     static void animLoaderTest(final DynamicTest test) {
         var entity = test.registrationHelper().entityTypes().registerEntityType("test", TestEntity::new, MobCategory.AMBIENT);
+        ResourceLocation itemModelId = ResourceLocation.fromNamespaceAndPath(test.createModId(), "test_item_model");
+        ResourceLocation itemModelFile = ResourceLocation.fromNamespaceAndPath(test.createModId(), "test_item");
         test.framework().modEventBus().addListener((EntityRenderersEvent.RegisterLayerDefinitions event) -> {
             event.registerLayerDefinition(TestEntityModel.LAYER_LOC, TestEntityModel::createLayer);
         });
         test.framework().modEventBus().addListener((EntityRenderersEvent.RegisterRenderers event) -> {
             event.registerEntityRenderer(entity.get(), context -> new TestEntityRenderer(context, test));
+        });
+        test.framework().modEventBus().addListener((RegisterItemModelsEvent event) -> {
+            event.register(itemModelId, new TestItemModel(test).codec);
         });
     }
 
@@ -90,6 +98,37 @@ public class AnimationLoaderTests {
         @Override
         public EntityRenderState createRenderState() {
             return new EntityRenderState();
+        }
+    }
+
+    private static final class TestItemModel implements ItemModel.Unbaked {
+        private final DynamicTest test;
+        private final MapCodec<TestItemModel> codec;
+
+        private TestItemModel(DynamicTest test) {
+            this.test = test;
+            this.codec = MapCodec.unit(this);
+        }
+
+        @Override
+        public ItemModel bake(ItemModel.BakingContext context) {
+            AnimationLoader.PendingAnimations pendingAnimations = context.pendingAnimations();
+            if (pendingAnimations == null) {
+                this.test.fail("PendingAnimations not provided by ItemModel.BakingContext");
+            } else if (pendingAnimations.get(TestEntityModel.ANIM_LOC) == null) {
+                this.test.fail("Test animation present in PendingAnimations");
+            } else {
+                this.test.pass();
+            }
+            return context.missingItemModel();
+        }
+
+        @Override
+        public void resolveDependencies(Resolver resolver) { }
+
+        @Override
+        public MapCodec<TestItemModel> type() {
+            return codec;
         }
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
@@ -124,7 +124,7 @@ public class AnimationLoaderTests {
         }
 
         @Override
-        public void resolveDependencies(Resolver resolver) { }
+        public void resolveDependencies(Resolver resolver) {}
 
         @Override
         public MapCodec<TestItemModel> type() {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/AnimationLoaderTests.java
@@ -113,10 +113,8 @@ public class AnimationLoaderTests {
         @Override
         public ItemModel bake(ItemModel.BakingContext context) {
             AnimationLoader.PendingAnimations pendingAnimations = context.pendingAnimations();
-            if (pendingAnimations == null) {
-                this.test.fail("PendingAnimations not provided by ItemModel.BakingContext");
-            } else if (pendingAnimations.get(TestEntityModel.ANIM_LOC) == null) {
-                this.test.fail("Test animation present in PendingAnimations");
+            if (pendingAnimations.get(TestEntityModel.ANIM_LOC) == null) {
+                this.test.fail("Test animation not present in PendingAnimations");
             } else {
                 this.test.pass();
             }

--- a/tests/src/main/resources/assets/neotests_anim_loader_test/items/test_item.json
+++ b/tests/src/main/resources/assets/neotests_anim_loader_test/items/test_item.json
@@ -1,0 +1,5 @@
+{
+    "model": {
+        "type": "neotests_anim_loader_test:test_item_model"
+    }
+}


### PR DESCRIPTION
This PR makes data-driven keyframe animations accessible to custom `ItemModel`s and `SpecialModelRenderer`s, allowing their use on entity models rendered in custom item models.
@ChampionAsh5357 pointed out in https://github.com/neoforged/NeoForge/pull/2578#discussion_r2280499739 that this would be useful to have. This was previously not possible as there was no way to share reload state across reload listeners in the async phase.