### PR TITLE
Remove fix for MC-271166 or #863 regarding the demo timer

### DIFF
--- a/patches/net/minecraft/client/gui/Gui.java.patch
+++ b/patches/net/minecraft/client/gui/Gui.java.patch
@@ -268,15 +268,6 @@
              }
          }
  
-@@ -639,7 +_,7 @@
-     }
- 
-     private void renderDemoOverlay(GuiGraphics p_281825_, DeltaTracker p_348679_) {
--        if (this.minecraft.isDemo()) {
-+        if (this.minecraft.isDemo() && !this.getDebugOverlay().showDebugScreen()) { // Neo: Hide demo timer when F3 debug overlay is open; fixes MC-271166
-             Profiler.get().push("demo");
-             p_281825_.nextStratum();
-             Component component;
 @@ -750,7 +_,15 @@
          return (int)Math.ceil(p_93013_ / 10.0);
      }

--- a/rejects_25w34b/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch.rej
+++ b/rejects_25w34b/net/minecraft/client/gui/components/DebugScreenOverlay.java.patch.rej
@@ -1,20 +1,3 @@
-++++ REJECTED HUNK: 4
-@@ -573,6 +597,13 @@
-             gpudevice.getRenderer(),
-             String.format(Locale.ROOT, "%s %s", gpudevice.getBackendName(), gpudevice.getVersion())
-         );
-+        if (this.minecraft.isDemo()) {
-+            if (this.minecraft.level.getGameTime() >= 120500L) {
-+                list.add(0, net.minecraft.network.chat.Component.translatable("demo.demoExpired").getString());
-+            } else {
-+                list.add(0, net.minecraft.network.chat.Component.translatable("demo.remainingTime", net.minecraft.util.StringUtil.formatTickDuration((int)(120500L - this.minecraft.level.getGameTime()), this.minecraft.level.tickRateManager().tickrate())).getString());
-+            }
-+        }
-         if (this.minecraft.showOnlyReducedInfo()) {
-             return list;
-         } else {
-++++ END HUNK
-
 ++++ REJECTED HUNK: 5
 @@ -609,6 +640,7 @@
                  list.add("");


### PR DESCRIPTION
This PR reverts to the vanilla behavior of showing the demo timer underneath the debug overlay, which fixes the current regression where the demo timer does not show up when the F3/debug overlay is enabled.

This PR also removes the corresponding leftover rejected hunk for `DebugScreenOverlay`.

The bug, [MC-271166](https://mojira.dev/MC-271166), was closed as working as intended after the fix was implemented in #865. 