### PR TITLE
[1.21.10] Add missing needs_netherite_tool tag to incorrect_for_copper_tools

### DIFF
--- a/src/generated/resources/data/minecraft/tags/block/incorrect_for_copper_tool.json
+++ b/src/generated/resources/data/minecraft/tags/block/incorrect_for_copper_tool.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#neoforge:needs_netherite_tool"
+  ]
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
@@ -173,6 +173,7 @@ public final class NeoForgeBlockTagsProvider extends BlockTagsProvider {
         tag(Tags.Blocks.NEEDS_NETHERITE_TOOL);
         tag(BlockTags.INCORRECT_FOR_WOODEN_TOOL).addTag(Tags.Blocks.NEEDS_NETHERITE_TOOL);
         tag(BlockTags.INCORRECT_FOR_STONE_TOOL).addTag(Tags.Blocks.NEEDS_NETHERITE_TOOL);
+        tag(BlockTags.INCORRECT_FOR_COPPER_TOOL).addTag(Tags.Blocks.NEEDS_NETHERITE_TOOL);
         tag(BlockTags.INCORRECT_FOR_IRON_TOOL).addTag(Tags.Blocks.NEEDS_NETHERITE_TOOL);
         tag(BlockTags.INCORRECT_FOR_GOLD_TOOL).addTag(Tags.Blocks.NEEDS_NETHERITE_TOOL);
         tag(BlockTags.INCORRECT_FOR_DIAMOND_TOOL).addTag(Tags.Blocks.NEEDS_NETHERITE_TOOL);


### PR DESCRIPTION
Add the NeoForge `needs_netherite_tool` tag to the `incorrect_for_copper_tools` tag. The missing tag causes tier comparison issues when breaking blocks.