### PR TITLE
[1.21.10] Fix mouse cursor not changing when using Extended widgets

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedButton.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedButton.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.client.gui.widget;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -46,5 +47,8 @@ public class ExtendedButton extends Button {
 
         final FormattedText buttonText = mc.font.ellipsize(this.getMessage(), this.width - 6); // Remove 6 pixels so that the text is always contained within the button's borders
         guiGraphics.drawCenteredString(mc.font, Language.getInstance().getVisualOrder(buttonText), this.getX() + this.width / 2, this.getY() + (this.height - 8) / 2, getFGColor());
+
+        if (this.isHovered())
+            guiGraphics.requestCursor(this.isActive() ? CursorTypes.POINTING_HAND : CursorTypes.NOT_ALLOWED);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedSlider.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedSlider.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.client.gui.widget;
 
+import com.mojang.blaze3d.platform.cursor.CursorTypes;
 import java.text.DecimalFormat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -206,5 +207,8 @@ public class ExtendedSlider extends AbstractSliderButton {
         guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, this.getHandleSprite(), this.getX() + (int) (this.value * (double) (this.width - 8)), this.getY(), 8, this.getHeight(), ARGB.white(this.alpha));
         int i = this.active ? 16777215 : 10526880;
         this.renderScrollingString(guiGraphics, minecraft.font, 2, i | Mth.ceil(this.alpha * 255.0F) << 24);
+
+        if (this.isHovered())
+            guiGraphics.requestCursor(this.dragging ? CursorTypes.RESIZE_EW : CursorTypes.POINTING_HAND);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedSlider.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedSlider.java
@@ -123,6 +123,7 @@ public class ExtendedSlider extends AbstractSliderButton {
 
     @Override
     public void onClick(MouseButtonEvent event, boolean doubleClick) {
+        this.dragging = this.active;
         this.setValueFromMouse(event.x());
     }
 

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -10,6 +10,7 @@ public net.minecraft.client.gui.Gui$HeartType
 protected net.minecraft.client.gui.components.AbstractButton SPRITES
 public net.minecraft.client.gui.components.AbstractSelectionList clearEntries()V
 protected net.minecraft.client.gui.components.AbstractSelectionList$Entry list # list
+protected net.minecraft.client.gui.components.AbstractSliderButton dragging
 protected net.minecraft.client.gui.components.AbstractSliderButton getSprite()Lnet/minecraft/resources/ResourceLocation; # getSprite
 protected net.minecraft.client.gui.components.AbstractSliderButton getHandleSprite()Lnet/minecraft/resources/ResourceLocation; # getHandleSprite
 public net.minecraft.client.gui.components.AbstractWidget renderScrollingString(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Lnet/minecraft/network/chat/Component;IIIII)V


### PR DESCRIPTION
In Minecraft 1.21.9, the feature of the mouse cursor changing its style (e.g. to a pointing hand) when interacting with certain GUI elements was added to vanilla. Because this funcionality was implemented in the vanilla widgets' `renderWidget` methods, and NeoForge's `ExtendedSlider` and `ExtendedButton` classes both override that method without calling `super`, this feature does not work natively for those widgets added by NeoForge.

This PR adds this vanilla feature to the Extended widgets by manually adding the correct call to change the mouse cursor when those widgets are hovered.