### PR TITLE
[1.21.9] Give custom sprite sources access to set of additional metadata sections

### DIFF
--- a/patches/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
+++ b/patches/net/minecraft/client/renderer/texture/SpriteLoader.java.patch
@@ -9,3 +9,12 @@
                  LOGGER.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.location, p_261919_, k1, j1);
                  l1 = k1;
              } else {
+@@ -130,7 +_,7 @@
+     ) {
+         SpriteResourceLoader spriteresourceloader = SpriteResourceLoader.create(p_432812_);
+         return CompletableFuture.<List<Function<SpriteResourceLoader, SpriteContents>>>supplyAsync(
+-                () -> SpriteSourceList.load(p_295469_, p_294925_).list(p_295469_), p_294720_
++                () -> SpriteSourceList.load(p_295469_, p_294925_).list(p_295469_, p_432812_), p_294720_
+             )
+             .thenCompose(p_293671_ -> runSpriteSuppliers(spriteresourceloader, (List<Function<SpriteResourceLoader, SpriteContents>>)p_293671_, p_294720_))
+             .thenApply(p_261393_ -> this.stitch((List<SpriteContents>)p_261393_, p_294855_, p_294720_));

--- a/patches/net/minecraft/client/renderer/texture/atlas/SpriteSourceList.java.patch
+++ b/patches/net/minecraft/client/renderer/texture/atlas/SpriteSourceList.java.patch
@@ -1,0 +1,27 @@
+--- a/net/minecraft/client/renderer/texture/atlas/SpriteSourceList.java
++++ b/net/minecraft/client/renderer/texture/atlas/SpriteSourceList.java
+@@ -36,7 +_,15 @@
+         this.sources = p_295898_;
+     }
+ 
++    /**
++     * @deprecated Neo: use {@link #list(ResourceManager, java.util.Set)} instead
++     */
++    @Deprecated
+     public List<Function<SpriteResourceLoader, SpriteContents>> list(ResourceManager p_294111_) {
++        return this.list(p_294111_, java.util.Set.of());
++    }
++
++    public List<Function<SpriteResourceLoader, SpriteContents>> list(ResourceManager p_294111_, java.util.Set<net.minecraft.server.packs.metadata.MetadataSectionType<?>> additionalMetadata) {
+         final Map<ResourceLocation, SpriteSource.SpriteSupplier> map = new HashMap<>();
+         SpriteSource.Output spritesource$output = new SpriteSource.Output() {
+             @Override
+@@ -60,7 +_,7 @@
+                 }
+             }
+         };
+-        this.sources.forEach(p_295860_ -> p_295860_.run(p_294111_, spritesource$output));
++        this.sources.forEach(p_295860_ -> p_295860_.run(p_294111_, spritesource$output, additionalMetadata));
+         Builder<Function<SpriteResourceLoader, SpriteContents>> builder = ImmutableList.builder();
+         builder.add(p_295583_ -> MissingTextureAtlasSprite.create());
+         builder.addAll(map.values());

--- a/src/client/java/net/neoforged/neoforge/client/extensions/SpriteSourceExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/SpriteSourceExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions;
+
+import java.util.Set;
+import net.minecraft.client.renderer.texture.atlas.SpriteSource;
+import net.minecraft.server.packs.metadata.MetadataSectionType;
+import net.minecraft.server.packs.resources.ResourceManager;
+
+public interface SpriteSourceExtension {
+    /**
+     * Called at the start of texture atlas loading to collect the {@link SpriteSource.SpriteSupplier}s providing the
+     * textures for the atlas being loaded.
+     *
+     * @param resourceManager    The resource manager to load the textures from
+     * @param output             The output to add the sprite suppliers to
+     * @param additionalMetadata The set of additional metadata sections specified by the atlas being loaded
+     */
+    default void run(ResourceManager resourceManager, SpriteSource.Output output, Set<MetadataSectionType<?>> additionalMetadata) {
+        self().run(resourceManager, output);
+    }
+
+    private SpriteSource self() {
+        return (SpriteSource) this;
+    }
+}

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -38,6 +38,9 @@
   "net/minecraft/client/renderer/blockentity/BlockEntityRenderer": [
     "net/neoforged/neoforge/client/extensions/IBlockEntityRendererExtension<T>"
   ],
+  "net/minecraft/client/renderer/texture/atlas/SpriteSource": [
+    "net/neoforged/neoforge/client/extensions/SpriteSourceExtension"
+  ],
   "net/minecraft/client/resources/model/BakedModel": [
     "net/neoforged/neoforge/client/extensions/IBakedModelExtension"
   ],


### PR DESCRIPTION
This PR gives custom `SpriteSource`s access to the set of additional `MetadataSectionType`s declared by the texture atlas they provide sprites for. This allows the produced `SpriteSuppliers` to create `SpriteContent`s with proper metadata without having to load the entire sprite through the vanilla path, effectively loading them twice, just to get access to the additional metadata.
In previous versions, the `SpriteContents` constructor directly took the `ResourceMetadata` from the incoming `Resource` which made metadata forwarding (potentially with filtering) fairly trivial. With `SpriteContents` now taking `AnimationMetadata` and a `List<MetadataSectionType.WithValue<?>>` separately this is no longer the case.