### PR TITLE
[1.21.10] Pass `MaterialSet` and `MultiBufferSource` to `RenderBlockScreenEffectEvent`

### DIFF
--- a/patches/net/minecraft/client/renderer/ScreenEffectRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/ScreenEffectRenderer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/ScreenEffectRenderer.java
 +++ b/net/minecraft/client/renderer/ScreenEffectRenderer.java
-@@ -59,19 +_,22 @@
+@@ -59,20 +_,23 @@
          Player player = this.minecraft.player;
          if (this.minecraft.options.getCameraType().isFirstPerson() && !p_416461_) {
              if (!player.noPhysics) {
@@ -8,24 +8,27 @@
 -                if (blockstate != null) {
 -                    renderTex(this.minecraft.getBlockRenderer().getBlockModelShaper().getParticleIcon(blockstate), posestack, this.bufferSource);
 +                org.apache.commons.lang3.tuple.Pair<BlockState, BlockPos> overlay = getOverlayBlock(player);
-+                if (overlay != null && !net.neoforged.neoforge.client.ClientHooks.renderBlockOverlay(player, posestack, net.neoforged.neoforge.client.event.RenderBlockScreenEffectEvent.OverlayType.BLOCK, overlay.getLeft(), overlay.getRight())) {
++                if (overlay != null && !net.neoforged.neoforge.client.ClientHooks.renderBlockOverlay(player, posestack, net.neoforged.neoforge.client.event.RenderBlockScreenEffectEvent.OverlayType.BLOCK, overlay.getLeft(), overlay.getRight(), materials, bufferSource)) {
 +                    renderTex(this.minecraft.getBlockRenderer().getBlockModelShaper().getParticleIcon(overlay.getLeft(), this.minecraft.level, overlay.getRight()), posestack, this.bufferSource);
                  }
              }
  
              if (!this.minecraft.player.isSpectator()) {
                  if (this.minecraft.player.isEyeInFluid(FluidTags.WATER)) {
-+                    if (!net.neoforged.neoforge.client.ClientHooks.renderWaterOverlay(player, posestack))
-                     renderWater(this.minecraft, posestack, this.bufferSource);
+-                    renderWater(this.minecraft, posestack, this.bufferSource);
++                    if (!net.neoforged.neoforge.client.ClientHooks.renderWaterOverlay(player, posestack, materials, bufferSource))
++                        renderWater(this.minecraft, posestack, this.bufferSource);
                  }
 +                else if (!player.getEyeInFluidType().isAir()) net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(player.getEyeInFluidType()).renderOverlay(this.minecraft, posestack, this.bufferSource);
  
                  if (this.minecraft.player.isOnFire()) {
                      TextureAtlasSprite textureatlassprite = this.materials.get(ModelBakery.FIRE_1);
-+                    if (!net.neoforged.neoforge.client.ClientHooks.renderFireOverlay(player, posestack))
-                     renderFire(posestack, this.bufferSource, textureatlassprite);
+-                    renderFire(posestack, this.bufferSource, textureatlassprite);
++                    if (!net.neoforged.neoforge.client.ClientHooks.renderFireOverlay(player, posestack, materials, bufferSource))
++                        renderFire(posestack, this.bufferSource, textureatlassprite);
                  }
              }
+         }
 @@ -123,6 +_,11 @@
  
      @Nullable

--- a/patches/net/minecraft/client/renderer/ScreenEffectRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/ScreenEffectRenderer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/ScreenEffectRenderer.java
 +++ b/net/minecraft/client/renderer/ScreenEffectRenderer.java
-@@ -59,20 +_,23 @@
+@@ -59,19 +_,22 @@
          Player player = this.minecraft.player;
          if (this.minecraft.options.getCameraType().isFirstPerson() && !p_416461_) {
              if (!player.noPhysics) {
@@ -15,20 +15,17 @@
  
              if (!this.minecraft.player.isSpectator()) {
                  if (this.minecraft.player.isEyeInFluid(FluidTags.WATER)) {
--                    renderWater(this.minecraft, posestack, this.bufferSource);
 +                    if (!net.neoforged.neoforge.client.ClientHooks.renderWaterOverlay(player, posestack, materials, bufferSource))
-+                        renderWater(this.minecraft, posestack, this.bufferSource);
+                     renderWater(this.minecraft, posestack, this.bufferSource);
                  }
 +                else if (!player.getEyeInFluidType().isAir()) net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions.of(player.getEyeInFluidType()).renderOverlay(this.minecraft, posestack, this.bufferSource);
  
                  if (this.minecraft.player.isOnFire()) {
                      TextureAtlasSprite textureatlassprite = this.materials.get(ModelBakery.FIRE_1);
--                    renderFire(posestack, this.bufferSource, textureatlassprite);
 +                    if (!net.neoforged.neoforge.client.ClientHooks.renderFireOverlay(player, posestack, materials, bufferSource))
-+                        renderFire(posestack, this.bufferSource, textureatlassprite);
+                     renderFire(posestack, this.bufferSource, textureatlassprite);
                  }
              }
-         }
 @@ -123,6 +_,11 @@
  
      @Nullable

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -83,6 +83,7 @@ import net.minecraft.client.player.ClientInput;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelTargetBundle;
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.model.BlockElement;
@@ -102,6 +103,7 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.resources.model.AtlasManager;
 import net.minecraft.client.resources.model.EquipmentClientInfo;
 import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.MaterialSet;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.resources.sounds.SoundInstance;
@@ -861,16 +863,16 @@ public class ClientHooks {
         return NeoForge.EVENT_BUS.post(new ToastAddEvent(toast)).isCanceled();
     }
 
-    public static boolean renderFireOverlay(Player player, PoseStack mat) {
-        return renderBlockOverlay(player, mat, RenderBlockScreenEffectEvent.OverlayType.FIRE, Blocks.FIRE.defaultBlockState(), player.blockPosition());
+    public static boolean renderFireOverlay(Player player, PoseStack poseStack, MaterialSet materials, MultiBufferSource bufferSource) {
+        return renderBlockOverlay(player, poseStack, RenderBlockScreenEffectEvent.OverlayType.FIRE, Blocks.FIRE.defaultBlockState(), player.blockPosition(), materials, bufferSource);
     }
 
-    public static boolean renderWaterOverlay(Player player, PoseStack mat) {
-        return renderBlockOverlay(player, mat, RenderBlockScreenEffectEvent.OverlayType.WATER, Blocks.WATER.defaultBlockState(), player.blockPosition());
+    public static boolean renderWaterOverlay(Player player, PoseStack poseStack, MaterialSet materials, MultiBufferSource bufferSource) {
+        return renderBlockOverlay(player, poseStack, RenderBlockScreenEffectEvent.OverlayType.WATER, Blocks.WATER.defaultBlockState(), player.blockPosition(), materials, bufferSource);
     }
 
-    public static boolean renderBlockOverlay(Player player, PoseStack mat, RenderBlockScreenEffectEvent.OverlayType type, BlockState block, BlockPos pos) {
-        return NeoForge.EVENT_BUS.post(new RenderBlockScreenEffectEvent(player, mat, type, block, pos)).isCanceled();
+    public static boolean renderBlockOverlay(Player player, PoseStack mat, RenderBlockScreenEffectEvent.OverlayType type, BlockState block, BlockPos pos, MaterialSet materials, MultiBufferSource bufferSource) {
+        return NeoForge.EVENT_BUS.post(new RenderBlockScreenEffectEvent(player, mat, type, block, pos, materials, bufferSource)).isCanceled();
     }
 
     public static int getMaxMipmapLevel(int width, int height) {

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -855,7 +855,7 @@ public class ClientHooks {
     }
 
     public static boolean renderBlockOverlay(Player player, PoseStack poseStack, RenderBlockScreenEffectEvent.OverlayType type, BlockState block, BlockPos pos, MaterialSet materials, MultiBufferSource bufferSource) {
-        return NeoForge.EVENT_BUS.post(new RenderBlockScreenEffectEvent(player, mat, type, block, pos, materials, bufferSource)).isCanceled();
+        return NeoForge.EVENT_BUS.post(new RenderBlockScreenEffectEvent(player, poseStack, type, block, pos, materials, bufferSource)).isCanceled();
     }
 
     public static int getMaxMipmapLevel(int width, int height) {

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -871,7 +871,7 @@ public class ClientHooks {
         return renderBlockOverlay(player, poseStack, RenderBlockScreenEffectEvent.OverlayType.WATER, Blocks.WATER.defaultBlockState(), player.blockPosition(), materials, bufferSource);
     }
 
-    public static boolean renderBlockOverlay(Player player, PoseStack mat, RenderBlockScreenEffectEvent.OverlayType type, BlockState block, BlockPos pos, MaterialSet materials, MultiBufferSource bufferSource) {
+    public static boolean renderBlockOverlay(Player player, PoseStack poseStack, RenderBlockScreenEffectEvent.OverlayType type, BlockState block, BlockPos pos, MaterialSet materials, MultiBufferSource bufferSource) {
         return NeoForge.EVENT_BUS.post(new RenderBlockScreenEffectEvent(player, mat, type, block, pos, materials, bufferSource)).isCanceled();
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderBlockScreenEffectEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderBlockScreenEffectEvent.java
@@ -6,6 +6,8 @@
 package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.resources.model.MaterialSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
@@ -18,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Fired before a block texture will be overlaid on the player's view.
  *
- * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
+ * <p>This event is {@linkplain ICancellableEvent cancellable}.
  * If this event is cancelled, then the overlay will not be rendered.</p>
  *
  * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
@@ -50,14 +52,18 @@ public class RenderBlockScreenEffectEvent extends Event implements ICancellableE
     private final OverlayType overlayType;
     private final BlockState blockState;
     private final BlockPos blockPos;
+    private final MaterialSet materials;
+    private final MultiBufferSource bufferSource;
 
     @ApiStatus.Internal
-    public RenderBlockScreenEffectEvent(Player player, PoseStack poseStack, OverlayType type, BlockState block, BlockPos blockPos) {
+    public RenderBlockScreenEffectEvent(Player player, PoseStack poseStack, OverlayType type, BlockState block, BlockPos blockPos, MaterialSet materials, MultiBufferSource bufferSource) {
         this.player = player;
         this.poseStack = poseStack;
         this.overlayType = type;
         this.blockState = block;
         this.blockPos = blockPos;
+        this.materials = materials;
+        this.bufferSource = bufferSource;
     }
 
     /**
@@ -93,5 +99,19 @@ public class RenderBlockScreenEffectEvent extends Event implements ICancellableE
      */
     public BlockPos getBlockPos() {
         return blockPos;
+    }
+
+    /**
+     * {@return the materials used in rendering}
+     */
+    public MaterialSet getMaterials() {
+        return materials;
+    }
+
+    /**
+     * {@return the buffer source used in rendering}
+     */
+    public MultiBufferSource getBufferSource() {
+        return bufferSource;
     }
 }


### PR DESCRIPTION
Fixes #2701