### PR TITLE
[1.21.4] Add Deprecation Message for `IdMappingEvent`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/IdMappingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IdMappingEvent.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.Event;
-import net.neoforged.neoforge.common.NeoForge;
 
 /**
  * Called whenever the ID mapping might have changed. If you register for this event, you
@@ -26,8 +25,9 @@ import net.neoforged.neoforge.common.NeoForge;
  * this event to update caches or other in-mod artifacts that might be impacted by an ID
  * change.
  * <p>
- * Fired on the {@link NeoForge#EVENT_BUS forge bus}.
+ * @deprecated This event is no longer fired, use {@link DeferredRegister#addAlias(ResourceLocation, ResourceLocation)} or {@link IRegistryExtension#addAlias(ResourceLocation, ResourceLocation)} instead
  */
+@Deprecated(forRemoval = true, since = "1.20.2")
 public class IdMappingEvent extends Event {
     public static class ModRemapping {
         public final ResourceLocation registry;

--- a/src/main/java/net/neoforged/neoforge/registries/IdMappingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IdMappingEvent.java
@@ -25,6 +25,7 @@ import net.neoforged.bus.api.Event;
  * this event to update caches or other in-mod artifacts that might be impacted by an ID
  * change.
  * <p>
+ * 
  * @deprecated This event is no longer fired, use {@link DeferredRegister#addAlias(ResourceLocation, ResourceLocation)} or {@link IRegistryExtension#addAlias(ResourceLocation, ResourceLocation)} instead
  */
 @Deprecated(forRemoval = true, since = "1.20.2")


### PR DESCRIPTION
Closes #2686 

`IdMappingEvent` was removed as part of #2082 in 1.21.5 given that the registry rework in 1.20.2 removed the concept of persisting IDs, replacing any changes with `addAlias`. However, from 1.20.2 to its eventual removal, the event has not been fired whatsoever with no message to the contrary.

The following adds the deprecation message mentioning the event is no longer fired and since what version, along with the alternatives to use. If accepted, this will be backported to all other versions for clarity.