### PR TITLE
Cache item and fluid resources with no component patch + fix ItemAccessRH getCapacity

### DIFF
--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -24,7 +24,7 @@
      }
  
      @Deprecated
-@@ -145,6 +_,15 @@
+@@ -145,6 +_,28 @@
          return this.components;
      }
  
@@ -35,6 +35,19 @@
 +        var builder = DataComponentMap.builder().addAll(components);
 +        patch.entrySet().forEach(entry -> builder.set((DataComponentType)entry.getKey(), entry.getValue().orElse(null)));
 +        components = Properties.validateComponents(builder.build());
++        defaultResource = null;
++    }
++
++    @Nullable
++    private net.neoforged.neoforge.transfer.item.ItemResource defaultResource;
++
++    /** @deprecated Neo: do not use, use {@link net.neoforged.neoforge.transfer.item.ItemResource#of} instead. */
++    @org.jetbrains.annotations.ApiStatus.Internal @Deprecated
++    public net.neoforged.neoforge.transfer.item.ItemResource computeDefaultResource(java.util.function.Function<Item, net.neoforged.neoforge.transfer.item.ItemResource> resourceConstructor) {
++        if (this.defaultResource == null) {
++            this.defaultResource = resourceConstructor.apply(this);
++        }
++        return this.defaultResource;
 +    }
 +
      public int getDefaultMaxStackSize() {

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -9,6 +9,15 @@
      public static final ResourceLocation BASE_ATTACK_DAMAGE_ID = ResourceLocation.withDefaultNamespace("base_attack_damage");
      public static final ResourceLocation BASE_ATTACK_SPEED_ID = ResourceLocation.withDefaultNamespace("base_attack_speed");
      public static final int DEFAULT_MAX_STACK_SIZE = 64;
+@@ -109,6 +_,8 @@
+     private final Item craftingRemainingItem;
+     protected final String descriptionId;
+     private final FeatureFlagSet requiredFeatures;
++    @Nullable
++    private net.neoforged.neoforge.transfer.item.ItemResource defaultResource;
+ 
+     public static int getId(Item p_41394_) {
+         return p_41394_ == null ? 0 : BuiltInRegistries.ITEM.getId(p_41394_);
 @@ -128,12 +_,13 @@
          this.components = p_41383_.buildAndValidateComponents(Component.translatable(this.descriptionId), p_41383_.effectiveModel());
          this.craftingRemainingItem = p_41383_.craftingRemainingItem;
@@ -24,7 +33,7 @@
      }
  
      @Deprecated
-@@ -145,6 +_,28 @@
+@@ -145,6 +_,25 @@
          return this.components;
      }
  
@@ -37,9 +46,6 @@
 +        components = Properties.validateComponents(builder.build());
 +        defaultResource = null;
 +    }
-+
-+    @Nullable
-+    private net.neoforged.neoforge.transfer.item.ItemResource defaultResource;
 +
 +    /** @deprecated Neo: do not use, use {@link net.neoforged.neoforge.transfer.item.ItemResource#of} instead. */
 +    @org.jetbrains.annotations.ApiStatus.Internal @Deprecated

--- a/patches/net/minecraft/world/level/material/Fluid.java.patch
+++ b/patches/net/minecraft/world/level/material/Fluid.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/material/Fluid.java
 +++ b/net/minecraft/world/level/material/Fluid.java
+@@ -29,6 +_,8 @@
+     protected final StateDefinition<Fluid, FluidState> stateDefinition;
+     private FluidState defaultFluidState;
+     private final Holder.Reference<Fluid> builtInRegistryHolder = BuiltInRegistries.FLUID.createIntrusiveHolder(this);
++    @Nullable
++    private net.neoforged.neoforge.transfer.fluid.FluidResource defaultResource;
+ 
+     protected Fluid() {
+         StateDefinition.Builder<Fluid, FluidState> builder = new StateDefinition.Builder<>(this);
 @@ -64,6 +_,9 @@
      }
  
@@ -22,7 +31,7 @@
      @Nullable
      public AABB getAABB(FluidState p_397902_, BlockGetter p_397853_, BlockPos p_397764_) {
          if (this.isEmpty()) {
-@@ -125,5 +_,25 @@
+@@ -125,5 +_,22 @@
      @Deprecated
      public Holder.Reference<Fluid> builtInRegistryHolder() {
          return this.builtInRegistryHolder;
@@ -35,9 +44,6 @@
 +        if (forgeFluidType == null) forgeFluidType = net.neoforged.neoforge.common.CommonHooks.getVanillaFluidType(this);
 +        return forgeFluidType;
 +    }
-+
-+    @Nullable
-+    private net.neoforged.neoforge.transfer.fluid.FluidResource defaultResource;
 +
 +    /** @deprecated Neo: do not use, use {@link net.neoforged.neoforge.transfer.fluid.FluidResource#of} instead. */
 +    @org.jetbrains.annotations.ApiStatus.Internal @Deprecated

--- a/patches/net/minecraft/world/level/material/Fluid.java.patch
+++ b/patches/net/minecraft/world/level/material/Fluid.java.patch
@@ -22,7 +22,7 @@
      @Nullable
      public AABB getAABB(FluidState p_397902_, BlockGetter p_397853_, BlockPos p_397764_) {
          if (this.isEmpty()) {
-@@ -125,5 +_,13 @@
+@@ -125,5 +_,25 @@
      @Deprecated
      public Holder.Reference<Fluid> builtInRegistryHolder() {
          return this.builtInRegistryHolder;
@@ -34,5 +34,17 @@
 +    public net.neoforged.neoforge.fluids.FluidType getFluidType() {
 +        if (forgeFluidType == null) forgeFluidType = net.neoforged.neoforge.common.CommonHooks.getVanillaFluidType(this);
 +        return forgeFluidType;
++    }
++
++    @Nullable
++    private net.neoforged.neoforge.transfer.fluid.FluidResource defaultResource;
++
++    /** @deprecated Neo: do not use, use {@link net.neoforged.neoforge.transfer.fluid.FluidResource#of} instead. */
++    @org.jetbrains.annotations.ApiStatus.Internal @Deprecated
++    public net.neoforged.neoforge.transfer.fluid.FluidResource computeDefaultResource(java.util.function.Function<Fluid, net.neoforged.neoforge.transfer.fluid.FluidResource> resourceConstructor) {
++        if (this.defaultResource == null) {
++            this.defaultResource = resourceConstructor.apply(this);
++        }
++        return this.defaultResource;
      }
  }

--- a/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
@@ -108,7 +108,11 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
     @Override
     public long getCapacityAsLong(int index, T resource) {
         Objects.checkIndex(index, size());
-        return resource.isEmpty() || isValid(index, resource) ? getCapacity(index, resource) : 0;
+        if (resource.isEmpty() || isValid(index, resource)) {
+            // Cast as the product of two ints might overflow an int, but fits into a long
+            return (long) itemAccess.getAmount() * getCapacity(index, resource);
+        }
+        return 0;
     }
 
     // TODO: support "all or nothing" resource handlers better by optionally changing how insert and extract round

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -80,8 +80,7 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
      */
     public static FluidResource of(Fluid fluid) {
         if (fluid == Fluids.EMPTY) return EMPTY;
-        // TODO: cache the resource with an empty patch for each fluid
-        return new FluidResource(new FluidStack(fluid, FluidType.BUCKET_VOLUME));
+        return fluid.computeDefaultResource(f -> new FluidResource(new FluidStack(f, FluidType.BUCKET_VOLUME)));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
@@ -81,8 +81,7 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
     public static ItemResource of(ItemLike item) {
         Item value = item.asItem();
         if (value == Items.AIR) return EMPTY;
-        // TODO: cache the resource with an empty patch for each item
-        return new ItemResource(new ItemStack(value));
+        return value.computeDefaultResource(i -> new ItemResource(new ItemStack(i)));
     }
 
     /**

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/resources/ResourceTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/resources/ResourceTests.java
@@ -5,7 +5,11 @@
 
 package net.neoforged.neoforge.unittest.transfer.resources;
 
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,5 +22,41 @@ class ResourceTests {
         Assertions.assertFalse(apple.isEmpty(), "Apples should not be empty");
         Assertions.assertTrue(apple.is(Items.APPLE), "The item apple and the resource apple should match");
         Assertions.assertTrue(apple.isComponentsPatchEmpty(), "We didn't modify the apples from default");
+    }
+
+    @Test
+    void emptyPatchItemResourcesAreCached() {
+        ItemResource apple1 = ItemResource.of(Items.APPLE);
+        ItemResource apple2 = ItemResource.of(Items.APPLE);
+        Assertions.assertSame(apple1, apple2);
+    }
+
+    @Test
+    void patchedItemResourcesAreNotCached() {
+        var patch = DataComponentPatch.builder()
+                .set(DataComponents.MAX_STACK_SIZE, 10)
+                .build();
+
+        ItemResource apple1 = ItemResource.of(Items.APPLE, patch);
+        ItemResource apple2 = ItemResource.of(Items.APPLE, patch);
+        Assertions.assertNotSame(apple1, apple2);
+    }
+
+    @Test
+    void emptyPatchFluidResourcesAreCached() {
+        FluidResource lava1 = FluidResource.of(Fluids.LAVA);
+        FluidResource lava2 = FluidResource.of(Fluids.LAVA);
+        Assertions.assertSame(lava1, lava2);
+    }
+
+    @Test
+    void patchedFluidResourcesAreNotCached() {
+        var patch = DataComponentPatch.builder()
+                .set(DataComponents.MAX_STACK_SIZE, 10)
+                .build();
+
+        FluidResource lava1 = FluidResource.of(Fluids.LAVA, patch);
+        FluidResource lava2 = FluidResource.of(Fluids.LAVA, patch);
+        Assertions.assertNotSame(lava1, lava2);
     }
 }


### PR DESCRIPTION
- Cache item and fluid resources with no data component patch, to limit allocations in common cases. This is also validated by some JUnit tests.
- Add a forgotten multiplication by the current amount in `ItemAccessResourceHandler#getCapacity`.