### PR TITLE
[1.21.10] Add Tears to music disc tag

### DIFF
--- a/src/generated/resources/data/c/tags/item/music_discs.json
+++ b/src/generated/resources/data/c/tags/item/music_discs.json
@@ -11,14 +11,14 @@
     "minecraft:music_disc_strad",
     "minecraft:music_disc_ward",
     "minecraft:music_disc_11",
-    "minecraft:music_disc_creator_music_box",
     "minecraft:music_disc_wait",
-    "minecraft:music_disc_creator",
-    "minecraft:music_disc_precipice",
     "minecraft:music_disc_otherside",
-    "minecraft:music_disc_relic",
     "minecraft:music_disc_5",
     "minecraft:music_disc_pigstep",
+    "minecraft:music_disc_relic",
+    "minecraft:music_disc_creator",
+    "minecraft:music_disc_creator_music_box",
+    "minecraft:music_disc_precipice",
     "minecraft:music_disc_tears",
     "minecraft:music_disc_lava_chicken"
   ]

--- a/src/generated/resources/data/c/tags/item/music_discs.json
+++ b/src/generated/resources/data/c/tags/item/music_discs.json
@@ -11,14 +11,15 @@
     "minecraft:music_disc_strad",
     "minecraft:music_disc_ward",
     "minecraft:music_disc_11",
+    "minecraft:music_disc_creator_music_box",
     "minecraft:music_disc_wait",
+    "minecraft:music_disc_creator",
+    "minecraft:music_disc_precipice",
     "minecraft:music_disc_otherside",
+    "minecraft:music_disc_relic",
     "minecraft:music_disc_5",
     "minecraft:music_disc_pigstep",
-    "minecraft:music_disc_relic",
-    "minecraft:music_disc_creator",
-    "minecraft:music_disc_creator_music_box",
-    "minecraft:music_disc_precipice",
+    "minecraft:music_disc_tears",
     "minecraft:music_disc_lava_chicken"
   ]
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -178,10 +178,11 @@ public final class NeoForgeItemTagsProvider extends BlockTagCopyingItemTagProvid
         tag(Tags.Items.INGOTS_NETHERITE).add(Items.NETHERITE_INGOT);
         tag(Tags.Items.LEATHERS).add(Items.LEATHER);
         tag(Tags.Items.MUSHROOMS).add(Items.BROWN_MUSHROOM, Items.RED_MUSHROOM);
-        tag(Tags.Items.MUSIC_DISCS).add(Items.MUSIC_DISC_13, Items.MUSIC_DISC_CAT, Items.MUSIC_DISC_BLOCKS, Items.MUSIC_DISC_CHIRP,
-                Items.MUSIC_DISC_FAR, Items.MUSIC_DISC_MALL, Items.MUSIC_DISC_MELLOHI, Items.MUSIC_DISC_STAL, Items.MUSIC_DISC_STRAD,
-                Items.MUSIC_DISC_WARD, Items.MUSIC_DISC_11, Items.MUSIC_DISC_CREATOR_MUSIC_BOX, Items.MUSIC_DISC_WAIT, Items.MUSIC_DISC_CREATOR,
-                Items.MUSIC_DISC_PRECIPICE, Items.MUSIC_DISC_OTHERSIDE, Items.MUSIC_DISC_RELIC, Items.MUSIC_DISC_5, Items.MUSIC_DISC_PIGSTEP,
+        tag(Tags.Items.MUSIC_DISCS).add(
+                Items.MUSIC_DISC_13, Items.MUSIC_DISC_CAT, Items.MUSIC_DISC_BLOCKS, Items.MUSIC_DISC_CHIRP, Items.MUSIC_DISC_FAR,
+                Items.MUSIC_DISC_MALL, Items.MUSIC_DISC_MELLOHI, Items.MUSIC_DISC_STAL, Items.MUSIC_DISC_STRAD, Items.MUSIC_DISC_WARD,
+                Items.MUSIC_DISC_11, Items.MUSIC_DISC_WAIT, Items.MUSIC_DISC_OTHERSIDE, Items.MUSIC_DISC_5, Items.MUSIC_DISC_PIGSTEP,
+                Items.MUSIC_DISC_RELIC, Items.MUSIC_DISC_CREATOR, Items.MUSIC_DISC_CREATOR_MUSIC_BOX, Items.MUSIC_DISC_PRECIPICE,
                 Items.MUSIC_DISC_TEARS, Items.MUSIC_DISC_LAVA_CHICKEN);
         tag(Tags.Items.NETHER_STARS).add(Items.NETHER_STAR);
         copy(Tags.Blocks.NETHERRACKS, Tags.Items.NETHERRACKS);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -180,9 +180,9 @@ public final class NeoForgeItemTagsProvider extends BlockTagCopyingItemTagProvid
         tag(Tags.Items.MUSHROOMS).add(Items.BROWN_MUSHROOM, Items.RED_MUSHROOM);
         tag(Tags.Items.MUSIC_DISCS).add(Items.MUSIC_DISC_13, Items.MUSIC_DISC_CAT, Items.MUSIC_DISC_BLOCKS, Items.MUSIC_DISC_CHIRP,
                 Items.MUSIC_DISC_FAR, Items.MUSIC_DISC_MALL, Items.MUSIC_DISC_MELLOHI, Items.MUSIC_DISC_STAL, Items.MUSIC_DISC_STRAD,
-                Items.MUSIC_DISC_WARD, Items.MUSIC_DISC_11, Items.MUSIC_DISC_WAIT, Items.MUSIC_DISC_OTHERSIDE, Items.MUSIC_DISC_5,
-                Items.MUSIC_DISC_PIGSTEP, Items.MUSIC_DISC_RELIC, Items.MUSIC_DISC_CREATOR, Items.MUSIC_DISC_CREATOR_MUSIC_BOX,
-                Items.MUSIC_DISC_PRECIPICE, Items.MUSIC_DISC_LAVA_CHICKEN);
+                Items.MUSIC_DISC_WARD, Items.MUSIC_DISC_11, Items.MUSIC_DISC_CREATOR_MUSIC_BOX, Items.MUSIC_DISC_WAIT, Items.MUSIC_DISC_CREATOR,
+                Items.MUSIC_DISC_PRECIPICE, Items.MUSIC_DISC_OTHERSIDE, Items.MUSIC_DISC_RELIC, Items.MUSIC_DISC_5, Items.MUSIC_DISC_PIGSTEP,
+                Items.MUSIC_DISC_TEARS, Items.MUSIC_DISC_LAVA_CHICKEN);
         tag(Tags.Items.NETHER_STARS).add(Items.NETHER_STAR);
         copy(Tags.Blocks.NETHERRACKS, Tags.Items.NETHERRACKS);
         tag(Tags.Items.NUGGETS).addTags(Tags.Items.NUGGETS_COPPER, Tags.Items.NUGGETS_IRON, Tags.Items.NUGGETS_GOLD);


### PR DESCRIPTION
Should be backported to 1.21.6 (note Lava Chicken was added in 1.21.7 so keep that in mind when backporting)

<img width="1110" height="101" alt="image" src="https://github.com/user-attachments/assets/f64cde58-2c35-4290-b41b-c874086ee3c4" />
