### PR TITLE
Cleanup and improve javadocs around entity related events, remove broken javadoc references to removed Event#hasResult

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
+++ b/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
@@ -95,7 +95,7 @@ public class DamageContainer {
      * Adds a callback modifier to the vanilla damage reductions. Each function will be performed in sequence
      * on the vanilla value at the time the {@link DamageContainer.Reduction} type is set by vanilla.
      * <ul>
-     * <li>only the {@link LivingIncomingDamageEvent EntityPreDamageEvent}
+     * <li>only the {@link LivingIncomingDamageEvent}
      * happens early enough in the sequence for this method to have any effect.</li>
      * <li>if the vanilla reduction is not triggered, the reduction function will not execute.</li>
      * </ul>

--- a/src/main/java/net/neoforged/neoforge/event/DifficultyChangeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/DifficultyChangeEvent.java
@@ -15,8 +15,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * <br>
  * This event is fired via the {@link CommonHooks#onDifficultyChange(Difficulty, Difficulty)}.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class DifficultyChangeEvent extends Event {

--- a/src/main/java/net/neoforged/neoforge/event/brewing/PotionBrewEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/brewing/PotionBrewEvent.java
@@ -44,8 +44,6 @@ public abstract class PotionBrewEvent extends Event {
      * This event is {@link net.neoforged.bus.api.ICancellableEvent}.<br>
      * If the event is not canceled, the vanilla brewing will take place instead of modded brewing.
      * <br>
-     * This event does not have a result. {@link HasResult}<br>
-     * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      * <br>
      * If this event is canceled, and items have been modified, PotionBrewEvent.Post will automatically be fired.
@@ -64,8 +62,6 @@ public abstract class PotionBrewEvent extends Event {
      * {@link #stacks} contains the itemstack array from the TileEntityBrewer holding all items in Brewer.<br>
      * <br>
      * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      **/

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
@@ -36,8 +36,6 @@ public abstract class EntityEvent extends Event {
      * <p>
      * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
      * <p>
-     * This event does not have a result. {@link HasResult}
-     * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
@@ -55,8 +53,6 @@ public abstract class EntityEvent extends Event {
      * Use {@link EntityJoinLevelEvent} to detect new entities joining the world.
      * <p>
      * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
-     * <p>
-     * This event does not have a result. {@link HasResult}
      * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
@@ -13,13 +13,11 @@ import net.neoforged.bus.api.Event;
 import net.neoforged.neoforge.common.NeoForge;
 
 /**
- * EntityEvent is fired when an event involving any Entity occurs.<br>
- * If a method utilizes this {@link net.neoforged.bus.api.Event} as its parameter, the method will
- * receive every child event of this class.<br>
- * <br>
- * {@link #entity} contains the entity that caused this event to occur.<br>
- * <br>
- * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.<br>
+ * Base class of the events involving entities.
+ * <p>
+ * @see EntityEvent.EntityConstructing
+ * @see EntityEvent.EnteringSection
+ * @see EntityEvent.Size
  **/
 public abstract class EntityEvent extends Event {
     private final Entity entity;
@@ -33,14 +31,15 @@ public abstract class EntityEvent extends Event {
     }
 
     /**
-     * EntityConstructing is fired when an Entity is being created. <br>
-     * This event is fired within the constructor of the Entity.<br>
-     * <br>
-     * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult}<br>
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
+     * EntityConstructing is fired when an Entity is being created.
+     * This event is fired within the constructor of the Entity.
+     * <p>
+     * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
+     * <p>
+     * This event does not have a result. {@link HasResult}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class EntityConstructing extends EntityEvent {
         public EntityConstructing(Entity entity) {
@@ -49,16 +48,18 @@ public abstract class EntityEvent extends Event {
     }
 
     /**
-     * This event is fired on server and client after an Entity has entered a different section. <br>
-     * Sections are 16x16x16 block grids of the world.<br>
+     * This event is fired on server and client after an Entity has entered a different section.
+     * Sections are 16x16x16 block grids of the world.
+     * <p>
      * This event does not fire when a new entity is spawned, only when an entity moves from one section to another one.
      * Use {@link EntityJoinLevelEvent} to detect new entities joining the world.
-     * <br>
-     * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.<br>
-     * <br>
+     * <p>
+     * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
+     * <p>
      * This event does not have a result. {@link HasResult}
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class EnteringSection extends EntityEvent {
         private final long packedOldPos;
@@ -119,8 +120,10 @@ public abstract class EntityEvent extends Event {
      * <p><strong>Note:</strong> This event is fired from the {@code Entity} constructor, and therefore the entity instance
      * might not be fully initialized. Be cautious in using methods and fields from the instance, and check
      * {@link Entity#isAddedToLevel()} or {@link Entity#firstTick}.
-     *
-     * <p>This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * <p>
+     * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class Size extends EntityEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityEvent.java
@@ -15,6 +15,7 @@ import net.neoforged.neoforge.common.NeoForge;
 /**
  * Base class of the events involving entities.
  * <p>
+ * 
  * @see EntityEvent.EntityConstructing
  * @see EntityEvent.EnteringSection
  * @see EntityEvent.Size

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityMountEvent.java
@@ -18,8 +18,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link net.neoforged.bus.api.ICancellableEvent}.<br>
  * If this event is canceled, the entity does not mount/dismount the other entity.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  *
  */

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityStruckByLightningEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityStruckByLightningEvent.java
@@ -21,8 +21,6 @@ import net.neoforged.neoforge.event.EventHooks;
  * This event is {@link ICancellableEvent}.<br>
  * If this event is canceled, the Entity is not struck by the lightening.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
  **/
 public class EntityStruckByLightningEvent extends EntityEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityTeleportEvent.java
@@ -92,8 +92,6 @@ public class EntityTeleportEvent extends EntityEvent implements ICancellableEven
      * This event is {@link ICancellableEvent}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
-     * This event does not have a result. {@link HasResult}<br>
-     * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      * <br>
      * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
@@ -113,8 +111,6 @@ public class EntityTeleportEvent extends EntityEvent implements ICancellableEven
      * This event is {@link ICancellableEvent}.<br>
      * If the event is not canceled, the entity will be teleported.
      * <br>
-     * This event does not have a result. {@link HasResult}<br>
-     * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      * <br>
      * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
@@ -132,8 +128,6 @@ public class EntityTeleportEvent extends EntityEvent implements ICancellableEven
      * <br>
      * This event is {@link ICancellableEvent}.<br>
      * If the event is not canceled, the entity will be teleported.
-     * <br>
-     * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      * <br>
@@ -159,8 +153,6 @@ public class EntityTeleportEvent extends EntityEvent implements ICancellableEven
      * <br>
      * This event is {@link ICancellableEvent}.<br>
      * If the event is not canceled, the entity will be teleported.
-     * <br>
-     * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      * <br>
@@ -210,8 +202,6 @@ public class EntityTeleportEvent extends EntityEvent implements ICancellableEven
      * <br>
      * This event is {@link ICancellableEvent}.<br>
      * If the event is not canceled, the entity will be teleported.
-     * <br>
-     * This event does not have a result. {@link HasResult}<br>
      * <br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      * <br>

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityTravelToDimensionEvent.java
@@ -19,8 +19,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link net.neoforged.bus.api.ICancellableEvent}.<br>
  * If this event is canceled, the Entity does not travel to the dimension.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
  **/
 public class EntityTravelToDimensionEvent extends EntityEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -31,8 +31,6 @@ import org.jspecify.annotations.Nullable;
  * If this event is canceled, the child Entity is not added to the world, and the parents <br>
  * will no longer attempt to mate.
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class BabyEntitySpawnEvent extends net.neoforged.bus.api.Event implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingBreatheEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingBreatheEvent.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.event.entity.living;
 
 import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
 
@@ -15,8 +16,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is fired via {@link CommonHooks#onLivingBreathe(LivingEntity, int, int)}.<br>
  * <br>
  * This event is not {@link ICancellableEvent}.<br>
- * <br>
- * This event does not have a result. {@link HasResult}
  * <br>
  * This event is fired on {@link NeoForge#EVENT_BUS}
  */

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
@@ -15,24 +15,22 @@ import net.neoforged.neoforge.common.NeoForge;
 import org.jspecify.annotations.Nullable;
 
 /**
- * This event allows you to change the target an entity has. <br>
- * This event is fired before {@link LivingSetAttackTargetEvent}. <br>
- * <br>
- * This event is fired via the {@link CommonHooks#onLivingChangeTarget(LivingEntity, LivingEntity, ILivingTargetType)}<br>
- * <br>
- * {@link #getOriginalAboutToBeSetTarget()} returns the target that should originally be set.
- * The return value cannot be affected by calling {@link #setNewAboutToBeSetTarget(LivingEntity)}.<br>
- * {@link #getNewAboutToBeSetTarget()} returns the new target that this entity will have.
- * The return value can be affected by calling {@link #setNewAboutToBeSetTarget(LivingEntity)}.<br>
- * {@link #getTargetType()} returns the target type that caused the change of targets.<br>
- * <br>
- * This event is {@link net.neoforged.bus.api.ICancellableEvent}.<br>
- * <br>
- * If you cancel this event, the target will not be changed and it will stay the same.
- * Cancelling this event will prevent {@link LivingSetAttackTargetEvent} from being posted.<br>
- * <br>
- * This event does not have a result. {@link Event.HasResult}<br>
- * <br>
+ * This event allows you to change what target an entity is about to have.
+ * <p>
+ * This event is fired via the {@link CommonHooks#onLivingChangeTarget(LivingEntity, LivingEntity, ILivingTargetType)}
+ * <ul>
+ * <li>{@link #getOriginalAboutToBeSetTarget()} returns the target that should originally be set.
+ * The return value cannot be affected by calling {@link #setNewAboutToBeSetTarget(LivingEntity)}.</li>
+ * <li>{@link #getNewAboutToBeSetTarget()} returns the new target that this entity will have.
+ * The return value can be affected by calling {@link #setNewAboutToBeSetTarget(LivingEntity)}.</li>
+ * <li>{@link #getTargetType()} returns the target type that caused the change of targets.</li>
+ * </ul>
+ * This event is {@link net.neoforged.bus.api.ICancellableEvent}.
+ * <p>
+ * If you cancel this event, the target will stay the same to what the entity already is targeting and not be changed.
+ * <p>
+ * This event does not have a result. {@link Event.HasResult}
+ * <p>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  */
 public class LivingChangeTargetEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
@@ -19,7 +19,7 @@ import org.jspecify.annotations.Nullable;
  * This event is fired via the {@link CommonHooks#onLivingChangeTarget(LivingEntity, LivingEntity, ILivingTargetType)}
  * <ul>
  * <li>{@link #getOriginalAboutToBeSetTarget()} returns the target that should originally be set.
- * The return value cannot be affected by calling {@link #setNewAboutToBeSetTarget(LivingEntity)}.</li>
+ * The return value <strong>cannot</strong> be changed.</li>
  * <li>{@link #getNewAboutToBeSetTarget()} returns the new target that this entity will have.
  * The return value can be affected by calling {@link #setNewAboutToBeSetTarget(LivingEntity)}.</li>
  * <li>{@link #getTargetType()} returns the target type that caused the change of targets.</li>

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.event.entity.living;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.ai.behavior.StartAttacking;
-import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingChangeTargetEvent.java
@@ -29,8 +29,6 @@ import org.jspecify.annotations.Nullable;
  * <p>
  * If you cancel this event, the target will stay the same to what the entity already is targeting and not be changed.
  * <p>
- * This event does not have a result. {@link Event.HasResult}
- * <p>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  */
 public class LivingChangeTargetEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDeathEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDeathEvent.java
@@ -27,8 +27,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link ICancellableEvent}.<br>
  * If this event is canceled, the Entity does not die.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class LivingDeathEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDestroyBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDestroyBlockEvent.java
@@ -20,8 +20,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link ICancellableEvent}.<br>
  * If this event is canceled, the block will not be destroyed.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class LivingDestroyBlockEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDropsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDropsEvent.java
@@ -28,8 +28,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link ICancellableEvent}.<br>
  * If this event is canceled, the Entity does not drop anything.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class LivingDropsEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEquipmentChangeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEquipmentChangeEvent.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.event.entity.living;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.NeoForge;
 
 /**
@@ -21,8 +22,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * {@link #to} contains the {@link ItemStack} that is equipped now. <br>
  * <br>
  * This event is not {@link ICancellableEvent}. <br>
- * <br>
- * This event does not have a result. {@link HasResult} <br>
  * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
@@ -7,8 +7,6 @@ package net.neoforged.neoforge.event.entity.living;
 
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
-import net.neoforged.bus.api.Event;
-import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.EntityEvent;
@@ -17,6 +15,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Base class of the events specific to LivingEntities.
  * <p>
+ * 
  * @see LivingEvent.LivingJumpEvent
  * @see LivingEvent.LivingVisibilityEvent
  **/

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
@@ -15,11 +15,10 @@ import net.neoforged.neoforge.event.entity.EntityEvent;
 import org.jspecify.annotations.Nullable;
 
 /**
- * LivingEvent is fired whenever an event involving a {@link LivingEntity} occurs.<br>
- * If a method utilizes this {@link Event} as its parameter, the method will
- * receive every child event of this class.<br>
- * <br>
- * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.<br>
+ * Base class of the events specific to LivingEntities.
+ * <p>
+ * @see LivingEvent.LivingJumpEvent
+ * @see LivingEvent.LivingVisibilityEvent
  **/
 public abstract class LivingEvent extends EntityEvent {
     private final LivingEntity livingEntity;
@@ -35,19 +34,21 @@ public abstract class LivingEvent extends EntityEvent {
     }
 
     /**
-     * LivingJumpEvent is fired when an Entity jumps.<br>
-     * This event is fired whenever an Entity jumps in
+     * LivingJumpEvent is fired when a LivingEntity jumps.
+     * <p>
+     * This event is fired whenever a LivingEntity jumps in
      * {@code LivingEntity#jumpFromGround()}, {@code MagmaCube#jumpFromGround()},
      * {@code Slime#jumpFromGround()}, {@code Camel#executeRidersJump()},
-     * and {@code AbstractHorse#executeRidersJump()}.<br>
-     * <br>
-     * This event is fired via the {@link CommonHooks#onLivingJump(LivingEntity)}.<br>
-     * <br>
-     * This event is not {@link ICancellableEvent}.<br>
-     * <br>
-     * This event does not have a result. {@link HasResult}<br>
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.
+     * and {@code AbstractHorse#executeRidersJump()}.
+     * <p>
+     * This event is fired via the {@link CommonHooks#onLivingJump(LivingEntity)}.
+     * <p>
+     * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
+     * <p>
+     * This event does not have a result. {@link HasResult}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class LivingJumpEvent extends LivingEvent {
         public LivingJumpEvent(LivingEntity e) {
@@ -55,6 +56,20 @@ public abstract class LivingEvent extends EntityEvent {
         }
     }
 
+    /**
+     * LivingVisibilityEvent is fired when an LivingEntity's visibility is queried.
+     * <p>
+     * This event is fired whenever {@code LivingEntity#getVisibilityPercent()} is called.
+     * <p>
+     * This event is fired via the {@link CommonHooks#getEntityVisibilityMultiplier(LivingEntity, Entity, double)}.
+     * <p>
+     * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
+     * <p>
+     * This event does not have a result. {@link HasResult}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
+     **/
     public static class LivingVisibilityEvent extends LivingEvent {
         private double visibilityModifier;
         @Nullable

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
@@ -45,8 +45,6 @@ public abstract class LivingEvent extends EntityEvent {
      * <p>
      * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
      * <p>
-     * This event does not have a result. {@link HasResult}
-     * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
@@ -64,8 +62,6 @@ public abstract class LivingEvent extends EntityEvent {
      * This event is fired via the {@link CommonHooks#getEntityVisibilityMultiplier(LivingEntity, Entity, double)}.
      * <p>
      * <ul><li>{@link #getEntity} contains the entity that caused this event to occur.</li></ul>
-     * <p>
-     * This event does not have a result. {@link HasResult}
      * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingEvent.java
@@ -14,7 +14,6 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Base class of the events specific to LivingEntities.
- * <p>
  * 
  * @see LivingEvent.LivingJumpEvent
  * @see LivingEvent.LivingVisibilityEvent

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingGetProjectileEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingGetProjectileEvent.java
@@ -18,8 +18,6 @@ import net.neoforged.neoforge.event.entity.player.ArrowLooseEvent;
  * <p>
  * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.
  * <p>
- * This event does not have a result. {@link net.neoforged.bus.api.Event.HasResult}
- * <p>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  */
 public class LivingGetProjectileEvent extends LivingEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingHealEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingHealEvent.java
@@ -21,8 +21,6 @@ import net.neoforged.neoforge.event.EventHooks;
  * This event is {@link net.neoforged.bus.api.ICancellableEvent}.<br>
  * If this event is canceled, the Entity is not healed.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class LivingHealEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingKnockBackEvent.java
@@ -31,8 +31,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link ICancellableEvent}.<br>
  * If this event is canceled, the entity is not knocked back.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class LivingKnockBackEvent extends LivingEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ArrowLooseEvent.java
@@ -26,8 +26,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * If this event is canceled, the player does not stop using the bow.<br>
  * For crossbows, the charge will always be 1; Set it to -1 in order to prevent firing the arrow. <br>
  * <br>
- * This event does not have a result. {@link Event.HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class ArrowLooseEvent extends PlayerEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ArrowLooseEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ArrowLooseEvent.java
@@ -10,7 +10,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BowItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.NeoForge;
 

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/AttackEntityEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/AttackEntityEvent.java
@@ -20,8 +20,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * This event is {@link ICancellableEvent}.<br>
  * If this event is canceled, the player does not attack the Entity.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/
 public class AttackEntityEvent extends PlayerEvent implements ICancellableEvent {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -38,8 +38,6 @@ import org.jspecify.annotations.Nullable;
  * <br>
  * This event is not {@link ICancellableEvent}.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired from {@link EventHooks#onPlayerDestroyItem(Player, ItemStack, InteractionHand)}.<br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  **/

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -75,8 +75,6 @@ public abstract class PlayerEvent extends LivingEvent {
      * <li>{@link #success} contains the boolean value for whether the Block will be successfully harvested.</li>
      * <li>{@link #getEntity} contains the player that caused this event to occur.</li>
      * </ul>
-     * This event does not have a result. {@link Event.HasResult}
-     * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
@@ -129,8 +127,6 @@ public abstract class PlayerEvent extends LivingEvent {
      * <li>{@link #pos} contains the coordinates at which this event is occurring. Optional value.</li>
      * <li>{@link #getEntity} contains the player that caused this event to occur.</li>
      * </ul>
-     * This event does not have a result. {@link Event.HasResult}
-     * <p>
      * This event is {@link net.neoforged.bus.api.ICancellableEvent}.
      * If it is canceled, the player is unable to break the block.
      * <p>
@@ -183,8 +179,6 @@ public abstract class PlayerEvent extends LivingEvent {
      * <li>{@link #username} contains the username of the player.</li>
      * <li>{@link #displayname} contains the display name of the player.</li>
      * </ul>
-     * This event does not have a result. {@link Event.HasResult}
-     * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
@@ -220,8 +214,6 @@ public abstract class PlayerEvent extends LivingEvent {
      * This event is fired via the {@link EventHooks#getPlayerTabListDisplayName(Player)}.
      * <p>
      * {@link #getDisplayName()} contains the display name of the player or null if the client should determine the display name itself.
-     * <p>
-     * This event does not have a result. {@link Event.HasResult}
      * <p>
      * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
      * {@linkplain NeoForge#EVENT_BUS game event bus}.

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -23,7 +23,6 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.TeleportTransition;
-import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.EventHooks;
@@ -33,6 +32,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Base class of the events specific to Players.
  * <p>
+ * 
  * @see PlayerEvent.HarvestCheck
  * @see PlayerEvent.BreakSpeed
  * @see PlayerEvent.NameFormat

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -8,9 +8,12 @@ package net.neoforged.neoforge.event.entity.player;
 import java.io.File;
 import java.util.Optional;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.CommonListenerCookie;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -19,6 +22,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.portal.TeleportTransition;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.NeoForge;
@@ -27,11 +31,24 @@ import net.neoforged.neoforge.event.entity.living.LivingEvent;
 import org.jspecify.annotations.Nullable;
 
 /**
- * PlayerEvent is fired whenever an event involving a {@link Player} occurs. <br>
- * If a method utilizes this {@link net.neoforged.bus.api.Event} as its parameter, the method will
- * receive every child event of this class.<br>
- * <br>
- * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.
+ * Base class of the events specific to Players.
+ * <p>
+ * @see PlayerEvent.HarvestCheck
+ * @see PlayerEvent.BreakSpeed
+ * @see PlayerEvent.NameFormat
+ * @see PlayerEvent.TabListNameFormat
+ * @see PlayerEvent.Clone
+ * @see PlayerEvent.StartTracking
+ * @see PlayerEvent.StopTracking
+ * @see PlayerEvent.LoadFromFile
+ * @see PlayerEvent.SaveToFile
+ * @see PlayerEvent.ItemCraftedEvent
+ * @see PlayerEvent.ItemSmeltedEvent
+ * @see PlayerEvent.PlayerLoggedInEvent
+ * @see PlayerEvent.PlayerLoggedOutEvent
+ * @see PlayerEvent.PlayerRespawnEvent
+ * @see PlayerEvent.PlayerChangedDimensionEvent
+ * @see PlayerEvent.PlayerChangeGameModeEvent
  **/
 public abstract class PlayerEvent extends LivingEvent {
     private final Player player;
@@ -47,20 +64,21 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * HarvestCheck is fired when a player attempts to harvest a block.<br>
+     * HarvestCheck is fired when a player attempts to harvest a block.
+     * <p>
      * This event is fired whenever a player attempts to harvest a block in
-     * {@link Player#hasCorrectToolForDrops(BlockState)}.<br>
-     * <br>
-     * This event is fired via the {@link EventHooks#doPlayerHarvestCheck(Player, BlockState, BlockGetter, BlockPos)}.<br>
-     * <br>
-     * {@link #state} contains the {@link BlockState} that is being checked for harvesting. <br>
-     * {@link #success} contains the boolean value for whether the Block will be successfully harvested. <br>
-     * <br>
-     * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.<br>
-     * <br>
-     * This event does not have a result. {@link Event.HasResult}<br>
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.
+     * {@link Player#hasCorrectToolForDrops(BlockState)}.
+     * <p>
+     * This event is fired via the {@link EventHooks#doPlayerHarvestCheck(Player, BlockState, BlockGetter, BlockPos)}.
+     * <ul>
+     * <li>{@link #state} contains the {@link BlockState} that is being checked for harvesting.</li>
+     * <li>{@link #success} contains the boolean value for whether the Block will be successfully harvested.</li>
+     * <li>{@link #getEntity} contains the player that caused this event to occur.</li>
+     * </ul>
+     * This event does not have a result. {@link Event.HasResult}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class HarvestCheck extends PlayerEvent {
         private final BlockState state;
@@ -98,22 +116,24 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * BreakSpeed is fired when a player attempts to harvest a block.<br>
+     * BreakSpeed is fired when a player attempts to harvest a block.
+     * <p>
      * This event is fired whenever a player attempts to harvest a block in
-     * {@link Player#getDigSpeed(BlockState, BlockPos)}.<br>
-     * <br>
-     * This event is fired via the {@link EventHooks#getBreakSpeed(Player, BlockState, float, BlockPos)}.<br>
-     * <br>
-     * {@link #state} contains the block being broken. <br>
-     * {@link #originalSpeed} contains the original speed at which the player broke the block. <br>
-     * {@link #newSpeed} contains the newSpeed at which the player will break the block. <br>
-     * {@link #pos} contains the coordinates at which this event is occurring. Optional value.<br>
-     * <br>
-     * This event is {@link net.neoforged.bus.api.ICancellableEvent}.<br>
-     * If it is canceled, the player is unable to break the block.<br>
-     * <br>
-     * This event does not have a result. {@link Event.HasResult}<br>
-     * <br>
+     * {@link Player#getDigSpeed(BlockState, BlockPos)}.
+     * <p>
+     * This event is fired via the {@link EventHooks#getBreakSpeed(Player, BlockState, float, BlockPos)}.
+     * <ul>
+     * <li>{@link #state} contains the block being broken.</li>
+     * <li>{@link #originalSpeed} contains the original speed at which the player broke the block.</li>
+     * <li>{@link #newSpeed} contains the newSpeed at which the player will break the block.</li>
+     * <li>{@link #pos} contains the coordinates at which this event is occurring. Optional value.</li>
+     * <li>{@link #getEntity} contains the player that caused this event to occur.</li>
+     * </ul>
+     * This event does not have a result. {@link Event.HasResult}
+     * <p>
+     * This event is {@link net.neoforged.bus.api.ICancellableEvent}.
+     * If it is canceled, the player is unable to break the block.
+     * <p>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.
      **/
     public static class BreakSpeed extends PlayerEvent implements ICancellableEvent {
@@ -153,20 +173,20 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * NameFormat is fired when a player's display name is retrieved.<br>
+     * NameFormat is fired when a player's display name is retrieved.
+     * <p>
      * This event is fired whenever a player's name is retrieved in
-     * {@link Player#getDisplayName()} or {@link Player#refreshDisplayName()}.<br>
-     * <br>
-     * This event is fired via the {@link EventHooks#getPlayerDisplayName(Player, Component)}.<br>
-     * <br>
-     * {@link #username} contains the username of the player.
-     * {@link #displayname} contains the display name of the player.
-     * <br>
-     * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.
-     * <br>
+     * {@link Player#getDisplayName()} or {@link Player#refreshDisplayName()}.
+     * <p>
+     * This event is fired via the {@link EventHooks#getPlayerDisplayName(Player, Component)}.
+     * <ul>
+     * <li>{@link #username} contains the username of the player.</li>
+     * <li>{@link #displayname} contains the display name of the player.</li>
+     * </ul>
      * This event does not have a result. {@link Event.HasResult}
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class NameFormat extends PlayerEvent {
         private final Component username;
@@ -192,19 +212,19 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * TabListNameFormat is fired when a player's display name for the tablist is retrieved.<br>
+     * TabListNameFormat is fired when a player's display name for the tablist is retrieved.
+     * <p>
      * This event is fired whenever a player's display name for the tablist is retrieved in
-     * {@link ServerPlayer#getTabListDisplayName()} or {@link ServerPlayer#refreshTabListName()}.<br>
-     * <br>
-     * This event is fired via the {@link EventHooks#getPlayerTabListDisplayName(Player)}.<br>
-     * <br>
+     * {@link ServerPlayer#getTabListDisplayName()} or {@link ServerPlayer#refreshTabListName()}.
+     * <p>
+     * This event is fired via the {@link EventHooks#getPlayerTabListDisplayName(Player)}.
+     * <p>
      * {@link #getDisplayName()} contains the display name of the player or null if the client should determine the display name itself.
-     * <br>
-     * This event is not {@link net.neoforged.bus.api.ICancellableEvent}.
-     * <br>
+     * <p>
      * This event does not have a result. {@link Event.HasResult}
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      **/
     public static class TabListNameFormat extends PlayerEvent {
         @Nullable
@@ -225,8 +245,11 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * Fired when the EntityPlayer is cloned, typically caused by the impl sending a RESPAWN_PLAYER event.
+     * Fired when the player is cloned, typically caused by the impl sending a RESPAWN_PLAYER event.
      * Either caused by death, or by traveling from the End to the overworld.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      */
     public static class Clone extends PlayerEvent {
         private final Player original;
@@ -239,7 +262,7 @@ public abstract class PlayerEvent extends LivingEvent {
         }
 
         /**
-         * The old EntityPlayer that this new entity is a clone of.
+         * The old Player that this new entity is a clone of.
          */
         public Player getOriginal() {
             return original;
@@ -256,7 +279,9 @@ public abstract class PlayerEvent extends LivingEvent {
 
     /**
      * Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).
-     *
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      */
     public static class StartTracking extends PlayerEvent {
         private final Entity target;
@@ -276,7 +301,9 @@ public abstract class PlayerEvent extends LivingEvent {
 
     /**
      * Fired when an Entity is stopped to be "tracked" by this player (the player no longer receives updates about this entity, e.g. motion).
-     *
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      */
     public static class StopTracking extends PlayerEvent {
         private final Entity target;
@@ -295,10 +322,14 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * The player is being loaded from the world save. Note that the
-     * player won't have been added to the world yet. Intended to
+     * The player is being loaded from the world save.
+     * <p>
+     * Note: The player won't have been added to the world yet. Intended to
      * allow mods to load an additional file from the players directory
      * containing additional mod related player data.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      */
     public static class LoadFromFile extends PlayerEvent {
         private final File playerDirectory;
@@ -312,7 +343,7 @@ public abstract class PlayerEvent extends LivingEvent {
 
         /**
          * Construct and return a recommended file for the supplied suffix
-         * 
+         *
          * @param suffix The suffix to use.
          */
         public File getPlayerFile(String suffix) {
@@ -338,17 +369,20 @@ public abstract class PlayerEvent extends LivingEvent {
     }
 
     /**
-     * The player is being saved to the world store. Note that the
-     * player may be in the process of logging out or otherwise departing
-     * from the world. Don't assume it's association with the world.
+     * The player is being saved to the world store.
+     * <p>
+     * Note: The player may be in the process of logging out or otherwise
+     * departing from the world. Don't assume its association with the world.
      * This allows mods to load an additional file from the players directory
      * containing additional mod related player data.
-     * <br>
+     * <p>
      * Use this event to save the additional mod related player data to the world.
-     *
-     * <br>
+     * <p>
      * <em>WARNING</em>: Do not overwrite the player's .dat file here. You will
      * corrupt the world state.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
      */
     public static class SaveToFile extends PlayerEvent {
         private final File playerDirectory;
@@ -406,6 +440,14 @@ public abstract class PlayerEvent extends LivingEvent {
         }
     }
 
+    /**
+     * Fired when a player takes the resultant ItemStack from a furnace-like block.
+     * <p>
+     * This event is fired via the {@link EventHooks#firePlayerSmeltedEvent(Player, ItemStack, int)}.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
+     */
     public static class ItemSmeltedEvent extends PlayerEvent {
         private final ItemStack smelting;
         private final int amountRemoved;
@@ -425,18 +467,37 @@ public abstract class PlayerEvent extends LivingEvent {
         }
     }
 
+    /**
+     * Fired when the player is placed into the server via {@link PlayerList#placeNewPlayer(Connection, ServerPlayer, CommonListenerCookie)}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
+     */
     public static class PlayerLoggedInEvent extends PlayerEvent {
         public PlayerLoggedInEvent(Player player) {
             super(player);
         }
     }
 
+    /**
+     * Fired when the player is removed from the server via {@link PlayerList#remove(ServerPlayer)}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
+     */
     public static class PlayerLoggedOutEvent extends PlayerEvent {
         public PlayerLoggedOutEvent(Player player) {
             super(player);
         }
     }
 
+    /**
+     * Fired when the player is respawned via {@link PlayerList#respawn(ServerPlayer, boolean)}
+     * after creating and initializing the new {@link ServerPlayer}.
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
+     */
     public static class PlayerRespawnEvent extends PlayerEvent {
         private final boolean endConquered;
 
@@ -455,6 +516,12 @@ public abstract class PlayerEvent extends LivingEvent {
         }
     }
 
+    /**
+     * Fired when the player is teleported to a new dimension via {@link ServerPlayer#teleport(TeleportTransition)}
+     * <p>
+     * This event is not {@linkplain net.neoforged.bus.api.ICancellableEvent cancellable}, and is fired on the
+     * {@linkplain NeoForge#EVENT_BUS game event bus}.
+     */
     public static class PlayerChangedDimensionEvent extends PlayerEvent {
         private final ResourceKey<Level> fromDim;
         private final ResourceKey<Level> toDim;
@@ -476,7 +543,10 @@ public abstract class PlayerEvent extends LivingEvent {
 
     /**
      * Fired when the game type of a server player is changed to a different value than what it was previously. Eg Creative to Survival, not Survival to Survival.
+     * <p>
      * If the event is cancelled the game mode of the player is not changed and the value of <code>newGameMode</code> is ignored.
+     * <p>
+     * This event is fired on the {@link NeoForge#EVENT_BUS}.
      */
     public static class PlayerChangeGameModeEvent extends PlayerEvent implements ICancellableEvent {
         private final GameType currentGameMode;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -31,7 +31,6 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Base class of the events specific to Players.
- * <p>
  * 
  * @see PlayerEvent.HarvestCheck
  * @see PlayerEvent.BreakSpeed

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerEvent.java
@@ -365,6 +365,7 @@ public abstract class PlayerEvent extends LivingEvent {
      * <p>
      * Note: The player may be in the process of logging out or otherwise
      * departing from the world. Don't assume its association with the world.
+     * <p>
      * This allows mods to load an additional file from the players directory
      * containing additional mod related player data.
      * <p>

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
@@ -11,11 +11,11 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.NeoForge;
 
 /**
- * PlayerXpEvent is fired whenever an event involving player experience occurs. <br>
- * If a method utilizes this {@link net.neoforged.bus.api.Event} as its parameter, the method will
- * receive every child event of this class.<br>
- * <br>
- * All children of this event are fired on the {@link NeoForge#EVENT_BUS}.
+ * Base class of events involving player experience.
+ * <p>
+ * @see PlayerXpEvent.PickupXp
+ * @see PlayerXpEvent.XpChange
+ * @see PlayerXpEvent.LevelChange
  */
 public abstract class PlayerXpEvent extends PlayerEvent {
     public PlayerXpEvent(Player player) {
@@ -24,7 +24,10 @@ public abstract class PlayerXpEvent extends PlayerEvent {
 
     /**
      * This event is fired after the player collides with an experience orb, but before the player has been given the experience.
+     * <p>
      * It can be cancelled, and no further processing will be done.
+     * <p>
+     * This event is fired on the {@link NeoForge#EVENT_BUS}.
      */
     public static class PickupXp extends PlayerXpEvent implements ICancellableEvent {
         private final ExperienceOrb orb;
@@ -41,7 +44,10 @@ public abstract class PlayerXpEvent extends PlayerEvent {
 
     /**
      * This event is fired when the player's experience changes through the {@link Player#giveExperiencePoints(int)} method.
+     * <p>
      * It can be cancelled, and no further processing will be done.
+     * <p>
+     * This event is fired on the {@link NeoForge#EVENT_BUS}.
      */
     public static class XpChange extends PlayerXpEvent implements ICancellableEvent {
         private int amount;
@@ -62,7 +68,10 @@ public abstract class PlayerXpEvent extends PlayerEvent {
 
     /**
      * This event is fired when the player's experience level changes through the {@link Player#giveExperienceLevels(int)} method.
+     * <p>
      * It can be cancelled, and no further processing will be done.
+     * <p>
+     * This event is fired on the {@link NeoForge#EVENT_BUS}.
      */
     public static class LevelChange extends PlayerXpEvent implements ICancellableEvent {
         private int levels;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerXpEvent.java
@@ -13,6 +13,7 @@ import net.neoforged.neoforge.common.NeoForge;
 /**
  * Base class of events involving player experience.
  * <p>
+ * 
  * @see PlayerXpEvent.PickupXp
  * @see PlayerXpEvent.XpChange
  * @see PlayerXpEvent.LevelChange

--- a/src/main/java/net/neoforged/neoforge/event/level/ExplosionEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ExplosionEvent.java
@@ -22,7 +22,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * <br>
  * ExplosionEvent.Start is {@link ICancellableEvent}.<br>
  * ExplosionEvent.Detonate can modify the affected blocks and entities.<br>
- * Children do not use {@link HasResult}.<br>
  * Children of this event are fired on the {@link NeoForge#EVENT_BUS}.<br>
  */
 public abstract class ExplosionEvent extends Event {
@@ -46,7 +45,6 @@ public abstract class ExplosionEvent extends Event {
      * ExplosionEvent.Start is fired before the explosion actually occurs. Canceling this event will stop the explosion.<br>
      * <br>
      * This event is {@link ICancellableEvent}.<br>
-     * This event does not use {@link HasResult}.<br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      */
     public static class Start extends ExplosionEvent implements ICancellableEvent {
@@ -59,7 +57,6 @@ public abstract class ExplosionEvent extends Event {
      * ExplosionEvent.Detonate is fired once the explosion has a list of affected blocks and entities. These lists can be modified to change the outcome.<br>
      * <br>
      * This event is not {@link ICancellableEvent}.<br>
-     * This event does not use {@link HasResult}.<br>
      * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
      */
     public static class Detonate extends ExplosionEvent {

--- a/src/main/java/net/neoforged/neoforge/event/level/ExplosionKnockbackEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/ExplosionKnockbackEvent.java
@@ -18,7 +18,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * ExplosionKnockbackEvent is fired once the explosion has calculated the knockback velocity to add to the entity caught in blast.<br>
  * <br>
  * This event is not {@link ICancellableEvent}.<br>
- * This event does not use {@link HasResult}.<br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
  */
 public class ExplosionKnockbackEvent extends ExplosionEvent {

--- a/src/main/java/net/neoforged/neoforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/village/VillageSiegeEvent.java
@@ -19,8 +19,6 @@ import net.neoforged.neoforge.common.NeoForge;
  * <br>
  * This event is {@link ICancellableEvent}; canceling stops the siege.<br>
  * <br>
- * This event does not have a result. {@link HasResult}<br>
- * <br>
  * This event is fired on the {@link NeoForge#EVENT_BUS}.
  */
 public class VillageSiegeEvent extends Event implements ICancellableEvent {


### PR DESCRIPTION
Tried to keep this at a more manageable size PR but still hit a bunch of the reported javadoc issues we had. Since Event#hasResult was removed, those references was an easy cleanup to do and shouldn't be objectionable. For the entity event related javadocs, I tried to clean them up and put them into a similar format that we did for ClientTickEvent for consistency.  And for `EntityPreDamageEvent`, that was renamed to `LivingIncomingDamageEvent` in the damage type PR but this javadoc typo slipped by when merged.

Closes the following:
- https://github.com/neoforged/NeoForge/issues/2722
- https://github.com/neoforged/NeoForge/issues/2391
- https://github.com/neoforged/NeoForge/issues/1996

Event#hasResult was removed in this Neo PR: 
- https://github.com/neoforged/NeoForge/pull/588