### PR TITLE
[1.21.9] Fix crash when opening config screen

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
@@ -1052,7 +1052,7 @@ public final class ConfigurationScreen extends OptionsSubScreen {
         @Override
         protected ConfigurationSectionScreen rebuild() {
             if (list != null) { // this may be called early, skip and wait for init() then
-                list.children().clear();
+                list.clearEntries();
 
                 for (int idx = 0; idx < cfgList.size(); idx++) {
                     var entry = cfgList.get(idx);


### PR DESCRIPTION
This PR fixes a crash when opening the config screen with a certain setup of config entries.
An identical crash in `ConfigurationScreen.ConfigurationSectionScreen` was already fixed during porting.

Fixes #2676