### PR TITLE
[1.21.8] Fix for shearing leads with custom shears

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -214,7 +214,12 @@
              p_426271_.addFreshEntity(itementity);
              return itementity;
          }
-@@ -2092,7 +_,7 @@
+@@ -2088,11 +_,11 @@
+         }
+ 
+         ItemStack itemstack = p_19978_.getItemInHand(p_19979_);
+-        if (itemstack.is(Items.SHEARS) && this.shearOffAllLeashConnections(p_19978_)) {
++        if (itemstack.canPerformAction(net.neoforged.neoforge.common.ItemAbilities.SHEARS_HARVEST) && this.shearOffAllLeashConnections(p_19978_)) {
              itemstack.hurtAndBreak(1, p_19978_, p_19979_);
              return InteractionResult.SUCCESS;
          } else if (this instanceof Mob mob

--- a/patches/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java.patch
+++ b/patches/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
++++ b/net/minecraft/world/entity/decoration/LeashFenceKnotEntity.java
+@@ -72,7 +_,7 @@
+         if (this.level().isClientSide) {
+             return InteractionResult.SUCCESS;
+         } else {
+-            if (p_31842_.getItemInHand(p_31843_).is(Items.SHEARS)) {
++            if (p_31842_.getItemInHand(p_31843_).canPerformAction(net.neoforged.neoforge.common.ItemAbilities.SHEARS_HARVEST)) {
+                 InteractionResult interactionresult = super.interact(p_31842_, p_31843_);
+                 if (interactionresult instanceof InteractionResult.Success interactionresult$success && interactionresult$success.wasItemInteraction()) {
+                     return interactionresult;


### PR DESCRIPTION
It is a backport of #2757.

This PR fixes shearing leads with custom shears. Interacting with entites or leash knots (lead on fences) didn't result in shearing off the leads as vanilla shears.

I reused the item ability SHEARS_HARVEST, because I don't think an extra ability for handling leads is necessary.

