### PR TITLE
[1.21.10] Add properties supplier variants for item registration methods

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -600,11 +600,28 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(String, Supplier)
          * @see #registerSimpleBlockItem(Holder, Item.Properties)
          * @see #registerSimpleBlockItem(Holder)
-         * @deprecated Use {@link #registerSimpleBlockItem(String, Supplier, UnaryOperator)} instead.
+         * @deprecated Use {@link #registerSimpleBlockItem(String, Supplier, Supplier)} or {@link #registerSimpleBlockItem(String, Supplier, UnaryOperator)} instead.
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Item.Properties properties) {
-            return this.registerSimpleBlockItem(name, block, props -> properties);
+            return this.registerSimpleBlockItem(name, block, () -> properties);
+        }
+
+        /**
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * returns a {@link DeferredItem} that will be populated with the created item automatically.
+         *
+         * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param block      The supplier for the block to create a {@link BlockItem} for.
+         * @param properties The supplied properties for the created {@link BlockItem}.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, Supplier)
+         * @see #registerSimpleBlockItem(Holder)
+         */
+        public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Supplier<Item.Properties> properties) {
+            return this.registerItem(name, props -> new BlockItem(block.get(), props), () -> properties.get().useBlockDescriptionPrefix());
         }
 
         /**
@@ -615,6 +632,7 @@ public class DeferredRegister<T> {
          * @param block      The supplier for the block to create a {@link BlockItem} for.
          * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, Supplier)
          * @see #registerSimpleBlockItem(String, Supplier)
          * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          * @see #registerSimpleBlockItem(Holder)
@@ -631,7 +649,9 @@ public class DeferredRegister<T> {
          * @param name  The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param block The supplier for the block to create a {@link BlockItem} for.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, Supplier)
          * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
+         * @see #registerSimpleBlockItem(Holder, Supplier)
          * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          * @see #registerSimpleBlockItem(Holder)
          */
@@ -650,11 +670,29 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(String, Supplier, Item.Properties)
          * @see #registerSimpleBlockItem(String, Supplier)
          * @see #registerSimpleBlockItem(Holder)
-         * @deprecated Use {@link #registerSimpleBlockItem(Holder, UnaryOperator)} instead.
+         * @deprecated Use {@link #registerSimpleBlockItem(Holder, Supplier)} or {@link #registerSimpleBlockItem(Holder, UnaryOperator)} instead.
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, Item.Properties properties) {
-            return this.registerSimpleBlockItem(block, props -> properties);
+            return this.registerSimpleBlockItem(block, () -> properties);
+        }
+
+        /**
+         * Adds a new simple {@link BlockItem} for the given {@link Block} to the list of entries to be registered and
+         * returns a {@link DeferredItem} that will be populated with the created item automatically.
+         * Where the name is determined by the name of the given block.
+         *
+         * @param block      The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
+         * @param properties The supplied properties for the created {@link BlockItem}.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, Supplier)
+         * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
+         * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, UnaryOperator)
+         * @see #registerSimpleBlockItem(Holder)
+         */
+        public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, Supplier<Item.Properties> properties) {
+            return this.registerSimpleBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
         }
 
         /**
@@ -665,8 +703,10 @@ public class DeferredRegister<T> {
          * @param block      The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, Supplier)
          * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
          * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, Supplier)
          * @see #registerSimpleBlockItem(Holder)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, UnaryOperator<Item.Properties> properties) {
@@ -680,8 +720,10 @@ public class DeferredRegister<T> {
          *
          * @param block The {@link DeferredHolder} of the {@link Block} for the {@link BlockItem}.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerSimpleBlockItem(String, Supplier, Supplier)
          * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
          * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, Supplier)
          * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block) {
@@ -698,11 +740,28 @@ public class DeferredRegister<T> {
          * @see #registerItem(String, Function)
          * @see #registerSimpleItem(String, Item.Properties)
          * @see #registerSimpleItem(String)
-         * @deprecated Use {@link #registerItem(String, Function, UnaryOperator)} instead.
+         * @deprecated Use {@link #registerItem(String, Function, Supplier)} or {@link #registerItem(String, Function, UnaryOperator)} instead.
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Item.Properties props) {
-            return this.registerItem(name, func, properties -> props);
+            return this.registerItem(name, func, () -> props);
+        }
+
+        /**
+         * Adds a new item to the list of entries to be registered and returns a {@link DeferredItem} that will be populated with the created item automatically.
+         *
+         * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param func       A factory for the new item. The factory should not cache the created item.
+         * @param properties The supplied properties for the created item.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, UnaryOperator)
+         * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String, Supplier)
+         * @see #registerSimpleItem(String, UnaryOperator)
+         * @see #registerSimpleItem(String)
+         */
+        public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Supplier<Item.Properties> properties) {
+            return this.register(name, key -> func.apply(properties.get().setId(ResourceKey.create(Registries.ITEM, key))));
         }
 
         /**
@@ -712,12 +771,14 @@ public class DeferredRegister<T> {
          * @param func       A factory for the new item. The factory should not cache the created item.
          * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, Supplier)
          * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String, Supplier)
          * @see #registerSimpleItem(String, UnaryOperator)
          * @see #registerSimpleItem(String)
          */
         public <I extends Item> DeferredItem<I> registerItem(String name, Function<Item.Properties, ? extends I> func, UnaryOperator<Item.Properties> properties) {
-            return this.register(name, key -> func.apply(properties.apply(new Item.Properties()).setId(ResourceKey.create(Registries.ITEM, key))));
+            return this.registerItem(name, func, () -> properties.apply(new Item.Properties()));
         }
 
         /**
@@ -727,7 +788,9 @@ public class DeferredRegister<T> {
          * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @param func A factory for the new item. The factory should not cache the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, Supplier)
          * @see #registerItem(String, Function, UnaryOperator)
+         * @see #registerSimpleItem(String, Supplier)
          * @see #registerSimpleItem(String, UnaryOperator)
          * @see #registerSimpleItem(String)
          */
@@ -745,7 +808,7 @@ public class DeferredRegister<T> {
          * @see #registerItem(String, Function, Item.Properties)
          * @see #registerItem(String, Function)
          * @see #registerSimpleItem(String)
-         * @deprecated Use {@link #registerSimpleItem(String, UnaryOperator)} instead.
+         * @deprecated Use {@link #registerSimpleItem(String, Supplier)} or {@link #registerSimpleItem(String, UnaryOperator)} instead.
          */
         @Deprecated(since = "1.21.10", forRemoval = true)
         public DeferredItem<Item> registerSimpleItem(String name, Item.Properties props) {
@@ -757,10 +820,29 @@ public class DeferredRegister<T> {
          * returns a {@link DeferredItem} that will be populated with the created item automatically.
          *
          * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
-         * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created item.
+         * @param properties The supplied properties for the created item.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, Supplier)
          * @see #registerItem(String, Function, UnaryOperator)
          * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String, UnaryOperator)
+         * @see #registerSimpleItem(String)
+         */
+        public DeferredItem<Item> registerSimpleItem(String name, Supplier<Item.Properties> properties) {
+            return this.registerItem(name, Item::new, properties);
+        }
+
+        /**
+         * Adds a new simple {@link Item} with the given {@link Item.Properties properties} to the list of entries to be registered and
+         * returns a {@link DeferredItem} that will be populated with the created item automatically.
+         *
+         * @param name       The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
+         * @param properties The unary operator, which is passed a new {@link Item.Properties} for the created item.
+         * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, Supplier)
+         * @see #registerItem(String, Function, UnaryOperator)
+         * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String, Supplier)
          * @see #registerSimpleItem(String)
          */
         public DeferredItem<Item> registerSimpleItem(String name, UnaryOperator<Item.Properties> properties) {
@@ -773,8 +855,10 @@ public class DeferredRegister<T> {
          *
          * @param name The new item's name. It will automatically have the {@linkplain #getNamespace() namespace} prefixed.
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
+         * @see #registerItem(String, Function, Supplier)
          * @see #registerItem(String, Function, UnaryOperator)
          * @see #registerItem(String, Function)
+         * @see #registerSimpleItem(String, Supplier)
          * @see #registerSimpleItem(String, UnaryOperator)
          */
         public DeferredItem<Item> registerSimpleItem(String name) {

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -640,7 +640,7 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(Holder)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, UnaryOperator<Item.Properties> properties) {
-            return this.registerItem(name, props -> new BlockItem(block.get(), props), props -> properties.apply(props).useBlockDescriptionPrefix());
+            return this.registerSimpleBlockItem(name, block, () -> properties.apply(new Item.Properties()));
         }
 
         /**
@@ -712,7 +712,7 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(Holder)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(Holder<Block> block, UnaryOperator<Item.Properties> properties) {
-            return this.registerSimpleBlockItem(block.unwrapKey().orElseThrow().location().getPath(), block::value, properties);
+            return this.registerSimpleBlockItem(block, () -> properties.apply(new Item.Properties()));
         }
 
         /**

--- a/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DeferredRegister.java
@@ -618,6 +618,7 @@ public class DeferredRegister<T> {
          * @see #registerSimpleBlockItem(String, Supplier, UnaryOperator)
          * @see #registerSimpleBlockItem(String, Supplier)
          * @see #registerSimpleBlockItem(Holder, Supplier)
+         * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          * @see #registerSimpleBlockItem(Holder)
          */
         public DeferredItem<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Supplier<Item.Properties> properties) {
@@ -634,6 +635,7 @@ public class DeferredRegister<T> {
          * @return A {@link DeferredItem} that will track updates from the registry for this item.
          * @see #registerSimpleBlockItem(String, Supplier, Supplier)
          * @see #registerSimpleBlockItem(String, Supplier)
+         * @see #registerSimpleBlockItem(Holder, Supplier)
          * @see #registerSimpleBlockItem(Holder, UnaryOperator)
          * @see #registerSimpleBlockItem(Holder)
          */

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
@@ -8,6 +8,7 @@ package net.neoforged.testframework.registration;
 import com.mojang.serialization.MapCodec;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import net.minecraft.client.color.item.ItemTintSource;

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
@@ -57,9 +57,7 @@ public class DeferredBlockBuilder<T extends Block> extends DeferredBlock<T> {
      */
     @Deprecated(since = "1.21.10", forRemoval = true)
     public DeferredBlockBuilder<T> withBlockItem(Item.Properties properties, Consumer<DeferredItemBuilder<BlockItem>> consumer) {
-        consumer.accept(helper.items().registerSimpleBlockItem(this, () -> properties));
-        hasItem = true;
-        return this;
+        return this.withBlockItem(() -> properties, consumer);
     }
 
     public DeferredBlockBuilder<T> withBlockItem(Supplier<Item.Properties> properties, Consumer<DeferredItemBuilder<BlockItem>> consumer) {

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredBlockBuilder.java
@@ -52,11 +52,17 @@ public class DeferredBlockBuilder<T extends Block> extends DeferredBlock<T> {
     }
 
     /**
-     * @deprecated Use {@link #withBlockItem(UnaryOperator, Consumer)} instead
+     * @deprecated Use {@link #withBlockItem(Supplier, Consumer)} or {@link #withBlockItem(UnaryOperator, Consumer)} instead
      */
     @Deprecated(since = "1.21.10", forRemoval = true)
     public DeferredBlockBuilder<T> withBlockItem(Item.Properties properties, Consumer<DeferredItemBuilder<BlockItem>> consumer) {
-        consumer.accept(helper.items().registerSimpleBlockItem(this, props -> properties));
+        consumer.accept(helper.items().registerSimpleBlockItem(this, () -> properties));
+        hasItem = true;
+        return this;
+    }
+
+    public DeferredBlockBuilder<T> withBlockItem(Supplier<Item.Properties> properties, Consumer<DeferredItemBuilder<BlockItem>> consumer) {
+        consumer.accept(helper.items().registerSimpleBlockItem(this, properties));
         hasItem = true;
         return this;
     }

--- a/testframework/src/main/java/net/neoforged/testframework/registration/DeferredItems.java
+++ b/testframework/src/main/java/net/neoforged/testframework/registration/DeferredItems.java
@@ -41,6 +41,11 @@ public class DeferredItems extends DeferredRegister.Items {
     }
 
     @Override
+    public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, Supplier<Item.Properties> properties) {
+        return (DeferredItemBuilder<BlockItem>) super.registerSimpleBlockItem(name, block, properties);
+    }
+
+    @Override
     public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block, UnaryOperator<Item.Properties> properties) {
         return (DeferredItemBuilder<BlockItem>) super.registerSimpleBlockItem(name, block, properties);
     }
@@ -48,6 +53,11 @@ public class DeferredItems extends DeferredRegister.Items {
     @Override
     public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(String name, Supplier<? extends Block> block) {
         return (DeferredItemBuilder<BlockItem>) super.registerSimpleBlockItem(name, block);
+    }
+
+    @Override
+    public DeferredItemBuilder<BlockItem> registerSimpleBlockItem(Holder<Block> block, Supplier<Item.Properties> properties) {
+        return (DeferredItemBuilder<BlockItem>) super.registerSimpleBlockItem(block, properties);
     }
 
     @Override
@@ -61,6 +71,11 @@ public class DeferredItems extends DeferredRegister.Items {
     }
 
     @Override
+    public <I extends Item> DeferredItemBuilder<I> registerItem(String name, Function<Item.Properties, ? extends I> func, Supplier<Item.Properties> properties) {
+        return (DeferredItemBuilder<I>) super.registerItem(name, func, properties);
+    }
+
+    @Override
     public <I extends Item> DeferredItemBuilder<I> registerItem(String name, Function<Item.Properties, ? extends I> func, UnaryOperator<Item.Properties> properties) {
         return (DeferredItemBuilder<I>) super.registerItem(name, func, properties);
     }
@@ -68,6 +83,11 @@ public class DeferredItems extends DeferredRegister.Items {
     @Override
     public <I extends Item> DeferredItemBuilder<I> registerItem(String name, Function<Item.Properties, ? extends I> func) {
         return (DeferredItemBuilder<I>) super.registerItem(name, func);
+    }
+
+    @Override
+    public DeferredItemBuilder<Item> registerSimpleItem(String name, Supplier<Item.Properties> properties) {
+        return (DeferredItemBuilder<Item>) super.registerSimpleItem(name, properties);
     }
 
     @Override


### PR DESCRIPTION
Closes #2761

Motivations:
- Allows extending `Item.Properties` in case someone desires that
- Is more consistent with what you could do using non-lazy properties, allowing for smother transition
- Consistent with block registration which already has such methods
- Concept of suppliers is more widely known than unary operators, this might reduce confusion for starting mod developers

` `

There are two more things I can suggest but I'm not sure If they should be done:
1. If using operators in the preferred way, should they be suggested in javadoc first? Currently supplier methods are suggested first for blocks and I have made it the same for items to be consistent.
2. Entities and data components could also use similar methods, for entities a `BiFunction` can be used instead of `Supplier`.

I have already made these changes in different branches in my fork if someone wants to check out how that would look like.