### PR TITLE
Fix EphemeralTestServerProvider trying to class-load when it shuts down after FML in tests

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/junit/EphemeralTestServerProvider.java
+++ b/testframework/src/main/java/net/neoforged/testframework/junit/EphemeralTestServerProvider.java
@@ -52,7 +52,9 @@ import net.minecraft.world.level.levelgen.WorldOptions;
 import net.minecraft.world.level.levelgen.presets.WorldPresets;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.PrimaryLevelData;
+import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
@@ -116,10 +118,10 @@ public class EphemeralTestServerProvider implements ParameterResolver, Extension
                 final MinecraftServer server = MinecraftServer.spin(
                         thread -> JUnitServer.create(thread, tempDir, storageAccess, packrepository));
 
-                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                FMLLoader.getCurrent().addCloseCallback(() -> {
                     server.stopServer();
                     LogManager.shutdown();
-                }));
+                });
             } catch (Exception ex) {
                 LogUtils.getLogger().error(LogUtils.FATAL_MARKER, "Failed to start the minecraft server", ex);
                 throw new RuntimeException(ex);
@@ -239,7 +241,7 @@ public class EphemeralTestServerProvider implements ParameterResolver, Extension
                 storageSource.deleteLevel();
                 this.storageSource.close();
 
-                Files.delete(tempDir);
+                FileUtils.deleteDirectory(tempDir.toFile());
             } catch (IOException ioexception) {
                 LOGGER.error("Failed to unlock level {}", this.storageSource.getLevelId(), ioexception);
             }


### PR DESCRIPTION
This fixes this error where the server might close after FMLLoader:

```
> Task :neoforge:installerJar
Exception in thread "Thread-3" java.lang.NoClassDefFoundError: net/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess$1
	at TRANSFORMER/minecraft@1.21.10/net.minecraft.world.level.storage.LevelStorageSource$LevelStorageAccess.deleteLevel(LevelStorageSource.java:546)
	at TRANSFORMER/testframework@21.10.52-beta/net.neoforged.testframework.junit.EphemeralTestServerProvider$JUnitServer.stopServer(EphemeralTestServerProvider.java:239)
	at TRANSFORMER/testframework@21.10.52-beta/net.neoforged.testframework.junit.EphemeralTestServerProvider.lambda$grabServer$1(EphemeralTestServerProvider.java:120)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: net.minecraft.world.level.storage.LevelStorageSource$LevelStorageAccess$1
	at net.neoforged.fml.classloading.ModuleClassLoader.readerToClass(ModuleClassLoader.java:221)
	at net.neoforged.fml.classloading.ModuleClassLoader.loadClass(ModuleClassLoader.java:245)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 4 more
Caused by: java.io.IOException: Module minecraft has been closed
	at net.neoforged.fml.classloading.ModuleClassLoader$ModuleInfo.getReader(ModuleClassLoader.java:519)
	at net.neoforged.fml.classloading.ModuleClassLoader.getClassBytes(ModuleClassLoader.java:202)
	at net.neoforged.fml.classloading.ModuleClassLoader.readerToClass(ModuleClassLoader.java:219)
	... 6 more
Caused by: java.lang.ClassNotFoundException: net.minecraft.world.level.storage.LevelStorageSource$LevelStorageAccess$1

Caused by: java.io.IOException: Module minecraft has been closed
```