### PR TITLE
Add alternate CombinedResourceHandler constructor to avoid unchecked casts for users

### DIFF
--- a/src/main/java/net/neoforged/neoforge/transfer/CombinedResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/CombinedResourceHandler.java
@@ -31,7 +31,7 @@ public class CombinedResourceHandler<T extends Resource> implements ResourceHand
     private final int sizeCache;
 
     @SuppressWarnings("unchecked")
-    public CombinedResourceHandler(SequencedCollection<ResourceHandler<T>> handlers) {
+    public CombinedResourceHandler(SequencedCollection<? extends ResourceHandler<T>> handlers) {
         this(handlers.toArray(ResourceHandler[]::new));
     }
 

--- a/src/main/java/net/neoforged/neoforge/transfer/CombinedResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/CombinedResourceHandler.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.transfer;
 
+import java.util.SequencedCollection;
 import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 
@@ -28,6 +29,11 @@ public class CombinedResourceHandler<T extends Resource> implements ResourceHand
      * The total number of indices in the combined handler, which is the sum of the sizes of all wrapped handlers.
      */
     private final int sizeCache;
+
+    @SuppressWarnings("unchecked")
+    public CombinedResourceHandler(SequencedCollection<ResourceHandler<T>> handlers) {
+        this(handlers.toArray(ResourceHandler[]::new));
+    }
 
     @SafeVarargs
     public CombinedResourceHandler(ResourceHandler<T>... handlers) {


### PR DESCRIPTION
Since you cannot construct generic arrays safely, calling the existing constructor for runtime-variable-sized lists of handlers is only possible using an checked cast. This change moves that burden into Neo.