### PR TITLE
Fix stencil

### DIFF
--- a/patches/com/mojang/blaze3d/opengl/GlTextureView.java.patch
+++ b/patches/com/mojang/blaze3d/opengl/GlTextureView.java.patch
@@ -1,0 +1,37 @@
+--- a/com/mojang/blaze3d/opengl/GlTextureView.java
++++ b/com/mojang/blaze3d/opengl/GlTextureView.java
+@@ -45,10 +_,11 @@
+ 
+     public int getFbo(DirectStateAccess p_461283_, @Nullable GpuTexture p_460970_) {
+         int i = p_460970_ == null ? 0 : ((GlTexture)p_460970_).id;
++        var useStencil = p_460970_ != null && p_460970_.getFormat().hasStencilAspect();
+         if (this.firstFboDepthId == i) {
+             return this.firstFboId;
+         } else if (this.firstFboId == -1) {
+-            this.firstFboId = this.createFbo(p_461283_, i);
++            this.firstFboId = this.createFbo(p_461283_, i, useStencil);
+             this.firstFboDepthId = i;
+             return this.firstFboId;
+         } else {
+@@ -56,13 +_,19 @@
+                 this.fboCache = new Int2IntArrayMap();
+             }
+ 
+-            return this.fboCache.computeIfAbsent(i, p_470463_ -> this.createFbo(p_461283_, p_470463_));
++            return this.fboCache.computeIfAbsent(i, p_470463_ -> this.createFbo(p_461283_, p_470463_, useStencil));
+         }
+     }
+ 
++    /** @deprecated use overload that takes useStencil */
++    @Deprecated
+     private int createFbo(DirectStateAccess p_470787_, int p_470630_) {
++        return createFbo(p_470787_, p_470630_, false);
++    }
++
++    private int createFbo(DirectStateAccess p_470787_, int p_470630_, boolean useStencil) {
+         int i = p_470787_.createFrameBufferObject();
+-        p_470787_.bindFrameBufferTextures(i, this.texture().id, p_470630_, this.baseMipLevel(), 0);
++        p_470787_.bindFrameBufferTextures(i, this.texture().id, p_470630_, this.baseMipLevel(), 0, useStencil);
+         return i;
+     }
+ 


### PR DESCRIPTION
Maybe stencil and I are meant to be.
This bug started appearing in snapshot **25w44a**.
This bug is composed of `GlCommandEncoder` and `GlTextureView`.
This bug causes the stencil attachment of the FBO to remain unbound, which in turn causes the stencil to not work.

The place where this bug occurs is in the createRenderPass method of GlCommandEncoder, before calling GlStateManager._glBindFramebuffer.

In **25w43a**:

```
int i = ((GlTexture)gputextureview.texture())
    .getFbo(this.device.directStateAccess(), gputexture
GlStateManager._glBindFramebuffer(36160, i);
```

Because Neo correctly patched `GlTexture` to handle the stencil, it worked properly.

In **25w44a**:

```
int i = ((GlTextureView)gputextureview).getFbo(this.device.directStateAccess(), gputextureview1 == null ? null : gputextureview1.texture());
GlStateManager._glBindFramebuffer(36160, i);
```

Because Neo didn’t patch `GlTextureView`, the stencil wasn’t handled, causing the bug.

I added a patch to **GlTextureView** following the approach used in **GlTexture**, and it works correctly in my local tests.
