### PR TITLE
[1.21.9] Fix custom payload handling order

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientCommonPacketListenerImpl.java.patch
@@ -75,7 +75,7 @@
 +    }
 +
 +    @Override
-+    public net.minecraft.util.thread.ReentrantBlockableEventLoop<?> getMainThreadEventLoop() {
-+        return Minecraft.getInstance();
++    public net.minecraft.network.PacketProcessor getPacketProcessor() {
++        return this.minecraft.packetProcessor();
      }
  }

--- a/patches/net/minecraft/network/PacketProcessor.java.patch
+++ b/patches/net/minecraft/network/PacketProcessor.java.patch
@@ -1,0 +1,31 @@
+--- a/net/minecraft/network/PacketProcessor.java
++++ b/net/minecraft/network/PacketProcessor.java
+@@ -11,7 +_,7 @@
+ 
+ public class PacketProcessor implements AutoCloseable {
+     static final Logger LOGGER = LogUtils.getLogger();
+-    private final Queue<PacketProcessor.ListenerAndPacket<?>> packetsToBeHandled = Queues.newConcurrentLinkedQueue();
++    private final Queue<net.neoforged.neoforge.network.handling.QueuedPacket> packetsToBeHandled = Queues.newConcurrentLinkedQueue();
+     private final Thread runningThread;
+     private boolean closed;
+ 
+@@ -28,6 +_,19 @@
+             throw new RejectedExecutionException("Server already shutting down");
+         } else {
+             this.packetsToBeHandled.add(new PacketProcessor.ListenerAndPacket<>(p_446530_, p_445832_));
++        }
++    }
++
++    /**
++     * Neo: Enqueue a main thread task from a custom payload packet handler.
++     * Use via {@link net.neoforged.neoforge.network.handling.IPayloadContext#enqueueWork}
++     */
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public void scheduleIfPossible(Runnable task) {
++        if (this.closed) {
++            throw new RejectedExecutionException("Server already shutting down");
++        } else {
++            this.packetsToBeHandled.add(new net.neoforged.neoforge.network.handling.QueuedPacket.CustomPayload(task));
+         }
+     }
+ 

--- a/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -97,8 +97,8 @@
 +    }
 +
 +    @Override
-+    public net.minecraft.util.thread.ReentrantBlockableEventLoop<?> getMainThreadEventLoop() {
-+        return server;
++    public net.minecraft.network.PacketProcessor getPacketProcessor() {
++        return this.server.packetProcessor();
 +    }
 +
 +    @Override

--- a/src/client/java/net/neoforged/neoforge/client/network/handling/ClientPayloadContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/handling/ClientPayloadContext.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.client.network.handling;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import net.minecraft.client.Minecraft;
+import net.minecraft.network.PacketProcessor;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.ClientCommonPacketListener;
 import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
@@ -28,19 +29,21 @@ public record ClientPayloadContext(ClientCommonPacketListener listener, Resource
 
     @Override
     public CompletableFuture<Void> enqueueWork(Runnable task) {
-        if (listener.getMainThreadEventLoop().isSameThread()) {
+        PacketProcessor processor = listener.getPacketProcessor();
+        if (processor.isSameThread()) {
             task.run();
             return CompletableFuture.completedFuture(null);
         }
-        return NetworkRegistry.guard(listener.getMainThreadEventLoop().submit(task), this.payloadId);
+        return NetworkRegistry.guard(CompletableFuture.runAsync(task, processor::scheduleIfPossible), this.payloadId);
     }
 
     @Override
     public <T> CompletableFuture<T> enqueueWork(Supplier<T> task) {
-        if (listener.getMainThreadEventLoop().isSameThread()) {
+        PacketProcessor processor = listener.getPacketProcessor();
+        if (processor.isSameThread()) {
             return CompletableFuture.completedFuture(task.get());
         }
-        return NetworkRegistry.guard(listener.getMainThreadEventLoop().submit(task), this.payloadId);
+        return NetworkRegistry.guard(CompletableFuture.supplyAsync(task, processor::scheduleIfPossible), this.payloadId);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommonPacketListener.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommonPacketListener.java
@@ -7,13 +7,13 @@ package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.network.Connection;
 import net.minecraft.network.PacketListener;
+import net.minecraft.network.PacketProcessor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.common.ClientCommonPacketListener;
 import net.minecraft.network.protocol.common.ServerCommonPacketListener;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.thread.ReentrantBlockableEventLoop;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.registration.NetworkRegistry;
 
@@ -45,9 +45,9 @@ public interface ICommonPacketListener extends PacketListener {
     Connection getConnection();
 
     /**
-     * {@return the main thread event loop}
+     * {@return the main thread packet processor}
      */
-    ReentrantBlockableEventLoop<?> getMainThreadEventLoop();
+    PacketProcessor getPacketProcessor();
 
     /**
      * Checks if the connection has negotiated and opened a channel for the payload.

--- a/src/main/java/net/neoforged/neoforge/network/handling/QueuedPacket.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/QueuedPacket.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.network.handling;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public interface QueuedPacket {
+    void handle();
+
+    record CustomPayload(Runnable task) implements QueuedPacket {
+        @Override
+        public void handle() {
+            task.run();
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/network/handling/ServerPayloadContext.java
+++ b/src/main/java/net/neoforged/neoforge/network/handling/ServerPayloadContext.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.network.handling;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import net.minecraft.network.PacketProcessor;
 import net.minecraft.network.protocol.PacketFlow;
 import net.minecraft.network.protocol.common.ServerCommonPacketListener;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
@@ -28,19 +29,21 @@ public record ServerPayloadContext(ServerCommonPacketListener listener, Resource
 
     @Override
     public CompletableFuture<Void> enqueueWork(Runnable task) {
-        if (listener.getMainThreadEventLoop().isSameThread()) {
+        PacketProcessor processor = listener.getPacketProcessor();
+        if (processor.isSameThread()) {
             task.run();
             return CompletableFuture.completedFuture(null);
         }
-        return NetworkRegistry.guard(listener.getMainThreadEventLoop().submit(task), this.payloadId);
+        return NetworkRegistry.guard(CompletableFuture.runAsync(task, processor::scheduleIfPossible), this.payloadId);
     }
 
     @Override
     public <T> CompletableFuture<T> enqueueWork(Supplier<T> task) {
-        if (listener.getMainThreadEventLoop().isSameThread()) {
+        PacketProcessor processor = listener.getPacketProcessor();
+        if (processor.isSameThread()) {
             return CompletableFuture.completedFuture(task.get());
         }
-        return NetworkRegistry.guard(listener.getMainThreadEventLoop().submit(task), this.payloadId);
+        return NetworkRegistry.guard(CompletableFuture.supplyAsync(task, processor::scheduleIfPossible), this.payloadId);
     }
 
     @Override

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -101,6 +101,9 @@
   "net/minecraft/network/FriendlyByteBuf": [
     "net/neoforged/neoforge/common/extensions/IFriendlyByteBufExtension"
   ],
+  "net/minecraft/network/PacketProcessor$ListenerAndPacket": [
+    "net/neoforged/neoforge/network/handling/QueuedPacket"
+  ],
   "net/minecraft/network/protocol/PacketFlow": [
     "net/neoforged/neoforge/common/extensions/IPacketFlowExtension"
   ],


### PR DESCRIPTION
This PR fixes the order in which custom payloads are handled on the main thread relative to vanilla packets.

In previous versions, both vanilla and NeoForge used the "standard" task queue of the relevant side (i.e. `Minecraft`'s and `MinecraftServer`'s implementation of `ReentrantBlockableEventLoop`) to queue up main thread handling of packets. In 1.21.9 vanilla switched to instead do this via a dedicated `PacketProcessor` whose tasks are handled before the "standard" task queue. Neo however kept using the "standard" task queue, causing custom payloads sent right before vanilla packets to be handled after these vanilla packets.

Fixes #2666