### PR TITLE
[1.21.10] Fix crash when deserializing empty BlockEntity attachments

### DIFF
--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentType.java
@@ -14,6 +14,8 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.level.ServerPlayer;
@@ -213,6 +215,16 @@ public final class AttachmentType<T> {
                 @Override
                 public T read(IAttachmentHolder holder, ValueInput input) {
                     final Optional<T> parsingResult = input.read(codec);
+                    if (parsingResult.isPresent()) {
+                        return parsingResult.get();
+                    }
+
+                    if (input.keySet().isEmpty()) {
+                        return codec.codec()
+                                .parse(NbtOps.INSTANCE, new CompoundTag())
+                                .result()
+                                .orElseThrow(() -> new IllegalStateException("Codec failed to decode an empty CompoundTag."));
+                    }
                     return parsingResult.orElseThrow(() -> buildException("read"));
                 }
 

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import com.mojang.serialization.MapCodec;
+import java.util.Collections;
 import java.util.Set;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.storage.ValueInput;
@@ -24,7 +25,7 @@ public interface ValueInputExtension {
      */
     default Set<String> keySet() {
         //noinspection deprecation
-        return self().read(MapCodec.assumeMapUnsafe(CompoundTag.CODEC)).orElseThrow().keySet();
+        return self().read(MapCodec.assumeMapUnsafe(CompoundTag.CODEC)).map(CompoundTag::keySet).orElse(Collections.emptySet());
     }
 
     /**


### PR DESCRIPTION
Fixes #2728

This PR fixes a crash that occurs when deserializing empty `BlockEntity` attachments, a situation that can arise when using a `Codec` with optional fields.

The fix is implemented through two key changes:

1.  **`ValueInput#keySet()` is now safe for empty inputs.**
    The implementation has been changed to safely return an empty `Set` instead of throwing an exception. This prevents the game from crashing when iterating over an attachment holder that contains empty attachment data.

2.  **The attachment serializer for `MapCodec` now safely handles empty data.**
    It now uses `orElseGet` to fall back to the attachment's default value when deserialization fails due to empty input, instead of throwing an exception.