### PR TITLE
Fix typos and grammar issues in documentation and error messages

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/event/SelectMusicEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/SelectMusicEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
  * If the music is set to {@code null} by a modder, it will cancel any music that was already playing.<br>
  * <br>
  * Note that the higher priority you make your event listener, the earlier the music will be set.<br>
- * Because of this, if you want your music to take precedence over others (perhaps you want to have seperate nighttime music for a biome for instance) then you may want it to have a lower priority.<br>
+ * Because of this, if you want your music to take precedence over others (perhaps you want to have separate nighttime music for a biome for instance) then you may want it to have a lower priority.<br>
  * <br>
  * To make your music instantly play rather than waiting for the playing music to stop, set the music to one that {@linkplain Music#replaceCurrentMusic() is set to replace the current music.}<br>
  * <br>

--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -998,7 +998,7 @@ public class ModConfigSpec implements IConfigSpec {
             this.min = min;
             this.max = max;
             if (min.compareTo(max) > 0) {
-                throw new IllegalArgumentException("Range min must be less then max.");
+                throw new IllegalArgumentException("Range min must be less than max.");
             }
         }
 

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -60,7 +60,7 @@ public abstract class BlockEvent extends Event {
      * <ul>
      * <li>If {@link Player#blockActionRestricted} is true.</li>
      * <li>If the target block is a {@link GameMasterBlock} and {@link Player#canUseGameMasterBlocks()} is false.</li>
-     * <li>If the the player is holding an item, and {@link Item#canAttackBlock} is false.</li>
+     * <li>If the player is holding an item, and {@link Item#canAttackBlock} is false.</li>
      * </ul>
      *
      * In the first two cases, un-cancelling the event will not permit the block to be broken.

--- a/src/main/java/net/neoforged/neoforge/network/filters/NetworkFilters.java
+++ b/src/main/java/net/neoforged/neoforge/network/filters/NetworkFilters.java
@@ -52,7 +52,7 @@ public class NetworkFilters {
     public static void cleanIfNecessary(Connection manager) {
         ChannelPipeline pipeline = manager.channel().pipeline();
 
-        //Grab the pipeline filters to remove in a seperate list to avoid a ConcurrentModificationException
+        //Grab the pipeline filters to remove in a separate list to avoid a ConcurrentModificationException
         final List<DynamicChannelHandler> toRemove = pipeline.names()
                 .stream()
                 .map(pipeline::get)


### PR DESCRIPTION
This PR fixes several typos and grammar issues found in the codebase:

1. **ModConfigSpec.java**: Fixed error message typo 'less then' → 'less than'
2. **NetworkFilters.java**: Fixed comment typo 'seperate' → 'separate'  
3. **SelectMusicEvent.java**: Fixed javadoc typo 'seperate' → 'separate'
4. **BlockEvent.java**: Fixed duplicate word 'the the' → 'the' in javadoc

These are minor documentation and error message improvements that enhance code quality and readability.