### PR TITLE
Revert #2095 due to Leader Zombie health bugfix breaking vanilla farms

### DIFF
--- a/patches/net/minecraft/world/entity/monster/Zombie.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Zombie.java.patch
@@ -37,18 +37,3 @@
              if (p_219160_.getDifficulty() != Difficulty.HARD && this.random.nextBoolean()) {
                  return flag;
              }
-@@ -564,10 +_,14 @@
-                 .addOrReplacePermanentModifier(
-                     new AttributeModifier(LEADER_ZOMBIE_BONUS_ID, this.random.nextDouble() * 0.25 + 0.5, AttributeModifier.Operation.ADD_VALUE)
-                 );
-+            var damageTaken = getMaxHealth() - getHealth();
-             this.getAttribute(Attributes.MAX_HEALTH)
-                 .addOrReplacePermanentModifier(
-                     new AttributeModifier(LEADER_ZOMBIE_BONUS_ID, this.random.nextDouble() * 3.0 + 1.0, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
-                 );
-+            // Neo: fix MC-219981 by resetting the leader zombie's health based on the new max health
-+            // without disregarding damage already taken (if any)
-+            setHealth(getMaxHealth() - damageTaken);
-             this.setCanBreakDoors(true);
-         }
-     }


### PR DESCRIPTION
So the bug originally is [MC-219981](https://bugs.mojang.com/browse/MC/issues/MC-219981) which is confirmed issue. However, fixing this will break any AFK farm that is not designed around zombies getting a health boost out of nowhere (it is random). Because of this, it seems better for NeoForge not to fix the bug and let mods be the one to do so. That way users have the choice of putting on a mod that fixes it or waiting for Mojang to fix it.

The original PR: https://github.com/neoforged/NeoForge/pull/2451
The issue it was fixing: https://github.com/neoforged/NeoForge/issues/2095

needs backporting to 1.21.8, 1.21.5, 1.21.4, 1.21.3, 1.21.1