### PR TITLE
Move installation of the client from the installer to runtime

### DIFF
--- a/autoinstall/build.gradle
+++ b/autoinstall/build.gradle
@@ -61,11 +61,6 @@ jar {
         rename(s -> "neoform.tsrg.lzma")
     }
 
-    manifest {
-        attributes.put("version", project.getVersion().toString())
-        attributes.put("minecraft", project.property("minecraft_version").toString())
-    }
-
     dependsOn(project.configurations.binaryPatchFiles.getIncoming().getArtifacts().getArtifactFiles())
 }
 
@@ -90,10 +85,6 @@ tasks.shadowJar {
     from(project.configurations.neoFormMappingFiles.getSingleFile()) {
         into("./")
         rename(s -> "neoform.tsrg.lzma")
-    }
-
-    manifest {
-        attributes.put("version", project.getVersion().toString())
     }
 
     dependsOn(project.configurations.binaryPatchFiles.getIncoming().getArtifacts().getArtifactFiles())

--- a/autoinstall/build.gradle
+++ b/autoinstall/build.gradle
@@ -65,6 +65,8 @@ jar {
         attributes.put("version", project.getVersion().toString())
         attributes.put("minecraft", project.property("minecraft_version").toString())
     }
+
+    dependsOn(project.configurations.binaryPatchFiles.getIncoming().getArtifacts().getArtifactFiles())
 }
 
 license {
@@ -93,4 +95,6 @@ tasks.shadowJar {
     manifest {
         attributes.put("version", project.getVersion().toString())
     }
+
+    dependsOn(project.configurations.binaryPatchFiles.getIncoming().getArtifacts().getArtifactFiles())
 }

--- a/autoinstall/build.gradle
+++ b/autoinstall/build.gradle
@@ -1,0 +1,95 @@
+plugins {
+    id 'java-library'
+    id 'net.neoforged.licenser'
+    id 'neoforge.formatting-conventions'
+    id 'com.gradleup.shadow' version '9.0.2'
+}
+
+jar {
+    manifest {
+        attributes(
+                "Automatic-Module-Name": "neoforge.coremods",
+                FMLModType: "LIBRARY",
+        )
+    }
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(project.java_version))
+    }
+}
+
+configurations {
+    dependencyScope("binaryPatches")
+    dependencyScope("neoFormMappings")
+
+    resolvable("binaryPatchFiles")
+    resolvable("neoFormMappingFiles")
+
+    binaryPatchFiles.extendsFrom binaryPatches
+    neoFormMappingFiles.extendsFrom neoFormMappings
+}
+
+dependencies {
+    compileOnly "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
+    compileOnly "net.neoforged.fancymodloader:loader:${project.fancy_mod_loader_version}"
+
+    binaryPatches(project(':neoforge')) {
+        capabilities {
+            requireCapability 'net.neoforged:neoforge-patches'
+        }
+        endorseStrictVersions()
+    }
+
+    neoFormMappings("net.neoforged:neoform:${project.minecraft_version}-${project.neoform_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:neoform-parameter-mappings'
+        }
+    }
+
+    api "net.neoforged.installertools:installertools:${project.installertools_version}:fatjar"
+}
+
+jar {
+    from(configurations.binaryPatchFiles.getSingleFile()) {
+        into("./")
+        rename(s -> "patches.lzma")
+    }
+    from(configurations.neoFormMappingFiles.getSingleFile()) {
+        into("./")
+        rename(s -> "neoform.tsrg.lzma")
+    }
+
+    manifest {
+        attributes.put("version", project.getVersion().toString())
+    }
+}
+
+license {
+    header = rootProject.file('codeformat/HEADER.txt')
+    include '**/*.java'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+tasks.shadowJar {
+    minimize()
+    enableAutoRelocation = true
+    relocationPrefix = "shadowed"
+
+    from(project.configurations.binaryPatchFiles.getSingleFile()) {
+        into("./")
+        rename(s -> "patches.lzma")
+    }
+    from(project.configurations.neoFormMappingFiles.getSingleFile()) {
+        into("./")
+        rename(s -> "neoform.tsrg.lzma")
+    }
+
+    manifest {
+        attributes.put("version", project.getVersion().toString())
+    }
+}

--- a/autoinstall/build.gradle
+++ b/autoinstall/build.gradle
@@ -63,6 +63,7 @@ jar {
 
     manifest {
         attributes.put("version", project.getVersion().toString())
+        attributes.put("minecraft", project.property("minecraft_version").toString())
     }
 }
 

--- a/autoinstall/gradle.properties
+++ b/autoinstall/gradle.properties
@@ -1,0 +1,1 @@
+neoforge.package-infos.disabled=true

--- a/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
+++ b/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
@@ -11,14 +11,12 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Objects;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
+import java.util.Properties;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.loading.MavenCoordinate;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
@@ -125,25 +123,26 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
 
     @Nullable
     private static String getNeoForgeVersion() throws IOException {
-        return getManifestAttribute("version");
+        return getVersionPropertiesFileEntry("neoforge_version");
     }
 
     @Nullable
     private static String getMinecraftVersion() throws IOException {
-        return getManifestAttribute("minecraft");
+        return getVersionPropertiesFileEntry("minecraft_version");
     }
 
-    private static @Nullable String getManifestAttribute(final String version) throws IOException {
-        String className = ClientAutoInstaller.class.getSimpleName() + ".class";
-        String classPath = Objects.requireNonNull(ClientAutoInstaller.class.getResource(className)).toString();
-        if (!classPath.startsWith("jar")) {
-            return null;
-        }
-        String jarPath = classPath.substring("jar:file:".length(), classPath.indexOf("!"));
-        try (JarFile jarFile = new JarFile(Paths.get(jarPath).toFile())) {
-            Manifest manifest = jarFile.getManifest();
-            Attributes attrs = manifest.getMainAttributes();
-            return attrs.getValue(version);
+    private static @Nullable String getVersionPropertiesFileEntry(final String version) throws IOException {
+        var versionPropertiesResource = ClientAutoInstaller.class.getResource("/net/neoforged/neoforge/common/version.properties");
+        try (var stream = Objects.requireNonNull(versionPropertiesResource).openStream()) {
+            var content = new String(stream.readAllBytes());
+            try (var reader = new StringReader(content)) {
+                var properties = new Properties();
+                properties.load(reader);
+                if (!properties.containsKey(version))
+                    return null;
+
+                return properties.getProperty(version, null);
+            }
         }
     }
 

--- a/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
+++ b/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
@@ -175,7 +175,7 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
         var targetFile = tempDir.resolve(targetName);
         var patchResource = ClientAutoInstaller.class.getResource(packagedName);
         if (patchResource == null) {
-            throw new IllegalStateException("Could not find patches in the auto installer.");
+            throw new IllegalStateException("Could not find %s in the auto installer.".formatted(packagedName));
         }
 
         try (BufferedInputStream in = new BufferedInputStream(patchResource.openStream());

--- a/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
+++ b/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
@@ -65,7 +65,7 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
         var output = tempDir.resolve("client.jar");
 
         progress.increment();
-        progress.label("Installation - Updating your Minecraft Instance...");
+        progress.label("Installation - Installing NeoForge...");
 
         new ProcessMinecraftJar().process(
                 new String[] {

--- a/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
+++ b/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
@@ -38,7 +38,7 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
     }
 
     @Override
-    public @Nullable Result discoverOrInstall(final String neoForgeVersion, final Dist dist) throws Exception {
+    public @Nullable Result discoverOrInstall(final Dist dist) throws Exception {
         //We only support clients!
         if (!dist.isClient()) {
             return null;
@@ -49,12 +49,17 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
             return null;
         }
 
+        var minecraftVersion = getMinecraftVersion();
+        if (minecraftVersion == null) {
+            return null;
+        }
+
         var progress = StartupNotificationManager.addProgressBar("Installation", 3);
         progress.label("Installation - Extracting resources...");
 
         var tempDir = Files.createTempDirectory("nf-auto-installer");
         var minecraftClientJar = getRawMinecraftClient();
-        var clientMappings = getClientMappings();
+        var clientMappings = getClientMappings(minecraftVersion);
         var binaryPatches = getBinaryPatches(tempDir);
         var neoFormMappings = getNeoFormMappings(tempDir);
         var output = tempDir.resolve("client.jar");
@@ -74,7 +79,7 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
         progress.increment();
         progress.label("Installation - Finalizing changes...");
 
-        var patchedMinecraftPath = copyToLibraries(neoForgeVersion, dist, output);
+        var patchedMinecraftPath = copyToLibraries(version, dist, output);
 
         progress.increment();
         progress.complete();
@@ -120,6 +125,15 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
 
     @Nullable
     private static String getNeoForgeVersion() throws IOException {
+        return getManifestAttribute("version");
+    }
+
+    @Nullable
+    private static String getMinecraftVersion() throws IOException {
+        return getManifestAttribute("minecraft");
+    }
+
+    private static @Nullable String getManifestAttribute(final String version) throws IOException {
         String className = ClientAutoInstaller.class.getSimpleName() + ".class";
         String classPath = Objects.requireNonNull(ClientAutoInstaller.class.getResource(className)).toString();
         if (!classPath.startsWith("jar")) {
@@ -129,17 +143,18 @@ public record ClientAutoInstaller() implements GameDiscoveryOrInstallationServic
         try (JarFile jarFile = new JarFile(Paths.get(jarPath).toFile())) {
             Manifest manifest = jarFile.getManifest();
             Attributes attrs = manifest.getMainAttributes();
-            return attrs.getValue("version");
+            return attrs.getValue(version);
         }
     }
 
-    private static Path getClientMappings() {
+    private static Path getClientMappings(final String minecraftVersion) {
+        var fileName = "mappings-%s-client.jar".formatted(minecraftVersion);
+
         String classpath = System.getProperty("java.class.path");
         String[] entries = classpath.split(File.pathSeparator);
         for (String entry : entries) {
             File file = new File(entry);
-            if (file.isFile() && (file.getName().equals("client.txt") ||
-                    (file.getName().endsWith("-client.jar") && file.getName().startsWith("mappings")))) {
+            if (file.isFile() && file.getName().equals(fileName)) {
                 return Path.of(file.getAbsolutePath());
             }
 

--- a/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
+++ b/autoinstall/src/main/java/net/neoforged/neoforge/autoinstall/ClientAutoInstaller.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.autoinstall;
+
+import static net.neoforged.fml.loading.game.GameDiscovery.LIBRARIES_DIRECTORY_PROPERTY;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.loading.MavenCoordinate;
+import net.neoforged.fml.loading.progress.StartupNotificationManager;
+import net.neoforged.fml.util.ClasspathResourceUtils;
+import net.neoforged.installertools.ProcessMinecraftJar;
+import net.neoforged.neoforgespi.installation.GameDiscoveryOrInstallationService;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public record ClientAutoInstaller() implements GameDiscoveryOrInstallationService {
+    private static final Logger LOG = LoggerFactory.getLogger(ClientAutoInstaller.class);
+
+    @Override
+    public String name() {
+        return "default";
+    }
+
+    @Override
+    public @Nullable Result discoverOrInstall(final String neoForgeVersion, final Dist dist) throws Exception {
+        //We only support clients!
+        if (!dist.isClient()) {
+            return null;
+        }
+
+        var version = getNeoForgeVersion();
+        if (version == null) {
+            return null;
+        }
+
+        var progress = StartupNotificationManager.addProgressBar("Installation", 3);
+        progress.label("Installation - Extracting resources...");
+
+        var tempDir = Files.createTempDirectory("nf-auto-installer");
+        var minecraftClientJar = getRawMinecraftClient();
+        var clientMappings = getClientMappings();
+        var binaryPatches = getBinaryPatches(tempDir);
+        var neoFormMappings = getNeoFormMappings(tempDir);
+        var output = tempDir.resolve("client.jar");
+
+        progress.increment();
+        progress.label("Installation - Updating your Minecraft Instance...");
+
+        new ProcessMinecraftJar().process(
+                new String[] {
+                        "--input", minecraftClientJar.toAbsolutePath().toString(),
+                        "--output", output.toAbsolutePath().toString(),
+                        "--input-mappings", clientMappings.toAbsolutePath().toString(),
+                        "--neoform-data", neoFormMappings.toAbsolutePath().toString(),
+                        "--apply-patches", binaryPatches.toAbsolutePath().toString()
+                });
+
+        progress.increment();
+        progress.label("Installation - Finalizing changes...");
+
+        var patchedMinecraftPath = copyToLibraries(neoForgeVersion, dist, output);
+
+        progress.increment();
+        progress.complete();
+
+        return new Result(patchedMinecraftPath);
+    }
+
+    private static Path copyToLibraries(final String neoForgeVersion, final Dist dist, final Path output) throws IOException {
+        var librariesDirectory = System.getProperty(LIBRARIES_DIRECTORY_PROPERTY);
+        var patchedMinecraftPath = Path.of(librariesDirectory).resolve((switch (dist) {
+            case CLIENT -> new MavenCoordinate("net.neoforged", "minecraft-client-patched", "", "", neoForgeVersion);
+            case DEDICATED_SERVER -> new MavenCoordinate("net.neoforged", "minecraft-server-patched", "", "", neoForgeVersion);
+        }).toRelativeRepositoryPath());
+
+        Files.createDirectories(patchedMinecraftPath.getParent());
+        Files.copy(output, patchedMinecraftPath);
+        return patchedMinecraftPath;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    private static Path getRawMinecraftClient() throws IOException {
+        var jarsWithEntrypoint = new HashSet<Path>();
+
+        var ourCl = Thread.currentThread().getContextClassLoader();
+        var resources = ourCl.getResources("net/minecraft/client/main/Main.class");
+        while (resources.hasMoreElements()) {
+            jarsWithEntrypoint.add(ClasspathResourceUtils.findJarPathFor("net/minecraft/client/main/Main.class", "minecraft jar", resources.nextElement()));
+        }
+
+        // This class would only be present in deobfuscated jars
+        resources = ourCl.getResources("net/minecraft/client/Minecraft.class");
+        while (resources.hasMoreElements()) {
+            jarsWithEntrypoint.remove(ClasspathResourceUtils.findJarPathFor("net/minecraft/client/Minecraft.class", "minecraft jar", resources.nextElement()));
+        }
+
+        if (jarsWithEntrypoint.size() != 1) {
+            throw new IllegalStateException("Failed to find the raw minecraft client from the classpath");
+        }
+
+        //Get the minecraft jar (currently obfuscated)
+        return jarsWithEntrypoint.iterator().next();
+    }
+
+    @Nullable
+    private static String getNeoForgeVersion() throws IOException {
+        String className = ClientAutoInstaller.class.getSimpleName() + ".class";
+        String classPath = Objects.requireNonNull(ClientAutoInstaller.class.getResource(className)).toString();
+        if (!classPath.startsWith("jar")) {
+            return null;
+        }
+        String jarPath = classPath.substring("jar:file:".length(), classPath.indexOf("!"));
+        try (JarFile jarFile = new JarFile(Paths.get(jarPath).toFile())) {
+            Manifest manifest = jarFile.getManifest();
+            Attributes attrs = manifest.getMainAttributes();
+            return attrs.getValue("version");
+        }
+    }
+
+    private static Path getClientMappings() {
+        String classpath = System.getProperty("java.class.path");
+        String[] entries = classpath.split(File.pathSeparator);
+        for (String entry : entries) {
+            File file = new File(entry);
+            if (file.isFile() && (file.getName().equals("client.txt") ||
+                    (file.getName().endsWith("-client.jar") && file.getName().startsWith("mappings")))) {
+                return Path.of(file.getAbsolutePath());
+            }
+
+        }
+
+        throw new IllegalStateException("Failed to find the client mappings on the classpath");
+    }
+
+    private static Path getBinaryPatches(Path tempDir) throws IOException {
+        return extractFromAutoInstallerJar(tempDir, "patches.lzma", "/patches.lzma");
+    }
+
+    private static Path getNeoFormMappings(Path tempDir) throws IOException {
+        return extractFromAutoInstallerJar(tempDir, "neoform.tsrg.lzma", "/neoform.tsrg.lzma");
+    }
+
+    private static Path extractFromAutoInstallerJar(final Path tempDir, final String targetName, final String packagedName) throws IOException {
+        var targetFile = tempDir.resolve(targetName);
+        var patchResource = ClientAutoInstaller.class.getResource(packagedName);
+        if (patchResource == null) {
+            throw new IllegalStateException("Could not find patches in the auto installer.");
+        }
+
+        try (BufferedInputStream in = new BufferedInputStream(patchResource.openStream());
+                FileOutputStream fileOutputStream = new FileOutputStream(targetFile.toFile())) {
+            byte[] dataBuffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
+                fileOutputStream.write(dataBuffer, 0, bytesRead);
+            }
+        }
+
+        return targetFile;
+    }
+}

--- a/autoinstall/src/main/resources/META-INF/services/net.neoforged.neoforgespi.installation.GameDiscoveryOrInstallationService
+++ b/autoinstall/src/main/resources/META-INF/services/net.neoforged.neoforgespi.installation.GameDiscoveryOrInstallationService
@@ -1,0 +1,1 @@
+net.neoforged.neoforge.autoinstall.ClientAutoInstaller

--- a/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
+++ b/buildSrc/src/main/groovy/neoforge.formatting-conventions.gradle
@@ -32,11 +32,14 @@ abstract class GeneratePackageInfos extends DefaultTask {
         }
     }
 }
+
 final generatePackageInfos = tasks.register('generatePackageInfos', GeneratePackageInfos) {
     it.files.from fileTree("src/main/java")
     if (file("src/client/java").exists()) {
         it.files.from fileTree("src/client/java")
     }
+    it.enabled(!project.hasProperty("neoforge.package-infos.disabled") ||
+            !Boolean.parseBoolean(project.property("neoforge.package-infos.disabled").toString()))
 }
 
 immaculate {

--- a/buildSrc/src/main/java/net/neoforged/neodev/CreateCleanArtifacts.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/CreateCleanArtifacts.java
@@ -33,8 +33,12 @@ abstract class CreateCleanArtifacts extends CreateMinecraftArtifacts {
     @OutputFile
     abstract RegularFileProperty getClientMappings();
 
+    @OutputFile
+    abstract RegularFileProperty getVersionJson();
+
     @Inject
     public CreateCleanArtifacts() {
+        getAdditionalResults().put("node.downloadJson.output.output", getVersionJson().getAsFile());
         getAdditionalResults().put("node.downloadClient.output.output", getRawClientJar().getAsFile());
         getAdditionalResults().put("node.stripClient.output.output", getCleanClientJar().getAsFile());
         getAdditionalResults().put("node.downloadServer.output.output", getRawServerJar().getAsFile());

--- a/buildSrc/src/main/java/net/neoforged/neodev/GenerateBaseJar.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/GenerateBaseJar.java
@@ -3,6 +3,7 @@ package net.neoforged.neodev;
 import javax.inject.Inject;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.JavaExec;
@@ -14,6 +15,7 @@ import org.gradle.api.tasks.PathSensitivity;
 /**
  * Create the base jar file that will be diffed against the modified jar to create binary patch files.
  */
+@CacheableTask
 abstract class GenerateBaseJar extends JavaExec {
     @Inject
     public GenerateBaseJar() {}

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevConfigurations.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevConfigurations.java
@@ -59,11 +59,14 @@ class NeoDevConfigurations {
      * Note that the client&server dependencies are differentiated by attributes on the resolving configuration.
      */
     final Configuration minecraftDependencies;
+    /**
+     * The auto installers fat jar to use.
+     */
+    final Configuration autoInstaller;
 
     //
     // Resolvable configurations.
     //
-
     /**
      * Resolved {@link #neoFormMappings}.
      * This is used to add the parameter mappings file from NeoForm to the installer libraries.
@@ -98,6 +101,10 @@ class NeoDevConfigurations {
      * Resolvable {@link #minecraftDependencies} for the server-side.
      */
     final Configuration minecraftServerClasspath;
+    /**
+     * Resolvable {@link #autoInstaller} to resolve.
+     */
+    final Configuration autoInstallerClasspath;
 
     //
     // The configurations for resolution only are declared in the build.gradle file.
@@ -133,6 +140,7 @@ class NeoDevConfigurations {
         userdevCompileOnly = dependencyScope(configurations, "userdevCompileOnly");
         userdevTestFixtures = dependencyScope(configurations, "userdevTestFixtures");
         minecraftDependencies = dependencyScope(configurations, "minecraftDependencies");
+        autoInstaller = dependencyScope(configurations, "autoInstaller");
 
         neoFormMappingsFiles = resolvable(configurations, "neoFormMappingsFiles");
         neoFormClasspath = resolvable(configurations, "neoFormClasspath");
@@ -141,6 +149,7 @@ class NeoDevConfigurations {
         launcherProfileClasspath = resolvable(configurations, "launcherProfileClasspath");
         minecraftClientClasspath = resolvable(configurations, "minecraftClientClasspath");
         minecraftServerClasspath = resolvable(configurations, "minecraftServerClasspath");
+        autoInstallerClasspath = resolvable(configurations, "autoInstallerClasspath");
 
         // Libraries & module libraries & MC dependencies need to be available when compiling in NeoDev,
         // and on the runtime classpath too for IDE debugging support.
@@ -171,6 +180,13 @@ class NeoDevConfigurations {
         minecraftServerClasspath.extendsFrom(minecraftDependencies);
         minecraftServerClasspath.getAttributes().attribute(
                 Attribute.of("net.neoforged.distribution", String.class), "server");
+
+        autoInstallerClasspath.extendsFrom(autoInstaller);
+        autoInstallerClasspath.getAttributes().attribute(
+                Bundling.BUNDLING_ATTRIBUTE, project.getObjects().named(Bundling.class, Bundling.SHADOWED));
+
+        autoInstaller.getDependencies().add(
+                project.getDependencies().create(project.project(":autoinstall")));
 
         toolClasspaths = createToolClasspaths(project);
     }

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -1,7 +1,10 @@
 package net.neoforged.neodev;
 
+import com.google.gson.GsonBuilder;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -22,7 +25,11 @@ import net.neoforged.neodev.installer.CreateInstallerProfile;
 import net.neoforged.neodev.installer.CreateLauncherProfile;
 import net.neoforged.neodev.installer.IdentifiedFile;
 import net.neoforged.neodev.installer.InstallerProcessor;
+import net.neoforged.neodev.installer.Library;
+import net.neoforged.neodev.installer.LibraryArtifact;
+import net.neoforged.neodev.installer.LibraryDownload;
 import net.neoforged.neodev.utils.DependencyUtils;
+import net.neoforged.neodev.utils.MavenIdentifier;
 import net.neoforged.nfrtgradle.CreateMinecraftArtifacts;
 import net.neoforged.nfrtgradle.DownloadAssets;
 import net.neoforged.nfrtgradle.NeoFormRuntimePlugin;
@@ -30,6 +37,7 @@ import net.neoforged.nfrtgradle.NeoFormRuntimeTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.RegularFile;
@@ -87,6 +95,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.getCleanJoinedJar().set(cleanArtifactsDir.map(dir -> dir.file("joined.jar")));
             task.getMergedMappings().set(cleanArtifactsDir.map(dir -> dir.file("merged-mappings.txt")));
             task.getClientMappings().set(cleanArtifactsDir.map(dir -> dir.file("client-mappings.txt")));
+            task.getVersionJson().set(cleanArtifactsDir.map(dir -> dir.file("version.json")));
             task.getNeoFormArtifact().set(mcAndNeoFormVersion.map(version -> "net.neoforged:neoform:" + version + "@zip"));
         });
 
@@ -318,10 +327,16 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.getMinecraftVersion().set(minecraftVersion);
             task.getNeoForgeVersion().set(neoForgeVersion);
             task.getRawNeoFormVersion().set(rawNeoFormVersion);
-            task.setLibraries(configurations.launcherProfileClasspath);
+            task.addLibraries(configurations.launcherProfileClasspath);
+            task.addProjectLibraries(configurations.autoInstallerClasspath);
             task.setMinecraftLibraries(configurations.neoFormClasspath);
             task.getRepositoryURLs().set(installerRepositoryUrls);
             task.getLauncherProfile().set(neoDevBuildDir.map(dir -> dir.file("launcher-profile.json")));
+            task.getAdditionalLibraries().add(extractClientMappings(createCleanArtifacts.flatMap(CreateCleanArtifacts::getVersionJson), minecraftVersion));
+            task.getUniversalJar().set(universalJar.flatMap(AbstractArchiveTask::getArchiveFile));
+
+            task.dependsOn(createCleanArtifacts);
+            task.dependsOn(universalJar);
         });
 
         // Installer profile = the .json file used by the NeoForge installer.
@@ -334,6 +349,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             // Anything that is on the launcher classpath should be downloaded by the installer.
             // (At least on the server side).
             task.addLibraries(configurations.launcherProfileClasspath);
+            task.addProjectLibraries(configurations.autoInstallerClasspath);
             // Note: to properly support that, we need to know which libraries are part of the Vanilla server jar
             // to *not* download them before it is unpacked.
             task.addMinecraftServerLibraries(configurations.minecraftServerClasspath);
@@ -342,6 +358,8 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.addLibraries(configurations.neoFormMappingsFiles);
             task.getRepositoryURLs().set(installerRepositoryUrls);
             task.getUniversalJar().set(universalJar.flatMap(AbstractArchiveTask::getArchiveFile));
+            task.getAutoInstallerJar().fileProvider(configurations.autoInstallerClasspath.getIncoming().getArtifacts().getResolvedArtifacts().map(r -> r.iterator().next()).map(
+                    ResolvedArtifactResult::getFile));
             task.getInstallerProfile().set(neoDevBuildDir.map(dir -> dir.file("installer-profile.json")));
 
             // Make all installer processor tools available to the profile
@@ -429,6 +447,10 @@ public class NeoDevPlugin implements Plugin<Project> {
                     spec.into(String.format("/maven/net/neoforged/neoforge/%s/", neoForgeVersion.get()));
                     spec.rename(name -> String.format("neoforge-%s-universal.jar", neoForgeVersion.get()));
                 });
+                task.from(configurations.autoInstallerClasspath.getIncoming().getArtifacts().getArtifactFiles(), spec -> {
+                    spec.into(String.format("/maven/net/neoforged/autoinstall/%s/", neoForgeVersion.get()));
+                    spec.rename(name -> String.format("autoinstall-%s.jar", neoForgeVersion.get()));
+                });
             }
         });
 
@@ -473,8 +495,45 @@ public class NeoDevPlugin implements Plugin<Project> {
                 installerJar,
                 minecraftVersion,
                 neoForgeVersion,
-                createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawClientJar));
+                createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawClientJar),
+                createCleanArtifacts,
+                universalJar);
         setupProductionServerTest(project, installerJar);
+    }
+
+    private Provider<Library> extractClientMappings(final Provider<RegularFile> regularFileProvider, final Provider<String> minecraftVersion) {
+        record Download(
+                String sha1,
+                int size,
+                String url) {}
+        record Downloads(Download client_mappings) {}
+        record VersionJson(Downloads downloads) {}
+
+        var parsed = regularFileProvider.map(file -> {
+            var gson = new GsonBuilder().create();
+            try {
+                return gson.fromJson(Files.readString(file.getAsFile().toPath()), VersionJson.class);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to parse the VersionJson file.", e);
+            }
+        });
+
+        return parsed.zip(minecraftVersion, (p, v) -> new Library(
+                "net.minecraft:mappings:" + v + ":client",
+                new LibraryDownload(
+                        new LibraryArtifact(
+                                p.downloads().client_mappings().sha1(),
+                                p.downloads().client_mappings().size(),
+                                p.downloads().client_mappings().url(),
+                                "net/minecraft/mappings/%s/client.txt".formatted(v)))));
+    }
+
+    private IdentifiedFile extractClientMappingsIdentifier(final Project project, final Provider<RegularFile> mappings, final Provider<String> minecraftVersion) {
+        IdentifiedFile identifiedFile = project.getObjects().newInstance(IdentifiedFile.class);
+        identifiedFile.getFile().set(mappings);
+        identifiedFile.getIdentifier().set(minecraftVersion.map(v -> MavenIdentifier.parse("net.minecraft:mappings:" + v + ":client")));
+
+        return identifiedFile;
     }
 
     /**
@@ -666,7 +725,8 @@ public class NeoDevPlugin implements Plugin<Project> {
         // Create the jar file in its target state. We will create binary patches to convert the base-jar to this jar.
         var sourceSets = project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
         var modifiedJar = tasks.register(type.taskName("createModifiedJar"), Jar.class, task -> {
-            task.setDescription("Create the jar file for " + type + " in the state that we want to create binpatches from. This jar only contains classes since we don't modify original resources at the moment.");
+            task.setDescription("Create the jar file for " + type
+                    + " in the state that we want to create binpatches from. This jar only contains classes since we don't modify original resources at the moment.");
             task.setGroup(INTERNAL_GROUP);
             task.getDestinationDirectory().set(binpatchesDir);
             task.getArchiveFileName().set(type + "-modified-classes.jar");
@@ -694,7 +754,9 @@ public class NeoDevPlugin implements Plugin<Project> {
             TaskProvider<? extends AbstractArchiveTask> installer,
             Provider<String> minecraftVersion,
             Provider<String> neoForgeVersion,
-            Provider<RegularFile> originalClientJar) {
+            Provider<RegularFile> originalClientJar,
+            TaskProvider<CreateCleanArtifacts> createCleanArtifacts,
+            TaskProvider<Jar> universalJar) {
         var installClient = project.getTasks().register("installProductionClient", InstallProductionClient.class, task -> {
             task.setGroup(INTERNAL_GROUP);
             task.setDescription("Runs the installer produced by this build and installs a production client.");
@@ -705,8 +767,19 @@ public class NeoDevPlugin implements Plugin<Project> {
         });
 
         Consumer<RunProductionClient> configureRunProductionClient = task -> {
-            task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(project, configurations.neoFormClasspath));
-            task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(project, configurations.launcherProfileClasspath));
+            task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(task.getObjectFactory(), configurations.neoFormClasspath, task));
+            task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(task.getObjectFactory(), configurations.launcherProfileClasspath, task));
+            task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(task.getObjectFactory(), configurations.autoInstallerClasspath, task));
+            task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(task.getObjectFactory(), configurations.neoFormMappingsFiles, task));
+            task.getLibraryFiles().add(extractClientMappingsIdentifier(project, createCleanArtifacts.flatMap(CreateCleanArtifacts::getClientMappings), minecraftVersion));
+            task.getLibraryFiles().add(
+                    neoForgeVersion.zip(universalJar.map(AbstractArchiveTask::getArchiveFile), (version, file) -> {
+                        final IdentifiedFile f = task.getObjectFactory().newInstance(IdentifiedFile.class);
+                        f.getIdentifier().set(
+                                MavenIdentifier.parse("net.neoforged:neoforge:%s:universal".formatted(version)));
+                        f.getFile().set(file);
+                        return f;
+                    }));
             task.getAssetPropertiesFile().set(downloadAssets.flatMap(DownloadAssets::getAssetPropertiesFile));
             task.getMinecraftVersion().set(minecraftVersion);
             task.getNeoForgeVersion().set(neoForgeVersion);

--- a/buildSrc/src/main/java/net/neoforged/neodev/e2e/RunProductionClient.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/e2e/RunProductionClient.java
@@ -25,6 +25,7 @@ import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -86,6 +87,9 @@ public abstract class RunProductionClient extends JavaExec {
      */
     @InputFile
     public abstract RegularFileProperty getOriginalClientJar();
+
+    @Inject
+    public abstract ObjectFactory getObjectFactory();
 
     @Inject
     public RunProductionClient(ExecOperations execOperations) {
@@ -205,6 +209,7 @@ public abstract class RunProductionClient extends JavaExec {
                         id.extension());
 
                 if (!librariesAdded.add(idWithoutVersion)) {
+                    getLogger().warn("Skipped library: {}", idWithoutVersion.repositoryPath());
                     continue; // The library was overridden by a child profile
                 }
 
@@ -230,6 +235,7 @@ public abstract class RunProductionClient extends JavaExec {
         placeholders.put("version_name", versionId);
 
         var classpath = String.join(File.pathSeparator, classpathItems);
+        getLogger().warn("Classpath: {}", classpath);
         placeholders.putIfAbsent("classpath", classpath);
 
         expandPlaceholders(mergedProgramArgs, placeholders);

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
@@ -21,9 +21,11 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Nested;
@@ -51,11 +53,21 @@ public abstract class CreateInstallerProfile extends DefaultTask {
     @InputFile
     public abstract RegularFileProperty getIcon();
 
+    @Inject
+    public abstract ObjectFactory getObjectFactory();
+
     @Nested
     protected abstract ListProperty<IdentifiedFile> getLibraryFiles();
 
     public void addLibraries(Configuration libraries) {
-        getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(getProject(), libraries));
+        getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(getObjectFactory(), libraries, this));
+    }
+
+    @Nested
+    protected abstract ListProperty<IdentifiedFile> getProjectLibraryFiles();
+
+    public void addProjectLibraries(Configuration libraries) {
+        getProjectLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(getObjectFactory(), libraries, this));
     }
 
     /**
@@ -65,7 +77,7 @@ public abstract class CreateInstallerProfile extends DefaultTask {
     protected abstract ListProperty<IdentifiedFile> getMinecraftServerLibraries();
 
     public void addMinecraftServerLibraries(Configuration libraries) {
-        getMinecraftServerLibraries().addAll(IdentifiedFile.listFromConfiguration(getProject(), libraries));
+        getMinecraftServerLibraries().addAll(IdentifiedFile.listFromConfiguration(getObjectFactory(), libraries, this));
     }
 
     /**
@@ -75,7 +87,7 @@ public abstract class CreateInstallerProfile extends DefaultTask {
     protected abstract ListProperty<IdentifiedFile> getMinecraftClientLibraries();
 
     public void addMinecraftClientLibraries(Configuration libraries) {
-        getMinecraftClientLibraries().addAll(IdentifiedFile.listFromConfiguration(getProject(), libraries));
+        getMinecraftClientLibraries().addAll(IdentifiedFile.listFromConfiguration(getObjectFactory(), libraries, this));
     }
 
     @Input
@@ -90,6 +102,9 @@ public abstract class CreateInstallerProfile extends DefaultTask {
     @InputFile
     public abstract RegularFileProperty getUniversalJar();
 
+    @InputFile
+    public abstract RegularFileProperty getAutoInstallerJar();
+
     @OutputFile
     public abstract RegularFileProperty getInstallerProfile();
 
@@ -101,6 +116,9 @@ public abstract class CreateInstallerProfile extends DefaultTask {
         }
         processors.add(new ProcessorEntry(sides, mainJar, classpath, args));
     }
+
+    @Inject
+    public abstract ProviderFactory getProviderFactory();
 
     @TaskAction
     public void createInstallerProfile() throws IOException {
@@ -131,9 +149,11 @@ public abstract class CreateInstallerProfile extends DefaultTask {
                         "--from", "data/win_args.txt", "--to", "{ROOT}/libraries/net/neoforged/neoforge/%s/win_args.txt".formatted(getNeoForgeVersion().get()),
                         "--from", "data/unix_args.txt", "--to", "{ROOT}/libraries/net/neoforged/neoforge/%s/unix_args.txt".formatted(getNeoForgeVersion().get())));
 
+        var librariesToResolve = new ArrayList<>(getLibraryFiles().get());
+
         var neoformMappingsDependency = "net.neoforged:neoform:" + getMcAndNeoFormVersion().get() + ":mappings@tsrg.lzma";
         // Validate it will actually be downloaded
-        if (getLibraryFiles().get().stream().noneMatch(l -> {
+        if (librariesToResolve.stream().noneMatch(l -> {
             var identifier = l.getIdentifier().get();
             return identifier.artifactNotation().equals(neoformMappingsDependency);
         })) {
@@ -142,10 +162,10 @@ public abstract class CreateInstallerProfile extends DefaultTask {
 
         // This task will be auto-replaced by legacyinstaller and is mostly here for other launchers that
         // never implemented the optimization of downloading mojmaps ahead of time.
-        commonProcessor.accept(InstallerProcessor.INSTALLERTOOLS,
+        serverProcessor.accept(InstallerProcessor.INSTALLERTOOLS,
                 List.of("--task", "DOWNLOAD_MOJMAPS", "--version", getMinecraftVersion().get(), "--side", "{SIDE}", "--output", "{MOJMAPS}"));
 
-        commonProcessor.accept(
+        serverProcessor.accept(
                 InstallerProcessor.INSTALLERTOOLS,
                 List.of(
                         "--task",
@@ -165,8 +185,8 @@ public abstract class CreateInstallerProfile extends DefaultTask {
 
         getLogger().info("Collecting libraries for Installer Profile");
         // Remove potential duplicates.
-        var libraryFilesToResolve = new LinkedHashMap<MavenIdentifier, IdentifiedFile>(getLibraryFiles().get().size());
-        for (var libraryFile : getLibraryFiles().get()) {
+        var libraryFilesToResolve = new LinkedHashMap<MavenIdentifier, IdentifiedFile>(librariesToResolve.size());
+        for (var libraryFile : librariesToResolve) {
             var existingFile = libraryFilesToResolve.putIfAbsent(libraryFile.getIdentifier().get(), libraryFile);
             if (existingFile != null) {
                 var existing = existingFile.getFile().getAsFile().get();
@@ -186,6 +206,8 @@ public abstract class CreateInstallerProfile extends DefaultTask {
 
         var libraries = new ArrayList<>(
                 LibraryCollector.resolveLibraries(getRepositoryURLs().get(), libraryFilesToResolve.values()));
+        libraries.addAll(
+                LibraryCollector.expectedPublishedJar(getProjectLibraryFiles().get(), getProviderFactory()));
 
         var universalJar = getUniversalJar().getAsFile().get().toPath();
         libraries.add(new Library(

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateLauncherProfile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateLauncherProfile.java
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -20,9 +21,12 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -43,8 +47,20 @@ public abstract class CreateLauncherProfile extends DefaultTask {
     @Input
     public abstract Property<String> getRawNeoFormVersion();
 
+    @Inject
+    public abstract ObjectFactory getObjectFactory();
+
+    @Nested
+    public abstract ListProperty<Library> getAdditionalLibraries();
+
+    @InputFile
+    public abstract RegularFileProperty getUniversalJar();
+
     @Nested
     protected abstract ListProperty<IdentifiedFile> getLibraryFiles();
+
+    @Nested
+    protected abstract ListProperty<IdentifiedFile> getProjectLibraryFiles();
 
     /**
      * The libraries that the Minecraft version we target already has as dependencies.
@@ -52,8 +68,12 @@ public abstract class CreateLauncherProfile extends DefaultTask {
     @Input
     protected abstract ListProperty<MavenIdentifier> getMinecraftLibraryIds();
 
-    public void setLibraries(Configuration libraries) {
-        getLibraryFiles().set(IdentifiedFile.listFromConfiguration(getProject(), libraries));
+    public void addLibraries(Configuration libraries) {
+        getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(getObjectFactory(), libraries, this));
+    }
+
+    public void addProjectLibraries(Configuration libraries) {
+        getProjectLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(getObjectFactory(), libraries, this));
     }
 
     public void setMinecraftLibraries(Configuration configuration) {
@@ -68,6 +88,9 @@ public abstract class CreateLauncherProfile extends DefaultTask {
 
     @OutputFile
     public abstract RegularFileProperty getLauncherProfile();
+
+    @Inject
+    public abstract ProviderFactory getProviderFactory();
 
     @TaskAction
     public void createLauncherProfile() throws IOException {
@@ -101,7 +124,22 @@ public abstract class CreateLauncherProfile extends DefaultTask {
             }
         });
 
-        var libraries = LibraryCollector.resolveLibraries(getRepositoryURLs().get(), libraryFiles);
+        var libraries = new ArrayList<>(LibraryCollector.resolveLibraries(getRepositoryURLs().get(), libraryFiles));
+        libraries.addAll(LibraryCollector.expectedPublishedJar(getProjectLibraryFiles().get(), getProviderFactory()));
+        libraries.addAll(getAdditionalLibraries().get());
+
+        var universalJar = getUniversalJar().getAsFile().get().toPath();
+        libraries.add(new Library(
+                "net.neoforged:neoforge:%s:universal".formatted(getNeoForgeVersion().get()),
+                new LibraryDownload(new LibraryArtifact(
+                        LibraryCollector.sha1Hash(universalJar),
+                        Files.size(universalJar),
+                        "https://maven.neoforged.net/releases/net/neoforged/neoforge/%s/neoforge-%s-universal.jar".formatted(
+                                getNeoForgeVersion().get(),
+                                getNeoForgeVersion().get()),
+                        "net/neoforged/neoforge/%s/neoforge-%s-universal.jar".formatted(
+                                getNeoForgeVersion().get(),
+                                getNeoForgeVersion().get())))));
 
         var gameArguments = new ArrayList<>(List.of(
                 "--fml.neoForgeVersion", getNeoForgeVersion().get(),

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/IdentifiedFile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/IdentifiedFile.java
@@ -5,10 +5,11 @@ import java.util.List;
 import javax.inject.Inject;
 import net.neoforged.neodev.utils.DependencyUtils;
 import net.neoforged.neodev.utils.MavenIdentifier;
-import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
@@ -21,15 +22,16 @@ import org.gradle.api.tasks.PathSensitivity;
  * for usage as task inputs that will be passed to {@link LibraryCollector}.
  */
 public abstract class IdentifiedFile {
-    public static Provider<List<IdentifiedFile>> listFromConfiguration(Project project, Configuration configuration) {
+    public static Provider<List<IdentifiedFile>> listFromConfiguration(ObjectFactory objectFactory, Configuration configuration, Task task) {
+        task.dependsOn(configuration.getIncoming().getArtifacts().getArtifactFiles());
         return configuration.getIncoming().getArtifacts().getResolvedArtifacts().map(
                 artifacts -> artifacts.stream()
-                        .map(artifact -> IdentifiedFile.of(project, artifact))
+                        .map(artifact -> IdentifiedFile.of(objectFactory, artifact))
                         .toList());
     }
 
-    private static IdentifiedFile of(Project project, ResolvedArtifactResult resolvedArtifact) {
-        var identifiedFile = project.getObjects().newInstance(IdentifiedFile.class);
+    private static IdentifiedFile of(ObjectFactory project, ResolvedArtifactResult resolvedArtifact) {
+        var identifiedFile = project.newInstance(IdentifiedFile.class);
         identifiedFile.getFile().set(resolvedArtifact.getFile());
         identifiedFile.getIdentifier().set(DependencyUtils.guessMavenIdentifier(resolvedArtifact));
         return identifiedFile;

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/Library.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/Library.java
@@ -1,3 +1,3 @@
 package net.neoforged.neodev.installer;
 
-record Library(String name, LibraryDownload downloads) {}
+public record Library(String name, LibraryDownload downloads) {}

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryArtifact.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryArtifact.java
@@ -1,6 +1,6 @@
 package net.neoforged.neodev.installer;
 
-record LibraryArtifact(
+public record LibraryArtifact(
         String sha1,
         long size,
         String url,

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryCollector.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryCollector.java
@@ -8,26 +8,49 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Future;
 import java.util.function.Function;
+import net.neoforged.neodev.utils.HashFunction;
 import net.neoforged.neodev.utils.MavenIdentifier;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.ProviderFactory;
 
 /**
  * For each file in a collection, finds the repository that the file came from.
  */
-class LibraryCollector {
+public class LibraryCollector {
+    public static List<Library> expectedPublishedJar(Collection<IdentifiedFile> libraries, ProviderFactory providerFactory) throws IOException {
+        var expectedUrl = providerFactory.gradleProperty("publishing.libraries.url")
+                .map(repo -> repo.endsWith("/") ? repo : "%s/".formatted(repo))
+                .orElse("https://maven.neoforged.net/releases/")
+                .get();
+
+        List<Library> list = new ArrayList<>();
+        for (IdentifiedFile library : libraries) {
+            var file = library.getFile().get().getAsFile();
+
+            var sha1 = sha1Hash(file.toPath());
+            var fileSize = Files.size(file.toPath());
+
+            Library apply = new Library(
+                    library.getIdentifier().get().artifactNotation(),
+                    new LibraryDownload(new LibraryArtifact(
+                            sha1,
+                            fileSize,
+                            expectedUrl + library.getIdentifier().get().repositoryPath(),
+                            library.getIdentifier().get().repositoryPath())));
+            list.add(apply);
+        }
+        return list;
+    }
+
     public static List<Library> resolveLibraries(List<URI> repositoryUrls, Collection<IdentifiedFile> libraries) throws IOException {
         var collector = new LibraryCollector(repositoryUrls);
         for (var library : libraries) {
@@ -144,21 +167,20 @@ class LibraryCollector {
         libraries.add(libraryFuture);
     }
 
-    static String sha1Hash(Path path) throws IOException {
-        MessageDigest digest;
+    public static String sha1Hash(Path path) {
         try {
-            digest = MessageDigest.getInstance("SHA-1");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            return HashFunction.SHA1.hash(Files.readAllBytes(path));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read the hash of: " + path, e);
         }
+    }
 
-        try (var in = Files.newInputStream(path);
-                var din = new DigestInputStream(in, digest)) {
-            byte[] buffer = new byte[8192];
-            while (din.read(buffer) != -1) {}
+    public static long fileSize(Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to calculate file size for: " + path, e);
         }
-
-        return HexFormat.of().formatHex(digest.digest());
     }
 
     private static URI joinUris(URI repositoryUrl, String path) {

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryDownload.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/LibraryDownload.java
@@ -1,4 +1,4 @@
 package net.neoforged.neodev.installer;
 
-record LibraryDownload(
+public record LibraryDownload(
         LibraryArtifact artifact) {}

--- a/buildSrc/src/main/java/net/neoforged/neodev/utils/HashFunction.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/utils/HashFunction.java
@@ -1,0 +1,98 @@
+/*
+ * Installer
+ * Copyright (c) 2016-2018.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+package net.neoforged.neodev.utils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+
+// These are all standard hashing functions the JRE is REQUIRED to have, so add a nice factory that doesn't require catching annoying exceptions;
+public enum HashFunction {
+    MD5("md5", 32),
+    SHA1("SHA-1", 40),
+    SHA256("SHA-256", 64);
+
+    private String algo;
+    private String pad;
+
+    private HashFunction(String algo, int length) {
+        this.algo = algo;
+        // must specify locale to get correct number formatting
+        this.pad = String.format(Locale.ENGLISH, "%0" + length + "d", 0);
+    }
+
+    public String getExtension() {
+        return this.name().toLowerCase(Locale.ENGLISH);
+    }
+
+    public MessageDigest get() {
+        try {
+            return MessageDigest.getInstance(algo);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e); //Never happens
+        }
+    }
+
+    public String hash(File file) throws IOException {
+        try (FileInputStream fin = new FileInputStream(file)) {
+            return hash(fin);
+        }
+    }
+
+    public String hash(Iterable<File> files) throws IOException {
+        MessageDigest hash = get();
+        byte[] buf = new byte[1024];
+
+        for (File file : files) {
+            if (!file.exists())
+                continue;
+
+            try (FileInputStream fin = new FileInputStream(file)) {
+                int count = -1;
+                while ((count = fin.read(buf)) != -1)
+                    hash.update(buf, 0, count);
+            }
+        }
+        return pad(new BigInteger(1, hash.digest()).toString(16));
+    }
+
+    public String hash(String data) {
+        return hash(data == null ? new byte[0] : data.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String hash(InputStream stream) throws IOException {
+        MessageDigest hash = get();
+        byte[] buf = new byte[1024];
+        int count = -1;
+        while ((count = stream.read(buf)) != -1)
+            hash.update(buf, 0, count);
+        return pad(new BigInteger(1, hash.digest()).toString(16));
+    }
+
+    public String hash(byte[] data) {
+        return pad(new BigInteger(1, get().digest(data)).toString(16));
+    }
+
+    public String pad(String hash) {
+        return (pad + hash).substring(hash.length());
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ neoforge_snapshot_next_stable=21.9
 
 # renovate: net.neoforged.jst:jst-cli-bundle
 jst_version=1.0.67
-legacyinstaller_version=3.0.+
+legacyinstaller_version=3.0.41-fix-more-download-logging
 # renovate: net.neoforged.installertools:installertools
 installertools_version=4.0.6
 
@@ -39,7 +39,7 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=10.0.32
+fancy_mod_loader_version=10.0.47-pr-383-feature-autoinstall
 typetools_version=0.6.3
 mixin_extras_version=0.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ neoforge_snapshot_next_stable=21.9
 
 # renovate: net.neoforged.jst:jst-cli-bundle
 jst_version=1.0.67
-legacyinstaller_version=3.0.42-fix-result-path-respecting
+legacyinstaller_version=3.0.+
 # renovate: net.neoforged.installertools:installertools
 installertools_version=4.0.6
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ neoforge_snapshot_next_stable=21.9
 
 # renovate: net.neoforged.jst:jst-cli-bundle
 jst_version=1.0.67
-legacyinstaller_version=3.0.+
+legacyinstaller_version=3.0.42-fix-result-path-respecting
 # renovate: net.neoforged.installertools:installertools
 installertools_version=4.0.6
 
@@ -39,7 +39,7 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=10.0.47-pr-383-feature-autoinstall
+fancy_mod_loader_version=10.0.49-pr--
 typetools_version=0.6.3
 mixin_extras_version=0.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ neoforge_snapshot_next_stable=21.9
 
 # renovate: net.neoforged.jst:jst-cli-bundle
 jst_version=1.0.67
-legacyinstaller_version=3.0.41-fix-more-download-logging
+legacyinstaller_version=3.0.+
 # renovate: net.neoforged.installertools:installertools
 installertools_version=4.0.6
 

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -506,6 +506,18 @@ configurations {
         }
         javaComponent.addVariantsFromConfiguration(it) {}
     }
+    binaryPatches {
+        canBeDeclared = false
+        canBeResolved = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "patches"))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "patching"))
+        }
+        outgoing {
+            capability("net.neoforged:neoforge-patches:${project.version}")
+        }
+        javaComponent.addVariantsFromConfiguration(it) {}
+    }
 }
 
 sourcesJar {
@@ -544,6 +556,11 @@ artifacts {
         builtBy(createChangelog)
         setClassifier("changelog")
         setExtension("txt")
+    }
+    binaryPatches(generatePatchBundle.outputFile) {
+        builtBy(generatePatchBundle)
+        setClassifier("patches")
+        setExtension("lzma")
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,7 +21,20 @@ dependencyResolutionManagement {
     repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
     rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
     repositories {
+        mavenLocal()
         mavenCentral()
+    }
+
+    repositories {
+        maven {
+            name = "Maven for PR #383" // https://github.com/neoforged/FancyModLoader/pull/383
+            url = uri("https://prmaven.neoforged.net/FancyModLoader/pr383")
+            content {
+                includeModule("net.neoforged.fancymodloader", "earlydisplay")
+                includeModule("net.neoforged.fancymodloader", "junit-fml")
+                includeModule("net.neoforged.fancymodloader", "loader")
+            }
+        }
     }
 }
 
@@ -43,6 +56,8 @@ include ':coremods'
 // Ensure a unique artifact id within JIJ that does not conflict with net.neoforged:coremods, which is
 // another external dependency.
 project(":coremods").name = "neoforge-coremods"
+
+include ':autoinstall'
 
 // Expose the repository base URLs to projects to be able to access them
 // See this Gradle issue for tracking a more permanent solution:


### PR DESCRIPTION
## TLDR: Automatic installation at startup
This PR changes the way the installer creates the client, the end goal is to provide a simple `version.json` and have the launcher deal with downloading the libraries, and then have FML invoke a discovery and installation service which will trigger the installation.

---

## Changes:
- Updated FML to the new version with the new ELS.
- Create the AutoInstall module which implements this new interface, whoes jar contains the neoform mappings, as well as the binary patches.
- Add the minecraft client mappings, the AutoInstall and the Universal Jar to the libraries of the launchers `version.json`, causing it to download them and put them on the classpath of the launch.

### TODO:
- [ ] Discuss isolation of the autoinstaller (right now it is shadowed and works properly without isolation, but we might want to have CL Isolation?)
- [ ] Clean this up, right now the launcher puts the mappings on the CP as a jar.... not a text file which makes looking things up annoying
- [x] Clean up the ELS Interface, neoforge version should not be there.

### Requires:
- https://github.com/neoforged/FancyModLoader/pull/383