### PR TITLE
[1.21.x] Add tooltip support for FluidStack

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
@@ -5,16 +5,16 @@
 
 package net.neoforged.neoforge.common.extensions;
 
-import java.util.List;
+import java.util.function.Consumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.block.state.BlockState;
@@ -162,20 +162,20 @@ public interface IFluidExtension {
     }
 
     /**
-     * Adds additional tooltip lines to the given {@link FluidStack}.
+     * Adds additional tooltip components for the given {@link FluidStack}.
      *
      * <p>This method is invoked when building the fluid's tooltip and allows
-     * fluids to append custom informational lines (e.g. temperature, effects,
-     * mod-specific data).</p>
+     * fluids to contribute custom informational lines (for example temperature,
+     * effects, or mod-specific data).</p>
      *
-     * <p>Implementations should append to {@code tooltip} and must not
-     * assume it is empty.</p>
+     * <p>Implementations should emit tooltip components via the provided
+     * {@code builder} consumer.</p>
      *
-     * @param fluidStack the fluid stack being rendered
-     * @param tooltip    the list of tooltip components to append to
-     * @param context    the tooltip context
-     * @param player     the player viewing the tooltip, or {@code null}
-     * @param flag       controls tooltip verbosity and advanced information
+     * @param fluidStack  the fluid stack being rendered
+     * @param context     the tooltip context
+     * @param display     controls which tooltip elements should be displayed
+     * @param builder     consumer used to append tooltip components
+     * @param tooltipFlag controls tooltip verbosity and advanced information
      */
-    default void appendHoverText(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {}
+    default void appendHoverText(FluidStack fluidStack, Item.TooltipContext context, TooltipDisplay display, Consumer<Component> builder, TooltipFlag tooltipFlag) {}
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
@@ -177,5 +177,5 @@ public interface IFluidExtension {
      * @param player     the player viewing the tooltip, or {@code null}
      * @param flag       controls tooltip verbosity and advanced information
      */
-    default void appendTooltip(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {}
+    default void appendHoverText(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {}
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
@@ -177,6 +177,5 @@ public interface IFluidExtension {
      * @param player     the player viewing the tooltip, or {@code null}
      * @param flag       controls tooltip verbosity and advanced information
      */
-    default void appendTooltip(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {
-    }
+    default void appendTooltip(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {}
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import java.util.List;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -24,8 +25,6 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import org.jspecify.annotations.Nullable;
-
-import java.util.List;
 
 public interface IFluidExtension {
     private Fluid self() {
@@ -173,12 +172,11 @@ public interface IFluidExtension {
      * assume it is empty.</p>
      *
      * @param fluidStack the fluid stack being rendered
-     * @param tooltip the list of tooltip components to append to
-     * @param context the tooltip context
-     * @param player the player viewing the tooltip, or {@code null}
-     * @param flag controls tooltip verbosity and advanced information
+     * @param tooltip    the list of tooltip components to append to
+     * @param context    the tooltip context
+     * @param player     the player viewing the tooltip, or {@code null}
+     * @param flag       controls tooltip verbosity and advanced information
      */
     default void appendTooltip(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {
-
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
@@ -6,10 +6,14 @@
 package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.boat.AbstractBoat;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.block.state.BlockState;
@@ -17,8 +21,11 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.pathfinder.PathType;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidType;
 import org.jspecify.annotations.Nullable;
+
+import java.util.List;
 
 public interface IFluidExtension {
     private Fluid self() {
@@ -153,5 +160,25 @@ public interface IFluidExtension {
      */
     default boolean canExtinguish(FluidState state, BlockGetter getter, BlockPos pos) {
         return getFluidType().canExtinguish(state, getter, pos);
+    }
+
+    /**
+     * Adds additional tooltip lines to the given {@link FluidStack}.
+     *
+     * <p>This method is invoked when building the fluid's tooltip and allows
+     * fluids to append custom informational lines (e.g. temperature, effects,
+     * mod-specific data).</p>
+     *
+     * <p>Implementations should append to {@code tooltip} and must not
+     * assume it is empty.</p>
+     *
+     * @param fluidStack the fluid stack being rendered
+     * @param tooltip the list of tooltip components to append to
+     * @param context the tooltip context
+     * @param player the player viewing the tooltip, or {@code null}
+     * @param flag controls tooltip verbosity and advanced information
+     */
+    default void appendTooltip(FluidStack fluidStack, List<Component> tooltip, Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {
+
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -145,6 +145,7 @@ import net.neoforged.neoforge.event.entity.player.ArrowNockEvent;
 import net.neoforged.neoforge.event.entity.player.BonemealEvent;
 import net.neoforged.neoforge.event.entity.player.CanContinueSleepingEvent;
 import net.neoforged.neoforge.event.entity.player.CanPlayerSleepEvent;
+import net.neoforged.neoforge.event.entity.player.FluidTooltipEvent;
 import net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent;
 import net.neoforged.neoforge.event.entity.player.ItemTooltipEvent;
 import net.neoforged.neoforge.event.entity.player.PermissionsChangedEvent;
@@ -177,6 +178,7 @@ import net.neoforged.neoforge.event.tick.EntityTickEvent;
 import net.neoforged.neoforge.event.tick.LevelTickEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.resource.ReloadListenerSort;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
@@ -437,6 +439,12 @@ public class EventHooks {
 
     public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags, Item.TooltipContext context) {
         ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, list, flags, context);
+        NeoForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static FluidTooltipEvent onFluidTooltip(FluidStack fluidStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags, Item.TooltipContext context) {
+        FluidTooltipEvent event = new FluidTooltipEvent(fluidStack, entityPlayer, list, flags, context);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/FluidTooltipEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/FluidTooltipEvent.java
@@ -5,14 +5,13 @@
 
 package net.neoforged.neoforge.event.entity.player;
 
+import java.util.List;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.neoforge.fluids.FluidStack;
 import org.jspecify.annotations.Nullable;
-
-import java.util.List;
 
 public class FluidTooltipEvent extends PlayerEvent {
     private final TooltipFlag flags;

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/FluidTooltipEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/FluidTooltipEvent.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.player;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item.TooltipContext;
+import net.minecraft.world.item.TooltipFlag;
+import net.neoforged.neoforge.fluids.FluidStack;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+public class FluidTooltipEvent extends PlayerEvent {
+    private final TooltipFlag flags;
+    private final FluidStack fluidStack;
+    private final List<Component> toolTip;
+    private final TooltipContext context;
+
+    /**
+     * This event is fired in {@link FluidStack#getTooltipLines(TooltipContext, Player, TooltipFlag)}, which in turn is called from its respective modded GUI.
+     * Tooltips may also be gathered with a null player during startup by other mods.
+     */
+    public FluidTooltipEvent(FluidStack fluidStack, @Nullable Player player, List<Component> list, TooltipFlag flags, TooltipContext context) {
+        super(player);
+        this.fluidStack = fluidStack;
+        this.toolTip = list;
+        this.flags = flags;
+        this.context = context;
+    }
+
+    /**
+     * Use to determine if the advanced information on fluid tooltips is being shown, toggled by F3+H.
+     */
+    public TooltipFlag getFlags() {
+        return flags;
+    }
+
+    /**
+     * The {@link FluidStack} with the tooltip.
+     */
+    public FluidStack getFluidStack() {
+        return fluidStack;
+    }
+
+    /**
+     * The {@link FluidStack} tooltip.
+     */
+    public List<Component> getToolTip() {
+        return toolTip;
+    }
+
+    /**
+     * This event is fired with a null player during startup when populating search trees for tooltips.
+     */
+    @Override
+    @Nullable
+    public Player getEntity() {
+        return super.getEntity();
+    }
+
+    /**
+     * The {@link TooltipContext tooltip context}.
+     */
+    public TooltipContext getContext() {
+        return context;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -30,7 +30,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.tags.TagKey;
@@ -38,10 +37,8 @@ import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
-import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.MutableDataComponentHolder;
@@ -387,7 +384,7 @@ public final class FluidStack implements MutableDataComponentHolder {
         } else {
             Fluid fluid = getFluid();
             List<Component> list = Lists.newArrayList();
-            list.add(this.getStyledHoverName());
+            list.add(this.getHoverName());
             fluid.appendHoverText(this, context, tooltipDisplay, list::add, flag);
             EventHooks.onFluidTooltip(this, player, list, flag, context);
             if (flag.isAdvanced()) {
@@ -398,47 +395,6 @@ public final class FluidStack implements MutableDataComponentHolder {
                 }
             }
             return list;
-        }
-    }
-
-    /**
-     * Returns the styled hover name for this fluid stack.
-     *
-     * <p>The returned component applies the fluid's rarity styling and mirrors
-     * {@link ItemStack#getStyledHoverName()} semantics. If the stack has a custom
-     * name, the name is additionally rendered in italics.</p>
-     *
-     * @return the styled hover name component
-     */
-    public Component getStyledHoverName() {
-        MutableComponent mutablecomponent = Component.empty()
-                .append(this.getHoverName())
-                .withStyle(getRarity().getStyleModifier());
-        if (this.has(DataComponents.CUSTOM_NAME)) {
-            mutablecomponent.withStyle(ChatFormatting.ITALIC);
-        }
-        return mutablecomponent;
-    }
-
-    /**
-     * Returns the effective rarity of this fluid stack.
-     *
-     * <p>The base rarity is read from {@link DataComponents#RARITY}. If the stack
-     * has enchantments present, the rarity is promoted in the same manner as
-     * {@link ItemStack#getRarity()}:</p>
-     *
-     * @return the computed rarity of this fluid stack
-     */
-    public Rarity getRarity() {
-        Rarity rarity = this.getOrDefault(DataComponents.RARITY, Rarity.COMMON);
-        if (this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty()) {
-            return rarity;
-        } else {
-            return switch (rarity) {
-                case COMMON, UNCOMMON -> Rarity.RARE;
-                case RARE -> Rarity.EPIC;
-                default -> rarity;
-            };
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -381,14 +381,14 @@ public final class FluidStack implements MutableDataComponentHolder {
      * @return a list of tooltip components, possibly empty
      */
     public List<Component> getTooltipLines(Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {
-        TooltipDisplay tooltipdisplay = this.getOrDefault(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.DEFAULT);
-        if (!flag.isCreative() && tooltipdisplay.hideTooltip()) {
+        TooltipDisplay tooltipDisplay = this.getOrDefault(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.DEFAULT);
+        if (!flag.isCreative() && tooltipDisplay.hideTooltip()) {
             return List.of();
         } else {
             Fluid fluid = getFluid();
             List<Component> list = Lists.newArrayList();
             list.add(this.getStyledHoverName());
-            fluid.appendHoverText(this, list, context, player, flag);
+            fluid.appendHoverText(this, context, tooltipDisplay, list::add, flag);
             EventHooks.onFluidTooltip(this, player, list, flag, context);
             if (flag.isAdvanced()) {
                 list.add(Component.literal(BuiltInRegistries.FLUID.getKey(fluid).toString()).withStyle(ChatFormatting.DARK_GRAY));

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.fluids;
 
+import com.google.common.collect.Lists;
 import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
@@ -12,28 +13,39 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.component.PatchedDataComponentMap;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Rarity;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.MutableDataComponentHolder;
+import net.neoforged.neoforge.event.EventHooks;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -341,6 +353,89 @@ public final class FluidStack implements MutableDataComponentHolder {
     @Override
     public String toString() {
         return this.getAmount() + " " + this.getFluid();
+    }
+
+    /**
+     * Builds the tooltip lines for this fluid stack, intended for use by mods
+     * rendering fluids in GUIs.
+     *
+     * <p>This mirrors the behavior of
+     * {@link ItemStack#getTooltipLines(Item.TooltipContext, Player, TooltipFlag)}
+     * as closely as possible for fluids.</p>
+     *
+     * <p>The tooltip consists of:
+     * <ul>
+     *   <li>The styled hover name</li>
+     *   <li>Additional lines provided by the fluid itself</li>
+     *   <li>Lines added by {@link EventHooks#onFluidTooltip}</li>
+     *   <li>The registry name when advanced tooltips are enabled</li>
+     * </ul>
+     * </p>
+     *
+     * <p>If tooltips are hidden via {@link TooltipDisplay} and the tooltip is not
+     * being rendered in creative mode, an empty list is returned.</p>
+     *
+     * @param context the tooltip context
+     * @param player the player viewing the tooltip, or {@code null}
+     * @param flag controls tooltip verbosity and advanced information
+     * @return a list of tooltip components, possibly empty
+     */
+    public List<Component> getTooltipLines(Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {
+        TooltipDisplay tooltipdisplay = this.getOrDefault(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.DEFAULT);
+        if (!flag.isCreative() && tooltipdisplay.hideTooltip()) {
+            return List.of();
+        } else {
+            Fluid fluid = getFluid();
+            List<Component> list = Lists.newArrayList();
+            list.add(this.getStyledHoverName());
+            fluid.appendTooltip(this, list, context, player, flag);
+            EventHooks.onFluidTooltip(this, player, list, flag, context);
+            if (flag.isAdvanced()) {
+                list.add(Component.literal(BuiltInRegistries.FLUID.getKey(fluid).toString()).withStyle(ChatFormatting.DARK_GRAY));
+            }
+            return list;
+        }
+    }
+
+    /**
+     * Returns the styled hover name for this fluid stack.
+     *
+     * <p>The returned component applies the fluid's rarity styling and mirrors
+     * {@link ItemStack#getStyledHoverName()} semantics. If the stack has a custom
+     * name, the name is additionally rendered in italics.</p>
+     *
+     * @return the styled hover name component
+     */
+    public Component getStyledHoverName() {
+        MutableComponent mutablecomponent = Component.empty()
+            .append(this.getHoverName())
+            .withStyle(getRarity().getStyleModifier());
+        if (this.has(DataComponents.CUSTOM_NAME)) {
+            mutablecomponent.withStyle(ChatFormatting.ITALIC);
+        }
+        return mutablecomponent;
+    }
+
+    /**
+     * Returns the effective rarity of this fluid stack.
+     *
+     * <p>The base rarity is read from {@link DataComponents#RARITY}. If the stack
+     * has enchantments present, the rarity is promoted in the same manner as
+     * {@link ItemStack#getRarity()}:</p>
+     *
+     * @return the computed rarity of this fluid stack
+     */
+    public Rarity getRarity() {
+        Rarity rarity = this.getOrDefault(DataComponents.RARITY, Rarity.COMMON);
+        if (this.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY).isEmpty()) {
+            return rarity;
+        } else {
+            return switch (rarity) {
+                case COMMON, UNCOMMON -> Rarity.RARE;
+                case RARE -> Rarity.EPIC;
+                default -> rarity;
+            };
+        }
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -365,10 +365,10 @@ public final class FluidStack implements MutableDataComponentHolder {
      *
      * <p>The tooltip consists of:
      * <ul>
-     *   <li>The styled hover name</li>
-     *   <li>Additional lines provided by the fluid itself</li>
-     *   <li>Lines added by {@link EventHooks#onFluidTooltip}</li>
-     *   <li>The registry name when advanced tooltips are enabled</li>
+     * <li>The styled hover name</li>
+     * <li>Additional lines provided by the fluid itself</li>
+     * <li>Lines added by {@link EventHooks#onFluidTooltip}</li>
+     * <li>The registry name when advanced tooltips are enabled</li>
      * </ul>
      * </p>
      *
@@ -376,8 +376,8 @@ public final class FluidStack implements MutableDataComponentHolder {
      * being rendered in creative mode, an empty list is returned.</p>
      *
      * @param context the tooltip context
-     * @param player the player viewing the tooltip, or {@code null}
-     * @param flag controls tooltip verbosity and advanced information
+     * @param player  the player viewing the tooltip, or {@code null}
+     * @param flag    controls tooltip verbosity and advanced information
      * @return a list of tooltip components, possibly empty
      */
     public List<Component> getTooltipLines(Item.TooltipContext context, @Nullable Player player, TooltipFlag flag) {
@@ -408,8 +408,8 @@ public final class FluidStack implements MutableDataComponentHolder {
      */
     public Component getStyledHoverName() {
         MutableComponent mutablecomponent = Component.empty()
-            .append(this.getHoverName())
-            .withStyle(getRarity().getStyleModifier());
+                .append(this.getHoverName())
+                .withStyle(getRarity().getStyleModifier());
         if (this.has(DataComponents.CUSTOM_NAME)) {
             mutablecomponent.withStyle(ChatFormatting.ITALIC);
         }

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -392,6 +392,10 @@ public final class FluidStack implements MutableDataComponentHolder {
             EventHooks.onFluidTooltip(this, player, list, flag, context);
             if (flag.isAdvanced()) {
                 list.add(Component.literal(BuiltInRegistries.FLUID.getKey(fluid).toString()).withStyle(ChatFormatting.DARK_GRAY));
+                int componentCount = this.components.size();
+                if (componentCount > 0) {
+                    list.add(Component.translatable("item.components", componentCount).withStyle(ChatFormatting.DARK_GRAY));
+                }
             }
             return list;
         }

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -388,7 +388,7 @@ public final class FluidStack implements MutableDataComponentHolder {
             Fluid fluid = getFluid();
             List<Component> list = Lists.newArrayList();
             list.add(this.getStyledHoverName());
-            fluid.appendTooltip(this, list, context, player, flag);
+            fluid.appendHoverText(this, list, context, player, flag);
             EventHooks.onFluidTooltip(this, player, list, flag, context);
             if (flag.isAdvanced()) {
                 list.add(Component.literal(BuiltInRegistries.FLUID.getKey(fluid).toString()).withStyle(ChatFormatting.DARK_GRAY));


### PR DESCRIPTION
Many mods display `FluidStack`s in GUIs, often shown in machine tanks or guides.
There is no real unified set of information that gets displayed in the tooltips, and no clean way for mods to adjust what gets shown.

This PR adds a standard tooltip for `FluidStack`, allows `Fluid` to append to it, and fires an event for any mod to edit the tooltips. All of these are closely modeled after `ItemStack`.