### PR TITLE
Mods screen bugfixes

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/ModListScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ModListScreen.java
@@ -304,7 +304,9 @@ public class ModListScreen extends Screen {
 
     @Override
     public void tick() {
-        modList.setSelected(selected);
+        if (modList.getSelected() != selected) {
+            modList.setSelected(selected);
+        }
 
         if (!search.getValue().equals(lastFilterText)) {
             reloadMods();

--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/ModListWidget.java
@@ -36,7 +36,6 @@ public class ModListWidget extends ObjectSelectionList<ModListWidget.ModEntry> {
         this.parent = parent;
         this.listWidth = listWidth;
         //this.setRenderBackground(false); // TODO: Porting 1.20.5 still needed?
-        this.refreshList();
     }
 
     @Override

--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/ScrollPanel.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/ScrollPanel.java
@@ -131,7 +131,7 @@ public abstract class ScrollPanel extends AbstractContainerEventHandler implemen
         int max = getMaxScroll();
 
         if (max < 0) {
-            max /= 2;
+            max = 0;
         }
 
         if (this.scrollDistance < 0.0F) {


### PR DESCRIPTION
Fixes three issues I noticed with the Mods screen:
1. When you first opened the screen, the mods list flickers before updating its x position to account for padding. I fixed this by removing the initial refreshList call that happens in the constructor, before the x position of the list is set.
2. When an item in the list is selected, you can't scroll beyond the item because every tick it is constantly being re-selected and scrolled to. I fixed this by checking that the item is not selected before selecting it again.
3. Certain mods without descriptions like Minecraft and NeoForge clamp to incorrect scroll positions when scrolling is attempted. This was because ScrollPanel had very strange behavior when the max scroll is negative, as it is for certain mod descriptions that don't have scroll bars. I truly could not figure out why the previous logic halved the max in this case, but it seems to work great once I change this behavior. I asked around on Discord if anyone knew why it was doing this (as it has always been like that since implementation over 13 years ago, likely copied from notchcode), but no one seemed to know the motivation for it.

In general, this screen is in pretty rough shape. Would you be interested in a more thorough overhaul/updating of this to be more user friendly and aesthetically pleasing? 