### PR TITLE
[1.21.9] Fix being unable to cancel world creation and editing

### DIFF
--- a/patches/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
+++ b/patches/net/minecraft/client/gui/screens/worldselection/WorldSelectionList.java.patch
@@ -8,14 +8,6 @@
      static final Logger LOGGER = LogUtils.getLogger();
      static final Component FROM_NEWER_TOOLTIP_1 = Component.translatable("selectWorld.tooltip.fromNewerVersion1").withStyle(ChatFormatting.RED);
      static final Component FROM_NEWER_TOOLTIP_2 = Component.translatable("selectWorld.tooltip.fromNewerVersion2").withStyle(ChatFormatting.RED);
-@@ -272,6 +_,7 @@
- 
-     public void returnToScreen() {
-         this.reloadWorldList();
-+        if (this.minecraft.screen instanceof ProgressScreen || this.minecraft.screen instanceof ConfirmScreen) // Neo - fix MC-251068
-         this.minecraft.setScreen(this.screen);
-     }
- 
 @@ -524,6 +_,7 @@
              this.infoText.setPosition(i, this.getContentY() + 9 + 9 + 3);
              this.infoText.render(p_439856_, p_439492_, p_440095_, p_439455_);


### PR DESCRIPTION
This PR fixes the cancel button on the world creation and world edit screens doing nothing when opened from the world list screen. This bug does not occur when the world creation screen is opened from the Singleplayer button due to the list being empty.
In previous versions the world creation screen was opened directly in `WorldSelectionList#loadLevels()`, before the `Minecraft#setScreen()` call guarded by the patch. In 1.21.9 the world creation screen is instead opened by `WorldSelectionList#handleNewLevels()` which is called from `WorldSelectionList#renderWidget()` with the result of the future created by `WorldSelectionList#loadLevels()`. This leads to the new screen being set after returning to the previous screen, making the patch obsolete.

Fixes #2673