### PR TITLE
Fix #2722: Update javadocs for abstract event classes

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
@@ -14,8 +14,9 @@ import net.neoforged.neoforge.common.NeoForge;
 
 /**
  * EntityEvent is fired when an event involving any Entity occurs.<br>
- * If a method utilizes this {@link net.neoforged.bus.api.Event} as its parameter, the method will
- * receive every child event of this class.<br>
+ * <br>
+ * This is an abstract class and cannot be listened to directly.
+ * Listeners should register to one of its subclasses instead.<br>
  * <br>
  * {@link #entity} contains the entity that caused this event to occur.<br>
  * <br>

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
@@ -16,8 +16,9 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * LivingEvent is fired whenever an event involving a {@link LivingEntity} occurs.<br>
- * If a method utilizes this {@link Event} as its parameter, the method will
- * receive every child event of this class.<br>
+ * <br>
+ * This is an abstract class and cannot be listened to directly.
+ * Listeners should register to one of its subclasses instead.<br>
  * <br>
  * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.<br>
  **/

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -28,8 +28,9 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * PlayerEvent is fired whenever an event involving a {@link Player} occurs. <br>
- * If a method utilizes this {@link net.neoforged.bus.api.Event} as its parameter, the method will
- * receive every child event of this class.<br>
+ * <br>
+ * This is an abstract class and cannot be listened to directly.
+ * Listeners should register to one of its subclasses instead.<br>
  * <br>
  * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.
  **/

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
@@ -12,8 +12,9 @@ import net.neoforged.neoforge.common.NeoForge;
 
 /**
  * PlayerXpEvent is fired whenever an event involving player experience occurs. <br>
- * If a method utilizes this {@link net.neoforged.bus.api.Event} as its parameter, the method will
- * receive every child event of this class.<br>
+ * <br>
+ * This is an abstract class and cannot be listened to directly.
+ * Listeners should register to one of its subclasses instead.<br>
  * <br>
  * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.
  */

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkDataEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkDataEvent.java
@@ -16,6 +16,9 @@ import net.neoforged.neoforge.common.NeoForge;
 
 /**
  * ChunkDataEvent is fired when a chunk is about to be loaded from disk or saved to disk.
+ * <br>
+ * This is an abstract class and cannot be listened to directly.
+ * Listeners should register to one of its subclasses instead.
  */
 public abstract class ChunkDataEvent extends ChunkEvent<ChunkAccess> {
     private final SerializableChunkData data;


### PR DESCRIPTION
Fixes #2722

This PR updates the javadocs for abstract event classes to reflect the current behavior where they cannot be directly listened to.

## Changes

- Removed outdated statements claiming methods would receive all child events when registering to abstract event classes
- Added clear documentation stating abstract event classes cannot be listened to directly  
- Specified that listeners must register to specific subclasses instead
- Updated javadocs for:
  - 
  - 
  - 
  - 
  - 
- Left  unchanged as it is not abstract

## Testing

Verified that all affected classes are indeed marked as abstract and throw  when attempting to register listeners directly.