### PR TITLE
[1.21.9] Add Block and Item Registration Methods with Lazy Properties

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -431,7 +431,7 @@ public class DeferredRegister<T> {
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public <B extends Block> DeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, BlockBehaviour.Properties props) {
-            return this.register(name, key -> func.apply(props.setId(ResourceKey.create(Registries.BLOCK, key))));
+            return this.registerBlock(name, func, () -> props);
         }
 
         /**
@@ -498,7 +498,7 @@ public class DeferredRegister<T> {
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredBlock<Block> registerSimpleBlock(String name, BlockBehaviour.Properties props) {
-            return this.registerBlock(name, Block::new, props);
+            return this.registerBlock(name, Block::new, () -> props);
         }
 
         /**
@@ -604,7 +604,7 @@ public class DeferredRegister<T> {
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
-            return this.register(name, key -> new BlockItem(block.get(), properties.setId(ResourceKey.create(Registries.ITEM, key)).useBlockDescriptionPrefix()));
+            return this.registerSimpleBlockItem(name, block, props -> properties);
         }
 
         /**
@@ -620,7 +620,7 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(Holder)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, UnaryOperator<Item.Properties> properties) {
-            return this.registerItem(name, props -> new BlockItem(block.get(), props), props -> properties.apply(props.useBlockDescriptionPrefix()));
+            return this.registerItem(name, props -> new BlockItem(block.get(), props), props -> properties.apply(props).useBlockDescriptionPrefix());
         }
 
         /**
@@ -654,7 +654,7 @@ public class DeferredRegister<T> {
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, Item.Properties properties) {
-            return this.registerSimpleBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
+            return this.registerSimpleBlockItem(block, props -> properties);
         }
 
         /**
@@ -702,7 +702,7 @@ public class DeferredRegister<T> {
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Item.Properties props) {
-            return this.register(name, key -> func.apply(props.setId(ResourceKey.create(Registries.ITEM, key))));
+            return this.registerItem(name, func, properties -> props);
         }
 
         /**
@@ -717,7 +717,7 @@ public class DeferredRegister<T> {
          * @see #registerSimpleItem(String)
          */
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, UnaryOperator<Item.Properties> properties) {
-            return this.register(name, key -> func.apply(properties.apply(new Item.Properties().setId(ResourceKey.create(Registries.ITEM, key)))));
+            return this.register(name, key -> func.apply(properties.apply(new Item.Properties()).setId(ResourceKey.create(Registries.ITEM, key))));
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -427,9 +427,45 @@ public class DeferredRegister<T> {
          * @see #registerBlock(String, Function)
          * @see #registerSimpleBlock(String, BlockBehaviour.Properties)
          * @see #registerSimpleBlock(String)
+         * @deprecated Use {@link #registerBlock(String, Function, Supplier)} or {@link #registerBlock(String, Function, UnaryOperator)} instead.
          */
+        @Deprecated(since = "1.21.10", forRemoval = true)
         public <B extends Block> DeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, BlockBehaviour.Properties props) {
             return this.register(name, key -> func.apply(props.setId(ResourceKey.create(Registries.BLOCK, key))));
+        }
+
+        /**
+         * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+         *
+         * @param name       The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param func       A factory for the new block. The factory should not cache the created block.
+         * @param properties The supplied properties for the created block.
+         * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+         * @see #registerBlock(String, Function, UnaryOperator)
+         * @see #registerBlock(String, Function)
+         * @see #registerSimpleBlock(String, Supplier)
+         * @see #registerSimpleBlock(String, UnaryOperator)
+         * @see #registerSimpleBlock(String)
+         */
+        public <B extends Block> DeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, Supplier<BlockBehaviour.Properties> properties) {
+            return this.register(name, key -> func.apply(properties.get().setId(ResourceKey.create(Registries.BLOCK, key))));
+        }
+
+        /**
+         * Adds a new block to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+         *
+         * @param name       The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param func       A factory for the new block. The factory should not cache the created block.
+         * @param properties The unary operator, which is passed a new {@link BlockBehaviour.Properties} for the created block.
+         * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+         * @see #registerBlock(String, Function, Supplier)
+         * @see #registerBlock(String, Function)
+         * @see #registerSimpleBlock(String, Supplier)
+         * @see #registerSimpleBlock(String, UnaryOperator)
+         * @see #registerSimpleBlock(String)
+         */
+        public <B extends Block> DeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, UnaryOperator<BlockBehaviour.Properties> properties) {
+            return this.registerBlock(name, func, () -> properties.apply(BlockBehaviour.Properties.of()));
         }
 
         /**
@@ -439,12 +475,14 @@ public class DeferredRegister<T> {
          * @param name The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param func A factory for the new block. The factory should not cache the created block.
          * @return A {@link DeferredHolder} that will track updates from the registry for this block.
-         * @see #registerBlock(String, Function, BlockBehaviour.Properties)
-         * @see #registerSimpleBlock(String, BlockBehaviour.Properties)
+         * @see #registerBlock(String, Function, Supplier)
+         * @see #registerBlock(String, Function, UnaryOperator)
+         * @see #registerSimpleBlock(String, Supplier)
+         * @see #registerSimpleBlock(String, UnaryOperator)
          * @see #registerSimpleBlock(String)
          */
         public <B extends Block> DeferredBlock<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func) {
-            return this.registerBlock(name, func, BlockBehaviour.Properties.of());
+            return this.registerBlock(name, func, UnaryOperator.identity());
         }
 
         /**
@@ -456,9 +494,43 @@ public class DeferredRegister<T> {
          * @see #registerBlock(String, Function, BlockBehaviour.Properties)
          * @see #registerBlock(String, Function)
          * @see #registerSimpleBlock(String)
+         * @deprecated Use {@link #registerSimpleBlock(String, Supplier)} or {@link #registerSimpleBlock(String, UnaryOperator)} instead.
          */
+        @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredBlock<Block> registerSimpleBlock(String name, BlockBehaviour.Properties props) {
             return this.registerBlock(name, Block::new, props);
+        }
+
+        /**
+         * Adds a new simple {@link Block} with the given {@link BlockBehaviour.Properties properties} to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+         *
+         * @param name       The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param properties The supplied properties for the created block.
+         * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+         * @see #registerBlock(String, Function, Supplier)
+         * @see #registerBlock(String, Function, UnaryOperator)
+         * @see #registerBlock(String, Function)
+         * @see #registerSimpleBlock(String, UnaryOperator)
+         * @see #registerSimpleBlock(String)
+         */
+        public DeferredBlock<Block> registerSimpleBlock(String name, Supplier<BlockBehaviour.Properties> properties) {
+            return this.registerBlock(name, Block::new, properties);
+        }
+
+        /**
+         * Adds a new simple {@link Block} with the given {@link BlockBehaviour.Properties properties} to the list of entries to be registered and returns a {@link DeferredHolder} that will be populated with the created block automatically.
+         *
+         * @param name       The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param properties The unary operator, which is passed a new {@link BlockBehaviour.Properties} for the created block.
+         * @return A {@link DeferredHolder} that will track updates from the registry for this block.
+         * @see #registerBlock(String, Function, Supplier)
+         * @see #registerBlock(String, Function, UnaryOperator)
+         * @see #registerBlock(String, Function)
+         * @see #registerSimpleBlock(String, Supplier)
+         * @see #registerSimpleBlock(String)
+         */
+        public DeferredBlock<Block> registerSimpleBlock(String name, UnaryOperator<BlockBehaviour.Properties> properties) {
+            return this.registerBlock(name, Block::new, properties);
         }
 
         /**
@@ -466,12 +538,14 @@ public class DeferredRegister<T> {
          *
          * @param name The new block's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @return A {@link DeferredHolder} that will track updates from the registry for this block.
-         * @see #registerBlock(String, Function, BlockBehaviour.Properties)
+         * @see #registerBlock(String, Function, Supplier)
+         * @see #registerBlock(String, Function, UnaryOperator)
          * @see #registerBlock(String, Function)
-         * @see #registerSimpleBlock(String, BlockBehaviour.Properties)
+         * @see #registerSimpleBlock(String, Supplier)
+         * @see #registerSimpleBlock(String, UnaryOperator)
          */
         public DeferredBlock<Block> registerSimpleBlock(String name) {
-            return this.registerSimpleBlock(name, BlockBehaviour.Properties.of());
+            return this.registerSimpleBlock(name, UnaryOperator.identity());
         }
 
         @Override
@@ -526,9 +600,27 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(String, Supplier)
          * @see #registerSimpleBlockItem(Holder, Item.Properties)
          * @see #registerSimpleBlockItem(Holder)
+         * @deprecated Use {@link #registerSimpleBlockItem(String, Supplier, UnaryOperator)} instead.
          */
+        @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
             return this.register(name, key -> new BlockItem(block.get(), properties.setId(ResourceKey.create(Registries.ITEM, key)).useBlockDescriptionPrefix()));
+        }
+
+        /**
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * returns a {@link DeferredItem} that will be populated with the created item automatically.
+         *
+         * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param block      The supplier for the block to create a {@link BlockItem} for.
+         * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created {@link BlockItem}.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, UnaryOperator)
+         * @see #registerSimpleBlockItem(Holder)
+         */
+        public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, UnaryOperator<Item.Properties> properties) {
+            return this.registerItem(name, props -> new BlockItem(block.get(), props), props -> properties.apply(props.useBlockDescriptionPrefix()));
         }
 
         /**
@@ -539,12 +631,12 @@ public class DeferredRegister<T> {
          * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param block The supplier for the block to create a {@link BlockItem} for.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
-         * @see #registerSimpleBlockItem(Holder, Item.Properties)
+         * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
+         * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          * @see #registerSimpleBlockItem(Holder)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block) {
-            return this.registerSimpleBlockItem(name, block, new Item.Properties());
+            return this.registerSimpleBlockItem(name, block, UnaryOperator.identity());
         }
 
         /**
@@ -558,8 +650,26 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
          * @see #registerSimpleBlockItem(String, Supplier)
          * @see #registerSimpleBlockItem(Holder)
+         * @deprecated Use {@link #registerSimpleBlockItem(Holder, UnaryOperator)} instead.
          */
+        @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, Item.Properties properties) {
+            return this.registerSimpleBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
+        }
+
+        /**
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * returns a {@link DeferredItem} that will be populated with the created item automatically.
+         * Where the name is determined by the name of the given block.
+         *
+         * @param block      The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
+         * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created {@link BlockItem}.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder)
+         */
+        public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, UnaryOperator<Item.Properties> properties) {
             return this.registerSimpleBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
         }
 
@@ -570,12 +680,12 @@ public class DeferredRegister<T> {
          *
          * @param block The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
+         * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
          * @see #registerSimpleBlockItem(String, Supplier)
-         * @see #registerSimpleBlockItem(Holder, Item.Properties)
+         * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block) {
-            return this.registerSimpleBlockItem(block, new Item.Properties());
+            return this.registerSimpleBlockItem(block, UnaryOperator.identity());
         }
 
         /**
@@ -588,9 +698,26 @@ public class DeferredRegister<T> {
          * @see #registerItem(String, Function)
          * @see #registerSimpleItem(String, Item.Properties)
          * @see #registerSimpleItem(String)
+         * @deprecated Use {@link #registerItem(String, Function, UnaryOperator)} instead.
          */
+        @Deprecated(since = "1.21.10", forRemoval = true)
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Item.Properties props) {
             return this.register(name, key -> func.apply(props.setId(ResourceKey.create(Registries.ITEM, key))));
+        }
+
+        /**
+         * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
+         *
+         * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param func       A factory for the new item. The factory should not cache the created item.
+         * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created item.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String, UnaryOperator)
+         * @see #registerSimpleItem(String)
+         */
+        public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, UnaryOperator<Item.Properties> properties) {
+            return this.register(name, key -> func.apply(properties.apply(new Item.Properties().setId(ResourceKey.create(Registries.ITEM, key)))));
         }
 
         /**
@@ -600,12 +727,12 @@ public class DeferredRegister<T> {
          * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param func A factory for the new item. The factory should not cache the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerItem(String, Function, Item.Properties)
-         * @see #registerSimpleItem(String, Item.Properties)
+         * @see #registerItem(String, Function, UnaryOperator)
+         * @see #registerSimpleItem(String, UnaryOperator)
          * @see #registerSimpleItem(String)
          */
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func) {
-            return this.registerItem(name, func, new Item.Properties());
+            return this.registerItem(name, func, UnaryOperator.identity());
         }
 
         /**
@@ -618,9 +745,26 @@ public class DeferredRegister<T> {
          * @see #registerItem(String, Function, Item.Properties)
          * @see #registerItem(String, Function)
          * @see #registerSimpleItem(String)
+         * @deprecated Use {@link #registerSimpleItem(String, UnaryOperator)} instead.
          */
+        @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<Item> registerSimpleItem(String name, Item.Properties props) {
             return this.registerItem(name, Item::new, props);
+        }
+
+        /**
+         * Adds a new simple {@link Item} with the given {@link Item.Properties properties} to the list of entries to be registered and
+         * returns a {@link DeferredItem} that will be populated with the created item automatically.
+         *
+         * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created item.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, UnaryOperator)
+         * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String)
+         */
+        public DeferredItem<Item> registerSimpleItem(String name, UnaryOperator<Item.Properties> properties) {
+            return this.registerItem(name, Item::new, properties);
         }
 
         /**
@@ -629,12 +773,12 @@ public class DeferredRegister<T> {
          *
          * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
-         * @see #registerItem(String, Function, Item.Properties)
+         * @see #registerItem(String, Function, UnaryOperator)
          * @see #registerItem(String, Function)
-         * @see #registerSimpleItem(String, Item.Properties)
+         * @see #registerSimpleItem(String, UnaryOperator)
          */
         public DeferredItem<Item> registerSimpleItem(String name) {
-            return this.registerItem(name, Item::new, new Item.Properties());
+            return this.registerItem(name, Item::new, UnaryOperator.identity());
         }
 
         @Override

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
@@ -8,6 +8,7 @@ package net.neoforged.testframework.registration;
 import com.mojang.serialization.MapCodec;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import net.minecraft.client.color.item.ItemTintSource;
 import net.minecraft.client.data.models.BlockModelGenerators;
@@ -43,14 +44,24 @@ public class DeferredBlockBuilder<T extends Block> extends DeferredBlock<T> {
     }
 
     public DeferredBlockBuilder<T> withBlockItem() {
-        return withBlockItem(new Item.Properties(), c -> {});
+        return withBlockItem(UnaryOperator.identity(), c -> {});
     }
 
     public DeferredBlockBuilder<T> withBlockItem(Consumer<DeferredItemBuilder<BlockItem>> consumer) {
-        return withBlockItem(new Item.Properties(), consumer);
+        return withBlockItem(UnaryOperator.identity(), consumer);
     }
 
+    /**
+     * @deprecated Use {@link #withBlockItem(UnaryOperator, Consumer)} instead
+     */
+    @Deprecated(since = "1.21.10", forRemoval = true)
     public DeferredBlockBuilder<T> withBlockItem(Item.Properties properties, Consumer<DeferredItemBuilder<BlockItem>> consumer) {
+        consumer.accept(helper.items().registerSimpleBlockItem(this, props -> properties));
+        hasItem = true;
+        return this;
+    }
+
+    public DeferredBlockBuilder<T> withBlockItem(UnaryOperator<Item.Properties> properties, Consumer<DeferredItemBuilder<BlockItem>> consumer) {
         consumer.accept(helper.items().registerSimpleBlockItem(this, properties));
         hasItem = true;
         return this;

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlocks.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlocks.java
@@ -8,6 +8,7 @@ package net.neoforged.testframework.registration;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -46,11 +47,37 @@ public class DeferredBlocks extends DeferredRegister.Blocks {
     }
 
     @Override
-    public <B extends Block> DeferredBlockBuilder<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, BlockBehaviour.Properties props) {
-        return (DeferredBlockBuilder<B>) super.registerBlock(name, func, props);
+    public <B extends Block> DeferredBlockBuilder<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, Supplier<BlockBehaviour.Properties> properties) {
+        return (DeferredBlockBuilder<B>) super.registerBlock(name, func, properties);
     }
 
+    @Override
+    public <B extends Block> DeferredBlockBuilder<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func, UnaryOperator<BlockBehaviour.Properties> properties) {
+        return (DeferredBlockBuilder<B>) super.registerBlock(name, func, properties);
+    }
+
+    @Override
+    public <B extends Block> DeferredBlockBuilder<B> registerBlock(String name, Function<BlockBehaviour.Properties, ? extends B> func) {
+        return (DeferredBlockBuilder<B>) super.registerBlock(name, func);
+    }
+
+    /**
+     * @deprecated Use {@link #registerBlockWithBEType(String, BiFunction, TriFunction, Supplier)} instead.
+     */
+    @Deprecated(since = "1.21.10", forRemoval = true)
     public <B extends Block, E extends BlockEntity> DeferredBlockBuilder<B> registerBlockWithBEType(String name, BiFunction<BlockBehaviour.Properties, Supplier<BlockEntityType<E>>, ? extends B> func, TriFunction<BlockEntityType<?>, BlockPos, BlockState, E> beType, BlockBehaviour.Properties props) {
+        return registerBlockWithBEType(name, func, beType, () -> props);
+    }
+
+    public <B extends Block, E extends BlockEntity> DeferredBlockBuilder<B> registerBlockWithBEType(String name, BiFunction<BlockBehaviour.Properties, Supplier<BlockEntityType<E>>, ? extends B> func, TriFunction<BlockEntityType<?>, BlockPos, BlockState, E> beType) {
+        return registerBlockWithBEType(name, func, beType, UnaryOperator.identity());
+    }
+
+    public <B extends Block, E extends BlockEntity> DeferredBlockBuilder<B> registerBlockWithBEType(String name, BiFunction<BlockBehaviour.Properties, Supplier<BlockEntityType<E>>, ? extends B> func, TriFunction<BlockEntityType<?>, BlockPos, BlockState, E> beType, UnaryOperator<BlockBehaviour.Properties> props) {
+        return registerBlockWithBEType(name, func, beType, () -> props.apply(BlockBehaviour.Properties.of()));
+    }
+
+    public <B extends Block, E extends BlockEntity> DeferredBlockBuilder<B> registerBlockWithBEType(String name, BiFunction<BlockBehaviour.Properties, Supplier<BlockEntityType<E>>, ? extends B> func, TriFunction<BlockEntityType<?>, BlockPos, BlockState, E> beType, Supplier<BlockBehaviour.Properties> props) {
         final Supplier<BlockEntityType<E>> be = registrationHelper.registrar(Registries.BLOCK_ENTITY_TYPE).register(name, () -> new BlockEntityType<>(
                 (pos, state) -> beType.apply(BuiltInRegistries.BLOCK_ENTITY_TYPE.getValue(ResourceLocation.fromNamespaceAndPath(getNamespace(), name)), pos, state),
                 BuiltInRegistries.BLOCK.getValue(ResourceLocation.fromNamespaceAndPath(getNamespace(), name))));
@@ -58,7 +85,17 @@ public class DeferredBlocks extends DeferredRegister.Blocks {
     }
 
     @Override
-    public DeferredBlockBuilder<Block> registerSimpleBlock(String name, BlockBehaviour.Properties props) {
-        return (DeferredBlockBuilder<Block>) super.registerSimpleBlock(name, props);
+    public DeferredBlockBuilder<Block> registerSimpleBlock(String name, Supplier<BlockBehaviour.Properties> properties) {
+        return (DeferredBlockBuilder<Block>) super.registerSimpleBlock(name, properties);
+    }
+
+    @Override
+    public DeferredBlockBuilder<Block> registerSimpleBlock(String name, UnaryOperator<BlockBehaviour.Properties> properties) {
+        return (DeferredBlockBuilder<Block>) super.registerSimpleBlock(name, properties);
+    }
+
+    @Override
+    public DeferredBlockBuilder<Block> registerSimpleBlock(String name) {
+        return (DeferredBlockBuilder<Block>) super.registerSimpleBlock(name);
     }
 }

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredItems.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredItems.java
@@ -7,6 +7,7 @@ package net.neoforged.testframework.registration;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
@@ -40,7 +41,7 @@ public class DeferredItems extends DeferredRegister.Items {
     }
 
     @Override
-    public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
+    public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, UnaryOperator<Item.Properties> properties) {
         return (DeferredItemBuilder<BlockItem>) super.registerSimpleBlockItem(name, block, properties);
     }
 
@@ -50,7 +51,7 @@ public class DeferredItems extends DeferredRegister.Items {
     }
 
     @Override
-    public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(Holder<Block> block, Item.Properties properties) {
+    public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(Holder<Block> block, UnaryOperator<Item.Properties> properties) {
         return (DeferredItemBuilder<BlockItem>) super.registerSimpleBlockItem(block, properties);
     }
 
@@ -60,8 +61,8 @@ public class DeferredItems extends DeferredRegister.Items {
     }
 
     @Override
-    public <I extends Item> DeferredItemBuilder<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Item.Properties props) {
-        return (DeferredItemBuilder<I>) super.registerItem(name, func, props);
+    public <I extends Item> DeferredItemBuilder<I> registerItem(String name, Function<Item.Properties, ? extends I> func, UnaryOperator<Item.Properties> properties) {
+        return (DeferredItemBuilder<I>) super.registerItem(name, func, properties);
     }
 
     @Override
@@ -70,8 +71,8 @@ public class DeferredItems extends DeferredRegister.Items {
     }
 
     @Override
-    public DeferredItemBuilder<Item> registerSimpleItem(String name, Item.Properties props) {
-        return (DeferredItemBuilder<Item>) super.registerSimpleItem(name, props);
+    public DeferredItemBuilder<Item> registerSimpleItem(String name, UnaryOperator<Item.Properties> properties) {
+        return (DeferredItemBuilder<Item>) super.registerSimpleItem(name, properties);
     }
 
     @Override

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/BlockEntityTypeValidBlocksEventTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/BlockEntityTypeValidBlocksEventTests.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.StandingSignBlock;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.properties.WoodType;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -41,8 +40,8 @@ public class BlockEntityTypeValidBlocksEventTests {
     @Mod(value = MOD_ID)
     public static class BlockEntityTypeValidBlocksEventTestMod {
         private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
-        private static final DeferredBlock<Block> TEST_SIGN_BLOCK = BLOCKS.registerBlock("test_sign_block", (properties) -> new StandingSignBlock(WoodType.BAMBOO, properties), BlockBehaviour.Properties.of());
-        private static final DeferredBlock<Block> TEST_BED_BLOCK = BLOCKS.registerBlock("test_bed_block", (properties) -> new BedBlock(DyeColor.BLUE, properties), BlockBehaviour.Properties.of());
+        private static final DeferredBlock<Block> TEST_SIGN_BLOCK = BLOCKS.registerBlock("test_sign_block", (properties) -> new StandingSignBlock(WoodType.BAMBOO, properties));
+        private static final DeferredBlock<Block> TEST_BED_BLOCK = BLOCKS.registerBlock("test_bed_block", (properties) -> new BedBlock(DyeColor.BLUE, properties));
 
         public BlockEntityTypeValidBlocksEventTestMod(IEventBus eventBus) {
             BLOCKS.register(eventBus);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/VanillaDataGenTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/VanillaDataGenTest.java
@@ -16,7 +16,6 @@ import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.equipment.EquipmentAsset;
 import net.minecraft.world.item.equipment.EquipmentAssets;
 import net.minecraft.world.item.equipment.Equippable;
@@ -35,13 +34,13 @@ public interface VanillaDataGenTest {
         var headModelName = ResourceKey.create(EquipmentAssets.ROOT_ID, ResourceLocation.fromNamespaceAndPath(reg.modId(), "vanilla_model_gen_item_head"));
         // item should appear as red/blue chessboard
         // when worn on head should be cyan/yellow chessboard
-        var item = reg.items().registerSimpleItem("vanilla_model_gen_item", new Item.Properties()
+        var item = reg.items().registerSimpleItem("vanilla_model_gen_item", props -> props
                 .component(DataComponents.EQUIPPABLE, Equippable.builder(EquipmentSlot.HEAD)
                         .setAsset(headModelName)
                         .build()));
 
         // block should appear green/red chessboard
-        var block = reg.blocks().registerSimpleBlock("vanilla_model_gen_block", BlockBehaviour.Properties.ofFullCopy(Blocks.STONE));
+        var block = reg.blocks().registerSimpleBlock("vanilla_model_gen_block", () -> BlockBehaviour.Properties.ofFullCopy(Blocks.STONE));
         var blockItem = reg.items().registerSimpleBlockItem(block);
 
         reg.addClientProvider(event -> new ModelProvider(event.getGenerator().getPackOutput(), reg.modId()) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEntityTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockEntityTests.java
@@ -16,7 +16,6 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.eventtest.internal.TestsMod;
 import net.neoforged.testframework.DynamicTest;
@@ -85,7 +84,7 @@ public class BlockEntityTests {
             }
         }
 
-        final var block = reg.blocks().registerBlockWithBEType("test_block", TestBlock::new, TestBlockEntity::new, BlockBehaviour.Properties.of())
+        final var block = reg.blocks().registerBlockWithBEType("test_block", TestBlock::new, TestBlockEntity::new)
                 .withBlockItem().withDefaultWhiteModel().withLang("Test load block").withColor(0x67fafd);
 
         test.onGameTest(helper -> helper.startSequence()

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockPropertyTests.java
@@ -49,7 +49,7 @@ public class BlockPropertyTests {
     @GameTest
     @TestHolder(description = "Adds a toggleable light source to test if level-sensitive light emission works")
     static void levelSensitiveLight(final DynamicTest test, final RegistrationHelper reg) {
-        final var lightBlock = reg.blocks().registerBlockWithBEType("light_block", LightBlock::new, LightBlockEntity::new, BlockBehaviour.Properties.of())
+        final var lightBlock = reg.blocks().registerBlockWithBEType("light_block", LightBlock::new, LightBlockEntity::new)
                 .withLang("Light block").withBlockItem();
 
         test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 4, 3)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -96,7 +96,7 @@ public class BlockTests {
     @EmptyTemplate
     @TestHolder(description = "Tests if custom fence gates without wood types work, allowing for the use of the vanilla block for non-wooden gates")
     static void woodlessFenceGate(final DynamicTest test, final RegistrationHelper reg) {
-        final var gate = reg.blocks().registerBlock("gate", props -> new FenceGateBlock(props, SoundEvents.BARREL_OPEN, SoundEvents.CHEST_CLOSE), BlockBehaviour.Properties.ofFullCopy(Blocks.ACACIA_FENCE_GATE))
+        final var gate = reg.blocks().registerBlock("gate", props -> new FenceGateBlock(props, SoundEvents.BARREL_OPEN, SoundEvents.CHEST_CLOSE), () -> BlockBehaviour.Properties.ofFullCopy(Blocks.ACACIA_FENCE_GATE))
                 .withLang("Woodless Fence Gate")
                 .withBlockItem();
 
@@ -178,12 +178,12 @@ public class BlockTests {
     @TestHolder(description = "Adds a block that can sustain Bubble Columns and verify it works")
     static void bubbleColumnTest(final DynamicTest test, final RegistrationHelper reg) {
         final var upwardBubbleColumnSustainingBlock = reg.blocks()
-                .registerBlock("upward_bubble_column_sustaining_block", (properties) -> new CustomBubbleColumnSustainingBlock(properties, BubbleColumnDirection.UPWARD), BlockBehaviour.Properties.of())
+                .registerBlock("upward_bubble_column_sustaining_block", (properties) -> new CustomBubbleColumnSustainingBlock(properties, BubbleColumnDirection.UPWARD))
                 .withLang("Upward Bubble Column Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
         final var downwardBubbleColumnSustainingBlock = reg.blocks()
-                .registerBlock("downward_bubble_column_sustaining_block", (properties) -> new CustomBubbleColumnSustainingBlock(properties, BubbleColumnDirection.DOWNWARD), BlockBehaviour.Properties.of())
+                .registerBlock("downward_bubble_column_sustaining_block", (properties) -> new CustomBubbleColumnSustainingBlock(properties, BubbleColumnDirection.DOWNWARD))
                 .withLang("Downward Bubble Column Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/CanSustainPlantTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/CanSustainPlantTests.java
@@ -19,7 +19,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChorusPlantBlock;
 import net.minecraft.world.level.block.MangrovePropaguleBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
@@ -38,7 +37,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityLilyPadTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -83,7 +82,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityRedMushroomTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -147,7 +146,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityWheatTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -191,7 +190,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityPitcherCropTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -235,7 +234,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityBambooTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -283,7 +282,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityCactusTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -326,7 +325,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityDeadBushTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -377,7 +376,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityOakSaplingTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -415,7 +414,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityHangingMangrovePropaguleTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -449,7 +448,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilitySugarCaneTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -507,7 +506,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilitySmallDripleafTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -565,7 +564,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityBigDripleafTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -619,7 +618,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityChorusPlantTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -661,7 +660,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityChorusFlowerTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();
@@ -704,7 +703,7 @@ public class CanSustainPlantTests {
     })
     static void survivabilityCocoaTest(final DynamicTest test, final RegistrationHelper reg) {
         final var sustainingBlock = reg.blocks()
-                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new, BlockBehaviour.Properties.of())
+                .registerBlock("super_sustaining_sustaining_block", CustomSuperSustainingBlock::new)
                 .withLang("Super Sustaining block")
                 .withDefaultWhiteModel()
                 .withBlockItem();

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/OnDestroyedByPushReactionTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/OnDestroyedByPushReactionTests.java
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DirectionalBlock;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.PistonType;
@@ -35,7 +34,7 @@ public class OnDestroyedByPushReactionTests {
                 .registerBlock(
                         "destroy_on_piston_move",
                         properties -> new DestroyedByPushReactionListeningBlock(properties, callback),
-                        BlockBehaviour.Properties.of()
+                        props -> props
                                 .pushReaction(PushReaction.DESTROY))
                 .withDefaultWhiteModel()
                 .withBlockItem()
@@ -47,7 +46,7 @@ public class OnDestroyedByPushReactionTests {
                 .registerBlock(
                         "push_on_piston_move",
                         properties -> new DestroyedByPushReactionListeningBlock(properties, callback),
-                        BlockBehaviour.Properties.of()
+                        props -> props
                                 .pushReaction(PushReaction.PUSH_ONLY))
                 .withDefaultWhiteModel()
                 .withBlockItem()

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/PistonTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/PistonTests.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.DirectionalBlock;
 import net.minecraft.world.level.block.piston.PistonStructureResolver;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.event.level.PistonEvent;
 import net.neoforged.testframework.DynamicTest;
@@ -32,7 +31,7 @@ public class PistonTests {
             "This test mod makes black wool pushed by a piston drop after being pushed."
     })
     static void pistonEvent(final DynamicTest test, final RegistrationHelper reg) {
-        final var shiftOnPistonMove = reg.blocks().registerSimpleBlock("shift_on_piston_move", BlockBehaviour.Properties.of())
+        final var shiftOnPistonMove = reg.blocks().registerSimpleBlock("shift_on_piston_move")
                 .withDefaultWhiteModel()
                 .withBlockItem()
                 .withLang("Shift on piston move");
@@ -114,7 +113,7 @@ public class PistonTests {
             public boolean isStickyBlock(BlockState state) {
                 return true;
             }
-        }, Block.Properties.of()).withBlockItem().withLang("Blue block").withDefaultWhiteModel().withColor(0x0000ff);
+        }).withBlockItem().withLang("Blue block").withDefaultWhiteModel().withColor(0x0000ff);
 
         final var redBlock = reg.blocks().registerBlock("red_block", props -> new Block(props) {
             @Override
@@ -132,7 +131,7 @@ public class PistonTests {
                 if (other.getBlock() == Blocks.SLIME_BLOCK) return false;
                 return state.isStickyBlock() || other.isStickyBlock();
             }
-        }, Block.Properties.of()).withBlockItem().withLang("Red block").withDefaultWhiteModel().withColor(0xff0000);
+        }).withBlockItem().withLang("Red block").withDefaultWhiteModel().withColor(0xff0000);
 
         test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(2, 5, 1)
                 .placeFloorLever(1, 1, 0, false)

--- a/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/ItemInventoryTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/capabilities/ItemInventoryTests.java
@@ -40,7 +40,7 @@ public class ItemInventoryTests {
     static {
         NonNullList<ItemStack> defaultContents = NonNullList.withSize(SLOTS, ItemStack.EMPTY);
         defaultContents.set(STICK_SLOT, Items.STICK.getDefaultInstance().copyWithCount(64));
-        BACKPACK = ITEMS.registerItem("test_backpack", Item::new, new Item.Properties().component(DataComponents.CONTAINER, ItemContainerContents.fromItems(defaultContents)));
+        BACKPACK = ITEMS.registerItem("test_backpack", Item::new, props -> props.component(DataComponents.CONTAINER, ItemContainerContents.fromItems(defaultContents)));
     }
 
     @OnInit

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/CustomFeatureFlagsTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/CustomFeatureFlagsTests.java
@@ -77,13 +77,13 @@ public class CustomFeatureFlagsTests {
         FeatureFlag extRangeDisabledTestFlag = FeatureFlags.REGISTRY.getFlag(ResourceLocation.fromNamespaceAndPath("custom_feature_flags_pack_test", "many_flags_100"));
 
         DeferredItem<Item> baseRangeEnabledTestItem = test.registrationHelper().items()
-                .registerSimpleItem("base_range_enabled_test", new Item.Properties().requiredFeatures(baseRangeEnabledTestFlag));
+                .registerSimpleItem("base_range_enabled_test", props -> props.requiredFeatures(baseRangeEnabledTestFlag));
         DeferredItem<Item> baseRangeDisabledTestItem = test.registrationHelper().items()
-                .registerSimpleItem("base_range_disabled_test", new Item.Properties().requiredFeatures(baseRangeDisabledTestFlag));
+                .registerSimpleItem("base_range_disabled_test", props -> props.requiredFeatures(baseRangeDisabledTestFlag));
         DeferredItem<Item> extRangeEnabledTestItem = test.registrationHelper().items()
-                .registerSimpleItem("ext_range_enabled_test", new Item.Properties().requiredFeatures(extRangeEnabledTestFlag));
+                .registerSimpleItem("ext_range_enabled_test", props -> props.requiredFeatures(extRangeEnabledTestFlag));
         DeferredItem<Item> extRangeDisabledTestItem = test.registrationHelper().items()
-                .registerSimpleItem("ext_range_disabled_test", new Item.Properties().requiredFeatures(extRangeDisabledTestFlag));
+                .registerSimpleItem("ext_range_disabled_test", props -> props.requiredFeatures(extRangeDisabledTestFlag));
 
         test.eventListeners().forge().addListener((ServerStartedEvent event) -> {
             if (event.getServer() instanceof GameTestServer) return; // The gametest server enables all flags, so we're not interested in running the check

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -43,7 +43,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraft.world.level.block.WeatheringCopper;
 import net.minecraft.world.level.block.WeatheringCopperFullBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.neoforged.neoforge.common.DataMapHooks;
 import net.neoforged.neoforge.common.NeoForge;
@@ -408,10 +407,10 @@ public class DataMapTests {
     static void oxidizablesAndWaxablesMapTest(final DynamicTest test, final RegistrationHelper reg) {
         BlockPos blockPos = new BlockPos(1, 1, 1);
 
-        Holder<Block> lightlyOxidizedIron = reg.blocks().registerBlock("lightly_oxidized_iron", props -> new WeatheringCopperFullBlock(WeatheringCopper.WeatherState.EXPOSED, props), BlockBehaviour.Properties.of());
-        Holder<Block> moreOxidizedIron = reg.blocks().registerBlock("more_oxidized_iron", props -> new WeatheringCopperFullBlock(WeatheringCopper.WeatherState.WEATHERED, props), BlockBehaviour.Properties.of());
+        Holder<Block> lightlyOxidizedIron = reg.blocks().registerBlock("lightly_oxidized_iron", props -> new WeatheringCopperFullBlock(WeatheringCopper.WeatherState.EXPOSED, props));
+        Holder<Block> moreOxidizedIron = reg.blocks().registerBlock("more_oxidized_iron", props -> new WeatheringCopperFullBlock(WeatheringCopper.WeatherState.WEATHERED, props));
 
-        Holder<Block> lightlyOxidizedWaxedIron = reg.blocks().registerBlock("lightly_oxidized_waxed_iron", Block::new, BlockBehaviour.Properties.of());
+        Holder<Block> lightlyOxidizedWaxedIron = reg.blocks().registerBlock("lightly_oxidized_waxed_iron", Block::new);
 
         reg.addClientProvider(event -> new DataMapProvider(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
             @Override

--- a/tests/src/main/java/net/neoforged/neoforge/debug/fluid/ClientFluidTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/fluid/ClientFluidTests.java
@@ -58,7 +58,7 @@ public class ClientFluidTests {
     @EmptyTemplate
     @TestHolder(description = "Tests if blocks can prevent neighboring fluids from rendering against them")
     static void testWaterGlassFaceRemoval(final DynamicTest test, final RegistrationHelper reg) {
-        final var glass = reg.blocks().registerBlock("water_glass", WaterGlassBlock::new, BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS))
+        final var glass = reg.blocks().registerBlock("water_glass", WaterGlassBlock::new, () -> BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS))
                 .withLang("Water Glass")
                 .withBlockItem();
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -12,7 +12,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.world.item.DyeColor;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
@@ -69,7 +68,7 @@ public class ItemComponentTests {
     @EmptyTemplate
     @TestHolder(description = "Tests if the ModifyDefaultComponentsEvent works", groups = EventTests.GROUP)
     static void testModifyDefaultComponentsEvent(DynamicTest test, RegistrationHelper reg) {
-        final var testItem = reg.items().registerSimpleItem("test_item", new Item.Properties()
+        final var testItem = reg.items().registerSimpleItem("test_item", props -> props
                 .component(DataComponents.BASE_COLOR, DyeColor.BLUE))
                 .withLang("Test components item");
         test.framework().modEventBus().addListener((final ModifyDefaultComponentsEvent event) -> {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -189,7 +189,7 @@ public class ItemTests {
     @TestHolder(description = "Tests if custom rarities (with custom styles) work on items")
     static void itemCustomRarity(final DynamicTest test, final RegistrationHelper reg) {
         final Rarity rarity = Rarity.valueOf("NEOTESTS_CUSTOM");
-        final Supplier<Item> item = reg.items().registerSimpleItem("test", new Item.Properties().rarity(rarity))
+        final Supplier<Item> item = reg.items().registerSimpleItem("test", props -> props.rarity(rarity))
                 .withLang("Custom rarity test");
 
         test.onGameTest(helper -> helper.startSequence(() -> item.get().getDefaultInstance())

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/CustomSoundTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/CustomSoundTypeTest.java
@@ -12,7 +12,6 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -36,7 +35,7 @@ public class CustomSoundTypeTest {
     private static final SoundType TEST_SOUND_TYPE = new DeferredSoundType(1.0F, 1.0F, TEST_STEP_EVENT, TEST_STEP_EVENT, TEST_STEP_EVENT, TEST_STEP_EVENT, TEST_STEP_EVENT);
 
     private static final DeferredBlock<Block> TEST_STEP_BLOCK = BLOCKS.registerSimpleBlock("test_block",
-            BlockBehaviour.Properties.of().mapColor(MapColor.WOOD).sound(TEST_SOUND_TYPE));
+            props -> props.mapColor(MapColor.WOOD).sound(TEST_SOUND_TYPE));
 
     private static final DeferredItem<BlockItem> TEST_STEP_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_STEP_BLOCK);
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredRegistryTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DeferredRegistryTest.java
@@ -56,7 +56,7 @@ public class DeferredRegistryTest {
     // Vanilla Registry - filled directly after all RegistryEvent.Register events are fired
     private static final DeferredRegister<PosRuleTestType<?>> POS_RULE_TEST_TYPES = DeferredRegister.create(Registries.POS_RULE_TEST, MODID);
 
-    private static final DeferredBlock<Block> BLOCK = BLOCKS.registerSimpleBlock("test", Block.Properties.of().mapColor(MapColor.STONE));
+    private static final DeferredBlock<Block> BLOCK = BLOCKS.registerSimpleBlock("test", props -> props.mapColor(MapColor.STONE));
     private static final DeferredHolder<DataComponentType<?>, DataComponentType<Integer>> COMPONENT_TYPE = COMPONENTS.registerComponentType("test", builder -> builder.persistent(Codec.INT));
     private static final DeferredItem<BlockItem> ITEM = ITEMS.registerSimpleBlockItem(BLOCK);
     private static final DeferredItem<Item> ITEM_WITH_COMPONENT = ITEMS.registerItem("test_with_component", properties -> new Item(properties.component(COMPONENT_TYPE.get(), 3)));

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomBreakSoundTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomBreakSoundTest.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -39,7 +38,7 @@ public class CustomBreakSoundTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock("testblock", Block::new, BlockBehaviour.Properties.of());
+    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock("testblock", Block::new);
     private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 
     public CustomBreakSoundTest(IEventBus modBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomHeadTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/CustomHeadTest.java
@@ -25,7 +25,6 @@ import net.minecraft.world.level.block.WallSkullBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
@@ -53,8 +52,8 @@ public class CustomHeadTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MODID);
-    private static final DeferredBlock<Block> BLAZE_HEAD = BLOCKS.registerBlock("blaze_head", props -> new CustomSkullBlock(SkullType.BLAZE, props), BlockBehaviour.Properties.of().strength(1.0F));
-    private static final DeferredBlock<Block> BLAZE_HEAD_WALL = BLOCKS.registerBlock("blaze_wall_head", props -> new CustomWallSkullBlock(SkullType.BLAZE, props.strength(1.0F).overrideLootTable(BLAZE_HEAD.get().getLootTable())), BlockBehaviour.Properties.of());
+    private static final DeferredBlock<Block> BLAZE_HEAD = BLOCKS.registerBlock("blaze_head", props -> new CustomSkullBlock(SkullType.BLAZE, props), props -> props.strength(1.0F));
+    private static final DeferredBlock<Block> BLAZE_HEAD_WALL = BLOCKS.registerBlock("blaze_wall_head", props -> new CustomWallSkullBlock(SkullType.BLAZE, props.strength(1.0F).overrideLootTable(BLAZE_HEAD.get().getLootTable())));
     private static final DeferredItem<Item> BLAZE_HEAD_ITEM = ITEMS.registerItem("blaze_head", props -> new StandingAndWallBlockItem(BLAZE_HEAD.get(), BLAZE_HEAD_WALL.get(), Direction.DOWN, props.rarity(Rarity.UNCOMMON).equippableUnswappable(EquipmentSlot.HEAD)));
     private static final DeferredHolder<BlockEntityType<?>, BlockEntityType<CustomSkullBlockEntity>> CUSTOM_SKULL = BLOCK_ENTITIES.register("custom_skull", () -> new BlockEntityType<>(CustomSkullBlockEntity::new, BLAZE_HEAD.get(), BLAZE_HEAD_WALL.get()));
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
@@ -30,8 +30,8 @@ public class FlowerPotTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
-    public static final DeferredBlock<FlowerPotBlock> EMPTY_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID, props -> new FlowerPotBlock(null, () -> Blocks.AIR, props), Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
-    public static final DeferredBlock<FlowerPotBlock> OAK_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID + "_oak", props -> new FlowerPotBlock(EMPTY_FLOWER_POT, () -> Blocks.OAK_SAPLING, props), Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
+    public static final DeferredBlock<FlowerPotBlock> EMPTY_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID, props -> new FlowerPotBlock(null, () -> Blocks.AIR, props), () -> Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
+    public static final DeferredBlock<FlowerPotBlock> OAK_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID + "_oak", props -> new FlowerPotBlock(EMPTY_FLOWER_POT, () -> Blocks.OAK_SAPLING, props), () -> Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
 
     static {
         ITEMS.register(BLOCK_ID, () -> new BlockItem(EMPTY_FLOWER_POT.get(), new Item.Properties().setId(ResourceKey.create(Registries.ITEM, EMPTY_FLOWER_POT.getId())).useBlockDescriptionPrefix()));

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
@@ -41,7 +41,6 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.FlowerPotBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.material.MapColor;
@@ -75,7 +74,7 @@ public class FullPotsAccessorDemo {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MOD_ID);
 
-    private static final DeferredBlock<Block> DIORITE_POT = BLOCKS.registerBlock("diorite_pot", DioriteFlowerPotBlock::new, BlockBehaviour.Properties.of().mapColor(MapColor.NONE).instabreak().noOcclusion());
+    private static final DeferredBlock<Block> DIORITE_POT = BLOCKS.registerBlock("diorite_pot", DioriteFlowerPotBlock::new, props -> props.mapColor(MapColor.NONE).instabreak().noOcclusion());
     private static final DeferredItem<BlockItem> DIORITE_POT_ITEM = ITEMS.registerSimpleBlockItem(DIORITE_POT);
     private static final DeferredHolder<BlockEntityType<?>, BlockEntityType<DioriteFlowerPotBlockEntity>> DIORITE_POT_BLOCK_ENTITY = BLOCK_ENTITIES.register(
             "diorite_pot",

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/HideNeighborFaceTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/HideNeighborFaceTest.java
@@ -34,7 +34,7 @@ public class HideNeighborFaceTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    private static final DeferredBlock<Block> GLASS_SLAB = BLOCKS.registerBlock("glass_slab", GlassSlab::new, BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS));
+    private static final DeferredBlock<Block> GLASS_SLAB = BLOCKS.registerBlock("glass_slab", GlassSlab::new, () -> BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS));
     private static final DeferredItem<BlockItem> GLASS_SLAB_ITEM = ITEMS.registerSimpleBlockItem(GLASS_SLAB);
 
     public HideNeighborFaceTest(IEventBus bus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/OnTreeGrowBlockTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/OnTreeGrowBlockTest.java
@@ -16,7 +16,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SaplingBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.material.MapColor;
@@ -56,13 +55,13 @@ public class OnTreeGrowBlockTest {
                 return true;
             }
         }
-    }, BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_LIGHT_BLUE).destroyTime(1.5f));
+    }, props -> props.mapColor(MapColor.COLOR_LIGHT_BLUE).destroyTime(1.5f));
     public static final Holder<Block> TEST_DIRT = BLOCKS.registerBlock("test_dirt", props -> new Block(props) {
         @Override
         public TriState canSustainPlant(BlockState state, BlockGetter world, BlockPos pos, Direction facing, BlockState plantable) {
             return plantable.getBlock() instanceof SaplingBlock ? TriState.TRUE : TriState.DEFAULT;
         }
-    }, BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_LIGHT_BLUE).destroyTime(1.5f));
+    }, props -> props.mapColor(MapColor.COLOR_LIGHT_BLUE).destroyTime(1.5f));
     public static final DeferredItem<BlockItem> TEST_GRASS_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_GRASS_BLOCK);
     public static final DeferredItem<BlockItem> TEST_DIRT_ITEM = ITEMS.registerSimpleBlockItem(TEST_DIRT);
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/RedstoneSidedConnectivityTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/RedstoneSidedConnectivityTest.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.redstone.Orientation;
 import net.neoforged.bus.api.IEventBus;
@@ -33,7 +32,7 @@ public class RedstoneSidedConnectivityTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
-    private static final DeferredBlock<Block> TEST_REDSTONE_BLOCK = BLOCKS.registerBlock(BLOCK_ID, EastRedstoneBlock::new, BlockBehaviour.Properties.of());
+    private static final DeferredBlock<Block> TEST_REDSTONE_BLOCK = BLOCKS.registerBlock(BLOCK_ID, EastRedstoneBlock::new);
     private static final DeferredItem<BlockItem> TEST_REDSTONE_BLOCKITEM = ITEMS.registerSimpleBlockItem(TEST_REDSTONE_BLOCK);
 
     public RedstoneSidedConnectivityTest(IEventBus modBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/ScaffoldingTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/ScaffoldingTest.java
@@ -22,7 +22,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ScaffoldingBlock;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.MapColor;
@@ -44,7 +43,7 @@ public class ScaffoldingTest {
     static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
     static final TagKey<Block> SCAFFOLDING = BlockTags.create(ResourceLocation.fromNamespaceAndPath("neoforge", "scaffolding"));
 
-    static final DeferredBlock<Block> SCAFFOLDING_METHOD_TEST = BLOCKS.registerBlock("scaffolding_method_test", ScaffoldingTest.ScaffoldingMethodTestBlock::new, Properties.of().mapColor(MapColor.SAND).noCollision().sound(SoundType.SCAFFOLDING).dynamicShape());
+    static final DeferredBlock<Block> SCAFFOLDING_METHOD_TEST = BLOCKS.registerBlock("scaffolding_method_test", ScaffoldingTest.ScaffoldingMethodTestBlock::new, props -> props.mapColor(MapColor.SAND).noCollision().sound(SoundType.SCAFFOLDING).dynamicShape());
     static final DeferredItem<BlockItem> SCAFFOLDING_METHOD_TEST_ITEM = ITEMS.registerSimpleBlockItem(SCAFFOLDING_METHOD_TEST);
 
     public ScaffoldingTest(IEventBus modBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/ValidRailShapeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/ValidRailShapeTest.java
@@ -14,7 +14,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.BaseRailBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -36,7 +35,7 @@ public class ValidRailShapeTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    private static final DeferredBlock<Block> RAIL_SLOPE_BLOCK = BLOCKS.registerBlock("rail_slope", RailSlopeBlock::new, Properties.of());
+    private static final DeferredBlock<Block> RAIL_SLOPE_BLOCK = BLOCKS.registerBlock("rail_slope", RailSlopeBlock::new);
     private static final DeferredItem<BlockItem> RAIL_SLOPE_ITEM = ITEMS.registerSimpleBlockItem(RAIL_SLOPE_BLOCK);
 
     public ValidRailShapeTest(IEventBus bus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/AmbientOcclusionElementsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/AmbientOcclusionElementsTest.java
@@ -9,7 +9,6 @@ import net.minecraft.core.Holder;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -28,10 +27,10 @@ public class AmbientOcclusionElementsTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    public static final Holder<Block> AO_BLOCK_SHADE = BLOCKS.registerSimpleBlock("ambient_occlusion_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final Holder<Block> AO_BLOCK_NO_SHADE = BLOCKS.registerSimpleBlock("ambient_occlusion_no_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final Holder<Block> NO_AO_BLOCK_SHADE = BLOCKS.registerSimpleBlock("no_ambient_occlusion_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
-    public static final Holder<Block> NO_AO_BLOCK_NO_SHADE = BLOCKS.registerSimpleBlock("no_ambient_occlusion_no_shade", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final Holder<Block> AO_BLOCK_SHADE = BLOCKS.registerSimpleBlock("ambient_occlusion_shade", props -> props.mapColor(MapColor.STONE));
+    public static final Holder<Block> AO_BLOCK_NO_SHADE = BLOCKS.registerSimpleBlock("ambient_occlusion_no_shade", props -> props.mapColor(MapColor.STONE));
+    public static final Holder<Block> NO_AO_BLOCK_SHADE = BLOCKS.registerSimpleBlock("no_ambient_occlusion_shade", props -> props.mapColor(MapColor.STONE));
+    public static final Holder<Block> NO_AO_BLOCK_NO_SHADE = BLOCKS.registerSimpleBlock("no_ambient_occlusion_no_shade", props -> props.mapColor(MapColor.STONE));
     public static final DeferredItem<BlockItem> AO_BLOCK_SHADE_ITEM = ITEMS.registerSimpleBlockItem(AO_BLOCK_SHADE);
     public static final DeferredItem<BlockItem> AO_BLOCK_NO_SHADE_ITEM = ITEMS.registerSimpleBlockItem(AO_BLOCK_NO_SHADE);
     public static final DeferredItem<BlockItem> NO_AO_BLOCK_SHADE_ITEM = ITEMS.registerSimpleBlockItem(NO_AO_BLOCK_SHADE);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomColorResolverTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/CustomColorResolverTest.java
@@ -10,7 +10,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ColorResolver;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
@@ -32,7 +31,7 @@ public class CustomColorResolverTest {
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
 
-    private static final DeferredBlock<Block> BLOCK = BLOCKS.registerBlock("test_block", Block::new, BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    private static final DeferredBlock<Block> BLOCK = BLOCKS.registerBlock("test_block", Block::new, props -> props.mapColor(MapColor.STONE));
 
     public CustomColorResolverTest(IEventBus modBus) {
         ITEMS.register(modBus);

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/EmissiveElementsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/EmissiveElementsTest.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.oldtest.client;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -26,7 +25,7 @@ public class EmissiveElementsTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MOD_ID);
 
-    public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerSimpleBlock("emissive", BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerSimpleBlock("emissive", props -> props.mapColor(MapColor.STONE));
     public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 
     public EmissiveElementsTest(IEventBus modEventBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CompositeModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CompositeModelTest.java
@@ -62,7 +62,7 @@ public class CompositeModelTest {
                     box(0, 11.2, 11.2, 4.8, 16, 16),
                     box(11.2, 11.2, 11.2, 16, 16, 16));
         }
-    }, Block.Properties.of().mapColor(MapColor.WOOD).strength(10));
+    }, props -> props.mapColor(MapColor.WOOD).strength(10));
 
     public static DeferredItem<Item> composite_item = ITEMS.registerItem("composite_block", props -> new BlockItem(composite_block.get(), props.useBlockDescriptionPrefix()) {
         @Override

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CustomItemDisplayContextTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/CustomItemDisplayContextTest.java
@@ -139,7 +139,7 @@ public class CustomItemDisplayContextTest {
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_TYPES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MODID);
 
-    public static final DeferredBlock<Block> ITEM_HANGER_BLOCK = BLOCKS.registerBlock("item_hanger", ItemHangerBlock::new, BlockBehaviour.Properties.of().noCollision().noOcclusion().noLootTable());
+    public static final DeferredBlock<Block> ITEM_HANGER_BLOCK = BLOCKS.registerBlock("item_hanger", ItemHangerBlock::new, props -> props.noCollision().noOcclusion().noLootTable());
     public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<ItemHangerBlockEntity>> ITEM_HANGER_BE = BLOCK_ENTITY_TYPES.register("item_hanger", () -> new BlockEntityType<>(ItemHangerBlockEntity::new, ITEM_HANGER_BLOCK.get()));
     public static final DeferredItem<Item> ITEM_HANGER_ITEM = ITEMS.registerItem("item_hanger", props -> new ItemHangerItem(ITEM_HANGER_BLOCK.get(), props));
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MegaModelTest.java
@@ -31,7 +31,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
@@ -79,7 +78,7 @@ public class MegaModelTest {
     private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES = DeferredRegister.create(BuiltInRegistries.BLOCK_ENTITY_TYPE, MOD_ID);
 
     private static final String REG_NAME = "test_block";
-    public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock(REG_NAME, TestBlock::new, BlockBehaviour.Properties.of().mapColor(MapColor.STONE));
+    public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock(REG_NAME, TestBlock::new, props -> props.mapColor(MapColor.STONE));
     public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
     public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<?>> TEST_BLOCK_ENTITY = BLOCK_ENTITIES.register(REG_NAME, () -> new BlockEntityType<>(
             TestBlock.Entity::new, Set.of(TEST_BLOCK.get())));

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MultiLayerModelTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/MultiLayerModelTest.java
@@ -26,7 +26,7 @@ public class MultiLayerModelTest {
 
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerSimpleBlock(blockName, Block.Properties.of().mapColor(MapColor.WOOD).noOcclusion());
+    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerSimpleBlock(blockName, props -> props.mapColor(MapColor.WOOD).noOcclusion());
     private static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 
     public MultiLayerModelTest(IEventBus modEventBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/NewModelLoaderTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/NewModelLoaderTest.java
@@ -68,11 +68,11 @@ public class NewModelLoaderTest {
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     public static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
-    public static DeferredBlock<Block> obj_block = BLOCKS.registerBlock("obj_block", TestBlock::new, Block.Properties.of().mapColor(MapColor.WOOD).strength(10));
+    public static DeferredBlock<Block> obj_block = BLOCKS.registerBlock("obj_block", TestBlock::new, props -> props.mapColor(MapColor.WOOD).strength(10));
 
     // Same at obj_block except all the parts in the obj model have the same name,
     // this is a test for neoforged/NeoForge#1755 that was fixed by neoforged/NeoForge#1759
-    public static DeferredBlock<Block> obj_block_same_part_names = BLOCKS.registerBlock("obj_block_same_part_names", TestBlock::new, Block.Properties.of().mapColor(MapColor.WOOD).strength(10));
+    public static DeferredBlock<Block> obj_block_same_part_names = BLOCKS.registerBlock("obj_block_same_part_names", TestBlock::new, props -> props.mapColor(MapColor.WOOD).strength(10));
 
     public static DeferredItem<Item> obj_item = ITEMS.registerItem("obj_block", props -> new BlockItem(obj_block.get(), props.useBlockDescriptionPrefix()) {
         @Override

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/TRSRTransformerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/model/TRSRTransformerTest.java
@@ -45,7 +45,7 @@ public class TRSRTransformerTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
-    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock("test", Block::new, Block.Properties.of().mapColor(MapColor.STONE));
+    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock("test", Block::new, props -> props.mapColor(MapColor.STONE));
     @SuppressWarnings("unused")
     private static final DeferredItem<BlockItem> TEST_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
 

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/fluid/FluidTypeTest.java
@@ -27,7 +27,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
@@ -93,7 +92,7 @@ public class FluidTypeTest {
             .addDripstoneDripping(0.25F, ParticleTypes.SCULK_SOUL, Blocks.POWDER_SNOW_CAULDRON, SoundEvents.END_PORTAL_SPAWN)));
     private static final DeferredHolder<Fluid, FlowingFluid> TEST_FLUID = FLUIDS.register("test_fluid", () -> new BaseFlowingFluid.Source(fluidProperties()));
     private static final DeferredHolder<Fluid, Fluid> TEST_FLUID_FLOWING = FLUIDS.register("test_fluid_flowing", () -> new BaseFlowingFluid.Flowing(fluidProperties()));
-    private static final DeferredBlock<LiquidBlock> TEST_FLUID_BLOCK = BLOCKS.registerBlock("test_fluid_block", props -> new LiquidBlock(TEST_FLUID.get(), props), BlockBehaviour.Properties.of().noCollision().strength(100.0F).noLootTable());
+    private static final DeferredBlock<LiquidBlock> TEST_FLUID_BLOCK = BLOCKS.registerBlock("test_fluid_block", props -> new LiquidBlock(TEST_FLUID.get(), props), props -> props.noCollision().strength(100.0F).noLootTable());
     private static final DeferredItem<Item> TEST_FLUID_BUCKET = ITEMS.registerItem("test_fluid_bucket", props -> new BucketItem(TEST_FLUID.get(), props.craftRemainder(Items.BUCKET).stacksTo(1)));
 
     public FluidTypeTest(IEventBus modEventBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/world/ForgeChunkManagerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/world/ForgeChunkManagerTest.java
@@ -15,7 +15,6 @@ import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockBehaviour.Properties;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.bus.api.IEventBus;
@@ -36,7 +35,7 @@ public class ForgeChunkManagerTest {
     private static final Logger LOGGER = LogManager.getLogger(MODID);
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
-    private static final DeferredBlock<Block> CHUNK_LOADER_BLOCK = BLOCKS.registerBlock("chunk_loader", ChunkLoaderBlock::new, Properties.of().mapColor(MapColor.STONE));
+    private static final DeferredBlock<Block> CHUNK_LOADER_BLOCK = BLOCKS.registerBlock("chunk_loader", ChunkLoaderBlock::new, props -> props.mapColor(MapColor.STONE));
     private static final DeferredItem<BlockItem> CHUNK_LOADER_ITEM = ITEMS.registerSimpleBlockItem(CHUNK_LOADER_BLOCK);
     private static final TicketController CONTROLLER = new TicketController(ResourceLocation.fromNamespaceAndPath(MODID, "default"), (world, ticketHelper) -> {
         for (Map.Entry<BlockPos, TicketSet> entry : ticketHelper.getBlockTickets().entrySet()) {


### PR DESCRIPTION
Many block and item properties make use of other registered objects as part of their class. For vanilla entries, this is normally not an issue as all of them are registered before mods can even classload. However, if using modded entries for the property values, proper steps must be taken to ensure that the properties aren't loaded until registration time. However, nearly all methods within `DeferredRegister.Blocks` and `Items` take a resolved properties argument, which can cause a host of different errors, some of which may be difficulty to track down.

Therefore, this PR adds in lazy variants for each of the property methods, deprecating the immediate resolution properties for removal in 1.22. Items only have variants that take in an `UnaryOperator`. Meanwhile, blocks have variants for `UnaryOperator` and `Supplier` in case they want to use a different builder constructor.