### PR TITLE
Fix RenderNameTagEvent.CanRender not being posted to event bus

### DIFF
--- a/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -25,12 +25,13 @@
          p_361028_.ageInTicks = p_362104_.tickCount + p_362204_;
          p_361028_.boundingBoxWidth = p_362104_.getBbWidth();
          p_361028_.boundingBoxHeight = p_362104_.getBbHeight();
-@@ -184,9 +_,10 @@
+@@ -184,9 +_,11 @@
  
          if (this.entityRenderDispatcher.camera != null) {
              p_361028_.distanceToCameraSq = this.entityRenderDispatcher.distanceToSqr(p_362104_);
 -            boolean flag1 = p_361028_.distanceToCameraSq < 4096.0 && this.shouldShowName(p_362104_, p_361028_.distanceToCameraSq);
 +            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.CanRender(p_362104_, p_361028_, this.getNameTag(p_362104_), this, p_362204_);
++            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
 +            boolean flag1 = event.canRender().isTrue() || (event.canRender().isDefault() && p_361028_.distanceToCameraSq < 4096.0 && this.shouldShowName(p_362104_, p_361028_.distanceToCameraSq));
              if (flag1) {
 -                p_361028_.nameTag = this.getNameTag(p_362104_);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
@@ -44,6 +44,7 @@ import net.neoforged.neoforge.client.event.ClientPlayerChangeGameTypeEvent;
 import net.neoforged.neoforge.client.event.RegisterRenderBuffersEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
 import net.neoforged.neoforge.client.event.RenderLivingEvent;
+import net.neoforged.neoforge.client.event.RenderNameTagEvent;
 import net.neoforged.neoforge.client.event.RenderPlayerEvent;
 import net.neoforged.neoforge.client.renderstate.RegisterRenderStateModifiersEvent;
 import net.neoforged.neoforge.common.NeoForge;
@@ -240,6 +241,15 @@ public class ClientEventTests {
                         });
                     });
                 }
+            });
+        });
+    }
+
+    @TestHolder(description = { "Test RenderNameTagEvent.CanRender is called" })
+    static void nameTagCanRender(final DynamicTest test) {
+        test.whenEnabled(listeners -> {
+            listeners.forge().addListener((final RenderNameTagEvent.CanRender canRenderEvent) -> {
+                test.pass();
             });
         });
     }


### PR DESCRIPTION
The event was broken in 2fe541ad0a7bc1c1851f1812ec6df017546e6a15 where the EVENT_BUS.post() call was accidentally removed. This restores the event posting so listeners can receive the event again.

Added a test to verify the event is fired correctly.