### PR TITLE
Fire GatherEffectScreenTooltipsEvent for all effect widgets

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/EffectsInInventory.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/EffectsInInventory.java.patch
@@ -80,17 +80,21 @@
      ) {
          int i = p_454754_ + 32;
          int j = p_455546_ + 7;
-@@ -112,7 +_,12 @@
+@@ -111,8 +_,15 @@
+             flag = true;
          }
  
-         if (flag && p_455390_ >= p_454754_ && p_455390_ <= p_454754_ + p_455809_ && p_455363_ >= p_455546_ && p_455363_ <= p_455546_ + p_455668_) {
+-        if (flag && p_455390_ >= p_454754_ && p_455390_ <= p_454754_ + p_455809_ && p_455363_ >= p_455546_ && p_455363_ <= p_455546_ + p_455668_) {
 -            p_456196_.setTooltipForNextFrame(this.screen.getFont(), List.of(p_455663_, p_467145_), Optional.empty(), p_455390_, p_455363_);
-+            // Neo: Allow mods to adjust the tooltip shown when hovering a mob effect.
-+            var list = List.of(p_455663_, p_467145_);
++        if (p_455390_ >= p_454754_ && p_455390_ <= p_454754_ + p_455809_ && p_455363_ >= p_455546_ && p_455363_ <= p_455546_ + p_455668_) {
++            // Neo: Allow mods to create or adjust the tooltip shown when hovering over a mob effect.
++            var list = flag ? List.of(p_455663_, p_467145_) : List.<Component>of();
 +            if (effectInstance != null) {
-+                list = net.neoforged.neoforge.client.ClientHooks.getEffectTooltip(screen, effectInstance, List.of(p_455663_, p_467145_));
++                list = net.neoforged.neoforge.client.ClientHooks.getEffectTooltip(screen, effectInstance, list);
 +            }
-+            p_456196_.setTooltipForNextFrame(this.screen.getFont(), list, Optional.empty(), p_455390_, p_455363_);
++            if (!list.isEmpty()) {
++                p_456196_.setTooltipForNextFrame(this.screen.getFont(), list, Optional.empty(), p_455390_, p_455363_);
++            }
          }
      }
  

--- a/src/client/java/net/neoforged/neoforge/client/event/GatherEffectScreenTooltipsEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/GatherEffectScreenTooltipsEvent.java
@@ -15,8 +15,9 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.Event;
 
 /**
- * This event is called when {@link EffectsInInventory} draws the tooltip lines for a hovered {@link MobEffectInstance} in an {@link AbstractContainerScreen}.
- * It can be used to modify the tooltip.
+ * This event is called when the cursor is hovering over an {@link MobEffectInstance} rendered by
+ * {@link EffectsInInventory} in an {@link AbstractContainerScreen}.
+ * It can be used to create or modify the tooltip.
  * <p>
  * This event is only fired on the {@linkplain Dist#CLIENT physical client}.
  */
@@ -32,21 +33,24 @@ public class GatherEffectScreenTooltipsEvent extends Event {
     }
 
     /**
-     * @return The screen which will be rendering the tooltip lines.
+     * {@return the screen which will be rendering the tooltip lines}
      */
     public AbstractContainerScreen<?> getScreen() {
         return this.screen;
     }
 
     /**
-     * @return The effect whose tooltip is being drawn.
+     * {@return The effect whose tooltip is being drawn}
      */
     public MobEffectInstance getEffectInstance() {
         return this.effectInst;
     }
 
     /**
-     * @return A mutable list of tooltip lines.
+     * {@return a mutable list of tooltip lines} If this list is empty, no tooltip will be rendered.
+     * <p>
+     * This list will be initially empty when hovering over an effect widget which has no tooltip by default
+     * (when the effect information is fully visible).
      */
     public List<Component> getTooltip() {
         return this.tooltip;


### PR DESCRIPTION
This PR implements and resolves #2870 by firing `GatherEffectScreenTooltipsEvent` for all effect widgets, not just those which have a tooltip by virtue of compact rendering or text cut-off.

This allows the use of `GatherEffectScreenTooltipsEvent` to unconditionally add tooltips for any effect widget, or to suppress the tooltip entirely when needed (by clearing the tooltip component list).

Example: ![A tooltip of 'BOOOOOOP' is rendered while hovering over a fully-rendered effect widget for Swiftness](https://github.com/user-attachments/assets/5ca70c1e-f376-4c37-9865-42aeabe37e63)