### PR TITLE
When creating the joined patches, use the clean jar as base.

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -539,7 +539,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.getModifiedClientJar().set(clientModifiedJar);
             task.getBaseServerJar().set(serverBaseJar);
             task.getModifiedServerJar().set(serverModifiedJar);
-            task.getBaseJoinedJar().set(joinedBaseJar);
+            task.getBaseJoinedJar().set(createCleanArtifacts.flatMap(CreateCleanArtifacts::getCleanJoinedJar));
             // Since we're filtering by *.class, the modified jar for client and joined is identical. They differ in manifest only.
             task.getModifiedJoinedJar().set(clientModifiedJar);
             task.getInclude().add("**/*.class");


### PR DESCRIPTION
We did make a change in the breaking change window, which was technically acceptable, yet unplanned.

We removed de-final from the invoke in PMJ, which causes an issue since it resides still in neoform. In practice this means that the constructors of enums still have the final modifier on parameters of enum constructors, no other methods seem to have this effect applied. This only is a problem for the joined jar at the moment as that is the last patched jar which has this effect. This was difficult to test because ArchLoom hardcoded all kinds of assumptions with regards to the patch locations and formats. Which is why it slipped through.

Our current solution is to either:

1) Patch PMJ to strip the finals before apply, which is possible as we have the patches, but would mean potentially undoing that again when unobf lands.

2) Fix the neoforge joined patches base jar, breaking anything that relies on PMJ in the neoform pipeline (currently NeoGradle in testing, but looks much more promising)

3) Do nothing, ArchLoom relied on undocumented features and on systems without a specification. As such they should adapt to our changes just as the launchers have to which go beyond the current specification. And a patch for archloom is prepared. They could use the feature flags to detect this format (like means a hand full of betas would not work as the FF was introduced to late).

We chose option 2) as we felt like this was not ArchLooms fault. It relied on tried and tested logic which was in place since MCF days, and we should have tested this better.

The fix is relatively simple: Use the clean jar as the base for the patch.

---

Tests performed:
- [X] PMJ Apply of this patch breaks
- [X] Apply on top of rename raw works.
- [x] ArchLoom

---

Closes: #2848