### PR TITLE
Defer BlockEntity attachment syncing to match the usual BE sync timing

### DIFF
--- a/patches/net/minecraft/server/level/ChunkHolder.java.patch
+++ b/patches/net/minecraft/server/level/ChunkHolder.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/server/level/ChunkHolder.java
++++ b/net/minecraft/server/level/ChunkHolder.java
+@@ -230,6 +_,7 @@
+             if (packet != null) {
+                 this.broadcast(players, packet);
+             }
++            net.neoforged.neoforge.attachment.AttachmentSync.syncBlockEntityUpdates(blockEntity, players);
+         }
+     }
+ 

--- a/patches/net/minecraft/world/level/block/entity/BlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BlockEntity.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/BlockEntity.java
-@@ -39,15 +_,18 @@
+@@ -39,15 +_,20 @@
  import org.jspecify.annotations.Nullable;
  import org.slf4j.Logger;
  
@@ -17,6 +17,8 @@
      private DataComponentMap components = DataComponentMap.EMPTY;
 +    @Nullable
 +    private CompoundTag customPersistentData;
++    @Nullable
++    private Set<net.neoforged.neoforge.attachment.AttachmentType<?>> attachmentTypesToSync;
  
      public BlockEntity(BlockEntityType<?> type, BlockPos worldPosition, BlockState blockState) {
          this.type = type;
@@ -65,7 +67,7 @@
      }
  
      public void preRemoveSideEffects(BlockPos pos, BlockState state) {
-@@ -272,6 +_,32 @@
+@@ -272,6 +_,48 @@
  
      public BlockEntityType<?> getType() {
          return this.type;
@@ -94,7 +96,23 @@
 +
 +    @Override
 +    public final void syncData(net.neoforged.neoforge.attachment.AttachmentType<?> type) {
-+        net.neoforged.neoforge.attachment.AttachmentSync.syncBlockEntityUpdate(this, type);
++        if (!(level instanceof ServerLevel serverLevel)) {
++            return;
++        }
++        if (attachmentTypesToSync == null) {
++            attachmentTypesToSync = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
++        }
++        attachmentTypesToSync.add(type);
++        // Schedule the BE for syncing
++        serverLevel.getChunkSource().blockChanged(worldPosition);
++    }
++
++    @Nullable
++    @org.jetbrains.annotations.ApiStatus.Internal
++    public final Set<net.neoforged.neoforge.attachment.AttachmentType<?>> getAndClearAttachmentTypesToSync() {
++        var ret = attachmentTypesToSync;
++        attachmentTypesToSync = null;
++        return ret;
      }
  
      @Override

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
@@ -20,7 +20,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -111,11 +110,18 @@ public final class AttachmentSync {
         }
     }
 
-    public static void syncBlockEntityUpdate(BlockEntity blockEntity, AttachmentType<?> type) {
-        if (type.syncHandler == null || !(blockEntity.getLevel() instanceof ServerLevel serverLevel)) {
+    public static void syncBlockEntityUpdates(BlockEntity blockEntity, List<ServerPlayer> players) {
+        var toSync = blockEntity.getAndClearAttachmentTypesToSync();
+        if (toSync == null) {
             return;
         }
-        syncUpdate(blockEntity, type, serverLevel.getChunkSource().chunkMap.getPlayers(ChunkPos.containing(blockEntity.getBlockPos()), false));
+        // For now, we send one packet per attachment type. In the future, consider bundling all the updates in a single packet.
+        for (var type : toSync) {
+            if (type.syncHandler == null) {
+                continue;
+            }
+            syncUpdate(blockEntity, type, players);
+        }
     }
 
     public static void syncChunkUpdate(LevelChunk chunk, AttachmentHolder.AsField holder, AttachmentType<?> type) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentSyncTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/attachment/AttachmentSyncTests.java
@@ -176,17 +176,22 @@ public class AttachmentSyncTests {
                     })
                     // Test that players receive updates for changes to block entities in tracked chunks
                     .thenExecute(() -> {
-                        var testValue = helper.randomInt();
+                        var testValue = 12345;
                         helper.setBlock(feetPos, Blocks.FURNACE);
                         var be = helper.getBlockEntity(feetPos, FurnaceBlockEntity.class);
                         be.setData(intAttachment, testValue);
-
+                    })
+                    // Wait for the BE to get synced
+                    .thenIdle(1)
+                    // Resume flushing after idling else packets won't get sent immediately
+                    .thenExecute(() -> player.connection.resumeFlushing())
+                    .thenExecute(() -> {
                         var payload = player.requireOutboundPayload(SyncAttachmentsPayload.class);
                         helper.expectTarget(payload, new SyncAttachmentsPayload.BlockEntityTarget(helper.absolutePos(feetPos)));
 
                         var holder = helper.holder();
                         holder.readFrom(payload);
-                        holder.assertEqual(intAttachment, testValue);
+                        holder.assertEqual(intAttachment, 12345);
 
                         player.clearOutboundPackets();
                     })

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/AttachmentSyncTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/AttachmentSyncTest.java
@@ -6,7 +6,10 @@
 package net.neoforged.neoforge.oldtest;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import java.util.function.Supplier;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.world.InteractionHand;
@@ -17,11 +20,16 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.attachment.IAttachmentHolder;
+import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 
@@ -42,10 +50,16 @@ public class AttachmentSyncTest {
         ITEMS.registerItem("tester_entity", EntityTester::new);
         ITEMS.registerItem("tester_level", LevelTester::new);
     }
+    private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MOD_ID);
+    private static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerBlock("test_block", TestBlock::new);
+    private static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_TYPES = DeferredRegister.create(Registries.BLOCK_ENTITY_TYPE, MOD_ID);
+    private static final Supplier<BlockEntityType<TestBlockEntity>> TEST_BLOCK_ENTITY_TYPE = BLOCK_ENTITY_TYPES.register("test_block", () -> new BlockEntityType<>(TestBlockEntity::new, TEST_BLOCK.get()));
 
     public AttachmentSyncTest(IEventBus modBus) {
         ATTACHMENT_TYPES.register(modBus);
         ITEMS.register(modBus);
+        BLOCKS.register(modBus);
+        BLOCK_ENTITY_TYPES.register(modBus);
     }
 
     /**
@@ -64,7 +78,7 @@ public class AttachmentSyncTest {
             Integer value = holder.getExistingDataOrNull(ATTACHMENT_TYPE);
             int newValue = value == null ? 1 : value + 1;
 
-            if (newValue == 5) {
+            if (newValue >= 5) {
                 holder.removeData(ATTACHMENT_TYPE);
             } else {
                 holder.setData(ATTACHMENT_TYPE, newValue);
@@ -141,6 +155,42 @@ public class AttachmentSyncTest {
         public InteractionResult use(Level level, Player player, InteractionHand hand) {
             testInteraction("level", player, level);
             return InteractionResult.SUCCESS_SERVER;
+        }
+    }
+
+    /// Block with a block entity that sets data attachments at unusual timings,
+    /// to test how robust data attachment sync is in those cases.
+    private static class TestBlock extends BaseEntityBlock {
+        public TestBlock(Properties properties) {
+            super(properties);
+        }
+
+        @Override
+        protected MapCodec<? extends BaseEntityBlock> codec() {
+            return simpleCodec(TestBlock::new);
+        }
+
+        @Override
+        public BlockEntity newBlockEntity(BlockPos worldPosition, BlockState blockState) {
+            return new TestBlockEntity(worldPosition, blockState);
+        }
+    }
+
+    private static class TestBlockEntity extends BlockEntity {
+        public TestBlockEntity(BlockPos worldPosition, BlockState blockState) {
+            super(TEST_BLOCK_ENTITY_TYPE.get(), worldPosition, blockState);
+        }
+
+        @Override
+        public void preRemoveSideEffects(BlockPos pos, BlockState state) {
+            super.preRemoveSideEffects(pos, state);
+            setData(ATTACHMENT_TYPE, 10);
+        }
+
+        @Override
+        public void setRemoved() {
+            super.setRemoved();
+            setData(ATTACHMENT_TYPE, 20);
         }
     }
 }


### PR DESCRIPTION
Instead of eagerly syncing block entity attachments, we store which attachment types need syncing, and we only send the update later, matching the timing of `BlockEntity#getUpdatePacket`. This fixes "unknown attachment" errors on the client when an attachment is updated on the server side on a block entity that was already deleted on the client, for example.

(I am planning on backporting this to 1.21.11 and 1.21.1 once it receives more testing in 26.1).