### PR TITLE
[1.21.10] Use Correct Pipeline for Rendering Text in GUIs

### DIFF
--- a/patches/net/minecraft/client/gui/font/GlyphRenderTypes.java.patch
+++ b/patches/net/minecraft/client/gui/font/GlyphRenderTypes.java.patch
@@ -21,7 +21,7 @@
              RenderType.textIntensitySeeThrough(p_285411_),
              RenderType.textIntensityPolygonOffset(p_285411_),
 -            RenderPipelines.GUI_TEXT_INTENSITY
-+            RenderPipelines.TEXT_INTENSITY,
++            RenderPipelines.GUI_TEXT_INTENSITY,
 +            net.neoforged.neoforge.client.NeoForgeRenderTypes.getTextIntensityFiltered(p_285411_),
 +            net.neoforged.neoforge.client.NeoForgeRenderTypes.getTextIntensitySeeThroughFiltered(p_285411_),
 +            net.neoforged.neoforge.client.NeoForgeRenderTypes.getTextIntensityPolygonOffsetFiltered(p_285411_)
@@ -31,7 +31,7 @@
      public static GlyphRenderTypes createForColorTexture(ResourceLocation p_285486_) {
          return new GlyphRenderTypes(
 -            RenderType.text(p_285486_), RenderType.textSeeThrough(p_285486_), RenderType.textPolygonOffset(p_285486_), RenderPipelines.GUI_TEXT
-+            RenderType.text(p_285486_), RenderType.textSeeThrough(p_285486_), RenderType.textPolygonOffset(p_285486_), RenderPipelines.TEXT,
++            RenderType.text(p_285486_), RenderType.textSeeThrough(p_285486_), RenderType.textPolygonOffset(p_285486_), RenderPipelines.GUI_TEXT,
 +            net.neoforged.neoforge.client.NeoForgeRenderTypes.getTextFiltered(p_285486_),
 +            net.neoforged.neoforge.client.NeoForgeRenderTypes.getTextSeeThroughFiltered(p_285486_),
 +            net.neoforged.neoforge.client.NeoForgeRenderTypes.getTextPolygonOffsetFiltered(p_285486_)


### PR DESCRIPTION
Closes #2745 

In 1.21.9, Mojang changed the GUI text pipeline from using `TEXT_INTENSITY` and `TEXT` to specific GUI variants `GUI_TEXT_INTENSITY` and `GUI_TEXT` respectively. The specific difference here is that, unlike the regular texts, the gui variant disables the depth function, which 21.9 switched to from the previous 'increase z by 0.01 for each element'. As such, this PR changes the glyph renderers to use the appropriate pipeline.