### PR TITLE
[1.21.11] Fix baked colors in quads applying incorrectly

### DIFF
--- a/patches/com/mojang/blaze3d/vertex/VertexConsumer.java.patch
+++ b/patches/com/mojang/blaze3d/vertex/VertexConsumer.java.patch
@@ -4,7 +4,7 @@
              long k = p_85989_.packedUV(j);
              float f = p_331397_[j];
              int l = ARGB.colorFromFloat(p_331416_, f * p_85990_, f * p_85991_, f * p_85992_);
-+            l = ARGB.multiply(l, ARGB.toABGR(p_85989_.bakedColors().color(j))); // Neo: apply baked color from the quad
++            l = ARGB.multiply(l, p_85989_.bakedColors().color(j)); // Neo: apply baked color from the quad
              int i1 = LightTexture.lightCoordsWithEmission(p_331378_[j], i);
              Vector3f vector3f1 = matrix4f.transformPosition(vector3fc1, new Vector3f());
              float f1 = UVPair.unpackU(k);


### PR DESCRIPTION
This PR fixes baked colors stored in `BakedQuad`s being applied with the R and B components swapped.

`BakedColors` stores the packed color in ARGB while the final vertex buffer sent to the GPU uses ABGR. When I implemented `BakedColors`, I incorrectly assumed that `VertexConsumer#addVertex()` (specifically the overload taking all attributes) takes the packed color as ABGR due to a flawed test case (it had an incorrect color format conversion that was valid in the old implementation). In practice, the `BufferBuilder#addVertex()` implementation takes ARGB and performs the conversion internally.