### PR TITLE
[1.21.11] Fix addToTooltip extension inconsistency

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -138,6 +138,14 @@
          if (this.has(DataComponents.CUSTOM_NAME)) {
              mutablecomponent.withStyle(ChatFormatting.ITALIC);
          }
+@@ -840,6 +_,7 @@
+         return mutablecomponent;
+     }
+ 
++    @Override // Neo: Add override annotation to ensure our extension method signature always matches vanilla
+     public <T extends TooltipProvider> void addToTooltip(
+         DataComponentType<T> p_331344_, Item.TooltipContext p_341231_, TooltipDisplay p_399720_, Consumer<Component> p_331885_, TooltipFlag p_331177_
+     ) {
 @@ -858,6 +_,7 @@
              List<Component> list = Lists.newArrayList();
              list.add(this.getStyledHoverName());

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IDataComponentHolderExtension.java
@@ -12,6 +12,7 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.item.component.TooltipProvider;
 
 public interface IDataComponentHolderExtension {
@@ -19,14 +20,15 @@ public interface IDataComponentHolderExtension {
         return (DataComponentHolder) this;
     }
 
-    default <T extends TooltipProvider> void addToTooltip(DataComponentType<T> type, Item.TooltipContext context, Consumer<Component> adder, TooltipFlag flag) {
+    default <T extends TooltipProvider> void addToTooltip(DataComponentType<T> type, Item.TooltipContext context, TooltipDisplay display, Consumer<Component> adder, TooltipFlag flag) {
         var value = self().get(type);
 
-        if (value != null)
+        if (value != null && display.shows(type)) {
             value.addToTooltip(context, adder, flag, self());
+        }
     }
 
-    default <T extends TooltipProvider> void addToTooltip(Supplier<? extends DataComponentType<T>> type, Item.TooltipContext context, Consumer<Component> adder, TooltipFlag flag) {
-        addToTooltip(type.get(), context, adder, flag);
+    default <T extends TooltipProvider> void addToTooltip(Supplier<? extends DataComponentType<T>> type, Item.TooltipContext context, TooltipDisplay display, Consumer<Component> adder, TooltipFlag flag) {
+        addToTooltip(type.get(), context, display, adder, flag);
     }
 }


### PR DESCRIPTION
This pr fixes a small inconsistency with our component holder `addToTooltip` extension methods.

Vanilla passes around the `TooltipDisplay` properties to tooltip providers and uses this to determine which providers should and should be appended to the finalized tooltip, our extension methods currently do not take in the display properties causing them to ignore component tooltip visibility settings.

I have also added the `@Override` annotation to `ItemStack.addToTooltip` as compile time test to try and ensure this inconsistency does not happen again.

Currently this pr is implemented as a breaking change due to method signatures changing but if desired i can easily add back the old overloads without `TooltipDisplay` (and mark them for removal in 21.6) by looking up the display properties within `addToTooltip`s body. This is not technically correct however as some users may want to pass around a custom set of display properties rather than falling back to the data component.