### PR TITLE
Fix Userdev Jar containing no patch files

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/CreateUserDevConfig.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/CreateUserDevConfig.java
@@ -60,7 +60,7 @@ abstract class CreateUserDevConfig extends DefaultTask {
                 2,
                 "net.neoforged:neoform:%s-%s@zip".formatted(getMinecraftVersion().get(), getRawNeoFormVersion().get()),
                 "ats/",
-                "joined.lzma",
+                "patches.lzma",
                 new BinpatcherConfig(
                         getBinpatcherGav().get(),
                         List.of("--clean", "{clean}", "--output", "{output}", "--apply", "{patch}")),

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -445,7 +445,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.from(binaryPatchOutputs, spec -> {
                 spec.rename(s -> "patches.lzma");
             });
-            task.from(project.fileTree(genProductionPatches.flatMap(GenerateSourcePatches::getPatchesFolder)), spec -> {
+            task.from(genProductionPatches.flatMap(GenerateSourcePatches::getPatchesFolder), spec -> {
                 spec.into("patches/");
             });
         });


### PR DESCRIPTION
Apparently there was previously no explicit task dependency between userdev jar and source patch creation. They were created implicitly by the binary patch tasks. Since binary patches now no longer depend on them, they're not being created at all and thus not included in the userdev jar.

This fixes that task dependency.

Additionally, the patch file was renamed in the userdev.jar, but the userdev config still refered to the old file.