### PR TITLE
Add support for AutoInstallation when using a client.

### DIFF
--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -357,11 +357,31 @@ public class NeoDevPlugin implements Plugin<Project> {
         });
 
         var createWindowsServerArgsFile = tasks.register("createWindowsServerArgsFile", CreateArgsFile.class, task -> {
-            task.setLibraries(";", configurations.launcherProfileClasspath);
+            task.addLibraries(configurations.launcherProfileClasspath);
+            task.getLibraryFiles().add(
+                    neoForgeVersion.zip(universalJar.map(AbstractArchiveTask::getArchiveFile), (version, file) -> {
+                        final IdentifiedFile f = project.getObjects().newInstance(IdentifiedFile.class);
+                        f.getIdentifier().set(
+                                MavenIdentifier.parse("net.neoforged:neoforge:%s:universal".formatted(version)));
+                        f.getFile().set(file);
+                        return f;
+                    }));
+
+            task.getPathSeparator().set(";");
             task.getArgsFile().set(neoDevBuildDir.map(dir -> dir.file("windows-server-args.txt")));
         });
         var createUnixServerArgsFile = tasks.register("createUnixServerArgsFile", CreateArgsFile.class, task -> {
-            task.setLibraries(":", configurations.launcherProfileClasspath);
+            task.addLibraries(configurations.launcherProfileClasspath);
+            task.getLibraryFiles().add(
+                    neoForgeVersion.zip(universalJar.map(AbstractArchiveTask::getArchiveFile), (version, file) -> {
+                        final IdentifiedFile f = project.getObjects().newInstance(IdentifiedFile.class);
+                        f.getIdentifier().set(
+                                MavenIdentifier.parse("net.neoforged:neoforge:%s:universal".formatted(version)));
+                        f.getFile().set(file);
+                        return f;
+                    }));
+
+            task.getPathSeparator().set(":");
             task.getArgsFile().set(neoDevBuildDir.map(dir -> dir.file("unix-server-args.txt")));
         });
 
@@ -369,9 +389,6 @@ public class NeoDevPlugin implements Plugin<Project> {
             taskProvider.configure(task -> {
                 task.setGroup(INTERNAL_GROUP);
                 task.getTemplate().set(project.getRootProject().file("server_files/args.txt"));
-                task.getMinecraftVersion().set(minecraftVersion);
-                task.getNeoForgeVersion().set(neoForgeVersion);
-                task.getRawNeoFormVersion().set(rawNeoFormVersion);
                 task.getRawServerJar().set(createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawServerJar));
             });
         }

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -23,6 +23,7 @@ import net.neoforged.neodev.installer.CreateLauncherProfile;
 import net.neoforged.neodev.installer.IdentifiedFile;
 import net.neoforged.neodev.installer.InstallerProcessor;
 import net.neoforged.neodev.utils.DependencyUtils;
+import net.neoforged.neodev.utils.MavenIdentifier;
 import net.neoforged.nfrtgradle.CreateMinecraftArtifacts;
 import net.neoforged.nfrtgradle.DownloadAssets;
 import net.neoforged.nfrtgradle.NeoFormRuntimePlugin;
@@ -474,6 +475,7 @@ public class NeoDevPlugin implements Plugin<Project> {
                 configurations,
                 downloadAssets,
                 installerJar,
+                universalJar,
                 minecraftVersion,
                 neoForgeVersion,
                 createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawClientJar));
@@ -710,6 +712,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             NeoDevConfigurations configurations,
             TaskProvider<? extends DownloadAssets> downloadAssets,
             TaskProvider<? extends AbstractArchiveTask> installer,
+            TaskProvider<Jar> universalJar,
             Provider<String> minecraftVersion,
             Provider<String> neoForgeVersion,
             Provider<RegularFile> originalClientJar) {
@@ -725,6 +728,15 @@ public class NeoDevPlugin implements Plugin<Project> {
         Consumer<RunProductionClient> configureRunProductionClient = task -> {
             task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(project, configurations.neoFormClasspath));
             task.getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(project, configurations.launcherProfileClasspath));
+            task.getLibraryFiles().add(
+                    neoForgeVersion.zip(universalJar.map(AbstractArchiveTask::getArchiveFile), (version, file) -> {
+                        final IdentifiedFile f = project.getObjects().newInstance(IdentifiedFile.class);
+                        f.getIdentifier().set(
+                                MavenIdentifier.parse("net.neoforged:neoforge:%s:universal".formatted(version)));
+                        f.getFile().set(file);
+                        return f;
+                    }));
+
             task.getAssetPropertiesFile().set(downloadAssets.flatMap(DownloadAssets::getAssetPropertiesFile));
             task.getMinecraftVersion().set(minecraftVersion);
             task.getNeoForgeVersion().set(neoForgeVersion);

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -388,6 +388,7 @@ public class NeoDevPlugin implements Plugin<Project> {
         for (var taskProvider : List.of(createWindowsServerArgsFile, createUnixServerArgsFile)) {
             taskProvider.configure(task -> {
                 task.setGroup(INTERNAL_GROUP);
+                task.getMinecraftVersion().set(minecraftVersion);
                 task.getTemplate().set(project.getRootProject().file("server_files/args.txt"));
                 task.getRawServerJar().set(createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawServerJar));
             });

--- a/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/NeoDevPlugin.java
@@ -323,6 +323,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.setMinecraftLibraries(configurations.minecraftClientClasspath);
             task.getRepositoryURLs().set(installerRepositoryUrls);
             task.getLauncherProfile().set(neoDevBuildDir.map(dir -> dir.file("launcher-profile.json")));
+            task.getUniversalJar().set(universalJar.flatMap(Jar::getArchiveFile));
         });
 
         // Installer profile = the .json file used by the NeoForge installer.
@@ -538,7 +539,7 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.setGroup(INTERNAL_GROUP);
             task.classpath(binpatcherConfig);
 
-            task.getBaseClientJar().set(clientBaseJar);
+            task.getBaseClientJar().set(createCleanArtifacts.flatMap(CreateCleanArtifacts::getRawClientJar));
             task.getModifiedClientJar().set(clientModifiedJar);
             task.getBaseServerJar().set(serverBaseJar);
             task.getModifiedServerJar().set(serverModifiedJar);
@@ -547,6 +548,8 @@ public class NeoDevPlugin implements Plugin<Project> {
             task.getModifiedJoinedJar().set(clientModifiedJar);
             task.getInclude().add("**/*.class");
             task.getInclude().add("META-INF/neoforge.mods.toml");
+            task.getInclude().add("META-INF/MANIFEST.MF");
+            task.getInclude().add("META-INF/*.SF");
 
             task.getOutputFile().set(neoDevBuildDir.map(dir -> dir.file("patches.lzma")));
         });

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateArgsFile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateArgsFile.java
@@ -43,6 +43,9 @@ public abstract class CreateArgsFile extends DefaultTask {
     @InputFile
     public abstract RegularFileProperty getRawServerJar();
 
+    @Input
+    public abstract Property<String> getMinecraftVersion();
+
     @OutputFile
     public abstract RegularFileProperty getArgsFile();
 
@@ -76,7 +79,11 @@ public abstract class CreateArgsFile extends DefaultTask {
                 .filter(path -> path.startsWith("libraries/"))
                 .collect(Collectors.joining(getPathSeparator().get()));
 
-        return ourClasspath + getPathSeparator().get() + filteredServerClasspath;
+        return ourClasspath + getPathSeparator().get() + getServerJarPath() + getPathSeparator().get() + filteredServerClasspath;
+    }
+
+    private String getServerJarPath() {
+        return "libraries/net/minecraft/server/" + getMinecraftVersion().get() + "/server-" + getMinecraftVersion().get() + ".jar";
     }
 
     // Example:

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateArgsFile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateArgsFile.java
@@ -8,14 +8,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
-import net.neoforged.neodev.utils.DependencyUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -30,23 +31,13 @@ public abstract class CreateArgsFile extends DefaultTask {
     public abstract RegularFileProperty getTemplate();
 
     @Input
-    public abstract Property<String> getMinecraftVersion();
+    public abstract Property<String> getPathSeparator();
 
-    @Input
-    public abstract Property<String> getNeoForgeVersion();
+    @Nested
+    public abstract ListProperty<IdentifiedFile> getLibraryFiles();
 
-    @Input
-    public abstract Property<String> getRawNeoFormVersion();
-
-    @Input
-    protected abstract Property<String> getPathSeparator();
-
-    @Input
-    protected abstract Property<String> getClasspath();
-
-    public void setLibraries(String separator, Configuration classpath) {
-        getPathSeparator().set(separator);
-        getClasspath().set(DependencyUtils.configurationToClasspath(classpath, "libraries/", separator));
+    public void addLibraries(Configuration libraries) {
+        getLibraryFiles().addAll(IdentifiedFile.listFromConfiguration(getProject(), libraries));
     }
 
     @InputFile
@@ -58,8 +49,16 @@ public abstract class CreateArgsFile extends DefaultTask {
     @Inject
     protected abstract ArchiveOperations getArchiveOperations();
 
+    private String buildOurClasspath() {
+        return getLibraryFiles().get()
+                .stream()
+                .map(library -> library.getIdentifier().get().repositoryPath())
+                .map(path -> "libraries/" + path)
+                .collect(Collectors.joining(getPathSeparator().get()));
+    }
+
     private String resolveClasspath() throws IOException {
-        var ourClasspath = getClasspath().get();
+        var ourClasspath = buildOurClasspath();
 
         // The raw server jar also contains its own classpath.
         // We want to make sure that our versions of the libraries are used when there is a conflict.
@@ -92,9 +91,6 @@ public abstract class CreateArgsFile extends DefaultTask {
     public void createArgsFile() throws IOException {
         var replacements = new HashMap<String, String>();
         replacements.put("@CLASS_PATH@", resolveClasspath());
-        replacements.put("@FORGE_VERSION@", getNeoForgeVersion().get());
-        replacements.put("@MC_VERSION@", getMinecraftVersion().get());
-        replacements.put("@MCP_VERSION@", getRawNeoFormVersion().get());
 
         var contents = Files.readString(getTemplate().get().getAsFile().toPath());
         for (var entry : replacements.entrySet()) {

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
@@ -115,7 +115,6 @@ public abstract class CreateInstallerProfile extends DefaultTask {
         data.put("MCP_VERSION", new LauncherDataEntry(String.format("'%s'", neoFormVersion), String.format("'%s'", neoFormVersion)));
 
         var processors = new ArrayList<ProcessorEntry>();
-        BiConsumer<InstallerProcessor, List<String>> commonProcessor = (processor, args) -> addProcessor(processors, null, processor, args);
         BiConsumer<InstallerProcessor, List<String>> serverProcessor = (processor, args) -> addProcessor(processors, List.of("server"), processor, args);
 
         serverProcessor.accept(InstallerProcessor.INSTALLERTOOLS,
@@ -126,7 +125,7 @@ public abstract class CreateInstallerProfile extends DefaultTask {
                         "--from", "data/win_args.txt", "--to", "{ROOT}/libraries/net/neoforged/neoforge/%s/win_args.txt".formatted(getNeoForgeVersion().get()),
                         "--from", "data/unix_args.txt", "--to", "{ROOT}/libraries/net/neoforged/neoforge/%s/unix_args.txt".formatted(getNeoForgeVersion().get())));
 
-        commonProcessor.accept(
+        serverProcessor.accept(
                 InstallerProcessor.INSTALLERTOOLS,
                 List.of(
                         "--task",

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateInstallerProfile.java
@@ -109,9 +109,8 @@ public abstract class CreateInstallerProfile extends DefaultTask {
         var neoFormVersion = getMcAndNeoFormVersion().get();
         data.put("BINPATCH", new LauncherDataEntry("/data/client.lzma", "/data/client.lzma"));
 
-        var patchedClientCoordinate = new MavenIdentifier("net.neoforged", "minecraft-client-patched", getNeoForgeVersion().get(), "", "jar");
-        var patchedServerCoordinate = new MavenIdentifier("net.neoforged", "minecraft-server-patched", getNeoForgeVersion().get(), "", "jar");
-        data.put("PATCHED", new LauncherDataEntry(patchedClientCoordinate, patchedServerCoordinate));
+        var serverCoordinate = new MavenIdentifier("net.minecraft", "server", getMinecraftVersion().get(), "", "jar");
+        data.put("ORIGINAL_SERVER", new LauncherDataEntry(serverCoordinate, serverCoordinate));
         data.put("MCP_VERSION", new LauncherDataEntry(String.format("'%s'", neoFormVersion), String.format("'%s'", neoFormVersion)));
 
         var processors = new ArrayList<ProcessorEntry>();
@@ -134,11 +133,9 @@ public abstract class CreateInstallerProfile extends DefaultTask {
                         "--input",
                         "{MINECRAFT_JAR}",
                         "--output",
-                        "{PATCHED}",
+                        "{ORIGINAL_SERVER}",
                         "--extract-libraries-to",
-                        "{ROOT}/libraries/",
-                        "--apply-patches",
-                        "{BINPATCH}"));
+                        "{ROOT}/libraries/"));
 
         getLogger().info("Collecting libraries for Installer Profile");
         // Remove potential duplicates.

--- a/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateLauncherProfile.java
+++ b/buildSrc/src/main/java/net/neoforged/neodev/installer/CreateLauncherProfile.java
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -69,6 +71,9 @@ public abstract class CreateLauncherProfile extends DefaultTask {
     @OutputFile
     public abstract RegularFileProperty getLauncherProfile();
 
+    @InputFile
+    public abstract RegularFileProperty getUniversalJar();
+
     @TaskAction
     public void createLauncherProfile() throws IOException {
         var time = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
@@ -101,7 +106,19 @@ public abstract class CreateLauncherProfile extends DefaultTask {
             }
         });
 
-        var libraries = LibraryCollector.resolveLibraries(getRepositoryURLs().get(), libraryFiles);
+        var libraries = new ArrayList<>(LibraryCollector.resolveLibraries(getRepositoryURLs().get(), libraryFiles));
+        var universalJar = getUniversalJar().getAsFile().get().toPath();
+        libraries.add(new Library(
+                "net.neoforged:neoforge:%s:universal".formatted(getNeoForgeVersion().get()),
+                new LibraryDownload(new LibraryArtifact(
+                        LibraryCollector.sha1Hash(universalJar),
+                        Files.size(universalJar),
+                        "https://maven.neoforged.net/releases/net/neoforged/neoforge/%s/neoforge-%s-universal.jar".formatted(
+                                getNeoForgeVersion().get(),
+                                getNeoForgeVersion().get()),
+                        "net/neoforged/neoforge/%s/neoforge-%s-universal.jar".formatted(
+                                getNeoForgeVersion().get(),
+                                getNeoForgeVersion().get())))));
 
         var gameArguments = new ArrayList<>(List.of(
                 "--fml.neoForgeVersion", getNeoForgeVersion().get(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=11.0.0
+fancy_mod_loader_version=11.0.26-pr-383-feature-autoinstall
 typetools_version=0.6.3
 mixin_extras_version=0.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=11.0.26-pr-383-feature-autoinstall
+fancy_mod_loader_version=11.0.31-pr--
 typetools_version=0.6.3
 mixin_extras_version=0.5.0
 

--- a/server_files/args.txt
+++ b/server_files/args.txt
@@ -5,6 +5,3 @@
 -classpath
 @CLASS_PATH@
 net.neoforged.fml.startup.Server
---fml.neoForgeVersion @FORGE_VERSION@
---fml.mcVersion @MC_VERSION@
---fml.neoFormVersion @MCP_VERSION@

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,16 @@ dependencyResolutionManagement {
     rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
     repositories {
         mavenCentral()
+
+        maven {
+            name = "Maven for PR #383" // https://github.com/neoforged/FancyModLoader/pull/383
+            url = uri("https://prmaven.neoforged.net/FancyModLoader/pr383")
+            content {
+                includeModule("net.neoforged.fancymodloader", "earlydisplay")
+                includeModule("net.neoforged.fancymodloader", "junit-fml")
+                includeModule("net.neoforged.fancymodloader", "loader")
+            }
+        }
     }
 }
 

--- a/src/main/templates/version.properties
+++ b/src/main/templates/version.properties
@@ -2,3 +2,4 @@ neoforge_version=${version}
 neoform_version=${minecraft_version}-${neoform_version}
 minecraft_version=${minecraft_version}
 build_type=${build_type}
+autoinstall_patches=net/neoforged/neoforge/common/patches.lzma


### PR DESCRIPTION
## Changes:
- Binary patch base for client distributions is set to the raw client.
- Update FML to the new AutoInstallation variant
- Remove all common and client processors from the installation
- Add the universal jar as a Library
- Set the auto install patches in our version properties file