### PR TITLE
Collect sortable mod list into a mutable collection

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -328,7 +328,7 @@ public class ModListScreen extends Screen {
     }
 
     private void reloadMods() {
-        this.mods = this.unsortedMods.stream().filter(mi -> stripControlCodes(mi.getModInfo().getDisplayName()).toLowerCase(Locale.ROOT).contains(search.getValue().toLowerCase(Locale.ROOT))).toList();
+        this.mods = this.unsortedMods.stream().filter(mi -> stripControlCodes(mi.getModInfo().getDisplayName()).toLowerCase(Locale.ROOT).contains(search.getValue().toLowerCase(Locale.ROOT))).collect(Collectors.toCollection(ArrayList::new));
         lastFilterText = search.getValue();
     }
 


### PR DESCRIPTION
#2688 replaced a `.collect(Collectors.toList())` call with `.toList()`, causing a crash upon opening the mod list screen. This PR fixes that by using `.collect(Collectors.toCollection(ArrayList::new))` which also clearly states the intention of returning a mutable list