### PR TITLE
Eagerly Report Mod Construction Errors

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -406,3 +406,19 @@
              boolean includeData = this.hasControlDown();
              switch (this.hitResult) {
                  case BlockHitResult blockHitResult:
+@@ -2393,7 +_,14 @@
+         systemReport.setDetail("Backend API", RenderSystem::getApiDescription);
+         systemReport.setDetail("Window size", () -> minecraft != null ? minecraft.window.getWidth() + "x" + minecraft.window.getHeight() : "<not initialized>");
+         systemReport.setDetail("GFLW Platform", Window::getPlatform);
+-        systemReport.setDetail("Render Extensions", () -> String.join(", ", RenderSystem.getDevice().getEnabledExtensions()));
++        systemReport.setDetail("Render Extensions", () -> {
++            GpuDevice device = RenderSystem.tryGetDevice();
++            if (device == null) {
++                return "<no renderer available>";
++            } else {
++                return String.join(", ", device.getEnabledExtensions());
++            }
++        });
+         systemReport.setDetail("GL debug messages", () -> {
+             GpuDevice device = RenderSystem.tryGetDevice();
+             if (device == null) {

--- a/patches/net/minecraft/client/main/Main.java.patch
+++ b/patches/net/minecraft/client/main/Main.java.patch
@@ -41,3 +41,17 @@
                  ),
                  new GameConfig.QuickPlayData(quickPlayLogPath, quickPlayVariant)
              );
+@@ -197,8 +_,11 @@
+             CrashReportCategory initialization = report.addCategory("Initialization");
+             NativeModuleLister.addCrashSection(initialization);
+             Minecraft.fillReport(null, null, launchedVersion, null, report);
+-            Minecraft.crash(null, gameDir, report);
+-            return;
++            // Neo: Instead of crash(...), we show the error immediately using our earlydisplay GUI
++            int exitCode = Minecraft.saveReport(gameDir, report);
++            net.neoforged.fml.startup.FatalErrorReporting.reportFatalError(var75);
++            System.exit(exitCode);
++            return; // Neo: Rethrow to let early error screen handle it
+         }
+ 
+         Thread shutdownThread = new Thread("Client Shutdown Thread") {

--- a/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
@@ -53,11 +53,12 @@ public class ClientModLoader extends CommonModLoader {
         loading = true;
         LanguageHook.loadBuiltinLanguages();
 
+        Runnable periodicTick = earlyLoadingScreen != null ? earlyLoadingScreen::periodicTick : () -> {};
         try {
-            Runnable periodicTick = earlyLoadingScreen != null ? earlyLoadingScreen::periodicTick : () -> {};
             begin(periodicTick, false);
         } catch (ModLoadingException e) {
-            error = e;
+            CrashReportExtender.dumpModLoadingCrashReport(LOGGER, e.getIssues(), new File("."));
+            throw e; // Rethrow so the early error screen can take over
         }
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/loading/ClientModLoader.java
@@ -54,12 +54,7 @@ public class ClientModLoader extends CommonModLoader {
         LanguageHook.loadBuiltinLanguages();
 
         Runnable periodicTick = earlyLoadingScreen != null ? earlyLoadingScreen::periodicTick : () -> {};
-        try {
-            begin(periodicTick, false);
-        } catch (ModLoadingException e) {
-            CrashReportExtender.dumpModLoadingCrashReport(LOGGER, e.getIssues(), new File("."));
-            throw e; // Rethrow so the early error screen can take over
-        }
+        begin(periodicTick, false);
     }
 
     public static void finish(final PackRepository defaultResourcePacks, final ReloadableResourceManager mcResourceManager) {


### PR DESCRIPTION
This adds reporting of errors using the earlydisplay error screen when they occur between the startup of Minecraft and before the `Minecraft` class is created.

Since we previously would crash on creation of the crash report when Blaze3D wasn't initialized yet, this also fixes that.

note: We have to change the FML API to allow us to pass the path to the crash report along.