### PR TITLE
Enforce format compatibility for texture copies

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/GlCommandEncoder.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlCommandEncoder.java.patch
@@ -34,7 +34,31 @@
      private void verifyColorTexture(GpuTexture p_416690_) {
          if (!p_416690_.getFormat().hasColorAspect()) {
              throw new IllegalStateException("Trying to clear a non-color texture as color");
-@@ -672,8 +_,19 @@
+@@ -667,13 +_,43 @@
+             } else if (p_410735_.getDepthOrLayers() > 1) {
+                 throw new UnsupportedOperationException("Textures with multiple depths or layers are not yet supported for copying");
+             } else {
++                var sourceFormat = p_410700_.getFormat();
++                var destFormat = p_410735_.getFormat();
++
++                if (sourceFormat.hasDepthAspect() || sourceFormat.hasStencilAspect()) {
++                    if (sourceFormat != destFormat) {
++                        throw new IllegalArgumentException(
++                                "When copying depth or stencil data, the source and destination texture formats must be identical. Source: "
++                                        + sourceFormat + ", Destination: " + destFormat
++                        );
++                    }
++                }
++
++                if (sourceFormat.hasColorAspect() != destFormat.hasColorAspect()) {
++                    throw new IllegalArgumentException(
++                            "Source and destination texture formats must have consistent color aspects. Source: "
++                                    + sourceFormat + ", Destination: " + destFormat
++                    );
++                }
++
+                 GlStateManager.clearGlErrors();
+                 GlStateManager._disableScissorTest();
                  boolean flag = p_410700_.getFormat().hasDepthAspect();
                  int i = ((GlTexture)p_410700_).glId();
                  int j = ((GlTexture)p_410735_).glId();


### PR DESCRIPTION
This PR fixes a bug in `GlCommandEncoder.java` that causes a `GL_INVALID_OPERATION` error when copying textures with incompatible depth or stencil formats. The fix aligns the method with its established error-handling pattern by adding a missing validation check.

The `copyTextureToTexture` method follows an established design pattern: it pre-emptively validates its parameters against explicitly defined error conditions from the OpenGL specification, throwing a descriptive Java exception on failure.

According to the OpenGL specification, one such explicit error condition is that if a blit operation involves the depth or stencil buffer, the source and destination formats must match.
(see `glBlitFramebuffer` reference: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBlitFramebuffer.xhtml)

This check was unnecessary in the vanilla implementation, as it exclusively used a single depth format, making a format mismatch impossible. The bug was introduced when NeoForge added new stencil-aware texture formats; however, the now-necessary validation check was overlooked, breaking the method's established design pattern.

Consequently, this oversight allows an illegal blit operation (e.g., from `DEPTH32` to `DEPTH24_STENCIL8`) to be sent to the driver, resulting in a cryptic `GL_INVALID_OPERATION` error instead of a clear, pre-emptive exception.

<details>
<summary><strong>Before:</strong> Cryptic `IllegalStateException` wrapping a generic GL error</summary>

```
[13:33:19] [Render thread/INFO] [mojang/GlDebug]: OpenGL debug message: id=1282, source=API, type=ERROR, severity=HIGH, message='GL_INVALID_OPERATION error generated. Depth formats do not match.'
[13:33:19] [Render thread/ERROR] [minecraft/Minecraft]: Unreported exception thrown!
java.lang.IllegalStateException: Couldn't perform copyToTexture for texture 8 to 17: GL error 1282
	at TRANSFORMER/minecraft@1.21.10/com.mojang.blaze3d.opengl.GlCommandEncoder.copyTextureToTexture(GlCommandEncoder.java:715)
	at TRANSFORMER/minecraft@1.21.10/com.mojang.blaze3d.pipeline.RenderTarget.copyDepthFrom(RenderTarget.java:86)
```

</details>

<details>
<summary><strong>After:</strong> Clear, fail-fast `IllegalArgumentException` with actionable details</summary>

```
[12Nov2025 18:33:12.844] [Render thread/ERROR] [net.minecraft.client.Minecraft/FATAL]: Unreported exception thrown!
java.lang.IllegalArgumentException: Source and destination texture formats must match for depth/stencil copies. Source: DEPTH32_STENCIL8, Destination: DEPTH32
	at TRANSFORMER/minecraft@1.21.10/com.mojang.blaze3d.opengl.GlCommandEncoder.copyTextureToTexture(GlCommandEncoder.java:681)
	at TRANSFORMER/neoforge@21.10.52-beta/net.neoforged.neoforge.client.blaze3d.validation.ValidationCommandEncoder.copyTextureToTexture(ValidationCommandEncoder.java:177)
	at TRANSFORMER/minecraft@1.21.10/com.mojang.blaze3d.pipeline.RenderTarget.copyDepthFrom(RenderTarget.java:86)
```

</details>

This commit corrects this oversight by implementing the required precondition check. If a copy operation involves a depth or stencil buffer, the formats are now compared. If they do not match, an `IllegalArgumentException` is thrown with a detailed message, preventing the illegal OpenGL call and bringing the method's behavior in line with its established error-handling pattern.
---
The Mojira report for color validation ([MC-305473](https://bugs.mojang.com/browse/MC-305473)) was closed as Invalid, so this PR has been updated to include the color format fix as well.