### PR TITLE
Prevent unnecessary slot changes in StackCopySlot

### DIFF
--- a/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
@@ -60,7 +60,10 @@ public abstract class StackCopySlot extends Slot {
 
     @Override
     public final void setChanged() {
-        if (cachedReturnedStack != null) {
+        // Verify that the stack has actually changed before setting it.
+        // Vanilla menu logic (like AbstractContainerMenu#moveItemStackTo) often already sets the stack through Slot#setByPlayer.
+        // This is done to prevent slot change logic from running multiple times when not necessary.
+        if (cachedReturnedStack != null && !ItemStack.isSameItemSameComponents(cachedReturnedStack, getStackCopy())) {
             set(cachedReturnedStack);
         }
     }

--- a/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
@@ -63,7 +63,7 @@ public abstract class StackCopySlot extends Slot {
         // Verify that the stack has actually changed before setting it.
         // Vanilla menu logic (like AbstractContainerMenu#moveItemStackTo) often already sets the stack through Slot#setByPlayer.
         // This is done to prevent slot change logic from running multiple times when not necessary.
-        if (cachedReturnedStack != null && !ItemStack.isSameItemSameComponents(cachedReturnedStack, getStackCopy())) {
+        if (cachedReturnedStack != null && !ItemStack.matches(cachedReturnedStack, getStackCopy())) {
             set(cachedReturnedStack);
         }
     }


### PR DESCRIPTION
Currently when inserting (or extracting) an item through `ResourceHandlerSlot` into a `StacksResourceHandler` the `onContentsChanged` method gets called multiple times, which is confusing and results in the ResourceHandler change logic running unnecessarily often.

The cause for this behaviour is that `StackCopySlot#setChanged` updates the stack every time, even if it didn't actually change. To fix this I added a check in `setChanged` to make sure the new stack is actually different.

