### PR TITLE
[1.21.10] Update Underwater field by checking if the eye is in the fluid

### DIFF
--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -54,16 +54,12 @@
      }
  
      @Override
-@@ -308,7 +_,11 @@
+@@ -308,7 +_,7 @@
      }
  
      protected boolean updateIsUnderwater() {
 -        this.wasUnderwater = this.isEyeInFluid(FluidTags.WATER);
-+        this.wasUnderwater = false;
-+        if (this.forgeFluidTypeHeight.isEmpty()) { return false; }
-+        for (net.neoforged.neoforge.fluids.FluidType fluidType : this.forgeFluidTypeHeight.keySet()) {
-+            if (fluidType.canSwim(this) && this.isInFluidType(fluidType)) { this.wasUnderwater = true; }
-+        }
++        this.wasUnderwater = this.getEyeInFluidType() != null && this.getEyeInFluidType().canSwim(this);
          return this.wasUnderwater;
      }
  


### PR DESCRIPTION
`Player#updateIsUnderwater` checks whether the player's eyes are within the water fluid. Neoforge patches this to mention any fluid the player can swim in, but instead of checking the eye fluid, it just checks all fluids the player is in.

This fixes that logic by only checking the eye fluid.

Fixes #2732 