### PR TITLE
Component-based Language Data Generation

### DIFF
--- a/patches/net/minecraft/locale/Language.java.patch
+++ b/patches/net/minecraft/locale/Language.java.patch
@@ -53,7 +53,7 @@
          JsonObject jsonobject = GSON.fromJson(new InputStreamReader(p_128109_, StandardCharsets.UTF_8), JsonObject.class);
  
          for (Entry<String, JsonElement> entry : jsonobject.entrySet()) {
-+            if (entry.getValue().isJsonArray()) {
++            if (entry.getValue().isJsonArray() || entry.getValue().isJsonObject()) {
 +                var component = net.minecraft.network.chat.ComponentSerialization.CODEC
 +                    .parse(com.mojang.serialization.JsonOps.INSTANCE, entry.getValue())
 +                    .getOrThrow(msg -> new com.google.gson.JsonParseException("Error parsing translation for " + entry.getKey() + ": " + msg));

--- a/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
@@ -5,7 +5,9 @@
 
 package net.neoforged.neoforge.common.data;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.mojang.serialization.Codec;
 import com.mojang.serialization.JsonOps;
 import java.nio.file.Path;
 import java.util.Map;
@@ -30,6 +32,8 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.extensions.ILevelExtension;
 
 public abstract class LanguageProvider implements DataProvider {
+    private static final Codec<Map<String, Component>> CODEC = Codec.unboundedMap(Codec.STRING, ComponentSerialization.CODEC);
+
     private final Map<String, Component> data = new TreeMap<>();
     private final PackOutput output;
     private final String modid;
@@ -59,13 +63,7 @@ public abstract class LanguageProvider implements DataProvider {
     }
 
     private CompletableFuture<?> save(CachedOutput cache, Path target) {
-        JsonObject json = this.data.entrySet()
-                .stream()
-                .collect(
-                        JsonObject::new,
-                        (obj, entry) -> obj.add(entry.getKey(), ComponentSerialization.CODEC.encodeStart(JsonOps.INSTANCE, entry.getValue()).getOrThrow()),
-                        (a, b) -> b.asMap().forEach(a::add));
-
+        final JsonElement json = CODEC.encode(this.data, JsonOps.INSTANCE, new JsonObject()).getOrThrow();
         return DataProvider.saveStable(cache, json, target);
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
@@ -6,6 +6,9 @@
 package net.neoforged.neoforge.common.data;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.JsonOps;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.TreeMap;
@@ -14,6 +17,8 @@ import java.util.function.Supplier;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentSerialization;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.effect.MobEffect;
@@ -27,7 +32,7 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.extensions.ILevelExtension;
 
 public abstract class LanguageProvider implements DataProvider {
-    private final Map<String, String> data = new TreeMap<>();
+    private final Map<String, Either<String, Component>> data = new TreeMap<>();
     private final PackOutput output;
     private final String modid;
     private final String locale;
@@ -56,8 +61,15 @@ public abstract class LanguageProvider implements DataProvider {
     }
 
     private CompletableFuture<?> save(CachedOutput cache, Path target) {
-        JsonObject json = new JsonObject();
-        this.data.forEach(json::addProperty);
+        JsonObject json = this.data.entrySet()
+                .stream()
+                .map(it -> Map.entry(it.getKey(), it.getValue().map(
+                        JsonPrimitive::new,
+                        component -> ComponentSerialization.CODEC.encodeStart(JsonOps.INSTANCE, component).getOrThrow())))
+                .collect(
+                        JsonObject::new,
+                        (obj, entry) -> obj.add(entry.getKey(), entry.getValue()),
+                        (a, b) -> b.asMap().forEach(a::add));
 
         return DataProvider.saveStable(cache, json, target);
     }
@@ -111,8 +123,11 @@ public abstract class LanguageProvider implements DataProvider {
     }
 
     public void add(String key, String value) {
-        if (data.put(key, value) != null)
-            throw new IllegalStateException("Duplicate translation key " + key);
+        add(key, Either.left(value));
+    }
+
+    public void add(String key, Component value) {
+        add(key, Either.right(value));
     }
 
     public void addDimension(ResourceKey<Level> dimension, String value) {
@@ -121,5 +136,11 @@ public abstract class LanguageProvider implements DataProvider {
 
     public void addBiome(ResourceKey<Biome> biome, String value) {
         add(biome.identifier().toLanguageKey("biome"), value);
+    }
+
+    private void add(String key, Either<String, Component> value) {
+        if (data.put(key, value) != null) {
+            throw new IllegalStateException("Duplicate translation key " + key);
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/LanguageProvider.java
@@ -6,8 +6,6 @@
 package net.neoforged.neoforge.common.data;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.JsonOps;
 import java.nio.file.Path;
 import java.util.Map;
@@ -32,7 +30,7 @@ import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.extensions.ILevelExtension;
 
 public abstract class LanguageProvider implements DataProvider {
-    private final Map<String, Either<String, Component>> data = new TreeMap<>();
+    private final Map<String, Component> data = new TreeMap<>();
     private final PackOutput output;
     private final String modid;
     private final String locale;
@@ -63,12 +61,9 @@ public abstract class LanguageProvider implements DataProvider {
     private CompletableFuture<?> save(CachedOutput cache, Path target) {
         JsonObject json = this.data.entrySet()
                 .stream()
-                .map(it -> Map.entry(it.getKey(), it.getValue().map(
-                        JsonPrimitive::new,
-                        component -> ComponentSerialization.CODEC.encodeStart(JsonOps.INSTANCE, component).getOrThrow())))
                 .collect(
                         JsonObject::new,
-                        (obj, entry) -> obj.add(entry.getKey(), entry.getValue()),
+                        (obj, entry) -> obj.add(entry.getKey(), ComponentSerialization.CODEC.encodeStart(JsonOps.INSTANCE, entry.getValue()).getOrThrow()),
                         (a, b) -> b.asMap().forEach(a::add));
 
         return DataProvider.saveStable(cache, json, target);
@@ -123,11 +118,13 @@ public abstract class LanguageProvider implements DataProvider {
     }
 
     public void add(String key, String value) {
-        add(key, Either.left(value));
+        add(key, Component.literal(value)); // Literals are serialized as strings directly by the codec
     }
 
     public void add(String key, Component value) {
-        add(key, Either.right(value));
+        if (data.put(key, value) != null) {
+            throw new IllegalStateException("Duplicate translation key " + key);
+        }
     }
 
     public void addDimension(ResourceKey<Level> dimension, String value) {
@@ -136,11 +133,5 @@ public abstract class LanguageProvider implements DataProvider {
 
     public void addBiome(ResourceKey<Biome> biome, String value) {
         add(biome.identifier().toLanguageKey("biome"), value);
-    }
-
-    private void add(String key, Either<String, Component> value) {
-        if (data.put(key, value) != null) {
-            throw new IllegalStateException("Duplicate translation key " + key);
-        }
     }
 }

--- a/tests/src/generated/resources/assets/data_gen_test/lang/en_us.json
+++ b/tests/src/generated/resources/assets/data_gen_test/lang/en_us.json
@@ -1,5 +1,25 @@
 {
   "block.minecraft.stone": "Stone",
+  "data_gen_test.test.component.appended": {
+    "extra": [
+      {
+        "color": "gold",
+        "text": "Second"
+      }
+    ],
+    "text": "First"
+  },
+  "data_gen_test.test.component.literal": "Literal",
+  "data_gen_test.test.component.nested": {
+    "translate": "data_gen_test.test.component.literal",
+    "with": [
+      "minecraft:test"
+    ]
+  },
+  "data_gen_test.test.component.styled": {
+    "color": "blue",
+    "text": "Blue"
+  },
   "data_gen_test.test.unicode": "ʇsǝ┴ ǝpoɔᴉu∩",
   "effect.minecraft.poison": "Poison",
   "entity.minecraft.cat": "Cat",

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/DataGeneratorTest.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import net.minecraft.ChatFormatting;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementType;
@@ -516,6 +517,10 @@ public class DataGeneratorTest {
             add(MobEffects.POISON.value(), "Poison");
             add(EntityType.CAT, "Cat");
             add(MODID + ".test.unicode", "\u0287s\u01DD\u2534 \u01DDpo\u0254\u1D09u\u2229");
+            add(MODID + ".test.component.literal", Component.literal("Literal"));
+            add(MODID + ".test.component.styled", Component.literal("Blue").withStyle(ChatFormatting.BLUE));
+            add(MODID + ".test.component.appended", Component.literal("First").append(Component.literal("Second").withStyle(ChatFormatting.GOLD)));
+            add(MODID + ".test.component.nested", Component.translatable(MODID + ".test.component.literal", Component.translationArg(Identifier.withDefaultNamespace("test"))));
         }
     }
 


### PR DESCRIPTION
NeoForge adds the ability to specify components with additional formatting directly in language files. Nevertheless, there is no ability to generate such kind of language files via the datagen framework.
Consequently, the goal of this PR is to add the ability to do so by providing an `add` overload that also accepts a `Component`.

At the same time, the PR modifies the patch in `Language` to allow for reading not only a JSON array but also a regular JSON object as a `Component`, as that ensures support for the codec's output (along with making it less verbose for users writing these files manually).

A question that still needs to be addressed is related to whether NeoForge wants to provide overloads for the other kind of `add` methods (e.g. `add(Item, String)`). I'd argue this is unnecessary as the functionality is essentially quite niche, so developers that might want to use `Component`s to dictate the presentation of their item's language string can simply perform the necessary conversions manually.
