### PR TITLE
[1.21.9] Add support for loading conditions in sprite sources

### DIFF
--- a/patches/net/minecraft/client/renderer/texture/atlas/SpriteSources.java.patch
+++ b/patches/net/minecraft/client/renderer/texture/atlas/SpriteSources.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/renderer/texture/atlas/SpriteSources.java
 +++ b/net/minecraft/client/renderer/texture/atlas/SpriteSources.java
+@@ -17,7 +_,7 @@
+ public class SpriteSources {
+     private static final ExtraCodecs.LateBoundIdMapper<ResourceLocation, MapCodec<? extends SpriteSource>> ID_MAPPER = new ExtraCodecs.LateBoundIdMapper<>();
+     public static final Codec<SpriteSource> CODEC = ID_MAPPER.codec(ResourceLocation.CODEC).dispatch(SpriteSource::codec, p_399350_ -> p_399350_);
+-    public static final Codec<List<SpriteSource>> FILE_CODEC = CODEC.listOf().fieldOf("sources").codec();
++    public static final Codec<List<SpriteSource>> FILE_CODEC = net.neoforged.neoforge.common.conditions.ConditionalOps.decodeListWithElementConditions(CODEC).fieldOf("sources").codec();
+ 
+     public static void bootstrap() {
+         ID_MAPPER.put(ResourceLocation.withDefaultNamespace("single"), SingleFile.MAP_CODEC);
 @@ -25,5 +_,7 @@
          ID_MAPPER.put(ResourceLocation.withDefaultNamespace("filter"), SourceFilter.MAP_CODEC);
          ID_MAPPER.put(ResourceLocation.withDefaultNamespace("unstitch"), Unstitcher.MAP_CODEC);

--- a/src/client/java/net/neoforged/neoforge/client/data/SpriteSourceProvider.java
+++ b/src/client/java/net/neoforged/neoforge/client/data/SpriteSourceProvider.java
@@ -5,41 +5,41 @@
 
 package net.neoforged.neoforge.client.data;
 
+import com.mojang.serialization.Codec;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.client.renderer.texture.atlas.SpriteSource;
 import net.minecraft.client.renderer.texture.atlas.SpriteSources;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.data.AtlasIds;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.common.conditions.ConditionalOps;
+import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.common.conditions.WithConditions;
 import net.neoforged.neoforge.common.data.JsonCodecProvider;
 
 /**
  * <p>Data provider for atlas configuration files.<br>
  * An atlas configuration is bound to a specific texture atlas such as the {@code minecraft:blocks} atlas and
  * allows adding additional textures to the atlas by adding {@link SpriteSource}s to the configuration.</p>
- * <p>See {@link SpriteSources} for the available sources and the constants in this class for the
+ * <p>See {@link SpriteSources} for the available sources and the constants in {@link AtlasIds} for the
  * atlases used in vanilla Minecraft</p>
  */
-public abstract class SpriteSourceProvider extends JsonCodecProvider<List<SpriteSource>> {
-    protected static final ResourceLocation BLOCKS_ATLAS = ResourceLocation.withDefaultNamespace("blocks");
-    protected static final ResourceLocation BANNER_PATTERNS_ATLAS = ResourceLocation.withDefaultNamespace("banner_patterns");
-    protected static final ResourceLocation BEDS_ATLAS = ResourceLocation.withDefaultNamespace("beds");
-    protected static final ResourceLocation CHESTS_ATLAS = ResourceLocation.withDefaultNamespace("chests");
-    protected static final ResourceLocation SHIELD_PATTERNS_ATLAS = ResourceLocation.withDefaultNamespace("shield_patterns");
-    protected static final ResourceLocation SHULKER_BOXES_ATLAS = ResourceLocation.withDefaultNamespace("shulker_boxes");
-    protected static final ResourceLocation SIGNS_ATLAS = ResourceLocation.withDefaultNamespace("signs");
-    protected static final ResourceLocation MOB_EFFECTS_ATLAS = ResourceLocation.withDefaultNamespace("mob_effects");
-    protected static final ResourceLocation PAINTINGS_ATLAS = ResourceLocation.withDefaultNamespace("paintings");
-    protected static final ResourceLocation PARTICLES_ATLAS = ResourceLocation.withDefaultNamespace("particles");
+public abstract class SpriteSourceProvider extends JsonCodecProvider<List<Optional<WithConditions<SpriteSource>>>> {
+    private static final Codec<List<Optional<WithConditions<SpriteSource>>>> CODEC = ConditionalOps.createConditionalCodecWithConditions(SpriteSources.CODEC)
+            .listOf()
+            .fieldOf("sources")
+            .codec();
 
     private final Map<ResourceLocation, SourceList> atlases = new HashMap<>();
 
     public SpriteSourceProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, String modId) {
-        super(output, PackOutput.Target.RESOURCE_PACK, "atlases", SpriteSources.FILE_CODEC, lookupProvider, modId);
+        super(output, PackOutput.Target.RESOURCE_PACK, "atlases", CODEC, lookupProvider, modId);
     }
 
     /**
@@ -51,20 +51,34 @@ public abstract class SpriteSourceProvider extends JsonCodecProvider<List<Sprite
      */
     protected final SourceList atlas(ResourceLocation id) {
         return atlases.computeIfAbsent(id, i -> {
-            final SourceList newAtlas = new SourceList(new ArrayList<>());
-            unconditional(i, newAtlas.sources());
+            SourceList newAtlas = new SourceList();
+            unconditional(i, newAtlas.sources);
             return newAtlas;
         });
     }
 
-    protected record SourceList(List<SpriteSource> sources) {
+    protected static final class SourceList {
+        private final List<Optional<WithConditions<SpriteSource>>> sources = new ArrayList<>();
+
+        private SourceList() {}
+
         /**
          * Add the given {@link SpriteSource} to this atlas configuration
          *
          * @param source The {@code SpriteSource} to be added
          */
         public SourceList addSource(SpriteSource source) {
-            sources.add(source);
+            sources.add(Optional.of(new WithConditions<>(source)));
+            return this;
+        }
+
+        /**
+         * Add the given {@link SpriteSource} to this atlas configuration with the given {@linkplain ICondition conditions}
+         *
+         * @param source The {@code SpriteSource} to be added
+         */
+        public SourceList addSource(SpriteSource source, ICondition... conditions) {
+            sources.add(Optional.of(new WithConditions<>(source, conditions)));
             return this;
         }
     }

--- a/src/client/java/net/neoforged/neoforge/client/data/internal/NeoForgeSpriteSourceProvider.java
+++ b/src/client/java/net/neoforged/neoforge/client/data/internal/NeoForgeSpriteSourceProvider.java
@@ -5,10 +5,10 @@
 
 package net.neoforged.neoforge.client.data.internal;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import net.minecraft.client.renderer.texture.atlas.sources.SingleFile;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.data.AtlasIds;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.client.data.SpriteSourceProvider;
@@ -20,6 +20,6 @@ public class NeoForgeSpriteSourceProvider extends SpriteSourceProvider {
 
     @Override
     protected void gather() {
-        atlas(SpriteSourceProvider.BLOCKS_ATLAS).addSource(new SingleFile(ResourceLocation.fromNamespaceAndPath("neoforge", "white"), Optional.empty()));
+        atlas(AtlasIds.BLOCKS).addSource(new SingleFile(ResourceLocation.fromNamespaceAndPath("neoforge", "white")));
     }
 }


### PR DESCRIPTION
This PR adds support for loading conditions to `SpriteSource`s at a per-source level and adjusts the Neo-provided `SpriteSourceProvider` to support conditions in `SpriteSource` datagen.
The `SpriteSourceProvider` is cleaned up in the process to avoid unnecessarily duplicating vanilla constants and remove outdated ones.