### PR TITLE
Introduce Transaction#openRoot() to have a more readable way of opening a root transaction

### DIFF
--- a/src/main/java/net/neoforged/neoforge/energy/EnergyHandlerAdapter.java
+++ b/src/main/java/net/neoforged/neoforge/energy/EnergyHandlerAdapter.java
@@ -18,7 +18,7 @@ class EnergyHandlerAdapter implements IEnergyStorage {
 
     @Override
     public int receiveEnergy(int toReceive, boolean simulate) {
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             int inserted = handler.insert(toReceive, tx);
             if (!simulate) tx.commit();
             return inserted;
@@ -27,7 +27,7 @@ class EnergyHandlerAdapter implements IEnergyStorage {
 
     @Override
     public int extractEnergy(int toExtract, boolean simulate) {
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             int extracted = handler.extract(toExtract, tx);
             if (!simulate) tx.commit();
             return extracted;

--- a/src/main/java/net/neoforged/neoforge/fluids/capability/FluidResourceHandlerAdapter.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/FluidResourceHandlerAdapter.java
@@ -45,7 +45,7 @@ class FluidResourceHandlerAdapter implements IFluidHandler {
         if (resource.isEmpty()) {
             return 0;
         }
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             int inserted = handler.insert(FluidResource.of(resource), resource.getAmount(), tx);
             if (action.execute()) {
                 tx.commit();
@@ -59,7 +59,7 @@ class FluidResourceHandlerAdapter implements IFluidHandler {
         if (resource.isEmpty()) {
             return FluidStack.EMPTY;
         }
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             int extracted = handler.extract(FluidResource.of(resource), resource.getAmount(), tx);
             if (action.execute()) {
                 tx.commit();
@@ -73,7 +73,7 @@ class FluidResourceHandlerAdapter implements IFluidHandler {
         if (maxDrain <= 0) {
             return FluidStack.EMPTY;
         }
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             var extracted = ResourceHandlerUtil.extractFirst(handler, fr -> true, maxDrain, tx);
             if (action.execute()) {
                 tx.commit();

--- a/src/main/java/net/neoforged/neoforge/items/ItemResourceHandlerAdapter.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemResourceHandlerAdapter.java
@@ -45,7 +45,7 @@ class ItemResourceHandlerAdapter implements IItemHandler {
         }
         // We have to limit to the max stack size, per the contract of extractItem
         amount = Math.min(amount, resource.getMaxStackSize());
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             int extracted = handler.extract(slot, resource, amount, tx);
             if (!simulate) {
                 tx.commit();

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -180,7 +180,7 @@ public final class FluidUtil {
                 return FluidStack.EMPTY;
             }
             // Try to insert it into the destination
-            try (var tx = Transaction.open(null)) {
+            try (var tx = Transaction.openRoot()) {
                 var resource = FluidResource.of(fluid);
                 int inserted = destination.insert(resource, FluidType.BUCKET_VOLUME, tx);
                 if (inserted != FluidType.BUCKET_VOLUME) {
@@ -248,7 +248,7 @@ public final class FluidUtil {
             if (resource.isEmpty()) {
                 continue;
             }
-            try (var tx = Transaction.open(null)) {
+            try (var tx = Transaction.openRoot()) {
                 int amount = source.extract(index, resource, FluidType.BUCKET_VOLUME, tx);
                 if (amount != FluidType.BUCKET_VOLUME) {
                     continue;

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ResourceHandlerSlot.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ResourceHandlerSlot.java
@@ -70,7 +70,7 @@ public class ResourceHandlerSlot extends StackCopySlot {
         if (resource.isEmpty()) {
             return false;
         }
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             // Simulated extraction
             return handler.extract(index, resource, 1, tx) == 1;
         }

--- a/src/main/java/net/neoforged/neoforge/transfer/item/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/VanillaInventoryCodeHooks.java
@@ -34,7 +34,7 @@ public class VanillaInventoryCodeHooks {
         for (int index = 0; index < size; index++) {
             var itemResource = handler.getResource(index);
             if (itemResource.isEmpty()) continue;
-            try (var tx = Transaction.open(null)) {
+            try (var tx = Transaction.openRoot()) {
                 int extracted = handler.extract(index, itemResource, 1, tx);
                 if (extracted == 0) {
                     continue;
@@ -71,7 +71,7 @@ public class VanillaInventoryCodeHooks {
         if (ResourceHandlerUtil.isFull(itemHandler)) {
             return false;
         }
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             int size = hopper.getContainerSize();
             for (int i = 0; i < size; ++i) {
                 var hopperItem = hopper.getItem(i);

--- a/src/main/java/net/neoforged/neoforge/transfer/transaction/Transaction.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/transaction/Transaction.java
@@ -71,6 +71,17 @@ public final class Transaction implements AutoCloseable, TransactionContext {
     private static final StackWalker STACK_WALKER = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
     /**
+     * Opens a new transaction without a parent: a root transaction.
+     *
+     * <p>For opening a transaction within an already running transaction, see {@link #open(TransactionContext)}.
+     *
+     * @throws IllegalStateException If a transaction is already active on the current thread.
+     */
+    public static Transaction openRoot() {
+        return TransactionManager.getManagerForThread().open(null, STACK_WALKER.getCallerClass());
+    }
+
+    /**
      * Opens a new transaction with a specified parent. The example below, we open the outermost layer or the `root`.
      *
      * <pre>
@@ -80,7 +91,8 @@ public final class Transaction implements AutoCloseable, TransactionContext {
      * }
      * }</pre>
      *
-     * @param parent the parent transaction, or null if this is the root transaction
+     * @param parent the parent transaction, or null if this is the root transaction. Passing {@code null} is equivalent
+     *               to calling {@link #openRoot()}.
      * @throws IllegalStateException If no parent is passed, but a transaction is already active on the current thread.
      * @throws IllegalStateException If a parent is passed, but it's not the current transaction.
      * @throws IllegalStateException If a parent is passed, but it was already closed.

--- a/src/main/java/net/neoforged/neoforge/transfer/transaction/Transaction.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/transaction/Transaction.java
@@ -78,6 +78,7 @@ public final class Transaction implements AutoCloseable, TransactionContext {
      * @throws IllegalStateException If a transaction is already active on the current thread.
      */
     public static Transaction openRoot() {
+        // Don't delegate to other method due to getCallerClass()
         return TransactionManager.getManagerForThread().open(null, STACK_WALKER.getCallerClass());
     }
 
@@ -98,6 +99,7 @@ public final class Transaction implements AutoCloseable, TransactionContext {
      * @throws IllegalStateException If a parent is passed, but it was already closed.
      */
     public static Transaction open(@Nullable TransactionContext parent) {
+        // Don't delegate to other method due to getCallerClass()
         return TransactionManager.getManagerForThread().open(parent, STACK_WALKER.getCallerClass());
     }
 

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/CombinedResourceHandlerTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/CombinedResourceHandlerTest.java
@@ -113,7 +113,7 @@ public class CombinedResourceHandlerTest {
                     i,
                     new HandlerTestUtil.SlotInfo<>(resource, capacity, capacity));
 
-            try (var tx = Transaction.open(null)) {
+            try (var tx = Transaction.openRoot()) {
                 int inserted = combinedHandler.insert(i, resource, (int) remainingCapacity, tx);
                 assertEquals(remainingCapacity, inserted);
                 assertThat(describeSlots(combinedHandler)).containsExactlyElementsOf(expectedContent);
@@ -131,7 +131,7 @@ public class CombinedResourceHandlerTest {
             handler.setAllValid(underlyingSlot.index);
         }
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             int inserted = combinedHandler.insert(TestResource.SOME, Integer.MAX_VALUE, transaction);
             assertEquals(combinedHandler.size(), inserted);
 
@@ -152,7 +152,7 @@ public class CombinedResourceHandlerTest {
             var expectedContent = new ArrayList<>(EXPECTED_CONTENT);
             expectedContent.set(i, null);
 
-            try (Transaction transaction = Transaction.open(null)) {
+            try (Transaction transaction = Transaction.openRoot()) {
                 int extracted = combinedHandler.extract(i, expectedResource, Integer.MAX_VALUE, transaction);
                 assertEquals(expectedAmount, extracted);
                 assertThat(describeSlots(combinedHandler)).containsExactlyElementsOf(expectedContent);
@@ -168,7 +168,7 @@ public class CombinedResourceHandlerTest {
             handler.set(underlyingSlot.index, TestResource.SOME, 1);
         }
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             int extracted = combinedHandler.extract(TestResource.SOME, Integer.MAX_VALUE, transaction);
             assertEquals(4, extracted);
 
@@ -181,7 +181,7 @@ public class CombinedResourceHandlerTest {
         firstHandler.set(1, TestResource.SOME, 30);
         secondHandler.set(0, TestResource.SOME, 20);
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             int extracted = combinedHandler.extract(TestResource.SOME, 100, transaction);
             assertEquals(50, extracted);
             assertEquals(0, firstHandler.getAmountAsLong(1));
@@ -214,13 +214,13 @@ public class CombinedResourceHandlerTest {
         });
 
         assertThrows(IndexOutOfBoundsException.class, () -> {
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 combinedHandler.insert(combinedHandler.size(), TestResource.SOME, 1, tx);
             }
         });
 
         assertThrows(IndexOutOfBoundsException.class, () -> {
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 combinedHandler.extract(combinedHandler.size(), TestResource.SOME, 1, tx);
             }
         });

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/EmptyResourceHandlerTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/EmptyResourceHandlerTest.java
@@ -26,7 +26,7 @@ public class EmptyResourceHandlerTest {
     @Test
     void testThrowsOnExtract() {
         emptyHandlerThrow(() -> {
-            try (var transaction = Transaction.open(null)) {
+            try (var transaction = Transaction.openRoot()) {
                 handler.extract(0, TestResource.SOME, 1, transaction);
             }
         });
@@ -35,7 +35,7 @@ public class EmptyResourceHandlerTest {
     @Test
     void testThrowsOnInsert() {
         emptyHandlerThrow(() -> {
-            try (var transaction = Transaction.open(null)) {
+            try (var transaction = Transaction.openRoot()) {
                 handler.insert(0, TestResource.SOME, 1, transaction);
             }
         });
@@ -73,7 +73,7 @@ public class EmptyResourceHandlerTest {
 
     @Test
     void testExtractWithoutIndexIsANoop() {
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             int inserted = handler.insert(TestResource.SOME, 100, transaction);
             Assertions.assertThat(0).isEqualTo(inserted);
         }
@@ -81,7 +81,7 @@ public class EmptyResourceHandlerTest {
 
     @Test
     void testInsertWithoutIndexIsANoop() {
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             int extracted = handler.extract(TestResource.SOME, 100, transaction);
             Assertions.assertThat(0).isEqualTo(extracted);
         }

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/EnergyTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/EnergyTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 class EnergyTests {
     @Test
     void testEmptyEnergyHandler() {
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             ensureEmpty(EmptyEnergyHandler.INSTANCE, transaction);
         }
     }
@@ -42,7 +42,7 @@ class EnergyTests {
         var simpleHandler = new SimpleEnergyHandler(100, 5, 7);
         assertEquals(0, simpleHandler.getAmountAsLong());
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             assertEquals(5, simpleHandler.insert(100, transaction));
             assertEquals(3, simpleHandler.insert(3, transaction));
             assertEquals(8, simpleHandler.getAmountAsLong());
@@ -52,7 +52,7 @@ class EnergyTests {
 
         assertEquals(0, simpleHandler.getAmountAsLong());
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             assertEquals(5, simpleHandler.insert(100, transaction));
             assertEquals(3, simpleHandler.insert(3, transaction));
             assertEquals(8, simpleHandler.getAmountAsLong());
@@ -75,7 +75,7 @@ class EnergyTests {
         // Create the energy handler
         var energyHandler = new ItemAccessEnergyHandler(itemAccess, TestMod.ENERGY.get(), 60, 50, 30);
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             // Insertion of 200 should only insert 100 (50 per item).
             assertEquals(100, energyHandler.insert(200, transaction));
             assertEquals(50, itemAccess.getResource().get(TestMod.ENERGY));

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ItemAccessHandlerTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ItemAccessHandlerTest.java
@@ -34,7 +34,7 @@ class ItemAccessHandlerTest {
         ResourceHandler<FluidResource> slot1Handler = new BucketResourceHandler(new StackingItemAccess(testContainer, 1).oneByOne());
         ResourceHandler<FluidResource> slot2Handler = new BucketResourceHandler(new StackingItemAccess(testContainer, 2).oneByOne());
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             // Test extract.
             if (slot2Handler.extract(water, FluidType.BUCKET_VOLUME, transaction) != FluidType.BUCKET_VOLUME) throw new AssertionError("Should have extracted from full bucket.");
             // Test that an empty bucket was added.

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ItemTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ItemTests.java
@@ -35,14 +35,14 @@ public class ItemTests {
         ItemStack stack = container.getItem(0);
 
         // Simulate should correctly reset the stack.
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             containerWrapper.extract(ItemResource.of(Items.DIAMOND), 2, tx);
         }
 
         if (stack != container.getItem(0)) throw new AssertionError("Stack should have stayed the same.");
 
         // Commit should modify the count of the original stack.
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             containerWrapper.extract(ItemResource.of(Items.DIAMOND), 1, tx);
             tx.commit();
         }
@@ -53,7 +53,7 @@ public class ItemTests {
         ItemResource oldResource = ItemResource.of(Items.DIAMOND);
         ItemResource newResource = oldResource.with(DataComponents.MAX_DAMAGE, 10);
 
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             containerWrapper.extract(oldResource, 1, tx);
             containerWrapper.insert(newResource, 5, tx);
             tx.commit();
@@ -80,7 +80,7 @@ public class ItemTests {
         for (int iter = 0; iter < 2; ++iter) {
             // First time, abort.
             // Second time, commit.
-            try (Transaction transaction = Transaction.open(null)) {
+            try (Transaction transaction = Transaction.openRoot()) {
                 // Insert bucket from down - should fail.
                 if (downWrapper.insert(emptyBucket, 1, transaction) != 0) throw new AssertionError("Bucket should not have been inserted.");
                 // Insert bucket unsided - should go in slot 1 (canPlaceItem returns false for slot 0).
@@ -110,7 +110,7 @@ public class ItemTests {
         SimpleContainer simpleContainer = new SimpleContainer(oversizedStack);
         var wrapper = VanillaContainerWrapper.of(simpleContainer);
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             assertEquals(0L, wrapper.insert(ItemResource.of(oversizedStack), 10, transaction));
             transaction.commit();
         }
@@ -167,7 +167,7 @@ public class ItemTests {
         var wrapper = VanillaContainerWrapper.of(container);
 
         // Should only be able to insert 2 diamonds per stack * 3 stacks = 6 diamonds.
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             if (wrapper.insert(diamond, 1000, transaction) != 6) {
                 throw new AssertionError("Only 6 diamonds should have been inserted.");
             }
@@ -186,7 +186,7 @@ public class ItemTests {
         var wrapper = VanillaContainerWrapper.of(container);
 
         // Should only be able to insert 5 pickaxes, as the item limits stack counts to 1.
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             if (wrapper.insert(diamondPickaxe, 1000, transaction) != 5) {
                 throw new AssertionError("Only 5 pickaxes should have been inserted.");
             }
@@ -232,12 +232,12 @@ public class ItemTests {
         ItemResource diamond = ItemResource.of(Items.DIAMOND);
 
         // Simulation should not trigger notifications.
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             wrapper.insert(diamond, 1000, tx);
         }
 
         // But commit after modification should.
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             wrapper.insert(diamond, 1000, tx);
 
             simpleContainer.throwOnSetChanges = false;

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/RangedResourceHandlerTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/RangedResourceHandlerTest.java
@@ -92,7 +92,7 @@ public class RangedResourceHandlerTest {
     public void testInsertAtIndex() {
         var ranged = RangedResourceHandler.of(mockHandler, 2, 5);
 
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             var inserted = ranged.insert(1, TestResource.SOME, 50, transaction);
             assertEquals(50, inserted, "Should insert 50 units");
             assertEquals(50, mockHandler.getAmountAsLong(3), "Should be inserted at delegate index 3");
@@ -105,7 +105,7 @@ public class RangedResourceHandlerTest {
         mockHandler.setCapacity(50);
         var ranged = RangedResourceHandler.of(mockHandler, 2, 4);
 
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             var inserted = ranged.insert(TestResource.SOME, 101, transaction);
             assertEquals(100, inserted, "Should only be able to fill two slots, which are limited to 50.");
 
@@ -120,7 +120,7 @@ public class RangedResourceHandlerTest {
         mockHandler.setCapacity(50);
         var ranged = RangedResourceHandler.of(mockHandler, 2, 4);
 
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             var inserted = ranged.insert(TestResource.SOME, 50, transaction);
             assertEquals(50, inserted);
 
@@ -135,7 +135,7 @@ public class RangedResourceHandlerTest {
         mockHandler.set(3, TestResource.SOME, 100L);
         var ranged = RangedResourceHandler.of(mockHandler, 2, 5);
 
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             var extracted = ranged.extract(1, TestResource.SOME, 50, transaction);
             assertEquals(50, extracted, "Should extract 50 units");
             assertEquals(50, mockHandler.getAmountAsLong(3), "Should have 50 units left at delegate index 3");
@@ -149,7 +149,7 @@ public class RangedResourceHandlerTest {
         mockHandler.set(2, TestResource.SOME, 100);
         var ranged = RangedResourceHandler.ofSingleIndex(mockHandler, 1);
 
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             var extracted = ranged.extract(TestResource.SOME, 180, transaction);
             assertEquals(1, extracted, "Should extract 1 unit total");
             assertEquals(0, mockHandler.getAmountAsLong(1));
@@ -161,7 +161,7 @@ public class RangedResourceHandlerTest {
         mockHandler.set(1, TestResource.SOME, 2);
         var ranged = RangedResourceHandler.ofSingleIndex(mockHandler, 1);
 
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             var extracted = ranged.extract(TestResource.SOME, 1, transaction);
             assertEquals(1, extracted, "Should extract 1 unit total");
             assertEquals(1, mockHandler.getAmountAsLong(1));

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ResourceHandlerUtilTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ResourceHandlerUtilTest.java
@@ -197,7 +197,7 @@ public class ResourceHandlerUtilTest {
         void transactionIsRespected() {
             var handler = handler(EMPTY_SLOT, EMPTY_SLOT);
 
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 int inserted = ResourceHandlerUtil.insertStacking(handler, TestResource.SOME, 10, tx);
                 assertEquals(10, inserted);
                 assertThat(describeStacks(handler))
@@ -326,7 +326,7 @@ public class ResourceHandlerUtilTest {
         void transactionIsRespected() {
             var handler = handlerForStacks(stack(TestResource.SOME, 10), EMPTY_STACK);
 
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 var result = ResourceHandlerUtil.extractFirst(handler, r -> true, 5, tx);
 
                 assertEquals(new ResourceStack<>(TestResource.SOME, 5), result);
@@ -483,7 +483,7 @@ public class ResourceHandlerUtilTest {
             var source = handlerForStacks(stack(TestResource.SOME, 10));
             var target = handler(EMPTY_SLOT);
 
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 int moved = ResourceHandlerUtil.move(source, target, r -> true, 5, tx);
 
                 assertEquals(5, moved);
@@ -618,7 +618,7 @@ public class ResourceHandlerUtilTest {
             var source = handlerForStacks(stack(TestResource.SOME, 10));
             var target = handler(EMPTY_SLOT);
 
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 var result = ResourceHandlerUtil.moveFirst(source, target, r -> true, 5, tx);
 
                 assertEquals(new ResourceStack<>(TestResource.SOME, 5), result);
@@ -747,7 +747,7 @@ public class ResourceHandlerUtilTest {
             var handler = handlerForStacks(stack(TestResource.SOME, 5));
 
             // This call should not modify the handler since findExtractableResource uses a nested transaction
-            try (var tx = Transaction.open(null)) {
+            try (var tx = Transaction.openRoot()) {
                 ResourceHandlerUtil.findExtractableResource(handler, r -> true, tx);
 
                 // Verify handler state is unchanged even within the transaction

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/TransactionTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/TransactionTests.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class TransactionTests {
     @Test
     void testHierarchy() {
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             Assertions.assertEquals(0, transaction.depth());
 
             try (Transaction subTransaction = Transaction.open(transaction)) {
@@ -27,16 +27,16 @@ public class TransactionTests {
 
     @Test
     void testSimultaneousRootValidation() {
-        try (Transaction root1 = Transaction.open(null)) {
+        try (Transaction root1 = Transaction.openRoot()) {
             Assertions.assertThrows(IllegalStateException.class, () -> {
-                try (Transaction root2 = Transaction.open(null)) {
+                try (Transaction root2 = Transaction.openRoot()) {
                     throw new AssertionError("Two root transactions on the same thread were opened and permitted.");
                 }
             }, "Two root transactions should not be openable simultaneously");
 
         }
         Assertions.assertDoesNotThrow(() -> {
-            try (Transaction root2 = Transaction.open(null)) {
+            try (Transaction root2 = Transaction.openRoot()) {
 
             }
         }, "The sub transaction should be able to be opened as a root since `root1` should be closed.");
@@ -46,7 +46,7 @@ public class TransactionTests {
     void testSimultaneousParentValidation() {
         // Ensures that 2 transactions cannot share the same parent at the same time, but reusing a parent is fine
         // just as long as the transactions are fully completed before doing so.
-        try (Transaction root = Transaction.open(null)) {
+        try (Transaction root = Transaction.openRoot()) {
             try (Transaction sub1 = Transaction.open(root)) {
                 Assertions.assertThrows(IllegalStateException.class, () -> {
                     try (Transaction sub2 = Transaction.open(root)) {
@@ -69,7 +69,7 @@ public class TransactionTests {
         final Container container = new Container();
         IntSnapshotJournal journal = IntSnapshotJournal.of(container::set, container::get);
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             Assertions.assertEquals(0, transaction.depth());
             try (Transaction subTransaction = Transaction.open(transaction)) {
                 journal.updateSnapshots(subTransaction);
@@ -80,7 +80,7 @@ public class TransactionTests {
 
         Assertions.assertEquals(0, container.value);
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             Assertions.assertEquals(0, transaction.depth());
             try (Transaction subTransaction = Transaction.open(transaction)) {
                 journal.updateSnapshots(subTransaction);
@@ -104,7 +104,7 @@ public class TransactionTests {
         Assertions.assertNull(Transaction.getCurrentOpenedTransaction());
         Assertions.assertFalse(Transaction.hasActiveTransaction());
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             Assertions.assertEquals(transaction, Transaction.getCurrentOpenedTransaction());
 
             try (Transaction subTransaction = Transaction.open(Transaction.getCurrentOpenedTransaction())) {
@@ -199,7 +199,7 @@ public class TransactionTests {
         }
 
         var journal = new VoidJournal();
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             journal.updateSnapshots(tx);
             assertThat(journal.createdSnapshots).isEqualTo(1);
             // Second update is a no-op because the snapshot already exists

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/VoidingResourceHandlerTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/VoidingResourceHandlerTest.java
@@ -44,21 +44,21 @@ public class VoidingResourceHandlerTest {
 
     @Test
     public void testInsertOperation() {
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             assertEquals(Integer.MAX_VALUE, handler.insert(0, TestResource.SOME, Integer.MAX_VALUE, transaction));
         }
     }
 
     @Test
     public void testInsertWithoutIndexOperation() {
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             assertEquals(Integer.MAX_VALUE, handler.insert(TestResource.SOME, Integer.MAX_VALUE, transaction));
         }
     }
 
     @Test
     public void testExtractOperation() {
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             assertEquals(0, handler.extract(0, TestResource.SOME, Integer.MAX_VALUE, transaction));
             assertEquals(0, handler.extract(TestResource.SOME, Integer.MAX_VALUE, transaction));
         }
@@ -66,7 +66,7 @@ public class VoidingResourceHandlerTest {
 
     @Test
     public void testExtractWithoutIndexOperation() {
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             assertEquals(0, handler.extract(TestResource.SOME, Integer.MAX_VALUE, transaction));
         }
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/transfer/VanillaHandlersTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/transfer/VanillaHandlersTests.java
@@ -72,7 +72,7 @@ public class VanillaHandlersTests {
         var hopper = VanillaContainerWrapper.of(hopperEntity);
 
         // Insertion into empty hopper -> cooldown
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             hopper.insert(RESOURCE, 10, transaction);
             transaction.commit();
         }
@@ -80,7 +80,7 @@ public class VanillaHandlersTests {
         hopperEntity.setCooldown(0);
 
         // Second insertion into hopper -> no cooldown because the hopper is not empty
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             hopper.insert(RESOURCE, 10, transaction);
             transaction.commit();
         }
@@ -90,14 +90,14 @@ public class VanillaHandlersTests {
         hopperEntity.setItem(4, RESOURCE.toStack());
 
         // Insertion into non-empty (with an item at a different index) hopper -> no cooldown
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             hopper.insert(RESOURCE, 10, transaction);
             transaction.commit();
         }
         helper.assertValueEqual(0, getHopperCooldown(hopperEntity), "hopper cooldown");
 
         // Extraction -> no cooldown
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             hopper.extract(RESOURCE, 15, transaction);
             transaction.commit();
         }
@@ -105,13 +105,13 @@ public class VanillaHandlersTests {
         helper.assertValueEqual(0, getHopperCooldown(hopperEntity), "hopper cooldown");
 
         // Simulated insertion into empty hopper -> no cooldown
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             hopper.insert(RESOURCE, 10, transaction);
         }
         helper.assertValueEqual(0, getHopperCooldown(hopperEntity), "hopper cooldown");
 
         // Insertion into empty hopper + extract in the same transaction -> cooldown
-        try (var transaction = Transaction.open(null)) {
+        try (var transaction = Transaction.openRoot()) {
             hopper.insert(RESOURCE, 10, transaction);
             helper.assertContainerContains(pos, RESOURCE.getItem());
             hopper.extract(RESOURCE, 10, transaction);
@@ -144,7 +144,7 @@ public class VanillaHandlersTests {
         helper.runAtTickTime(5, () -> {
             helper.assertTrue(cookingTimerAccessor.getAsInt() > 0, "Furnace should have started cooking.");
 
-            try (Transaction transaction = Transaction.open(null)) {
+            try (Transaction transaction = Transaction.openRoot()) {
                 if (furnaceWrapper.extract(rawIron, 64, transaction) != 64) {
                     throw helper.assertionException("Failed to extract 64 raw iron.");
                 }
@@ -152,7 +152,7 @@ public class VanillaHandlersTests {
 
             helper.assertTrue(cookingTimerAccessor.getAsInt() > 0, "Furnace should still cook after simulation.");
 
-            try (Transaction transaction = Transaction.open(null)) {
+            try (Transaction transaction = Transaction.openRoot()) {
                 if (furnaceWrapper.extract(rawIron, 64, transaction) != 64) {
                     throw helper.assertionException("Failed to extract 64 raw iron.");
                 }
@@ -192,7 +192,7 @@ public class VanillaHandlersTests {
         // comparator
         helper.setBlock(comparatorPos, Blocks.COMPARATOR.defaultBlockState().setValue(ComparatorBlock.FACING, comparatorFacing));
 
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             if (level.getBlockTicks().hasScheduledTick(absoluteComparatorPos, Blocks.COMPARATOR)) {
                 throw helper.assertionException("Comparator should not have a tick scheduled.");
             }
@@ -241,7 +241,7 @@ public class VanillaHandlersTests {
         var resourceHandler = VanillaContainerWrapper.of(bookshelf);
 
         // First, check that we can correctly undo insert operations, because vanilla's setItem doesn't permit it without our patches.
-        try (Transaction transaction = Transaction.open(null)) {
+        try (Transaction transaction = Transaction.openRoot()) {
             if (resourceHandler.insert(book, 2, transaction) != 2) throw helper.assertionException("Should have inserted 2 books");
 
             if (bookshelf.getItem(0).getCount() != 1) throw helper.assertionException("Bookshelf stack 0 should have size 1");
@@ -254,7 +254,7 @@ public class VanillaHandlersTests {
         if (!bookshelf.getItem(1).isEmpty()) throw helper.assertionException("Bookshelf stack 1 should be empty again after aborting transaction");
 
         // Second, check that we correctly update the last modified slot.
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             if (resourceHandler.insert(1, book, 1, tx) != 1) throw helper.assertionException("Should have inserted 1 book");
             if (bookshelf.getLastInteractedSlot() != 1) throw helper.assertionException("Last modified slot should be 1");
 
@@ -302,7 +302,7 @@ public class VanillaHandlersTests {
         for (var side : ArrayUtils.add(Direction.values(), null)) {
             var resourceHandler = new WorldlyContainerWrapper(shulker, side);
 
-            try (var tx = Transaction.open(null)) {
+            try (var tx = Transaction.openRoot()) {
                 if (resourceHandler.insert(ItemResource.of(Items.SHULKER_BOX), 1, tx) > 0) {
                     helper.fail("Expected shulker box to be rejected from side: " + side, pos);
                 }
@@ -326,7 +326,7 @@ public class VanillaHandlersTests {
         FurnaceBlockEntity furnace = helper.getBlockEntity(pos, FurnaceBlockEntity.class);
         var furnaceWrapper = VanillaContainerWrapper.of(furnace);
 
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             if (furnaceWrapper.insert(1, ItemResource.of(Items.BUCKET), 2, tx) != 1) {
                 throw helper.assertionException("Exactly 1 bucket should have been inserted");
             }
@@ -349,7 +349,7 @@ public class VanillaHandlersTests {
 
         var glassBottle = ItemResource.of(Items.GLASS_BOTTLE);
 
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             for (int bottleSlot = 0; bottleSlot < 3; ++bottleSlot) {
                 if (brewingStandWrapper.insert(bottleSlot, glassBottle, 2, tx) != 1) {
                     throw helper.assertionException("Exactly 1 glass bottle should have been inserted");
@@ -361,7 +361,7 @@ public class VanillaHandlersTests {
             }
         }
 
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             // Insertion of glass bottles should put exactly 1 bottle in each bottle slot
             if (brewingStandWrapper.insert(glassBottle, 10, tx) != 3) {
                 throw helper.assertionException("Exactly 3 glass bottles should have been inserted");
@@ -389,7 +389,7 @@ public class VanillaHandlersTests {
         ResourceHandler<ItemResource> handler = EmptyResourceHandler.instance(); // helper.requireCapability(Capabilities.ItemHandler.BLOCK, chestPos, Direction.UP);
 
         // Insert one item
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             helper.assertTrue(handler.insert(ItemResource.of(Items.DIAMOND), 1, tx) == 1, "Diamond should have been inserted");
             tx.commit();
         }
@@ -442,7 +442,7 @@ public class VanillaHandlersTests {
             helper.setBlock(pos, Blocks.COMPOSTER.defaultBlockState());
             var wrapper = ComposterWrapper.get(helper.getLevel(), helper.absolutePos(pos), Direction.UP);
 
-            try (Transaction tx = Transaction.open(null)) {
+            try (Transaction tx = Transaction.openRoot()) {
                 if (wrapper.insert(carrot, 1, tx) != 1) {
                     helper.fail("Carrot should have been inserted", pos);
                 }
@@ -467,7 +467,7 @@ public class VanillaHandlersTests {
         helper.setBlock(pos, Blocks.JUKEBOX.defaultBlockState());
         var resourceHandler = VanillaContainerWrapper.of(helper.getBlockEntity(pos, JukeboxBlockEntity.class));
 
-        try (Transaction tx = Transaction.open(null)) {
+        try (Transaction tx = Transaction.openRoot()) {
             resourceHandler.insert(ItemResource.of(Items.MUSIC_DISC_11), 1, tx);
             helper.assertBlockState(pos, state -> !state.getValue(JukeboxBlock.HAS_RECORD), b -> Component.literal("Jukebox should not have its state changed mid-transaction"));
             tx.commit();
@@ -501,7 +501,7 @@ public class VanillaHandlersTests {
 
             // Wait 1 tick such that the entity will start emitting (un)equip events
             helper.runAtTickTime(1, () -> {
-                try (var tx = Transaction.open(null)) {
+                try (var tx = Transaction.openRoot()) {
                     // Check that non-armor items can't be inserted
                     if (wrapper.insert(ItemResource.of(Items.DIAMOND_PICKAXE), 1, tx) != 0) {
                         helper.fail("Should have rejected diamond pickaxe as horse armor");
@@ -520,7 +520,7 @@ public class VanillaHandlersTests {
                     helper.assertValueEqual(0, unequipEvents.getPlain(), "unequip event count");
                 }
 
-                try (var tx = Transaction.open(null)) {
+                try (var tx = Transaction.openRoot()) {
                     if (wrapper.extract(ItemResource.of(Items.DIAMOND_HORSE_ARMOR), 1, tx) != 1) {
                         helper.fail("Should have extracted 1 diamond horse armor");
                     }
@@ -551,7 +551,7 @@ public class VanillaHandlersTests {
         curseOfBinding.set(helper.getHolder(Enchantments.BINDING_CURSE), 1);
         var cursedDiamondChestplate = diamondChestplate.with(DataComponents.ENCHANTMENTS, curseOfBinding.toImmutable());
 
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             if (chestWrapper.insert(ItemResource.of(Items.DIAMOND_PICKAXE), 1, tx) != 0) {
                 helper.fail("Should have rejected diamond pickaxe as player armor");
             }
@@ -573,7 +573,7 @@ public class VanillaHandlersTests {
         var survivalPlayer = helper.makeMockPlayer(GameType.SURVIVAL);
         var survivalChestWrapper = PlayerInventoryWrapper.of(survivalPlayer).getArmorSlot(EquipmentSlot.CHEST);
 
-        try (var tx = Transaction.open(null)) {
+        try (var tx = Transaction.openRoot()) {
             if (survivalChestWrapper.insert(cursedDiamondChestplate, 1, tx) != 1) {
                 helper.fail("Should have inserted 1 cursed diamond chestplate");
             }


### PR DESCRIPTION
Passing `null` to open does not immediately read "this opens a root transaction", so I'd like to add a way to express that explicitly:

```java
Transaction.openRoot()
```

That's kinda it. Not much else to it.

Note that the actual changes are only to src/main/java/net/neoforged/neoforge/transfer/transaction/Transaction.java
The rest of the PR just replaces uses of `open(null)` in our own codebase with `openRoot()`