### PR TITLE
Fix DynamicFluidContainerModel to use item atlas instead of block atlas

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -472,6 +472,11 @@ public class ClientHooks {
         return new Material(TextureAtlas.LOCATION_BLOCKS, loc);
     }
 
+    @SuppressWarnings("deprecation")
+    public static Material getItemMaterial(Identifier loc) {
+        return new Material(TextureAtlas.LOCATION_ITEMS, loc);
+    }
+
     public static boolean loadEntityShader(@Nullable Entity entity, GameRenderer gameRenderer) {
         if (entity != null) {
             Identifier shader = EntitySpectatorShaderManager.get(entity.getType());

--- a/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java
@@ -88,10 +88,10 @@ public class DynamicFluidContainerModel implements ItemModel {
     private ItemModel bakeModelForFluid(Fluid fluid) {
         var sprites = bakingContext.blockModelBaker().sprites();
 
-        Material particleLocation = unbakedModel.textures.particle.map(ClientHooks::getBlockMaterial).orElse(null);
-        Material baseLocation = unbakedModel.textures.base.map(ClientHooks::getBlockMaterial).orElse(null);
-        Material fluidMaskLocation = unbakedModel.textures.fluid.map(ClientHooks::getBlockMaterial).orElse(null);
-        Material coverLocation = unbakedModel.textures.cover.map(ClientHooks::getBlockMaterial).orElse(null);
+        Material particleLocation = unbakedModel.textures.particle.map(ClientHooks::getItemMaterial).orElse(null);
+        Material baseLocation = unbakedModel.textures.base.map(ClientHooks::getItemMaterial).orElse(null);
+        Material fluidMaskLocation = unbakedModel.textures.fluid.map(ClientHooks::getItemMaterial).orElse(null);
+        Material coverLocation = unbakedModel.textures.cover.map(ClientHooks::getItemMaterial).orElse(null);
 
         TextureAtlasSprite baseSprite = baseLocation != null ? sprites.get(baseLocation, DEBUG_NAME) : null;
         TextureAtlasSprite fluidSprite = fluid != Fluids.EMPTY ? sprites.get(ClientHooks.getBlockMaterial(IClientFluidTypeExtensions.of(fluid).getStillTexture()), DEBUG_NAME) : null;


### PR DESCRIPTION
Has items textures have been moved to the new `items` atlas, and they are no longer in the `blocks` one, we should create a new `ClientHooks.getItemMaterial` to replace the Material getters at <https://github.com/neoforged/NeoForge/blob/1.21.x/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java#L91>. Otherwise the bucket and mask textures can't be find by the SpriteGetter