### PR TITLE
Replace `MapCodec.assumeMapUnsafe(CompoundTag.CODEC)` with a custom codec  in `ValueInput.keySet()`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
@@ -5,9 +5,14 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.MapLike;
+import com.mojang.serialization.RecordBuilder;
 import java.util.Set;
-import net.minecraft.nbt.CompoundTag;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.minecraft.world.level.storage.ValueInput;
 import net.neoforged.neoforge.common.util.ValueIOSerializable;
 
@@ -15,6 +20,23 @@ import net.neoforged.neoforge.common.util.ValueIOSerializable;
  * Extension class for {@link ValueInput}
  */
 public interface ValueInputExtension {
+    MapCodec<Set<String>> EXTRACT_KEYS = new MapCodec<>() {
+        @Override
+        public <T> Stream<T> keys(DynamicOps<T> ops) {
+            return Stream.empty();
+        }
+
+        @Override
+        public <T> DataResult<Set<String>> decode(DynamicOps<T> ops, MapLike<T> input) {
+            return DataResult.success(input.entries().map(entry -> ops.getStringValue(entry.getFirst()).getOrThrow()).collect(Collectors.toSet()));
+        }
+
+        @Override
+        public <T> RecordBuilder<T> encode(Set<String> input, DynamicOps<T> ops, RecordBuilder<T> prefix) {
+            return prefix;
+        }
+    };
+
     private ValueInput self() {
         return (ValueInput) this;
     }
@@ -24,7 +46,7 @@ public interface ValueInputExtension {
      */
     default Set<String> keySet() {
         //noinspection deprecation
-        return self().read(MapCodec.assumeMapUnsafe(CompoundTag.CODEC)).orElseThrow().keySet();
+        return self().read(EXTRACT_KEYS).orElse(Set.of());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ValueInputExtension.java
@@ -46,7 +46,7 @@ public interface ValueInputExtension {
      */
     default Set<String> keySet() {
         //noinspection deprecation
-        return self().read(EXTRACT_KEYS).orElse(Set.of());
+        return self().read(EXTRACT_KEYS).orElseThrow();
     }
 
     /**


### PR DESCRIPTION
Replaces the unsafe `MapCodec.assumeMapUnsafe(CompoundTag.CODEC)` usage in `ValueInputExtension.keySet()` with a purpose-built `MapCodec` (`EXTRACT_KEYS`) that only extracts the top-level keys from a `MapLike`. The `keySet()` method now reads `EXTRACT_KEYS` instead of decoding a full `CompoundTag` and then taking its keys.