### PR TITLE
Forward firstPerson() and leftHand() methods of ItemDisplayContext to the fallback

### DIFF
--- a/patches/net/minecraft/world/item/ItemDisplayContext.java.patch
+++ b/patches/net/minecraft/world/item/ItemDisplayContext.java.patch
@@ -33,10 +33,17 @@
      }
  
      @Override
-@@ -42,5 +_,18 @@
+@@ -37,10 +_,23 @@
+     }
+ 
+     public boolean firstPerson() {
+-        return this == FIRST_PERSON_LEFT_HAND || this == FIRST_PERSON_RIGHT_HAND;
++        return this == FIRST_PERSON_LEFT_HAND || this == FIRST_PERSON_RIGHT_HAND || (fallback() != null && fallback().firstPerson());
+     }
  
      public boolean leftHand() {
-         return this == FIRST_PERSON_LEFT_HAND || this == THIRD_PERSON_LEFT_HAND;
+-        return this == FIRST_PERSON_LEFT_HAND || this == THIRD_PERSON_LEFT_HAND;
++        return this == FIRST_PERSON_LEFT_HAND || this == THIRD_PERSON_LEFT_HAND || (fallback() != null && fallback().leftHand());
 +    }
 +
 +    public boolean isModded() {


### PR DESCRIPTION
In my Tool Belt mod, the player sees the first two belt slots to the left and right of the player model (in thirdperson). In order to allow customizing of the item display in those slots, I use a pair of display contexts for the belt display, with fallbacks to the vanilla third person left and right hand. However, the item rendering logic does not apply the right rotations, resulting in the left hand item rendering 180 degrees from where it should be.

Forwarding these methods allows the custom display contexts to still be recognized as left hand or first person (which I don't use but included for completeness).