### PR TITLE
[1.21.11] Add `shears_efficient` tag

### DIFF
--- a/patches/net/minecraft/world/item/ShearsItem.java.patch
+++ b/patches/net/minecraft/world/item/ShearsItem.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/world/item/ShearsItem.java
 +++ b/net/minecraft/world/item/ShearsItem.java
+@@ -36,7 +_,9 @@
+                 Tool.Rule.minesAndDrops(HolderSet.direct(Blocks.COBWEB.builtInRegistryHolder()), 15.0F),
+                 Tool.Rule.overrideSpeed(holdergetter.getOrThrow(BlockTags.LEAVES), 15.0F),
+                 Tool.Rule.overrideSpeed(holdergetter.getOrThrow(BlockTags.WOOL), 5.0F),
+-                Tool.Rule.overrideSpeed(HolderSet.direct(Blocks.VINE.builtInRegistryHolder(), Blocks.GLOW_LICHEN.builtInRegistryHolder()), 2.0F)
++                Tool.Rule.overrideSpeed(HolderSet.direct(Blocks.VINE.builtInRegistryHolder(), Blocks.GLOW_LICHEN.builtInRegistryHolder()), 2.0F),
++                // Neo: Allow modded blocks be mined faster with shears
++                Tool.Rule.overrideSpeed(holdergetter.getOrThrow(net.neoforged.neoforge.common.Tags.Blocks.SHEARS_EFFICIENT), 5.0F)
+             ),
+             1.0F,
+             1,
 @@ -58,20 +_,57 @@
          }
      }

--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -129,6 +129,7 @@
   "tag.block.neoforge.needs_gold_tool": "Needs Gold Tools",
   "tag.block.neoforge.needs_netherite_tool": "Needs Netherite Tools",
   "tag.block.neoforge.needs_wood_tool": "Needs Wooden Tools",
+  "tag.block.neoforge.shears_efficient": "Shears Efficient",
   "tag.block.neoforge.villager_farmlands": "Villager Farmlands",
   "tag.enchantment.c.entity_auxiliary_movement_enhancements": "Entity Auxiliary Movement Enhancements",
   "tag.enchantment.c.entity_defense_enhancements": "Entity Defense Enhancements",

--- a/src/generated/resources/data/neoforge/tags/block/shears_efficient.json
+++ b/src/generated/resources/data/neoforge/tags/block/shears_efficient.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:wool"
+  ]
+}

--- a/src/generated/resources/data/neoforge/tags/block/shears_efficient.json
+++ b/src/generated/resources/data/neoforge/tags/block/shears_efficient.json
@@ -1,5 +1,3 @@
 {
-  "values": [
-    "#minecraft:wool"
-  ]
+  "values": []
 }

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -314,6 +314,11 @@ public class Tags {
          */
         public static final TagKey<Block> VILLAGER_FARMLANDS = neoforgeTag("villager_farmlands");
 
+        /**
+         * For blocks which should mine faster when shears are used.
+         */
+        public static final TagKey<Block> SHEARS_EFFICIENT = neoforgeTag("shears_efficient");
+
         private static TagKey<Block> tag(String name) {
             return BlockTags.create(Identifier.fromNamespaceAndPath("c", name));
         }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
@@ -310,7 +310,7 @@ public final class NeoForgeBlockTagsProvider extends BlockTagsProvider {
         tag(Tags.Blocks.SANDS).addOptionalTag(forge("sand"));
         tag(Tags.Blocks.SANDS_COLORLESS).addOptionalTag(forge("sand/colorless"));
         tag(Tags.Blocks.SANDS_RED).addOptionalTag(forge("sand/red"));
-        tag(Tags.Blocks.SHEARS_EFFICIENT).addTag(BlockTags.WOOL);
+        tag(Tags.Blocks.SHEARS_EFFICIENT);
     }
 
     private TagAppender<Block, Block> tagWithOptionalLegacy(TagKey<Block> tag) {

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeBlockTagsProvider.java
@@ -310,6 +310,7 @@ public final class NeoForgeBlockTagsProvider extends BlockTagsProvider {
         tag(Tags.Blocks.SANDS).addOptionalTag(forge("sand"));
         tag(Tags.Blocks.SANDS_COLORLESS).addOptionalTag(forge("sand/colorless"));
         tag(Tags.Blocks.SANDS_RED).addOptionalTag(forge("sand/red"));
+        tag(Tags.Blocks.SHEARS_EFFICIENT).addTag(BlockTags.WOOL);
     }
 
     private TagAppender<Block, Block> tagWithOptionalLegacy(TagKey<Block> tag) {

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -141,6 +141,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Blocks.STRIPPED_WOODS, "Stripped Woods");
         add(Tags.Blocks.VILLAGER_JOB_SITES, "Villager Job Sites");
         add(Tags.Blocks.VILLAGER_FARMLANDS, "Villager Farmlands");
+        add(Tags.Blocks.SHEARS_EFFICIENT, "Shears Efficient");
 
         // Items
         add(Tags.Items.BARRELS, "Barrels");


### PR DESCRIPTION
This PR introduces a new behaviour tag which can be used to mark blocks as effective when mined with shears.

This is done by adding a new `Tool.Rule` to the shears `Tool` component which looks for the `neoforge:shears_efficient` tag and overrides the mining speed to `5` similar to the existing `minecraft:wool` rule.

The name for this tag was derived from the existing `minecraft:sword_efficient` tag.