### PR TITLE
Rename patches in installer to /data/client.lzma to try work around CurseForge Launcher limitations

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -410,7 +410,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             });
             task.from(binaryPatchOutputs, spec -> {
                 spec.into("data");
-                spec.rename(s -> "patches.lzma");
+                spec.rename(s -> "client.lzma");
             });
             var mavenPath = neoForgeVersion.map(v -> "net/neoforged/neoforge/" + v);
             task.getInputs().property("mavenPath", mavenPath);

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
@@ -112,7 +112,7 @@ public abstract class CreateInstallerProfile extends DefaultTask {
         var data = new LinkedHashMap<String, LauncherDataEntry>();
         var neoFormVersion = getMcAndNeoFormVersion().get();
         data.put("MOJMAPS", new LauncherDataEntry(clientMappingsCoordinate, serverMappingsCoordinate));
-        data.put("BINPATCH", new LauncherDataEntry("/data/patches.lzma", "/data/patches.lzma"));
+        data.put("BINPATCH", new LauncherDataEntry("/data/client.lzma", "/data/client.lzma"));
 
         var patchedClientCoordinate = new MavenIdentifier("net.neoforged", "minecraft-client-patched", getNeoForgeVersion().get(), "", "jar");
         var patchedServerCoordinate = new MavenIdentifier("net.neoforged", "minecraft-server-patched", getNeoForgeVersion().get(), "", "jar");


### PR DESCRIPTION
CurseForge seems to hard-code their mirroring of the patches to look for /data/client.lzma, which leads to the installation of the releases where we renamed the patches to fail.