### PR TITLE
[1.21.10] Expand context provided to ExtractBlockOutlineRenderStateEvent

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -255,7 +255,7 @@
 +                    boolean flag = net.neoforged.neoforge.client.ClientHooks.isInTranslucentBlockOutlinePass(this.level, blockpos, blockstate);
                      boolean flag1 = this.minecraft.options.highContrastBlockOutline().get();
                      CollisionContext collisioncontext = CollisionContext.of(p_451355_.getEntity());
-+                    var event = new net.neoforged.neoforge.client.event.ExtractBlockOutlineRenderStateEvent(this, this.level, blockpos, blockstate, blockhitresult, collisioncontext, p_451355_, p_451261_);
++                    var event = new net.neoforged.neoforge.client.event.ExtractBlockOutlineRenderStateEvent(this, this.level, blockpos, blockstate, blockhitresult, collisioncontext, flag, flag1, p_451355_, p_451261_);
 +                    if (net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event).isCanceled()) {
 +                        return;
 +                    }

--- a/src/client/java/net/neoforged/neoforge/client/event/ExtractBlockOutlineRenderStateEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ExtractBlockOutlineRenderStateEvent.java
@@ -37,6 +37,8 @@ public final class ExtractBlockOutlineRenderStateEvent extends Event implements 
     private final BlockState state;
     private final BlockHitResult hitResult;
     private final CollisionContext collisionContext;
+    private final boolean inTranslucentPass;
+    private final boolean highContrast;
     private final Camera camera;
     private final LevelRenderState levelRenderState;
     private final List<CustomBlockOutlineRenderer> customRenderers = new ArrayList<>();
@@ -49,6 +51,8 @@ public final class ExtractBlockOutlineRenderStateEvent extends Event implements 
             BlockState state,
             BlockHitResult hitResult,
             CollisionContext collisionContext,
+            boolean inTranslucentPass,
+            boolean highContrast,
             Camera camera,
             LevelRenderState levelRenderState) {
         this.levelRenderer = levelRenderer;
@@ -57,6 +61,8 @@ public final class ExtractBlockOutlineRenderStateEvent extends Event implements 
         this.state = state;
         this.hitResult = hitResult;
         this.collisionContext = collisionContext;
+        this.inTranslucentPass = inTranslucentPass;
+        this.highContrast = highContrast;
         this.camera = camera;
         this.levelRenderState = levelRenderState;
     }
@@ -108,6 +114,20 @@ public final class ExtractBlockOutlineRenderStateEvent extends Event implements 
      */
     public CollisionContext getCollisionContext() {
         return this.collisionContext;
+    }
+
+    /**
+     * {@return whether the targeted block has translucent geometry and therefore needs to render its outline in the translucent pass}
+     */
+    public boolean isInTranslucentPass() {
+        return inTranslucentPass;
+    }
+
+    /**
+     * {@return whether the high-contrast outline setting is enabled in the accessibility settings}
+     */
+    public boolean isHighContrast() {
+        return highContrast;
     }
 
     public Camera getCamera() {


### PR DESCRIPTION
This PR adds further context to the `ExtractBlockOutlineRenderStateEvent`, primarily to allow setting the `BlockOutlineRenderState` manually. This is for example useful to render "non-default" `VoxelShape`s without having to use a full custom renderer.