### PR TITLE
Default fake players to survival

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -349,6 +349,14 @@
      public TextFilter getTextFilter() {
          return this.textFilter;
      }
+@@ -2024,6 +_,7 @@
+     }
+ 
+     private GameType calculateGameModeForNewPlayer(@Nullable GameType p_143424_) {
++        if (isFakePlayer()) return GameType.SURVIVAL; // Neo: Always default fake players to survival
+         GameType gametype = this.server.getForcedGameType();
+         if (gametype != null) {
+             return gametype;
 @@ -2060,11 +_,14 @@
  
      public boolean drop(boolean p_182295_) {


### PR DESCRIPTION
Minecraft 1.21.9 slightly changed how the default game mode for players is set. Previously, it was left at `GameType.DEFAULT_MODE` (survival), but now sets it to the server's default (see `calculateGameModeForNewPlayer`), which may be creative.

This patches `calculateGameModeForNewPlayer` to force fake players to default to survival. This is a little ugly, but felt slightly better than setting the game type in the the `FakePlayer` constructor, as it means we only initialise the game mode once. This matches what Fabric does, if it's any consolation!