### PR TITLE
[1.21.9] Handle custom chest textures in extract phase

### DIFF
--- a/patches/net/minecraft/client/renderer/blockentity/ChestRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/blockentity/ChestRenderer.java.patch
@@ -1,22 +1,36 @@
 --- a/net/minecraft/client/renderer/blockentity/ChestRenderer.java
 +++ b/net/minecraft/client/renderer/blockentity/ChestRenderer.java
+@@ -77,6 +_,8 @@
+         if (p_445744_.type != ChestType.SINGLE) {
+             p_445744_.lightCoords = neighborcombineresult.apply(new BrightnessCombiner<>()).applyAsInt(p_445744_.lightCoords);
+         }
++
++        p_445744_.customMaterial = getCustomMaterial(p_446382_, p_445744_);
+     }
+ 
+     public void submit(ChestRenderState p_446740_, PoseStack p_445661_, SubmitNodeCollector p_445570_, CameraRenderState p_451060_) {
 @@ -87,7 +_,7 @@
          float f = p_446740_.open;
          f = 1.0F - f;
          f = 1.0F - f * f * f;
 -        Material material = Sheets.chooseMaterial(p_446740_.material, p_446740_.type);
-+        Material material = getMaterial(p_446740_.material, p_446740_.type);
++        Material material = p_446740_.customMaterial != null ? p_446740_.customMaterial : Sheets.chooseMaterial(p_446740_.material, p_446740_.type);
          RenderType rendertype = material.renderType(RenderType::entityCutout);
          TextureAtlasSprite textureatlassprite = this.materials.get(material);
          if (p_446740_.type != ChestType.SINGLE) {
-@@ -153,5 +_,15 @@
+@@ -153,5 +_,20 @@
          } else {
              return ChestRenderState.ChestMaterialType.REGULAR;
          }
 +    }
 +
-+    protected Material getMaterial(ChestRenderState.ChestMaterialType materialType, ChestType chestType) {
-+        return Sheets.chooseMaterial(materialType, chestType);
++    /**
++     * Neo: Return a custom {@link Material} to render the chest with or {@code null} to
++     * fall back to the vanilla material selection.
++     */
++    @Nullable
++    protected Material getCustomMaterial(T blockEntity, ChestRenderState renderState) {
++        return null;
 +    }
 +
 +    @Override

--- a/patches/net/minecraft/client/renderer/blockentity/state/ChestRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/blockentity/state/ChestRenderState.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/client/renderer/blockentity/state/ChestRenderState.java
++++ b/net/minecraft/client/renderer/blockentity/state/ChestRenderState.java
+@@ -10,6 +_,8 @@
+     public float open;
+     public float angle;
+     public ChestRenderState.ChestMaterialType material = ChestRenderState.ChestMaterialType.REGULAR;
++    @org.jetbrains.annotations.Nullable
++    public net.minecraft.client.resources.model.Material customMaterial;
+ 
+     @OnlyIn(Dist.CLIENT)
+     public static enum ChestMaterialType {


### PR DESCRIPTION
This PR moves the handling of custom chest textures from the submit phase back to the extract phase to give custom chest renderers access to the chest BE and render state. This allows significantly more freedom than either forcing custom renderers to re-use the vanilla `ChestRenderState.ChestMaterialType`s or having them add custom entries to said enum.

This approach was suggested in a comment on the porting PR (https://github.com/neoforged/NeoForge/pull/2639#issuecomment-3322911403) and a use case mentioned in #neoforge-github on the Discord also benefits from this.