### PR TITLE
Fix fluid-pushing being performed twice

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -341,7 +341,7 @@
  
 +    @Deprecated // Forge: Use no parameter version instead, only for vanilla Tags
      public boolean updateFluidHeightAndDoFluidPushing(TagKey<Fluid> p_204032_, double p_204033_) {
-+        this.updateFluidHeightAndDoFluidPushing();
++        this.updateFluidHeightAndDoFluidPushing(true);
 +        if(p_204032_ == FluidTags.WATER) return this.isInFluidType(net.neoforged.neoforge.common.NeoForgeMod.WATER_TYPE.value());
 +        else if (p_204032_ == FluidTags.LAVA) return this.isInFluidType(net.neoforged.neoforge.common.NeoForgeMod.LAVA_TYPE.value());
 +        else return false;
@@ -350,8 +350,8 @@
 +    public boolean updateFluidHeightAndDoCanPushEntityFluidPushing(boolean performFluidPushing) {
 +        if (performFluidPushing) {
 +            this.forgeFluidTypeHeight.clear();
-+            this.updateFluidHeightAndDoFluidPushing();
 +        }
++        this.updateFluidHeightAndDoFluidPushing(performFluidPushing);
 +
 +        if (this.forgeFluidTypeHeight.isEmpty()) {
 +            return false;
@@ -366,7 +366,7 @@
 +        return false;
 +    }
 +
-+    public void updateFluidHeightAndDoFluidPushing() {
++    public void updateFluidHeightAndDoFluidPushing(boolean doFluidPushing) {
          if (this.touchingUnloadedChunk()) {
 -            return false;
 +            return;
@@ -426,7 +426,7 @@
 -                    vec3 = vec3.scale(1.0 / k1);
 +            if(interimCalcs != null) {
 +            interimCalcs.forEach((fluidType, interim) -> {
-+            if (interim.flowVector.length() > 0.0D) {
++            if (doFluidPushing && interim.flowVector.length() > 0.0D) {
 +                if (interim.blockCount > 0) {
 +                    interim.flowVector = interim.flowVector.scale(1.0D / (double)interim.blockCount);
                  }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -37,7 +37,7 @@
  
      protected LivingEntity(EntityType<? extends LivingEntity> p_20966_, Level p_20967_) {
          super(p_20966_, p_20967_);
-@@ -345,7 +_,9 @@
+@@ -345,13 +_,15 @@
              .add(Attributes.MOVEMENT_EFFICIENCY)
              .add(Attributes.ATTACK_KNOCKBACK)
              .add(Attributes.CAMERA_DISTANCE)
@@ -48,6 +48,13 @@
      }
  
      @Override
+     protected void checkFallDamage(double p_20990_, boolean p_20991_, BlockState p_20992_, BlockPos p_20993_) {
+         if (!this.isInWater()) {
+-            this.updateInWaterStateAndDoWaterCurrentPushing();
++            this.updateInWaterStateAndDoWaterCurrentPushing(false);
+         }
+ 
+         if (this.level() instanceof ServerLevel serverlevel && p_20991_ && this.fallDistance > 0.0) {
 @@ -372,7 +_,8 @@
  
                  double d7 = Math.min(0.2F + d6 / 15.0, 2.5);


### PR DESCRIPTION
This PR fixes #1575 and fixes #2684 by preventing fluid-pushing from being done twice.

`LivingEntity#checkFallDamage` accidentally causes a second fluid-push to be done, when it's meant only to double-check if the entity is in water.

This PR modifies `Entity#updateFluidHeightAndDoFluidPushing` to allow calling it to update fluid height without performing fluid pushing, and update other call-sites accordingly to ensure `LivingEntity#checkFallDamage` makes use of the parameter to avoid fluid-pushing.

See below screenshots showing the fix in action, for each linked issue respectively:

<img width="856" height="519" alt="Lava push speed gametest from Lithium, successfully run" src="https://github.com/user-attachments/assets/d32c0994-b71c-407a-9402-171e3ce33e77" />

<img width="856" height="518" alt="Armor stand in flowing lava is centered against enderchest" src="https://github.com/user-attachments/assets/04791d49-bf5d-4609-93cb-179a48e1ffff" />
