### PR TITLE
[1.21.9] Fix player remaining in swimming animation when head is above fluid surface

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -107,7 +107,7 @@
          } else {
              this.setSwimming(
 -                this.isSprinting() && this.isUnderWater() && !this.isPassenger() && this.level().getFluidState(this.blockPosition).is(FluidTags.WATER)
-+                this.isSprinting() && (this.isUnderWater() || this.canStartSwimming()) && !this.isPassenger()
++                this.isSprinting() && this.canStartSwimming() && !this.isPassenger()
              );
          }
      }


### PR DESCRIPTION
Fixes #2646

## Problem Description
The current logic for maintaining the swimming state in `updateSwimming()` was broadened by NeoForge to support custom fluid types. The condition `(this.isInWater() || this.isInFluidType(...))` allows a player to remain swimming as long as any part of their body is in a swimmable fluid.

This creates an issue where if the player's head is above the fluid surface (e.g., when trying to surface by holding the space bar), but their feet are still submerged, they remain stuck in the swimming animation and cannot properly transition to standing. This leads to the strange movement behavior shown in the issue's video.

## Solution
This PR introduces an additional check to the condition for maintaining the swimming state. By adding `&& this.canSwimInFluidType(this.getEyeInFluidType())`, we now ensure that the player's head (eye level) must also be within a swimmable fluid to continue swimming.

This change effectively restores the vanilla behavior of exiting the swimming state upon surfacing, while still retaining NeoForge's compatibility with custom swimmable fluids. The logic for initiating swimming remains unchanged.

### Testing
- Confirmed that the fix resolves the issue described in #2646.
- The player can now correctly surface from water and custom fluids, transitioning from swimming to standing/treading water as expected.
- Starting to swim by sprinting underwater is unaffected and works correctly.