### PR TITLE
Make NeoForge's packet dump print all the readable bytes properly

### DIFF
--- a/src/main/java/net/neoforged/neoforge/logging/PacketDump.java
+++ b/src/main/java/net/neoforged/neoforge/logging/PacketDump.java
@@ -18,7 +18,7 @@ public class PacketDump {
 
         // returnString.append("Buffer contents:\n");
         int i, j; // Loop variables
-        for (i = 0; i < currentLength; i++) {
+        for (i = buffer.readerIndex(); i < currentLength; i++) {
             if ((i != 0) && (i % 16 == 0)) {
                 // If it's a multiple of 16 and i isn't null, show the ascii
                 returnString.append('\t');


### PR DESCRIPTION
Fixes https://github.com/neoforged/NeoForge/issues/2820

Should be fine. readerIndex is not changed at all in this method so no worries there with starting at readerIndex and reading the entire readable bytes length.