### PR TITLE
New (and old) features for GameTestHelper

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/GameTestHelperExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/GameTestHelperExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.Entity;
+import net.neoforged.neoforge.capabilities.BlockCapability;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Additional functionality for {@link net.minecraft.gametest.framework.GameTestHelper}
+ */
+public interface GameTestHelperExtension {
+    private GameTestHelper self() {
+        return (GameTestHelper) this;
+    }
+
+    /**
+     * Same as {@link GameTestHelper#fail(Component, BlockPos)}, but for untranslated messages.
+     */
+    default void fail(String message, BlockPos pos) {
+        self().fail(Component.literal(message), pos);
+    }
+
+    /**
+     * Same as {@link GameTestHelper#fail(Component, Entity)}, but for untranslated messages.
+     */
+    default void fail(String message, Entity entity) {
+        self().fail(Component.literal(message), entity);
+    }
+
+    /**
+     * Gets a capability from the given relative position with the given context.
+     */
+    @Nullable
+    default <T, C extends @Nullable Object> T getCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
+        return self().getLevel().getCapability(cap, self().absolutePos(pos), context);
+    }
+
+    /**
+     * Gets a capability from the given relative position and fails the test, if it does not exist.
+     */
+    default <T, C extends @Nullable Object> T requireCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
+        var capability = getCapability(cap, pos, context);
+        if (capability == null) {
+            throw self().assertionException(pos, "Expected capability %s but there was none", cap);
+        }
+        return capability;
+    }
+}

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -317,5 +317,8 @@
   ],
   "net/minecraft/client/resources/model/EquipmentClientInfo$LayerType": [
     "net/neoforged/fml/common/asm/enumextension/IExtensibleEnum"
+  ],
+  "net/minecraft/gametest/framework/GameTestHelper": [
+    "net/neoforged/neoforge/common/extensions/GameTestHelperExtension"
   ]
 }

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -59,7 +59,6 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.Event;
-import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.util.FakePlayer;
 import net.neoforged.neoforge.event.entity.living.LivingKnockBackEvent;
@@ -184,19 +183,6 @@ public class ExtendedGameTestHelper extends GameTestHelper {
 
     public <T extends BlockEntity> T getBlockEntity(int x, int y, int z, Class<T> type) {
         return getBlockEntity(new BlockPos(x, y, z), type);
-    }
-
-    @Nullable
-    public <T, C extends @Nullable Object> T getCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
-        return getLevel().getCapability(cap, absolutePos(pos), context);
-    }
-
-    public <T, C extends @Nullable Object> T requireCapability(BlockCapability<T, C> cap, BlockPos pos, C context) {
-        final var capability = getCapability(cap, pos, context);
-        if (capability == null) {
-            throw this.assertionException(pos, "Expected capability %s but there was none", cap);
-        }
-        return capability;
     }
 
     public <T> ParametrizedGameTestSequence<T> startSequence(Supplier<T> value) {
@@ -362,14 +348,6 @@ public class ExtendedGameTestHelper extends GameTestHelper {
 
     public void assertNotNull(@Nullable Object var, String message) {
         this.assertTrue(var != null, message);
-    }
-
-    public void fail(String message) {
-        this.fail(Component.translatable(message));
-    }
-
-    public void fail(String message, BlockPos pos) {
-        this.fail(Component.translatable(message), pos);
     }
 
     public void assertBlock(BlockPos pos, Predicate<Block> predicate, String message) {


### PR DESCRIPTION
Introduces an extension interface for `GameTestHelper` which adds the following features:

- Adds back `fail(String, BlockPos)` and `fail(String, Entity)`
- Moves `getCapability` and `getRequiredCapability` from the testframeworks ExtendedGameTestHelper since those are basic NeoForge concepts that mods may want to access in their tests regardles of testframework use.

Note to reviewers: `fail(String)` is present in Vanilla, that's why I removed it from ExtendedGameTestHelper. It's redundant.