### PR TITLE
[1.21.10] Some small fixes and improvements to RecipeProvider

### DIFF
--- a/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
+++ b/patches/net/minecraft/data/recipes/RecipeProvider.java.patch
@@ -10,6 +10,17 @@
              .forEach(
                  (p_392602_, p_392603_) -> {
                      if (p_392603_.requiredFeatures().isSubsetOf(p_313879_)) {
+@@ -749,6 +_,10 @@
+         return Ingredient.of(this.items.getOrThrow(p_364630_));
+     }
+ 
++    protected ShapedRecipeBuilder shaped(RecipeCategory category, ItemStack stack) {
++        return ShapedRecipeBuilder.shaped(this.items, category, stack);
++    }
++
+     protected ShapedRecipeBuilder shaped(RecipeCategory p_360632_, ItemLike p_365035_) {
+         return ShapedRecipeBuilder.shaped(this.items, p_360632_, p_365035_);
+     }
 @@ -794,13 +_,13 @@
                          final List<CompletableFuture<?>> list = new ArrayList<>();
                          RecipeOutput recipeoutput = new RecipeOutput() {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -102,6 +102,7 @@ public net.minecraft.core.particles.SimpleParticleType <init>(Z)V # constructor
 protected net.minecraft.data.loot.BlockLootSubProvider createSilkTouchOnlyTable(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSilkTouchOnlyTable
 protected net.minecraft.data.loot.BlockLootSubProvider createPotFlowerItemTable(Lnet/minecraft/world/level/ItemLike;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createPotFlowerItemTable
 protected net.minecraft.data.loot.BlockLootSubProvider createSelfDropDispatchTable(Lnet/minecraft/world/level/block/Block;Lnet/minecraft/world/level/storage/loot/predicates/LootItemCondition$Builder;Lnet/minecraft/world/level/storage/loot/entries/LootPoolEntryContainer$Builder;)Lnet/minecraft/world/level/storage/loot/LootTable$Builder; # createSelfDropDispatchTable
+protected net.minecraft.data.recipes.RecipeProvider items # items
 protected net.minecraft.data.recipes.RecipeProvider getBaseBlock(Lnet/minecraft/data/BlockFamily;Lnet/minecraft/data/BlockFamily$Variant;)Lnet/minecraft/world/level/block/Block; # getBaseBlock
 protected net.minecraft.data.recipes.RecipeProvider buttonBuilder(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # buttonBuilder
 protected net.minecraft.data.recipes.RecipeProvider fenceBuilder(Lnet/minecraft/world/level/ItemLike;Lnet/minecraft/world/item/crafting/Ingredient;)Lnet/minecraft/data/recipes/RecipeBuilder; # fenceBuilder


### PR DESCRIPTION
This Pull Request makes the `items` field holding the `HolderGetter<Item>` accessable by subclasses and adds the missing overload of `shaped` for ItemStacks