### PR TITLE
Match MC-273464 fix to implemented fix in 24w33a

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -58,7 +58,7 @@
                  try {
 -                    this.minecraft.getOverlay().render(guigraphics, i, j, p_348648_.getRealtimeDeltaTicks());
 +                    // Neo: Fix https://bugs.mojang.com/browse/MC-273464
-+                    this.minecraft.getOverlay().render(guigraphics, i, j, p_348648_.getGameTimeDeltaPartialTick(false));
++                    this.minecraft.getOverlay().render(guigraphics, i, j, p_348648_.getGameTimeDeltaTicks());
                  } catch (Throwable throwable2) {
                      CrashReport crashreport = CrashReport.forThrowable(throwable2, "Rendering overlay");
                      CrashReportCategory crashreportcategory = crashreport.addCategory("Overlay render details");
@@ -69,7 +69,7 @@
 -                    this.minecraft.screen.renderWithTooltip(guigraphics, i, j, p_348648_.getRealtimeDeltaTicks());
 +                    // Neo: Wrap Screen#render to allow for GUI Layers and ScreenEvent.Render.[Pre/Post]
 +                    // Also fixes https://bugs.mojang.com/browse/MC-273464
-+                    net.neoforged.neoforge.client.ClientHooks.drawScreen(this.minecraft.screen, guigraphics, i, j, p_348648_.getGameTimeDeltaPartialTick(false));
++                    net.neoforged.neoforge.client.ClientHooks.drawScreen(this.minecraft.screen, guigraphics, i, j, p_348648_.getGameTimeDeltaTicks());
                  } catch (Throwable throwable1) {
                      CrashReport crashreport1 = CrashReport.forThrowable(throwable1, "Rendering screen");
                      CrashReportCategory crashreportcategory1 = crashreport1.addCategory("Screen render details");


### PR DESCRIPTION
This PR fixes #2871 by matching the fix for MC-273464 to the fix implemented by vanilla in 24w33a.

The code in `PanoramaRenderer` is left untouched (and deliberately not matched to vanilla's implementation in 24w33a) to preserve the static panorama of the accessibility onboarding screen. Based on my read of the code, the accessibility onboarding screen was changed to have a moving panorama from 24w33a to 25w15a, which probably means it was an unintentional change. (There is no bug report for it though, which potentially means it was caught in-house.)