### PR TITLE
[1.21.11] Fix #2869 Separate the key modifiers for Command and Control keys on OSX

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -9,6 +9,8 @@ import com.mojang.blaze3d.platform.InputConstants;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+
+import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.input.InputQuirks;
 import net.minecraft.network.chat.Component;
@@ -16,6 +18,15 @@ import org.jspecify.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 public enum KeyModifier {
+    /**
+     * Always matches the Control Key, even on OSX which normally uses the Command Key for hotkeys.
+     * Since 1.21.11, Mojang uses Control on OSX for hotkeys that conflict with OSX global system shortcuts.
+     * <p>
+     * For hotkeys that should use the Command key on OSX (like system hotkeys ⌘C for copy, ⌘P for paste, etc.),
+     * use {@link #CONTROL_OR_COMMAND} instead.
+     * For examples of places where Command should be used, see uses of
+     * `net.minecraft.client.input.InputWithModifiers#hasControlDownWithQuirk()`.
+     */
     CONTROL {
         private static final InputConstants.Key[] KEYS = new InputConstants.Key[] {
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_CONTROL),
@@ -35,13 +46,68 @@ public enum KeyModifier {
 
         @Override
         public Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic) {
-            String localizationFormatKey = InputQuirks.ON_OSX ? "neoforge.controlsgui.control.mac" : "neoforge.controlsgui.control";
-            return Component.translatable(localizationFormatKey, defaultLogic.get());
+            return Component.translatable("neoforge.controlsgui.control", defaultLogic.get());
         }
 
         @Override
         public InputConstants.Key[] codes() {
             return KEYS;
+        }
+    },
+    /**
+     * On Windows and Linux, this matches the Control Key.
+     * On OSX, this matches the Command Key (⌘).
+     * <p>
+     * This is the default behavior expected by OSX players for system hotkeys (like ⌘C for copy, ⌘P for paste, etc.),
+     * and this follows the {@link InputQuirks#REPLACE_CTRL_KEY_WITH_CMD_KEY} rule.
+     * For examples of places where Command should be used, see uses of
+     * `net.minecraft.client.input.InputWithModifiers#hasControlDownWithQuirk()`.
+     * <p>
+     * For hotkeys that should use Control even on OSX, use {@link #CONTROL} instead.
+     * <p>
+     * Since 1.21.11, Mojang uses Control on OSX for hotkeys that conflict with OSX global system shortcuts.
+     * Use caution when setting default hotkeys with this modifier, because it's possible to end up minimizing
+     * the window or triggering some other system behavior instead of what you intended.
+     */
+    CONTROL_OR_COMMAND {
+        private static final InputConstants.Key[] COMMAND_KEYS = new InputConstants.Key[]{
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SUPER),
+                InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_SUPER),
+        };
+
+        @Override
+        public boolean matches(InputConstants.Key key) {
+            if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
+                int keyCode = key.getValue();
+                return keyCode == GLFW.GLFW_KEY_LEFT_SUPER || keyCode == GLFW.GLFW_KEY_RIGHT_SUPER;
+            }
+            return CONTROL.matches(key);
+        }
+
+        @Override
+        public boolean isActive(@Nullable IKeyConflictContext conflictContext) {
+            if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
+                Minecraft minecraft = Minecraft.getInstance();
+                Window window = minecraft.getWindow();
+                return InputConstants.isKeyDown(window, 343) || InputConstants.isKeyDown(window, 347);
+            }
+            return CONTROL.isActive(conflictContext);
+        }
+
+        @Override
+        public Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic) {
+			if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
+                return Component.translatable("neoforge.controlsgui.control.mac", defaultLogic.get());
+            }
+			return CONTROL.getCombinedName(key, defaultLogic);
+		}
+
+        @Override
+        public InputConstants.Key[] codes() {
+            if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
+                return COMMAND_KEYS;
+            }
+            return CONTROL.codes();
         }
     },
     SHIFT {
@@ -127,7 +193,7 @@ public enum KeyModifier {
         }
     };
 
-    public static final KeyModifier[] MODIFIER_VALUES = { SHIFT, CONTROL, ALT };
+    public static final KeyModifier[] MODIFIER_VALUES = InputQuirks.ON_OSX ? new KeyModifier[]{SHIFT, CONTROL_OR_COMMAND, CONTROL, ALT} : new KeyModifier[]{SHIFT, CONTROL, ALT};
 
     public static List<KeyModifier> getActiveModifiers() {
         List<KeyModifier> modifiers = new ArrayList<>();
@@ -166,8 +232,5 @@ public enum KeyModifier {
 
     public abstract Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic);
 
-    // Neo: Make abstract in 1.21.5
-    public InputConstants.Key[] codes() {
-        return null;
-    }
+    public abstract InputConstants.Key[] codes();
 }

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -6,11 +6,10 @@
 package net.neoforged.neoforge.client.settings;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.blaze3d.platform.Window;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-
-import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.input.InputQuirks;
 import net.minecraft.network.chat.Component;
@@ -70,7 +69,7 @@ public enum KeyModifier {
      * the window or triggering some other system behavior instead of what you intended.
      */
     CONTROL_OR_COMMAND {
-        private static final InputConstants.Key[] COMMAND_KEYS = new InputConstants.Key[]{
+        private static final InputConstants.Key[] COMMAND_KEYS = new InputConstants.Key[] {
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SUPER),
                 InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_RIGHT_SUPER),
         };
@@ -96,11 +95,11 @@ public enum KeyModifier {
 
         @Override
         public Component getCombinedName(InputConstants.Key key, Supplier<Component> defaultLogic) {
-			if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
+            if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
                 return Component.translatable("neoforge.controlsgui.control.mac", defaultLogic.get());
             }
-			return CONTROL.getCombinedName(key, defaultLogic);
-		}
+            return CONTROL.getCombinedName(key, defaultLogic);
+        }
 
         @Override
         public InputConstants.Key[] codes() {
@@ -193,7 +192,7 @@ public enum KeyModifier {
         }
     };
 
-    public static final KeyModifier[] MODIFIER_VALUES = InputQuirks.ON_OSX ? new KeyModifier[]{SHIFT, CONTROL_OR_COMMAND, CONTROL, ALT} : new KeyModifier[]{SHIFT, CONTROL, ALT};
+    public static final KeyModifier[] MODIFIER_VALUES = InputQuirks.ON_OSX ? new KeyModifier[] { SHIFT, CONTROL_OR_COMMAND, CONTROL, ALT } : new KeyModifier[] { SHIFT, CONTROL, ALT };
 
     public static List<KeyModifier> getActiveModifiers() {
         List<KeyModifier> modifiers = new ArrayList<>();

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -54,7 +54,7 @@ public enum KeyModifier {
         }
     },
     /**
-     * On Windows and Linux, this matches the Control Key.
+     * On Windows and Linux, this matches the {@link #CONTROL Control} Key.
      * On OSX, this matches the Command Key (⌘).
      * <p>
      * This is the default behavior expected by OSX players for system hotkeys (like ⌘C for copy, ⌘P for paste, etc.),
@@ -64,7 +64,7 @@ public enum KeyModifier {
      * <p>
      * For hotkeys that should use Control even on OSX, use {@link #CONTROL} instead.
      * <p>
-     * Since 1.21.11, Mojang uses Control on OSX for hotkeys that conflict with OSX global system shortcuts.
+     * Since 1.21.11, Mojang uses {@link #CONTROL Control} on OSX for hotkeys that conflict with OSX global system shortcuts.
      * Use caution when setting default hotkeys with this modifier, because it's possible to end up minimizing
      * the window or triggering some other system behavior instead of what you intended.
      */

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -88,7 +88,7 @@ public enum KeyModifier {
             if (InputQuirks.REPLACE_CTRL_KEY_WITH_CMD_KEY) {
                 Minecraft minecraft = Minecraft.getInstance();
                 Window window = minecraft.getWindow();
-                return InputConstants.isKeyDown(window, 343) || InputConstants.isKeyDown(window, 347);
+                return InputConstants.isKeyDown(window, GLFW.GLFW_KEY_LEFT_SUPER) || InputConstants.isKeyDown(window, GLFW.GLFW_KEY_RIGHT_SUPER);
             }
             return CONTROL.isActive(conflictContext);
         }


### PR DESCRIPTION
# Issue Description

* https://github.com/neoforged/NeoForge/issues/2869

# Fix Description

This PR separates out the Command key modifier handling into its own modifier.
That allows most hotkeys to simply use Control across all platforms, to avoid conflicting with OSX global hotkeys, which is inline with Mojang's changes for 1.21.11.

# New Functionality

For special cases where Command is still wanted on OSX (copy, paste, text editing in general), the new modifier will allow it and still falls back to Control for other platforms.
For OSX players who want to bind hotkeys using Control or Command in any way they like, this is now supported.

<img width="854" height="480" alt="2025-12-13_12 03 31" src="https://github.com/user-attachments/assets/cfe0719b-5b55-464a-bf93-e2497e52859e" />

# Breaking Changes

Since NeoForge 1.21.11 is in beta, this introduces breaking changes by adding a new enum variation, and also makes `codes` abstract as some minor breaking cleanup.