### PR TITLE
Fix subtitle overlay wrapping not applying transformations

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -13,7 +13,7 @@
      private Pair<Gui.ContextualInfo, ContextualBarRenderer> contextualInfoBar = Pair.of(Gui.ContextualInfo.EMPTY, ContextualBarRenderer.EMPTY);
      private final Map<Gui.ContextualInfo, Supplier<ContextualBarRenderer>> contextualInfoBarRenderers;
      private float scopeScale;
-+    private final net.neoforged.neoforge.client.gui.GuiLayerManager layerManager = new net.neoforged.neoforge.client.gui.GuiLayerManager();
++    private final net.neoforged.neoforge.client.gui.GuiLayerManager layerManager = new net.neoforged.neoforge.client.gui.GuiLayerManager(this);
 +    /**
 +     * Neo: This variable controls the height of overlays on the left of the hotbar (e.g. health, armor).
 +     */
@@ -33,7 +33,7 @@
      }
  
      public void resetTitleTimes() {
-@@ -214,28 +_,47 @@
+@@ -214,28 +_,41 @@
  
      public void render(GuiGraphics p_282884_, DeltaTracker p_348630_) {
          if (!(this.minecraft.screen instanceof LevelLoadingScreen)) {
@@ -45,14 +45,26 @@
 -                this.renderEffects(p_282884_, p_348630_);
 -                this.renderBossOverlay(p_282884_, p_348630_);
 -            }
+-
+-            this.renderSleepOverlay(p_282884_, p_348630_);
+-            if (!this.minecraft.options.hideGui) {
+-                this.renderDemoOverlay(p_282884_, p_348630_);
+-                this.renderScoreboardSidebar(p_282884_, p_348630_);
+-                this.renderOverlayMessage(p_282884_, p_348630_);
+-                this.renderTitle(p_282884_, p_348630_);
+-                this.renderChat(p_282884_, p_348630_);
+-                this.renderTabList(p_282884_, p_348630_);
+-                this.renderSubtitleOverlay(p_282884_, this.minecraft.screen == null || this.minecraft.screen.isInGameUi());
+-            } else if (this.minecraft.screen != null && this.minecraft.screen.isInGameUi()) {
+-                this.renderSubtitleOverlay(p_282884_, true);
+-            }
 +            leftHeight = 39;
 +            rightHeight = 39;
 +            updateContextualBarRenderer();
 +            layerManager.render(p_282884_, p_348630_);
-+        }
+         }
 +    }
- 
--            this.renderSleepOverlay(p_282884_, p_348630_);
++
 +    private void registerVanillaLayers() {
 +        java.util.function.BooleanSupplier guiVisible = () -> !this.minecraft.options.hideGui;
 +        java.util.function.BooleanSupplier survivalVisible = () -> this.minecraft.gameMode.canHurtPlayer() && guiVisible.getAsBoolean();
@@ -80,22 +92,7 @@
 +        layerManager.add(TITLE, this::renderTitle, guiVisible);
 +        layerManager.add(CHAT, this::renderChat, guiVisible);
 +        layerManager.add(TAB_LIST, this::renderTabList, guiVisible);
-+        layerManager.add(SUBTITLE_OVERLAY, (graphics, deltaTracker) -> {
-             if (!this.minecraft.options.hideGui) {
--                this.renderDemoOverlay(p_282884_, p_348630_);
--                this.renderScoreboardSidebar(p_282884_, p_348630_);
--                this.renderOverlayMessage(p_282884_, p_348630_);
--                this.renderTitle(p_282884_, p_348630_);
--                this.renderChat(p_282884_, p_348630_);
--                this.renderTabList(p_282884_, p_348630_);
--                this.renderSubtitleOverlay(p_282884_, this.minecraft.screen == null || this.minecraft.screen.isInGameUi());
-+                this.renderSubtitleOverlay(graphics, this.minecraft.screen == null || this.minecraft.screen.isInGameUi());
-             } else if (this.minecraft.screen != null && this.minecraft.screen.isInGameUi()) {
--                this.renderSubtitleOverlay(p_282884_, true);
-+                this.renderSubtitleOverlay(graphics, true);
-             }
--        }
-+        });
++        layerManager.add(SUBTITLE_OVERLAY, (graphics, deltaTracker) -> this.subtitleOverlay.render(graphics));
      }
  
      private void renderBossOverlay(GuiGraphics p_416128_, DeltaTracker p_416660_) {
@@ -408,6 +405,17 @@
                  this.toolHighlightTimer = (int)(40.0 * this.minecraft.options.notificationDisplayTime().get());
              } else if (this.toolHighlightTimer > 0) {
                  this.toolHighlightTimer--;
+@@ -1196,6 +_,10 @@
+         this.autosaveIndicatorValue = Mth.lerp(0.2F, this.autosaveIndicatorValue, flag ? 1.0F : 0.0F);
+     }
+ 
++    public void setDeferredSubtitles(@Nullable Runnable deferredSubtitles){
++        this.deferredSubtitles = deferredSubtitles;
++    }
++
+     public void setNowPlaying(Component p_93056_) {
+         Component component = Component.translatable("record.nowPlaying", p_93056_);
+         this.setOverlayMessage(component, true);
 @@ -1461,12 +_,27 @@
                  gui$hearttype = NORMAL;
              }

--- a/src/client/java/net/neoforged/neoforge/client/gui/GuiLayerManager.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/GuiLayerManager.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
@@ -30,6 +31,11 @@ import org.jetbrains.annotations.ApiStatus;
 public class GuiLayerManager {
     private final List<NamedLayer> layers = new ArrayList<>();
     private boolean initialized = false;
+    private final Gui gui;
+
+    public GuiLayerManager(Gui gui) {
+        this.gui = gui;
+    }
 
     public record NamedLayer(ResourceLocation name, GuiLayer layer) {}
 
@@ -72,10 +78,28 @@ public class GuiLayerManager {
 
     private void renderInner(GuiGraphics guiGraphics, DeltaTracker partialTick) {
         for (var layer : this.layers) {
-            if (!NeoForge.EVENT_BUS.post(new RenderGuiLayerEvent.Pre(guiGraphics, partialTick, layer.name(), layer.layer())).isCanceled()) {
-                layer.layer().render(guiGraphics, partialTick);
-                NeoForge.EVENT_BUS.post(new RenderGuiLayerEvent.Post(guiGraphics, partialTick, layer.name(), layer.layer()));
+            if (layer.name.equals(VanillaGuiLayers.SUBTITLE_OVERLAY)) {
+                Minecraft minecraft = Minecraft.getInstance();
+                boolean shouldRender = !minecraft.options.hideGui || (minecraft.screen != null && minecraft.screen.isInGameUi());
+                if (shouldRender) {
+                    if (minecraft.screen == null || minecraft.screen.isInGameUi()) {
+                        gui.setDeferredSubtitles(() -> renderLayer(guiGraphics, partialTick, layer));
+                        continue;
+                    }
+                    gui.setDeferredSubtitles(null);
+                } else {
+                    continue;
+                }
             }
+
+            renderLayer(guiGraphics, partialTick, layer);
+        }
+    }
+
+    private void renderLayer(GuiGraphics guiGraphics, DeltaTracker partialTick, NamedLayer layer) {
+        if (!NeoForge.EVENT_BUS.post(new RenderGuiLayerEvent.Pre(guiGraphics, partialTick, layer.name(), layer.layer())).isCanceled()) {
+            layer.layer().render(guiGraphics, partialTick);
+            NeoForge.EVENT_BUS.post(new RenderGuiLayerEvent.Post(guiGraphics, partialTick, layer.name(), layer.layer()));
         }
     }
 


### PR DESCRIPTION
Fixes #2739 

When a mod wraps the `SUBTITLE_OVERLAY` using `RegisterGuiLayersEvent#wrapLayer`, the wrapping logic is completely decoupled from the actual rendering. This causes all code inside the wrapper to execute immediately and at the wrong time. As a result, visual transformations (like moving or scaling) fail, and the associated `RenderGuiLayerEvent` events are fired inappropriately. The root cause is that the original call in `Gui` merely schedules a deferred `Runnable`, failing to postpone the wrapper's logic along with it.

My solution is to completely migrate the deferral decision logic from `Gui` into `GuiLayerManager#renderInner`. Now, the `GuiLayerManager` identifies the `SUBTITLE_OVERLAY` layer; if deferral is needed, it encapsulates the **complete render unit**—including the mod's `wrapLayer` logic and the `RenderGuiLayerEvent` Pre/Post events—entirely within a new `Runnable` task. This task is then passed to `Gui` for later execution, ensuring that all related logic is executed completely, at the right time, and with the correct state.