### PR TITLE
[1.21.10] Add Method to get Raw Child from Value Input

### DIFF
--- a/patches/net/minecraft/world/level/storage/TagValueInput.java.patch
+++ b/patches/net/minecraft/world/level/storage/TagValueInput.java.patch
@@ -1,14 +1,27 @@
 --- a/net/minecraft/world/level/storage/TagValueInput.java
 +++ b/net/minecraft/world/level/storage/TagValueInput.java
-@@ -218,6 +_,11 @@
-         return this.context.lookup();
+@@ -118,6 +_,12 @@
      }
  
+     @Override
++    public ValueInput rawChildOrEmpty(String key) {
++        CompoundTag compoundtag = this.getOptionalTypedTag(key, CompoundTag.TYPE);
++        return compoundtag != null ? new TagValueInput(this.problemReporter.forChild(new ProblemReporter.FieldPathElement(key)), this.context, compoundtag) : this.context.empty();
++    }
++
++    @Override
+     public Optional<ValueInput.ValueInputList> childrenList(String p_421700_) {
+         ListTag listtag = this.getOptionalTypedTag(p_421700_, ListTag.TYPE);
+         return listtag != null ? Optional.of(this.wrapList(p_421700_, this.context, listtag)) : Optional.empty();
+@@ -216,6 +_,11 @@
+     @Override
+     public HolderLookup.Provider lookup() {
+         return this.context.lookup();
++    }
++
 +    @Override
 +    public java.util.Set<String> keySet() {
 +        return java.util.Collections.unmodifiableSet(input.keySet());
-+    }
-+
+     }
+ 
      private ValueInput wrapChild(String p_422021_, CompoundTag p_422689_) {
-         return (ValueInput)(p_422689_.isEmpty()
-             ? this.context.empty()

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentHolder.java
@@ -157,7 +157,7 @@ public abstract class AttachmentHolder implements IAttachmentHolder {
             }
 
             try {
-                getAttachmentMap().put(type, type.serializer.read(getExposedHolder(), input.childOrEmpty(key)));
+                getAttachmentMap().put(type, type.serializer.read(getExposedHolder(), input.rawChildOrEmpty(key)));
             } catch (Exception exception) {
                 LOGGER.error("Failed to deserialize data attachment {}. Skipping.", key, exception);
             }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
@@ -41,8 +41,9 @@ public interface ValueInputExtension {
     /**
      * Reads the {@code child} object from the given {@code key},
      * or provides an empty {@link ValueInput} if the child does not exist.
-     * Unlike {@link ValueInput#childOrEmpty(String)}, this will not attempt
-     * to use an empty context if no data exists in the backing object.
+     * Unlike {@link ValueInput#childOrEmpty(String)}, this will not return
+     * an empty context if there are no keys (as reported by {@link #keySet()}),
+     * within the child.
      * <br>
      * If not implemented, defaults to {@link ValueInput#childOrEmpty(String)}.
      *

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
@@ -37,4 +37,19 @@ public interface ValueInputExtension {
     default void readChild(String key, ValueIOSerializable object) {
         self().child(key).ifPresent(object::deserialize);
     }
+
+    /**
+     * Reads the {@code child} object from the given {@code key},
+     * or provides an empty {@link ValueInput} if the child does not exist.
+     * Unlike {@link ValueInput#childOrEmpty(String)}, this will not attempt
+     * to use an empty context if no data exists in the backing object.
+     * <br>
+     * If not implemented, defaults to {@link ValueInput#childOrEmpty(String)}.
+     *
+     * @param key the key to read the child from
+     * @return the {@link ValueInput} of the child, or an empty input
+     */
+    default ValueInput rawChildOrEmpty(String key) {
+        return self().childOrEmpty(key);
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
@@ -41,9 +41,12 @@ public interface ValueInputExtension {
     /**
      * Reads the {@code child} object from the given {@code key},
      * or provides an empty {@link ValueInput} if the child does not exist.
-     * Unlike {@link ValueInput#childOrEmpty(String)}, this will not return
-     * an empty context if there are no keys (as reported by {@link #keySet()}),
-     * within the child.
+     * This function behaves differently than {@link ValueInput#childOrEmpty(String)}
+     * in the case where the child exists (as reported by {@link #keySet()}) but is empty.
+     * While {@link ValueInput#childOrEmpty(String)} will return an empty {@code ValueInput}
+     * from which nothing can ever be read with a codec, this function will instead return a
+     * a wrapper around the empty child, allowing values to be read with a codec,
+     * provided that the codec can deserialize empty map-like objects.
      * <br>
      * If not implemented, defaults to {@link ValueInput#childOrEmpty(String)}.
      *

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -9,9 +9,14 @@ import static net.minecraft.commands.Commands.literal;
 
 import com.mojang.brigadier.Command;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.Objects;
+import java.util.Optional;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.ProblemReporter;
@@ -22,9 +27,12 @@ import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.storage.TagValueInput;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
+import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
+import net.neoforged.neoforge.attachment.AttachmentHolder;
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.util.ValueIOSerializable;
@@ -36,6 +44,7 @@ import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.gametest.GameTest;
 import net.neoforged.testframework.registration.RegistrationHelper;
+import org.jetbrains.annotations.Nullable;
 
 @ForEachTest(groups = "attachment")
 public class AttachmentTests {
@@ -157,5 +166,74 @@ public class AttachmentTests {
             });
             helper.succeed();
         });
+    }
+
+    @TestHolder(description = "Tests serialization for an empty object", enabledByDefault = true)
+    static void pseudoEmptyAttachmentSerialization(DynamicTest test, RegistrationHelper reg) {
+        class EmptyObject {
+            @Nullable
+            public Integer value;
+
+            public EmptyObject(Optional<Integer> value) {
+                this.value = value.orElse(null);
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                if (!(obj instanceof EmptyObject empty)) return false;
+                return Objects.equals(this.value, empty.value);
+            }
+        }
+
+        class HolderTest extends AttachmentHolder implements ValueIOSerializable {
+            @Override
+            public void serialize(ValueOutput output) {
+                this.serializeAttachments(output);
+            }
+
+            @Override
+            public void deserialize(ValueInput input) {
+                this.deserializeAttachments(input);
+            }
+        }
+
+        var nullableAttachment = reg.attachments()
+                .register("nullable_attachment", () -> AttachmentType.builder(() -> new EmptyObject(Optional.of(1)))
+                        .serialize(RecordCodecBuilder.mapCodec(
+                                instance -> instance.group(
+                                        Codec.INT.optionalFieldOf("value").forGetter(obj -> Optional.ofNullable(obj.value))).apply(instance, EmptyObject::new)))
+                        .build());
+
+        test.framework().modEventBus().addListener((FMLLoadCompleteEvent event) -> event.enqueueWork(() -> {
+            // Serialize and deserialize object
+            var lookup = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
+
+            var originalHolder = new HolderTest();
+            originalHolder.setData(nullableAttachment, new EmptyObject(Optional.empty()));
+
+            var output = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, lookup);
+            originalHolder.serializeAttachments(output);
+
+            var anotherHolder = new HolderTest();
+            try {
+                // Try to deserialize
+                anotherHolder.deserialize(TagValueInput.create(ProblemReporter.DISCARDING, lookup, output.buildResult()));
+            } catch (Exception e) {
+                // If an exception is thrown
+                test.fail(e.getMessage());
+            }
+
+            // Check if deserialized successfully
+            if (!anotherHolder.hasData(nullableAttachment)) {
+                test.fail("Unable to find nullable attachment data after deserialiation.");
+            }
+
+            // Check if data matches original
+            if (!originalHolder.getData(nullableAttachment).equals(anotherHolder.getData(nullableAttachment))) {
+                test.fail("Data from holder does not match after serialization loop.");
+            }
+
+            test.pass();
+        }));
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentTests.java
@@ -11,7 +11,6 @@ import com.mojang.brigadier.Command;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.Objects;
-import java.util.Optional;
 import net.minecraft.commands.Commands;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.RegistryAccess;
@@ -44,7 +43,6 @@ import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.gametest.GameTest;
 import net.neoforged.testframework.registration.RegistrationHelper;
-import org.jetbrains.annotations.Nullable;
 
 @ForEachTest(groups = "attachment")
 public class AttachmentTests {
@@ -168,53 +166,35 @@ public class AttachmentTests {
         });
     }
 
-    @TestHolder(description = "Tests serialization for an empty object", enabledByDefault = true)
+    @TestHolder(description = "Regression test for neoforged/Neoforge#2728", enabledByDefault = true)
     static void pseudoEmptyAttachmentSerialization(DynamicTest test, RegistrationHelper reg) {
-        class EmptyObject {
-            @Nullable
-            public Integer value;
+        record EmptyObject(int value) {}
 
-            public EmptyObject(Optional<Integer> value) {
-                this.value = value.orElse(null);
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                if (!(obj instanceof EmptyObject empty)) return false;
-                return Objects.equals(this.value, empty.value);
-            }
-        }
-
-        class HolderTest extends AttachmentHolder implements ValueIOSerializable {
-            @Override
-            public void serialize(ValueOutput output) {
-                this.serializeAttachments(output);
-            }
-
-            @Override
+        class TestAttachmentHolder extends AttachmentHolder {
             public void deserialize(ValueInput input) {
+                // Deserialize is protected final, so we need a wrapper method
                 this.deserializeAttachments(input);
             }
         }
 
         var nullableAttachment = reg.attachments()
-                .register("nullable_attachment", () -> AttachmentType.builder(() -> new EmptyObject(Optional.of(1)))
+                .register("nullable_attachment", () -> AttachmentType.builder(() -> new EmptyObject(1))
                         .serialize(RecordCodecBuilder.mapCodec(
                                 instance -> instance.group(
-                                        Codec.INT.optionalFieldOf("value").forGetter(obj -> Optional.ofNullable(obj.value))).apply(instance, EmptyObject::new)))
+                                        Codec.INT.optionalFieldOf("value", 0).forGetter(EmptyObject::value)).apply(instance, EmptyObject::new)))
                         .build());
 
         test.framework().modEventBus().addListener((FMLLoadCompleteEvent event) -> event.enqueueWork(() -> {
             // Serialize and deserialize object
             var lookup = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
 
-            var originalHolder = new HolderTest();
-            originalHolder.setData(nullableAttachment, new EmptyObject(Optional.empty()));
+            var originalHolder = new TestAttachmentHolder();
+            originalHolder.setData(nullableAttachment, new EmptyObject(0));
 
             var output = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, lookup);
             originalHolder.serializeAttachments(output);
 
-            var anotherHolder = new HolderTest();
+            var anotherHolder = new TestAttachmentHolder();
             try {
                 // Try to deserialize
                 anotherHolder.deserialize(TagValueInput.create(ProblemReporter.DISCARDING, lookup, output.buildResult()));
@@ -229,7 +209,9 @@ public class AttachmentTests {
             }
 
             // Check if data matches original
-            if (!originalHolder.getData(nullableAttachment).equals(anotherHolder.getData(nullableAttachment))) {
+            if (!Objects.equals(
+                    originalHolder.getData(nullableAttachment).value,
+                    anotherHolder.getData(nullableAttachment).value)) {
                 test.fail("Data from holder does not match after serialization loop.");
             }
 


### PR DESCRIPTION
Closes #2728 

Internally, `TagValueInput` wraps most objects and lists returning a new input through `TagValueInput#wrapChild`, which checks whether the backing tag is empty. If so, it returns an empty context as for most use cases, it's considered to be 'nothing exists'. However, modders may provide a different meaning to nothing exists, most prominently for data attachments. As such, a new method: `rawChildOrEmpty` is added to get the raw output of the input rather than attempting to wrap and resolve to an existing input.

Technically, this is one solution to do so, and it only implements the one method for handling the attachment holder use case. There are technically other solutions and implementations that could be done to make this feature complete, but for simplicity, only the one method was added to fix the underlying bug as the other implementations are generally sufficient enough.