### PR TITLE
Expose damage source to ArmorHurtEvent

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -368,7 +368,7 @@ public class CommonHooks {
             armorMap.put(slot, new ArmorHurtEvent.ArmorEntry(armorPiece, damageAfterFireResist));
         }
 
-        ArmorHurtEvent event = NeoForge.EVENT_BUS.post(new ArmorHurtEvent(armorMap, armoredEntity));
+        ArmorHurtEvent event = NeoForge.EVENT_BUS.post(new ArmorHurtEvent(armorMap, armoredEntity, source));
         if (event.isCanceled()) return;
         event.getArmorMap().forEach((slot, entry) -> entry.armorItemStack.hurtAndBreak((int) entry.newDamage, armoredEntity, slot));
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ArmorHurtEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ArmorHurtEvent.java
@@ -31,12 +31,14 @@ public class ArmorHurtEvent extends LivingEvent implements ICancellableEvent {
         }
     }
 
+    private final DamageSource source;
     private final EnumMap<EquipmentSlot, ArmorEntry> armorEntries;
 
     @ApiStatus.Internal
-    public ArmorHurtEvent(EnumMap<EquipmentSlot, ArmorEntry> armorMap, LivingEntity player) {
+    public ArmorHurtEvent(EnumMap<EquipmentSlot, ArmorEntry> armorMap, LivingEntity player, DamageSource source) {
         super(player);
         this.armorEntries = armorMap;
+        this.source = source;
     }
 
     /**
@@ -70,5 +72,10 @@ public class ArmorHurtEvent extends LivingEvent implements ICancellableEvent {
     /** Used internally to get the full map of {@link ItemStack}s to be hurt */
     public Map<EquipmentSlot, ArmorEntry> getArmorMap() {
         return armorEntries;
+    }
+
+    /** {@return the {@link DamageSource} causing the damage} */
+    public DamageSource getSource() {
+        return source;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/ArmorHurtEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/ArmorHurtEvent.java
@@ -75,7 +75,7 @@ public class ArmorHurtEvent extends LivingEvent implements ICancellableEvent {
     }
 
     /** {@return the {@link DamageSource} causing the damage} */
-    public DamageSource getSource() {
+    public DamageSource getDamageSource() {
         return source;
     }
 }


### PR DESCRIPTION
Makes the source responsible for the damage available in the ArmorHurtEvent