### PR TITLE
Fix #2514: Update 'Forge' references to 'NeoForge' in documentation

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -49,7 +49,7 @@ import net.neoforged.neoforge.common.NeoForge;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}, only on the
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}, only on the
  * {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class AddSectionGeometryEvent extends Event {

--- a/src/client/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/CalculateDetachedCameraDistanceEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class CalculateDetachedCameraDistanceEvent extends Event {

--- a/src/client/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/CalculatePlayerTurnEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
  * 
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class CalculatePlayerTurnEvent extends Event {

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientChatEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientChatEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the chat message will not be sent to the server.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  **/
 public class ClientChatEvent extends Event implements ICancellableEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientChatReceivedEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientChatReceivedEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the message is not displayed in the chat message window.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see ChatType
@@ -90,7 +90,7 @@ public class ClientChatReceivedEvent extends Event implements ICancellableEvent 
      * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
      * If the event is cancelled, the message is not displayed in the chat message window.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see ChatType
@@ -119,7 +119,7 @@ public class ClientChatReceivedEvent extends Event implements ICancellableEvent 
      * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
      * If the event is cancelled, the message is not displayed in the chat message window or in the overlay.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class System extends ClientChatReceivedEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientPauseChangeEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientPauseChangeEvent.java
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.common.NeoForge;
 /**
  * Fired when game pause state is about to change
  *
- * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public abstract class ClientPauseChangeEvent extends Event {
@@ -30,7 +30,7 @@ public abstract class ClientPauseChangeEvent extends Event {
      * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      * Cancelling this event will prevent the game change pause state even if the conditions match
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Pre extends ClientPauseChangeEvent implements ICancellableEvent {
@@ -44,7 +44,7 @@ public abstract class ClientPauseChangeEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Post extends ClientPauseChangeEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientPlayerChangeGameTypeEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientPlayerChangeGameTypeEvent.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class ClientPlayerChangeGameTypeEvent extends Event {

--- a/src/client/java/net/neoforged/neoforge/client/event/ClientPlayerNetworkEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ClientPlayerNetworkEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.Nullable;
  * Fired for different client connectivity events.
  * See the various subclasses to listen for specific events.
  *
- * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see LoggingIn
@@ -63,7 +63,7 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class LoggingIn extends ClientPlayerNetworkEvent {
@@ -78,7 +78,7 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     @SuppressWarnings("NullableProblems")
@@ -129,7 +129,7 @@ public abstract class ClientPlayerNetworkEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Clone extends ClientPlayerNetworkEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ComputeFovModifierEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ComputeFovModifierEvent.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see ViewportEvent.ComputeFov

--- a/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ContainerScreenEvent.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.ApiStatus;
  * Fired for hooking into {@link AbstractContainerScreen} events.
  * See the subclasses to listen for specific events.
  *
- * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see Render.Foreground
@@ -41,7 +41,7 @@ public abstract class ContainerScreenEvent extends Event {
      * Fired every time an {@link AbstractContainerScreen} renders.
      * See the two subclasses to listen for foreground or background rendering.
      *
-     * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see Foreground
@@ -90,7 +90,7 @@ public abstract class ContainerScreenEvent extends Event {
          *
          * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          *
          * @see ScreenEvent.Render.Background ScreenEvent.Render.Background, for listening to the background being drawn

--- a/src/client/java/net/neoforged/neoforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/CustomizeGuiOverlayEvent.java
@@ -51,7 +51,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
      * Cancelling this event will prevent the given bar from rendering.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class BossEventProgress extends CustomizeGuiOverlayEvent implements ICancellableEvent {
@@ -112,7 +112,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.<p/>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Chat extends CustomizeGuiOverlayEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/FrameGraphSetupEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FrameGraphSetupEvent.java
@@ -25,7 +25,7 @@ import org.joml.Matrix4f;
  * <p>
  * This event is not {@linkplain ICancellableEvent cancellable}.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.
  */
 public final class FrameGraphSetupEvent extends Event {

--- a/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
@@ -33,7 +33,7 @@ public abstract class InputEvent extends Event {
     /**
      * Fired when a mouse button is pressed/released. Sub-events get fired {@link Pre before} and {@link Post after} this happens.
      *
-     * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
@@ -95,7 +95,7 @@ public abstract class InputEvent extends Event {
          * <p>This event is {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, then the mouse event will not be processed by vanilla (e.g. keymappings and screens) </p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
@@ -112,7 +112,7 @@ public abstract class InputEvent extends Event {
          *
          * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          *
          * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
@@ -132,7 +132,7 @@ public abstract class InputEvent extends Event {
      * <p>This event is {@linkplain ICancellableEvent cancellable}.
      * If the event is cancelled, then the mouse scroll event will not be processed further.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see <a href="https://www.glfw.org/docs/latest/input_guide.html#input_mouse_button" target="_top">the online GLFW documentation</a>
@@ -212,7 +212,7 @@ public abstract class InputEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Key extends InputEvent {
@@ -294,7 +294,7 @@ public abstract class InputEvent extends Event {
      * If this event is cancelled, then the keymapping's action is not processed further, and the hand will be swung
      * according to {@link #shouldSwingHand()}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class InteractionKeyMappingTriggered extends InputEvent implements ICancellableEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/MovementInputUpdateEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/MovementInputUpdateEvent.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain Event.HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class MovementInputUpdateEvent extends PlayerEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterClientCommandsEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterClientCommandsEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see RegisterCommandsEvent

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If this event is cancelled, then the arm will not be rendered.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RenderArmEvent extends Event implements ICancellableEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderBlockScreenEffectEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderBlockScreenEffectEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is {@linkplain ICancellableEvent cancellable}.
  * If this event is cancelled, then the overlay will not be rendered.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class RenderBlockScreenEffectEvent extends Event implements ICancellableEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderGuiEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderGuiEvent.java
@@ -45,7 +45,7 @@ public abstract class RenderGuiEvent extends Event {
      * If this event is cancelled, then the overlay will not be rendered, and the corresponding {@link Post} event will
      * not be fired.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see Post
@@ -62,7 +62,7 @@ public abstract class RenderGuiEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Post extends RenderGuiEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderGuiLayerEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderGuiLayerEvent.java
@@ -62,7 +62,7 @@ public abstract class RenderGuiLayerEvent extends Event {
      * If this event is cancelled, then the layer will not be rendered, and the corresponding {@link Post} event will
      * not be fired.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see Post
@@ -79,7 +79,7 @@ public abstract class RenderGuiLayerEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Post extends RenderGuiLayerEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderHandEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderHandEvent.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If this event is cancelled, then the hand will not be rendered.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see RenderArmEvent

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderItemInFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderItemInFrameEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, then the item stack will not be rendered</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see ItemFrameRenderer

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderTooltipEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderTooltipEvent.java
@@ -105,7 +105,7 @@ public abstract class RenderTooltipEvent extends Event {
      * If this event is cancelled, then the list of components will be empty, causing the tooltip to not be rendered and
      * the corresponding {@link RenderTooltipEvent.Pre} and {@link RenderTooltipEvent.Texture} to not be fired.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class GatherComponents extends Event implements ICancellableEvent {
@@ -185,7 +185,7 @@ public abstract class RenderTooltipEvent extends Event {
      * If this event is cancelled, then the tooltip will not be rendered and the corresponding
      * {@link RenderTooltipEvent.Texture} will not be fired.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Pre extends RenderTooltipEvent implements ICancellableEvent {
@@ -256,7 +256,7 @@ public abstract class RenderTooltipEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Texture extends RenderTooltipEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -31,7 +31,7 @@ import org.lwjgl.glfw.GLFW;
  * Fired on different events/actions when a {@link Screen} is active and visible.
  * See the various subclasses for listening to different events.
  *
- * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see Init
@@ -111,7 +111,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the initialization method will not be called, and the widgets and children lists
          * will not be cleared.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends Init implements ICancellableEvent {
@@ -126,7 +126,7 @@ public abstract class ScreenEvent extends Event {
          *
          * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends Init {
@@ -194,7 +194,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, the screen will not be drawn.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends Render implements ICancellableEvent {
@@ -227,7 +227,7 @@ public abstract class ScreenEvent extends Event {
          *
          * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends Render {
@@ -246,7 +246,7 @@ public abstract class ScreenEvent extends Event {
      * <p>This event is {@linkplain ICancellableEvent cancellable}.
      * Cancelling this event will prevent vanilla rendering.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RenderInventoryMobEffects extends ScreenEvent implements ICancellableEvent {
@@ -384,7 +384,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's mouse click handler will be bypassed
          * and the corresponding {@link MouseButtonPressed.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends MouseButtonPressed implements ICancellableEvent {
@@ -501,7 +501,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's mouse release handler will be bypassed
          * and the corresponding {@link MouseButtonReleased.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends MouseButtonReleased implements ICancellableEvent {
@@ -636,7 +636,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's mouse drag handler will be bypassed
          * and the corresponding {@link MouseDragged.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends MouseDragged implements ICancellableEvent {
@@ -653,7 +653,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is not {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, the mouse drag will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends MouseDragged {
@@ -703,7 +703,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's mouse scroll handler will be bypassed
          * and the corresponding {@link MouseScrolled.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends MouseScrolled implements ICancellableEvent {
@@ -720,7 +720,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is not {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, the mouse scroll will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends MouseScrolled {
@@ -813,7 +813,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's key press handler will be bypassed
          * and the corresponding {@link KeyPressed.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends KeyPressed implements ICancellableEvent {
@@ -830,7 +830,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, the key press will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends KeyPressed implements ICancellableEvent {
@@ -861,7 +861,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's key release handler will be bypassed
          * and the corresponding {@link KeyReleased.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends KeyReleased implements ICancellableEvent {
@@ -878,7 +878,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, the key release will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends KeyReleased implements ICancellableEvent {
@@ -939,7 +939,7 @@ public abstract class ScreenEvent extends Event {
          * If the event is cancelled, the screen's character input handler will be bypassed
          * and the corresponding {@link CharacterTyped.Post} will not be fired.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Pre extends CharacterTyped implements ICancellableEvent {
@@ -956,7 +956,7 @@ public abstract class ScreenEvent extends Event {
          * <p>This event is {@linkplain ICancellableEvent cancellable}.
          * If the event is cancelled, the character input will be set as handled.</p>
          *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
          * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
          */
         public static class Post extends CharacterTyped {
@@ -976,7 +976,7 @@ public abstract class ScreenEvent extends Event {
      * will remain open. However, cancelling this event will not prevent the closing of screen layers which happened before
      * this event fired.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Opening extends ScreenEvent implements ICancellableEvent {
@@ -1023,7 +1023,7 @@ public abstract class ScreenEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class Closing extends ScreenEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenshotEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenshotEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
  * If this event is cancelled, then the screenshot is not written to disk, and the message in the event will be posted
  * to the player's chat.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see Screenshot

--- a/src/client/java/net/neoforged/neoforge/client/event/SelectMusicEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/SelectMusicEvent.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  * This event is {@linkplain ICancellableEvent cancellable}.<br>
  * If the event is canceled, then whatever the latest music set was will be used as the music.
  * <br>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},<br>
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},<br>
  * only on the {@linkplain LogicalSide#CLIENT logical client}.
  *
  */

--- a/src/client/java/net/neoforged/neoforge/client/event/ToastAddEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ToastAddEvent.java
@@ -18,7 +18,7 @@ import net.neoforged.neoforge.common.NeoForge;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * Cancelling the event stops the toast from being queued, which means it never renders.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public class ToastAddEvent extends Event implements ICancellableEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/ViewportEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ViewportEvent.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
  * These can be used for customizing the visual features visible to the player.
  * See the various subclasses for listening to different features.
  *
- * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see RenderFog
@@ -67,7 +67,7 @@ public abstract class ViewportEvent extends Event {
     /**
      * Fired for <b>rendering</b> custom fog. The plane distances are based on the player's render distance.
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class RenderFog extends ViewportEvent {
@@ -166,7 +166,7 @@ public abstract class ViewportEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class ComputeFogColor extends ViewportEvent {
@@ -237,7 +237,7 @@ public abstract class ViewportEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      */
     public static class ComputeCameraAngles extends ViewportEvent {
@@ -308,7 +308,7 @@ public abstract class ViewportEvent extends Event {
      *
      * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see ComputeFovModifierEvent

--- a/src/client/java/net/neoforged/neoforge/client/event/sound/PlaySoundEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/sound/PlaySoundEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see PlaySoundSourceEvent

--- a/src/client/java/net/neoforged/neoforge/client/event/sound/PlaySoundSourceEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/sound/PlaySoundSourceEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see PlayStreamingSourceEvent

--- a/src/client/java/net/neoforged/neoforge/client/event/sound/PlayStreamingSourceEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/sound/PlayStreamingSourceEvent.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see PlayStreamingSourceEvent

--- a/src/client/java/net/neoforged/neoforge/client/event/sound/SoundEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/sound/SoundEvent.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * Superclass for sound related events.
  *
- * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  *
  * @see SoundSourceEvent
@@ -41,7 +41,7 @@ public abstract class SoundEvent extends Event {
     /**
      * Superclass for when a sound has started to play on an audio channel.
      *
-     * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>These events are fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
      *
      * @see PlaySoundSourceEvent

--- a/src/main/java/net/neoforged/neoforge/event/CommandEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/CommandEvent.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
  * This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the command will not be executed.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 public class CommandEvent extends Event implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/LootTableLoadEvent.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the loot table will be made empty.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
 public class LootTableLoadEvent extends Event implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/RegisterStructureConversionsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/RegisterStructureConversionsEvent.java
@@ -26,7 +26,7 @@ import net.neoforged.neoforge.common.NeoForge;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancelable}, and does not {@linkplain HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain net.neoforged.fml.LogicalSide#SERVER logical server}. </p>
  *
  * @see StructuresBecomeConfiguredFix

--- a/src/main/java/net/neoforged/neoforge/event/ServerChatEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ServerChatEvent.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus;
  * This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
  * If the event is cancelled, the message will not be sent to clients.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 public class ServerChatEvent extends Event implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityJoinLevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityJoinLevelEvent.java
@@ -24,7 +24,7 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
  * If the event is canceled, the entity will not be added to the level.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
  * on both logical sides.
  **/
 public class EntityJoinLevelEvent extends EntityEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityLeaveLevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityLeaveLevelEvent.java
@@ -16,7 +16,7 @@ import net.neoforged.neoforge.common.NeoForge;
  * <p>
  * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain net.neoforged.bus.api.Event.HasResult have a result}.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
  * on both logical sides.
  **/
 public class EntityLeaveLevelEvent extends EntityEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/AdvancementEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/AdvancementEvent.java
@@ -37,7 +37,7 @@ public abstract class AdvancementEvent extends PlayerEvent {
      *
      * <p>This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and does not {@linkplain Event.HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain net.neoforged.fml.LogicalSide#SERVER logical server}.</p>
      *
      * @see AdvancementProgress#isDone()
@@ -53,7 +53,7 @@ public abstract class AdvancementEvent extends PlayerEvent {
      *
      * <p>This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and does not {@linkplain Event.HasResult have a result}.</p>
      *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
      * only on the {@linkplain net.neoforged.fml.LogicalSide#SERVER logical server}.</p>
      *
      * @see AdvancementEarnEvent

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/TradeWithVillagerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/TradeWithVillagerEvent.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}, and does not {@linkplain Event.HasResult have a result}.</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus},
  * only on the {@linkplain LogicalSide#SERVER logical server}.</p>
  */
 public class TradeWithVillagerEvent extends PlayerEvent {

--- a/src/main/java/net/neoforged/neoforge/event/level/AlterGroundEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/AlterGroundEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>
  * This event is not {@linkplain ICancellableEvent cancellable}.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus} only on the {@linkplain net.neoforged.fml.LogicalSide#SERVER logical server}.
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus} only on the {@linkplain net.neoforged.fml.LogicalSide#SERVER logical server}.
  * <p>
  * This event is fired on worker threads, meaning it is unsafe to access external global state.<br>
  * Doing so may induce {@link ConcurrentModificationException} or deadlocks.

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkTicketLevelUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkTicketLevelUpdatedEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 public class ChunkTicketLevelUpdatedEvent extends Event {

--- a/src/main/java/net/neoforged/neoforge/event/level/ChunkWatchEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ChunkWatchEvent.java
@@ -22,7 +22,7 @@ import net.neoforged.neoforge.common.NeoForge;
  * <p>
  * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
  * <p>
- * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+ * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
  * only on the {@linkplain LogicalSide#SERVER logical server}.
  **/
 public abstract class ChunkWatchEvent extends Event {
@@ -66,7 +66,7 @@ public abstract class ChunkWatchEvent extends Event {
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     public static class Watch extends ChunkWatchEvent {
@@ -90,7 +90,7 @@ public abstract class ChunkWatchEvent extends Event {
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     public static class Sent extends ChunkWatchEvent {
@@ -116,7 +116,7 @@ public abstract class ChunkWatchEvent extends Event {
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     public static class UnWatch extends ChunkWatchEvent {

--- a/src/main/java/net/neoforged/neoforge/event/level/LevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/LevelEvent.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * This event is fired whenever an event involving a {@link LevelAccessor} occurs.
  * <p>
- * All children of this event are fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}.
+ * All children of this event are fired on the {@linkplain NeoForge#EVENT_BUS game event bus}.
  */
 public abstract class LevelEvent extends Event {
     private final LevelAccessor level;
@@ -48,7 +48,7 @@ public abstract class LevelEvent extends Event {
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * on both logical sides.
      **/
     public static class Load extends LevelEvent {
@@ -66,7 +66,7 @@ public abstract class LevelEvent extends Event {
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * on both logical sides.
      **/
     public static class Unload extends LevelEvent {
@@ -82,7 +82,7 @@ public abstract class LevelEvent extends Event {
      * <p>
      * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      **/
     public static class Save extends LevelEvent {
@@ -98,7 +98,7 @@ public abstract class LevelEvent extends Event {
      * This event is {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
      * If the event is canceled, the vanilla logic to choose a spawn position will be skipped.
      * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
+     * This event is fired on the {@linkplain NeoForge#EVENT_BUS game event bus}
      * only on the {@linkplain LogicalSide#SERVER logical server}.
      *
      * @see ServerLevelData#isInitialized()


### PR DESCRIPTION
Fixes #2514

This PR updates outdated 'Forge' branding in documentation to reflect the NeoForge project name.

## Changes

- Changed all instances of 'main Forge event bus' to 'game event bus' in javadocs across the codebase
- This provides more accurate and brand-consistent documentation  
- Affects 43 files with event documentation across client and server event classes

## Context

The issue reported that warning messages and documentation still referenced 'Forge' instead of 'NeoForge'. While the copyright headers correctly reference 'Forge Development LLC' (the original copyright holder), user-facing documentation should use 'game event bus' for clarity and consistency.