### PR TITLE
[1.21.9] Fix and expand context of RenderNameTagEvent

### DIFF
--- a/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -4,7 +4,7 @@
  
      protected void submitNameTag(S p_436016_, PoseStack p_433473_, SubmitNodeCollector p_434265_, CameraRenderState p_451278_) {
          if (p_436016_.nameTag != null) {
-+            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.DoRender(p_436016_, p_436016_.nameTag, this, p_433473_, p_434265_, p_436016_.partialTick);
++            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.DoRender(p_436016_, p_436016_.nameTag, this, p_433473_, p_434265_, p_451278_, p_436016_.partialTick);
 +            if (!net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event).isCanceled())
              p_434265_.submitNameTag(
                  p_433473_,
@@ -17,3 +17,16 @@
          return s;
      }
  
+@@ -191,9 +_,10 @@
+ 
+         if (this.entityRenderDispatcher.camera != null) {
+             p_361028_.distanceToCameraSq = this.entityRenderDispatcher.distanceToSqr(p_362104_);
+-            boolean flag1 = p_361028_.distanceToCameraSq < 4096.0 && this.shouldShowName(p_362104_, p_361028_.distanceToCameraSq);
++            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.CanRender(p_362104_, p_361028_, this.getNameTag(p_362104_), this, p_362204_);
++            boolean flag1 = event.canRender().isTrue() || (event.canRender().isDefault() && p_361028_.distanceToCameraSq < 4096.0 && this.shouldShowName(p_362104_, p_361028_.distanceToCameraSq));
+             if (flag1) {
+-                p_361028_.nameTag = this.getNameTag(p_362104_);
++                p_361028_.nameTag = event.getContent();
+                 p_361028_.nameTagAttachment = p_362104_.getAttachments().getNullable(EntityAttachment.NAME_TAG, 0, p_362104_.getYRot(p_362204_));
+             } else {
+                 p_361028_.nameTag = null;

--- a/patches/net/minecraft/client/renderer/entity/player/AvatarRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/player/AvatarRenderer.java.patch
@@ -30,7 +30,7 @@
          }
  
          if (p_447013_.nameTag != null) {
-+            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.DoRender(p_447013_, p_447013_.nameTag, this, p_446358_, p_446248_, p_447013_.partialTick);
++            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.DoRender(p_447013_, p_447013_.nameTag, this, p_446358_, p_446248_, p_451056_, p_447013_.partialTick);
 +            if (!net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event).isCanceled())
              p_446248_.submitNameTag(
                  p_446358_,

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderNameTagEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderNameTagEvent.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.state.CameraRenderState;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.TriState;
 import net.minecraft.world.entity.Entity;
@@ -145,12 +146,14 @@ public abstract class RenderNameTagEvent extends Event {
         private final Component content;
         private final PoseStack poseStack;
         private final SubmitNodeCollector submitNodeCollector;
+        private final CameraRenderState cameraRenderState;
 
-        public DoRender(EntityRenderState renderState, Component content, EntityRenderer<?, ?> entityRenderer, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, float partialTick) {
+        public DoRender(EntityRenderState renderState, Component content, EntityRenderer<?, ?> entityRenderer, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, CameraRenderState cameraRenderState, float partialTick) {
             super(renderState, entityRenderer, partialTick);
             this.content = content;
             this.poseStack = poseStack;
             this.submitNodeCollector = submitNodeCollector;
+            this.cameraRenderState = cameraRenderState;
         }
 
         /**
@@ -172,6 +175,13 @@ public abstract class RenderNameTagEvent extends Event {
          */
         public SubmitNodeCollector getSubmitNodeCollector() {
             return this.submitNodeCollector;
+        }
+
+        /**
+         * {@return the render state of the camera from which the name tag is being observed}
+         */
+        public CameraRenderState getCameraRenderState() {
+            return cameraRenderState;
         }
     }
 }


### PR DESCRIPTION
This PR adds back the missed patch to fire `RenderNameTagEvent.CanRender` and adds the `CameraRenderState` as additional context to `RenderNameTagEvent.DoRender`.

Closes #2668