### PR TITLE
Fix framebuffer incompleteness caused by conflicting stencil attachments

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/DirectStateAccess.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/DirectStateAccess.java.patch
@@ -13,7 +13,7 @@
  
      abstract void blitFrameBuffers(
          int p_412546_,
-@@ -113,9 +_,10 @@
+@@ -113,9 +_,15 @@
          }
  
          @Override
@@ -21,12 +21,17 @@
 +        public void bindFrameBufferTextures(int p_412474_, int p_412101_, int p_412181_, int p_412742_, int p_412591_, boolean useStencil) {
              ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, 36064, p_412101_, p_412742_);
 -            ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, 36096, p_412181_, p_412742_);
-+            int depthAttachment = useStencil ? org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT : org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT;
-+            ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, depthAttachment, p_412181_, p_412742_);
++            if (useStencil) {
++                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, 0, 0);
++                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, p_412181_, p_412742_);
++            } else {
++                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, 0, 0);
++                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, p_412181_, p_412742_);
++            }
              if (p_412591_ != 0) {
                  GlStateManager._glBindFramebuffer(p_412591_, p_412474_);
              }
-@@ -250,12 +_,13 @@
+@@ -250,12 +_,18 @@
          }
  
          @Override
@@ -37,8 +42,13 @@
              GlStateManager._glBindFramebuffer(i, p_412192_);
              GlStateManager._glFramebufferTexture2D(i, 36064, 3553, p_412614_, p_412295_);
 -            GlStateManager._glFramebufferTexture2D(i, 36096, 3553, p_412332_, p_412295_);
-+            int depthAttachment = useStencil ? org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT : org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT;
-+            GlStateManager._glFramebufferTexture2D(i, depthAttachment, 3553, p_412332_, p_412295_);
++            if (useStencil){
++                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, 3553, 0, 0);
++                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, 3553, p_412332_, p_412295_);
++            }else {
++                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, 3553, 0, 0);
++                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, 3553, p_412332_, p_412295_);
++            }
              if (p_412775_ == 0) {
                  GlStateManager._glBindFramebuffer(i, j);
              }

--- a/patches/com/mojang/blaze3d/opengl/DirectStateAccess.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/DirectStateAccess.java.patch
@@ -13,25 +13,23 @@
  
      abstract void blitFrameBuffers(
          int p_412546_,
-@@ -113,9 +_,15 @@
+@@ -113,9 +_,14 @@
          }
  
          @Override
 -        public void bindFrameBufferTextures(int p_412474_, int p_412101_, int p_412181_, int p_412742_, int p_412591_) {
 +        public void bindFrameBufferTextures(int p_412474_, int p_412101_, int p_412181_, int p_412742_, int p_412591_, boolean useStencil) {
              ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, 36064, p_412101_, p_412742_);
--            ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, 36096, p_412181_, p_412742_);
+             ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, 36096, p_412181_, p_412742_);
 +            if (useStencil) {
-+                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, 0, 0);
-+                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, p_412181_, p_412742_);
++                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_STENCIL_ATTACHMENT, p_412181_, p_412742_);
 +            } else {
-+                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, 0, 0);
-+                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, p_412181_, p_412742_);
++                ARBDirectStateAccess.glNamedFramebufferTexture(p_412474_, org.lwjgl.opengl.GL32C.GL_STENCIL_ATTACHMENT, 0, 0);
 +            }
              if (p_412591_ != 0) {
                  GlStateManager._glBindFramebuffer(p_412591_, p_412474_);
              }
-@@ -250,12 +_,18 @@
+@@ -250,12 +_,17 @@
          }
  
          @Override
@@ -41,13 +39,11 @@
              int j = GlStateManager.getFrameBuffer(i);
              GlStateManager._glBindFramebuffer(i, p_412192_);
              GlStateManager._glFramebufferTexture2D(i, 36064, 3553, p_412614_, p_412295_);
--            GlStateManager._glFramebufferTexture2D(i, 36096, 3553, p_412332_, p_412295_);
-+            if (useStencil){
-+                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, 3553, 0, 0);
-+                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, 3553, p_412332_, p_412295_);
-+            }else {
-+                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_STENCIL_ATTACHMENT, 3553, 0, 0);
-+                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_DEPTH_ATTACHMENT, 3553, p_412332_, p_412295_);
+             GlStateManager._glFramebufferTexture2D(i, 36096, 3553, p_412332_, p_412295_);
++            if (useStencil) {
++                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_STENCIL_ATTACHMENT, 3553, p_412332_, p_412295_);
++            } else {
++                GlStateManager._glFramebufferTexture2D(i, org.lwjgl.opengl.GL32C.GL_STENCIL_ATTACHMENT, 3553, 0, 0);
 +            }
              if (p_412775_ == 0) {
                  GlStateManager._glBindFramebuffer(i, j);


### PR DESCRIPTION
This PR fixes a bug in `DirectStateAccess.java` that causes a `GL_INVALID_FRAMEBUFFER_OPERATION` error when toggling between depth-only and depth-stencil attachments for a framebuffer. The issue stems from the framebuffer being left in an incomplete state.

In both the `Core` and `Emulated` implementations of `DirectStateAccess.bindFrameBufferTextures`, when a texture is attached to either `GL_DEPTH_ATTACHMENT` or `GL_DEPTH_STENCIL_ATTACHMENT`, the other corresponding attachment point is not explicitly unbound.

This leads to a situation where a framebuffer might have conflicting attachments (e.g., both a depth and a depth-stencil attachment simultaneously), rendering it "framebuffer incomplete". As a consequence, any subsequent rendering operation that uses this framebuffer will trigger a `GL_INVALID_FRAMEBUFFER_OPERATION` error from OpenGL.

When `useStencil` is `true`, the `GL_DEPTH_ATTACHMENT` is now explicitly unbound.
When `useStencil` is `false`, the `GL_DEPTH_STENCIL_ATTACHMENT` is now explicitly unbound.