### PR TITLE
Rename IResource -> Resource (and subinterfaces)

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/ContainerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ContainerExtension.java
@@ -9,7 +9,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.item.VanillaContainerWrapper;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
@@ -39,8 +39,8 @@ public interface ContainerExtension {
 
     /**
      * Perform additional logic during the transaction, <strong>immediately</strong> after a successful transfer
-     * (i.e. {@linkplain ResourceHandler#insert(int, IResource, int, TransactionContext) insert} or
-     * {@linkplain ResourceHandler#extract(int, IResource, int, TransactionContext) extract} with result > 0).
+     * (i.e. {@linkplain ResourceHandler#insert(int, Resource, int, TransactionContext) insert} or
+     * {@linkplain ResourceHandler#extract(int, Resource, int, TransactionContext) extract} with result > 0).
      * Any logic performed by this method should be fully transactional, and support being rolled back.
      * In other words, the transaction is still ongoing.
      *

--- a/src/main/java/net/neoforged/neoforge/transfer/CombinedResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/CombinedResourceHandler.java
@@ -5,7 +5,7 @@
 
 package net.neoforged.neoforge.transfer;
 
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
@@ -15,7 +15,7 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
  * This means that indices added to the wrapped handlers will not be visible and indices removed will appear empty and read-only.
  * To adjust to size changes of the wrapped handlers, the wrapper must be recreated.
  */
-public class CombinedResourceHandler<T extends IResource> implements ResourceHandler<T> {
+public class CombinedResourceHandler<T extends Resource> implements ResourceHandler<T> {
     /**
      * The wrapped handlers.
      */

--- a/src/main/java/net/neoforged/neoforge/transfer/DelegatingResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/DelegatingResourceHandler.java
@@ -7,13 +7,13 @@ package net.neoforged.neoforge.transfer;
 
 import java.util.Objects;
 import java.util.function.Supplier;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
  * A resource handler that delegates all calls to another handler.
  */
-public class DelegatingResourceHandler<T extends IResource> implements ResourceHandler<T> {
+public class DelegatingResourceHandler<T extends Resource> implements ResourceHandler<T> {
     protected final Supplier<ResourceHandler<T>> delegate;
 
     public DelegatingResourceHandler(ResourceHandler<T> delegate) {

--- a/src/main/java/net/neoforged/neoforge/transfer/EmptyResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/EmptyResourceHandler.java
@@ -5,7 +5,7 @@
 
 package net.neoforged.neoforge.transfer;
 
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
@@ -13,14 +13,14 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
  * <p>It has zero indices and rejects all operations.
  * <p>Use {@link #instance()} to obtain an empty handler for any resource type.
  */
-public final class EmptyResourceHandler<T extends IResource> implements ResourceHandler<T> {
+public final class EmptyResourceHandler<T extends Resource> implements ResourceHandler<T> {
     private static final EmptyResourceHandler<?> INSTANCE = new EmptyResourceHandler<>();
 
     /**
      * Returns an empty resource handler for the desired resource type.
      */
     @SuppressWarnings("unchecked")
-    public static <T extends IResource> EmptyResourceHandler<T> instance() {
+    public static <T extends Resource> EmptyResourceHandler<T> instance() {
         return (EmptyResourceHandler<T>) INSTANCE;
     }
 

--- a/src/main/java/net/neoforged/neoforge/transfer/IndexModifier.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/IndexModifier.java
@@ -5,13 +5,13 @@
 
 package net.neoforged.neoforge.transfer;
 
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 
 /**
  * Represents a function to directly mutate the resource and amount at a specific index of a {@link ResourceHandler}.
  */
 @FunctionalInterface
-public interface IndexModifier<T extends IResource> {
+public interface IndexModifier<T extends Resource> {
     /**
      * Overrides the resource and amount at the given index.
      *

--- a/src/main/java/net/neoforged/neoforge/transfer/InfiniteResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/InfiniteResourceHandler.java
@@ -6,7 +6,7 @@
 package net.neoforged.neoforge.transfer;
 
 import java.util.Objects;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
  *
  * @param <T> The type of resource that this handler can accept.
  */
-public class InfiniteResourceHandler<T extends IResource> implements ResourceHandler<T> {
+public class InfiniteResourceHandler<T extends Resource> implements ResourceHandler<T> {
     protected final T infiniteResource;
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
@@ -8,7 +8,7 @@ package net.neoforged.neoforge.transfer;
 import java.util.Objects;
 import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.item.ItemResource;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
@@ -26,7 +26,7 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
  *
  * @param <T> The type of resource this handler manages.
  */
-public abstract class ItemAccessResourceHandler<T extends IResource> implements ResourceHandler<T> {
+public abstract class ItemAccessResourceHandler<T extends Resource> implements ResourceHandler<T> {
     protected final ItemAccess itemAccess;
     protected final int size;
 

--- a/src/main/java/net/neoforged/neoforge/transfer/RangedResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/RangedResourceHandler.java
@@ -7,20 +7,20 @@ package net.neoforged.neoforge.transfer;
 
 import java.util.Objects;
 import java.util.function.Supplier;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
  * A resource handler that wraps a range of indices of another handler.
  */
-public class RangedResourceHandler<T extends IResource> extends DelegatingResourceHandler<T> {
+public class RangedResourceHandler<T extends Resource> extends DelegatingResourceHandler<T> {
     /**
      * Creates a wrapper for a range of indices.
      *
      * @param start start of the range of indices, inclusive
      * @param end   end of the range of indices, exclusive
      */
-    public static <T extends IResource> RangedResourceHandler<T> of(ResourceHandler<T> delegate, int start, int end) {
+    public static <T extends Resource> RangedResourceHandler<T> of(ResourceHandler<T> delegate, int start, int end) {
         return new RangedResourceHandler<>(delegate, start, end);
     }
 
@@ -30,21 +30,21 @@ public class RangedResourceHandler<T extends IResource> extends DelegatingResour
      * @param start start of the range of indices, inclusive
      * @param end   end of the range of indices, exclusive
      */
-    public static <T extends IResource> RangedResourceHandler<T> of(Supplier<ResourceHandler<T>> delegate, int start, int end) {
+    public static <T extends Resource> RangedResourceHandler<T> of(Supplier<ResourceHandler<T>> delegate, int start, int end) {
         return new RangedResourceHandler<>(delegate, start, end);
     }
 
     /**
      * Creates a wrapper for a single index.
      */
-    public static <T extends IResource> RangedResourceHandler<T> ofSingleIndex(ResourceHandler<T> delegate, int index) {
+    public static <T extends Resource> RangedResourceHandler<T> ofSingleIndex(ResourceHandler<T> delegate, int index) {
         return new RangedResourceHandler<>(delegate, index, index + 1);
     }
 
     /**
      * Creates a wrapper for a single index, with the passed supplier being queried every time the handler is accessed.
      */
-    public static <T extends IResource> RangedResourceHandler<T> ofSingleIndex(Supplier<ResourceHandler<T>> delegate, int index) {
+    public static <T extends Resource> RangedResourceHandler<T> ofSingleIndex(Supplier<ResourceHandler<T>> delegate, int index) {
         return new RangedResourceHandler<>(delegate, index, index + 1);
     }
 

--- a/src/main/java/net/neoforged/neoforge/transfer/ResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ResourceHandler.java
@@ -6,14 +6,14 @@
 package net.neoforged.neoforge.transfer;
 
 import com.google.common.primitives.Ints;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- * A generic handler for the transfer and storage of {@link IResource resources} whether it be inserting, extracting, querying some value, etc.
+ * A generic handler for the transfer and storage of {@link Resource resources} whether it be inserting, extracting, querying some value, etc.
  *
  * <h2>Indices</h2>
  * <p>A resource handler is organized into indices, which are addressed using an int between {@code 0} and {@code size() - 1}.
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @param <T> The type of resource this handler manages.
  */
-public interface ResourceHandler<T extends IResource> {
+public interface ResourceHandler<T extends Resource> {
     /**
      * {@return the <i>current</i> number of indices in this resource handler}
      *
@@ -102,8 +102,8 @@ public interface ResourceHandler<T extends IResource> {
      * @param index    The index to get the capacity for.
      * @param resource The resource to get the capacity for. May be empty to get the general capacity at the index.
      * @return the capacity at the given index, as a long
-     * @implSpec This method should return 0 for any resource for which {@link #isValid(int,IResource)} returns {@code false}.
-     * @see #getCapacityAsInt(int, IResource)
+     * @implSpec This method should return 0 for any resource for which {@link #isValid(int, Resource)} returns {@code false}.
+     * @see #getCapacityAsInt(int, Resource)
      */
     long getCapacityAsLong(int index, T resource);
 
@@ -123,8 +123,8 @@ public interface ResourceHandler<T extends IResource> {
      * @param index    The index to get the limit for.
      * @param resource The resource to get the limit for. May be empty to get the general capacity at the index.
      * @return the capacity at the given index, as an {@code int}
-     * @implNote This method should not be implemented. The default method will call {@link #getCapacityAsLong(int, IResource)} and convert the result appropriately.
-     * @see #getCapacityAsLong(int, IResource)
+     * @implNote This method should not be implemented. The default method will call {@link #getCapacityAsLong(int, Resource)} and convert the result appropriately.
+     * @see #getCapacityAsLong(int, Resource)
      */
     @ApiStatus.NonExtendable
     default int getCapacityAsInt(int index, T resource) {
@@ -156,14 +156,14 @@ public interface ResourceHandler<T extends IResource> {
      * @throws IllegalArgumentException If the resource is empty or the amount is negative. See also {@link TransferPreconditions#checkNonEmptyNonNegative} to help perform this check.
      * @implSpec Implementations must properly support {@linkplain Transaction transactions}.
      *           Note that {@link SnapshotJournal} can serve as the base class for a transaction-aware resource handler.
-     * @see #insert(IResource, int, TransactionContext) Inserting without a specific index, which can be more efficient.
+     * @see #insert(Resource, int, TransactionContext) Inserting without a specific index, which can be more efficient.
      */
     int insert(int index, T resource, int amount, TransactionContext transaction);
 
     /**
      * Inserts up to the given amount of a resource into the handler.
      *
-     * <p>This function is preferred to the {@linkplain #insert(int, IResource, int, TransactionContext) index-specific overload}
+     * <p>This function is preferred to the {@linkplain #insert(int, Resource, int, TransactionContext) index-specific overload}
      * since it lets the handler decide how to distribute the resource.
      * <p>This method is expected to be more efficient than callers trying to find a suitable index for insertion themselves.
      *
@@ -176,7 +176,7 @@ public interface ResourceHandler<T extends IResource> {
      * @throws IllegalArgumentException If the resource is empty or the amount is negative. See also {@link TransferPreconditions#checkNonEmptyNonNegative} to help perform this check.
      * @implSpec Implementations must properly support {@linkplain Transaction transactions}.
      *           Note that {@link SnapshotJournal} can serve as the base class for a transaction-aware resource handler.
-     * @see #insert(int, IResource, int, TransactionContext) Inserting into a specific index of the handler.
+     * @see #insert(int, Resource, int, TransactionContext) Inserting into a specific index of the handler.
      */
     default int insert(T resource, int amount, TransactionContext transaction) {
         TransferPreconditions.checkNonEmptyNonNegative(resource, amount);
@@ -203,14 +203,14 @@ public interface ResourceHandler<T extends IResource> {
      * @throws IllegalArgumentException If the resource is empty or the amount is negative. See also {@link TransferPreconditions#checkNonEmptyNonNegative} to help perform this check.
      * @implSpec Implementations must properly support {@linkplain Transaction transactions}.
      *           Note that {@link SnapshotJournal} can serve as the base class for a transaction-aware resource handler.
-     * @see #extract(IResource, int, TransactionContext) Extracting without a specific index, which can be more efficient.
+     * @see #extract(Resource, int, TransactionContext) Extracting without a specific index, which can be more efficient.
      */
     int extract(int index, T resource, int amount, TransactionContext transaction);
 
     /**
      * Tries to extract up to the given amount of a resource from the handler.
      *
-     * <p>This function is preferred to the {@linkplain #extract(int, IResource, int, TransactionContext) index-specific overload}
+     * <p>This function is preferred to the {@linkplain #extract(int, Resource, int, TransactionContext) index-specific overload}
      * since it lets the handler decide how to find indices that contain the resource.
      * <p>This method is expected to be more efficient than callers trying to find indices that contain the resource themselves.
      *
@@ -223,7 +223,7 @@ public interface ResourceHandler<T extends IResource> {
      * @throws IllegalArgumentException If the resource is empty or the amount is negative. See also {@link TransferPreconditions#checkNonEmptyNonNegative} to help perform this check.
      * @implSpec Implementations must properly support {@linkplain Transaction transactions}.
      *           Note that {@link SnapshotJournal} can serve as the base class for a transaction-aware resource handler.
-     * @see #extract(int, IResource, int, TransactionContext) Extracting from a specific index of the handler.
+     * @see #extract(int, Resource, int, TransactionContext) Extracting from a specific index of the handler.
      */
     default int extract(T resource, int amount, TransactionContext transaction) {
         TransferPreconditions.checkNonEmptyNonNegative(resource, amount);
@@ -241,7 +241,7 @@ public interface ResourceHandler<T extends IResource> {
      * Creates a class with the right generic type, such that it can be used to register a capability.
      */
     @SuppressWarnings("unchecked")
-    static <T extends IResource> Class<ResourceHandler<T>> asClass() {
+    static <T extends Resource> Class<ResourceHandler<T>> asClass() {
         return (Class<ResourceHandler<T>>) (Object) ResourceHandler.class;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/transfer/ResourceHandlerUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ResourceHandlerUtil.java
@@ -13,7 +13,7 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.Container;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.redstone.Redstone;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.resource.ResourceStack;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
@@ -26,14 +26,14 @@ public final class ResourceHandlerUtil {
     private ResourceHandlerUtil() {}
 
     /**
-     * Determines if either the given resource or amount is classified as empty: if either {@link IResource#isEmpty()} is {@code true},
+     * Determines if either the given resource or amount is classified as empty: if either {@link Resource#isEmpty()} is {@code true},
      * or the amount is zero (or negative) then the resource is considered empty.
      *
      * @param resource The resource to check.
      * @param amount   An amount to check.
-     * @return {@code true} if either {@link IResource#isEmpty()} returns {@code true}, or the amount is {@code <= 0}.
+     * @return {@code true} if either {@link Resource#isEmpty()} returns {@code true}, or the amount is {@code <= 0}.
      */
-    public static boolean isEmpty(IResource resource, int amount) {
+    public static boolean isEmpty(Resource resource, int amount) {
         return amount <= 0 || resource.isEmpty();
     }
 
@@ -47,7 +47,7 @@ public final class ResourceHandlerUtil {
      * @param handler the {@link ResourceHandler} to check for emptiness
      * @return {@code true} if the {@link ResourceHandler} is empty, {@code false} otherwise
      */
-    public static boolean isEmpty(ResourceHandler<? extends IResource> handler) {
+    public static boolean isEmpty(ResourceHandler<? extends Resource> handler) {
         int size = handler.size();
         for (int i = 0; i < size; i++) {
             if (handler.getAmountAsLong(i) > 0) {
@@ -61,13 +61,13 @@ public final class ResourceHandlerUtil {
      * Checks if a {@link ResourceHandler} is full.
      * <p>
      * A {@code IResourceHandler} is considered full if all of its indices contain resources with amounts
-     * greater than or equal to their respective {@linkplain ResourceHandler#getCapacityAsLong(int, IResource) capacity}.
+     * greater than or equal to their respective {@linkplain ResourceHandler#getCapacityAsLong(int, Resource) capacity}.
      * <p>A handler of size zero is always considered full.
      *
      * @param handler the {@link ResourceHandler} to check
      * @return {@code true} if the {@link ResourceHandler} is full, {@code false} otherwise
      */
-    public static <T extends IResource> boolean isFull(ResourceHandler<T> handler) {
+    public static <T extends Resource> boolean isFull(ResourceHandler<T> handler) {
         int size = handler.size();
         for (int i = 0; i < size; i++) {
             if (handler.getAmountAsLong(i) < handler.getCapacityAsLong(i, handler.getResource(i))) {
@@ -83,9 +83,9 @@ public final class ResourceHandlerUtil {
      * @param handler  the {@link ResourceHandler} to check
      * @param resource the resource to check. <strong>Must be non-empty.</strong>
      * @return {@code true} if the resource is valid in any index of the handler.
-     * @see ResourceHandler#isValid(int, IResource)
+     * @see ResourceHandler#isValid(int, Resource)
      */
-    public static <T extends IResource> boolean isValid(ResourceHandler<T> handler, T resource) {
+    public static <T extends Resource> boolean isValid(ResourceHandler<T> handler, T resource) {
         TransferPreconditions.checkNonEmpty(resource);
 
         int size = handler.size();
@@ -105,7 +105,7 @@ public final class ResourceHandlerUtil {
      * @param <T>     the type of resource handled by the handler
      * @return the redstone signal strength
      */
-    public static <T extends IResource> int getRedstoneSignalFromResourceHandler(ResourceHandler<T> handler) {
+    public static <T extends Resource> int getRedstoneSignalFromResourceHandler(ResourceHandler<T> handler) {
         float proportion = 0.0F;
         int sampleCount = 0; // Number of samples in proportion
         int size = handler.size();
@@ -140,7 +140,7 @@ public final class ResourceHandlerUtil {
      *                    Passing in {@code null} will open a root transaction, and commit it at the end of the method.
      * @return the amount of the resource that was inserted
      */
-    public static <T extends IResource> int insertStacking(
+    public static <T extends Resource> int insertStacking(
             @Nullable ResourceHandler<T> handler,
             T resource,
             int amount,
@@ -187,7 +187,7 @@ public final class ResourceHandlerUtil {
      * @return the resource and amount that was extracted or {@code null} if nothing was extracted
      */
     @Nullable
-    public static <T extends IResource> ResourceStack<T> extractFirst(
+    public static <T extends Resource> ResourceStack<T> extractFirst(
             @Nullable ResourceHandler<T> handler,
             Predicate<T> filter,
             int amount,
@@ -249,7 +249,7 @@ public final class ResourceHandlerUtil {
      * @return the resource and amount that was transferred or {@code null} if nothing was transferred
      * @throws IllegalStateException If no transaction is passed and a transaction is already active on the current thread.
      */
-    public static <T extends IResource> int move(
+    public static <T extends Resource> int move(
             @Nullable ResourceHandler<T> from,
             @Nullable ResourceHandler<T> to,
             Predicate<T> filter,
@@ -326,7 +326,7 @@ public final class ResourceHandlerUtil {
      * @return the resource and amount that was transferred or {@code null} if nothing was transferred
      */
     @Nullable
-    public static <T extends IResource> ResourceStack<T> moveFirst(
+    public static <T extends Resource> ResourceStack<T> moveFirst(
             @Nullable ResourceHandler<T> from,
             @Nullable ResourceHandler<T> to,
             Predicate<T> filter,
@@ -403,7 +403,7 @@ public final class ResourceHandlerUtil {
      * @param handler  The handler to check for the resource.
      * @param resource The resource to check for. <strong>Must be non-empty.</strong>
      */
-    public static <T extends IResource> boolean contains(ResourceHandler<T> handler, T resource) {
+    public static <T extends Resource> boolean contains(ResourceHandler<T> handler, T resource) {
         return indexOf(handler, resource) != -1;
     }
 
@@ -413,7 +413,7 @@ public final class ResourceHandlerUtil {
      * @param handler  The handler to check for the resource.
      * @param resource The resource to find. <strong>Must be non-empty.</strong>
      */
-    public static <T extends IResource> int indexOf(ResourceHandler<T> handler, T resource) {
+    public static <T extends Resource> int indexOf(ResourceHandler<T> handler, T resource) {
         TransferPreconditions.checkNonEmpty(resource);
         int size = handler.size();
         for (int index = 0; index < size; index++) {
@@ -435,7 +435,7 @@ public final class ResourceHandlerUtil {
      * @param <T> The type of resource handled by the handler.
      */
     @Nullable
-    public static <T extends IResource> T findExtractableResource(
+    public static <T extends Resource> T findExtractableResource(
             ResourceHandler<T> handler,
             Predicate<T> filter,
             @Nullable TransactionContext transaction) {

--- a/src/main/java/net/neoforged/neoforge/transfer/ResourceStacksResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ResourceStacksResourceHandler.java
@@ -7,7 +7,7 @@ package net.neoforged.neoforge.transfer;
 
 import com.mojang.serialization.Codec;
 import net.minecraft.core.NonNullList;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.resource.ResourceStack;
 
 /**
@@ -22,7 +22,7 @@ import net.neoforged.neoforge.transfer.resource.ResourceStack;
  *
  * @see StacksResourceHandler
  */
-public abstract class ResourceStacksResourceHandler<R extends IResource> extends StacksResourceHandler<ResourceStack<R>, R> {
+public abstract class ResourceStacksResourceHandler<R extends Resource> extends StacksResourceHandler<ResourceStack<R>, R> {
     // TODO: do we want to be passing a resource codec instead?
     public ResourceStacksResourceHandler(int size, R emptyResource, Codec<ResourceStack<R>> stackCodec) {
         super(size, new ResourceStack<>(emptyResource, 0), stackCodec);

--- a/src/main/java/net/neoforged/neoforge/transfer/StacksResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/StacksResourceHandler.java
@@ -20,7 +20,7 @@ import net.neoforged.neoforge.transfer.fluid.FluidStacksResourceHandler;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.item.ItemStacksResourceHandler;
 import net.neoforged.neoforge.transfer.item.ResourceHandlerSlot;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.resource.ResourceStack;
 import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
@@ -46,7 +46,7 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
  * @see FluidStacksResourceHandler the FluidStack-based subclass
  * @see ResourceStacksResourceHandler the ResourceStack-based subclass
  */
-public abstract class StacksResourceHandler<S, T extends IResource> implements ResourceHandler<T>, ValueIOSerializable {
+public abstract class StacksResourceHandler<S, T extends Resource> implements ResourceHandler<T>, ValueIOSerializable {
     public static final String VALUE_IO_KEY = "stacks";
 
     protected final S emptyStack;
@@ -124,7 +124,7 @@ public abstract class StacksResourceHandler<S, T extends IResource> implements R
     /**
      * Creates a stack from a resource and an amount.
      *
-     * <p>If the stack {@linkplain ResourceHandlerUtil#isEmpty(IResource, int) would be empty},
+     * <p>If the stack {@linkplain ResourceHandlerUtil#isEmpty(Resource, int) would be empty},
      * consider returning {@link #emptyStack} instead of creating a new empty stack instance.
      */
     protected abstract S getStackFrom(T resource, int amount);

--- a/src/main/java/net/neoforged/neoforge/transfer/TransferPreconditions.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/TransferPreconditions.java
@@ -5,7 +5,7 @@
 
 package net.neoforged.neoforge.transfer;
 
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 
 /**
  * Precondition checks useful for implementing {@link ResourceHandler}.
@@ -18,7 +18,7 @@ public class TransferPreconditions {
      *
      * @throws IllegalArgumentException when resource is empty.
      */
-    public static void checkNonEmpty(IResource resource) {
+    public static void checkNonEmpty(Resource resource) {
         if (resource.isEmpty()) {
             throw new IllegalArgumentException("Expected resource to be non-empty: " + resource);
         }
@@ -40,7 +40,7 @@ public class TransferPreconditions {
      *
      * @throws IllegalArgumentException when resource is empty or value is negative.
      */
-    public static void checkNonEmptyNonNegative(IResource resource, int value) {
+    public static void checkNonEmptyNonNegative(Resource resource, int value) {
         checkNonEmpty(resource);
         checkNonNegative(value);
     }

--- a/src/main/java/net/neoforged/neoforge/transfer/VoidingResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/VoidingResourceHandler.java
@@ -6,7 +6,7 @@
 package net.neoforged.neoforge.transfer;
 
 import java.util.Objects;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
 /**
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
  *
  * @param <T> The type of resource that this handler can accept.
  */
-public class VoidingResourceHandler<T extends IResource> implements ResourceHandler<T> {
+public class VoidingResourceHandler<T extends Resource> implements ResourceHandler<T> {
     protected final T emptyResource;
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/access/ItemAccess.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/access/ItemAccess.java
@@ -18,7 +18,7 @@ import net.neoforged.neoforge.transfer.TransferPreconditions;
 import net.neoforged.neoforge.transfer.item.CarriedSlotWrapper;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.item.PlayerInventoryWrapper;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.SnapshotJournal;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
@@ -94,7 +94,7 @@ public interface ItemAccess {
      * with any overflow being sent to the rest of the handler.
      *
      * <p>Overflow on insertion will be sent to the rest of the handler via
-     * {@linkplain ResourceHandler#insert(IResource, int, TransactionContext) the slotless insert} method.
+     * {@linkplain ResourceHandler#insert(Resource, int, TransactionContext) the slotless insert} method.
      * If this is not desired, use the {@link #forHandlerIndexStrict} method instead.
      */
     static ItemAccess forHandlerIndex(ResourceHandler<ItemResource> handler, int index) {

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -25,13 +25,13 @@ import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.transfer.TransferPreconditions;
-import net.neoforged.neoforge.transfer.resource.IDataComponentHolderResource;
+import net.neoforged.neoforge.transfer.resource.DataComponentHolderResource;
 
 /**
  * Immutable combination of a {@link Fluid} and data components.
  * Similar to a {@link FluidStack}, but immutable and without amount information.
  */
-public final class FluidResource implements IDataComponentHolderResource<Fluid> {
+public final class FluidResource implements DataComponentHolderResource<Fluid> {
     /**
      * The empty resource instance of a {@link FluidResource}
      */

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
@@ -25,13 +25,13 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.neoforge.transfer.TransferPreconditions;
-import net.neoforged.neoforge.transfer.resource.IDataComponentHolderResource;
+import net.neoforged.neoforge.transfer.resource.DataComponentHolderResource;
 
 /**
  * Immutable combination of an {@link Item} and data components.
  * Similar to an {@link ItemStack}, but immutable and without a count.
  */
-public final class ItemResource implements IDataComponentHolderResource<Item> {
+public final class ItemResource implements DataComponentHolderResource<Item> {
     /**
      * The empty resource instance of a {@link ItemResource}
      */

--- a/src/main/java/net/neoforged/neoforge/transfer/resource/DataComponentHolderResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/resource/DataComponentHolderResource.java
@@ -18,7 +18,7 @@ import net.minecraft.core.component.DataComponentType;
  *
  * @param <T> The type of the backing registry entry.
  */
-public interface IDataComponentHolderResource<T> extends IRegisteredResource<T>, DataComponentHolder {
+public interface DataComponentHolderResource<T> extends RegisteredResource<T>, DataComponentHolder {
     /**
      * Checks if the resource's data component holder has no patches applied to it.
      * Equivalent to checking if the {@link #getComponentsPatch() patch} is empty, but more efficient.
@@ -31,7 +31,7 @@ public interface IDataComponentHolderResource<T> extends IRegisteredResource<T>,
      * @param patch The patch added to the new resource instance.
      * @implSpec If the patch is empty, the same resource instance is returned directly.
      */
-    IDataComponentHolderResource<T> withMergedPatch(DataComponentPatch patch);
+    DataComponentHolderResource<T> withMergedPatch(DataComponentPatch patch);
 
     /**
      * {@return a resource with the data component set to the given value}
@@ -40,14 +40,14 @@ public interface IDataComponentHolderResource<T> extends IRegisteredResource<T>,
      * @param data the data to set
      * @param <D>  the type of data component
      */
-    <D> IDataComponentHolderResource<T> with(DataComponentType<D> type, D data);
+    <D> DataComponentHolderResource<T> with(DataComponentType<D> type, D data);
 
     /**
      * {@return a resource without the data component, i.e. with the data component explicitly removed}
      *
      * @param type the type of data component
      */
-    IDataComponentHolderResource<T> without(DataComponentType<?> type);
+    DataComponentHolderResource<T> without(DataComponentType<?> type);
 
     /**
      * Patches currently applied to the resource's data component holder.
@@ -61,7 +61,7 @@ public interface IDataComponentHolderResource<T> extends IRegisteredResource<T>,
      * @param data the data to set
      * @param <D>  the type of data component
      */
-    default <D> IDataComponentHolderResource<T> with(Supplier<? extends DataComponentType<D>> type, D data) {
+    default <D> DataComponentHolderResource<T> with(Supplier<? extends DataComponentType<D>> type, D data) {
         return with(type.get(), data);
     }
 
@@ -70,7 +70,7 @@ public interface IDataComponentHolderResource<T> extends IRegisteredResource<T>,
      *
      * @param type the supplier for the type of data component
      */
-    default IDataComponentHolderResource<T> without(Supplier<? extends DataComponentType<?>> type) {
+    default DataComponentHolderResource<T> without(Supplier<? extends DataComponentType<?>> type) {
         return without(type.get());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/transfer/resource/RegisteredResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/resource/RegisteredResource.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * @param <T> The type of the backing registry entry.
  */
-public interface IRegisteredResource<T> extends IResource {
+public interface RegisteredResource<T> extends Resource {
     /**
      * {@return the backing instance of the resource}
      */

--- a/src/main/java/net/neoforged/neoforge/transfer/resource/Resource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/resource/Resource.java
@@ -13,7 +13,7 @@ package net.neoforged.neoforge.transfer.resource;
  * <p>
  * Note, the amount is not encoded in the resource, for that you can use something like {@link ResourceStack}.
  */
-public interface IResource {
+public interface Resource {
     /**
      * Returns {@code true} if this represents an empty resource.
      *

--- a/src/main/java/net/neoforged/neoforge/transfer/resource/ResourceStack.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/resource/ResourceStack.java
@@ -8,15 +8,15 @@ package net.neoforged.neoforge.transfer.resource;
 import net.neoforged.neoforge.transfer.ResourceHandlerUtil;
 
 /**
- * Creates a resource stack from a given {@link IResource resource} and {@code amount}.
+ * Creates a resource stack from a given {@link Resource resource} and {@code amount}.
  *
  * @param resource The resource to wrap the stack around.
  * @param amount   The amount of the resource the stack is holding.
  */
-public record ResourceStack<T extends IResource>(T resource, int amount) {
+public record ResourceStack<T extends Resource>(T resource, int amount) {
     /**
      * Checks if the resource stack is empty, meaning that the amount is zero
-     * or that the resource is {@link IResource#isEmpty() empty}.
+     * or that the resource is {@link Resource#isEmpty() empty}.
      *
      * @return {@code true} if empty
      */

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/HandlerTestUtil.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/HandlerTestUtil.java
@@ -8,7 +8,7 @@ package net.neoforged.neoforge.unittest.transfer;
 import java.util.ArrayList;
 import java.util.List;
 import net.neoforged.neoforge.transfer.ResourceHandler;
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.resource.ResourceStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,7 +20,7 @@ final class HandlerTestUtil {
 
     private HandlerTestUtil() {}
 
-    static <T extends IResource> List<SlotInfo<T>> describeSlots(ResourceHandler<T> handler) {
+    static <T extends Resource> List<SlotInfo<T>> describeSlots(ResourceHandler<T> handler) {
         List<SlotInfo<T>> content = new ArrayList<>(handler.size());
         for (int i = 0; i < handler.size(); i++) {
             T resource = handler.getResource(i);
@@ -35,7 +35,7 @@ final class HandlerTestUtil {
         return content;
     }
 
-    static <T extends IResource> List<ResourceStack<T>> describeStacks(ResourceHandler<T> handler) {
+    static <T extends Resource> List<ResourceStack<T>> describeStacks(ResourceHandler<T> handler) {
         List<ResourceStack<T>> content = new ArrayList<>(handler.size());
         for (int i = 0; i < handler.size(); i++) {
             T resource = handler.getResource(i);
@@ -93,7 +93,7 @@ final class HandlerTestUtil {
         return new ResourceStack<>(resource, amount);
     }
 
-    record SlotInfo<T extends IResource>(T resource, long amount, long capacity) {
+    record SlotInfo<T extends Resource>(T resource, long amount, long capacity) {
         @Override
         public String toString() {
             return amount + "x" + resource + " (cap: " + capacity + ")";

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/TestResource.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/TestResource.java
@@ -5,9 +5,9 @@
 
 package net.neoforged.neoforge.unittest.transfer;
 
-import net.neoforged.neoforge.transfer.resource.IResource;
+import net.neoforged.neoforge.transfer.resource.Resource;
 
-public enum TestResource implements IResource {
+public enum TestResource implements Resource {
     EMPTY,
     SOME,
     OTHER_1,


### PR DESCRIPTION
For consistency with the other interfaces of the transfer rework, which do not use any I prefix.

Note that vanilla also has a `Resource` (`net.minecraft.server.packs.resources.Resource`), but I don't think that this is likely to cause issues in practice. Resource pack manipulation code and resource transfer code should be quite disjoint.