### PR TITLE
[1.21.11] Fix UI elements with connected primitives not getting flushed separately

### DIFF
--- a/patches/net/minecraft/client/gui/render/GuiRenderer.java.patch
+++ b/patches/net/minecraft/client/gui/render/GuiRenderer.java.patch
@@ -40,6 +40,14 @@
          if (SharedConstants.DEBUG_SHUFFLE_UI_RENDERING_ORDER) {
              RenderPipeline.updateSortKeySeed();
              TextureSetup.updateSortKeySeed();
+@@ -292,6 +_,7 @@
+         ScreenRectangle screenrectangle = p_419849_.scissorArea();
+         if (renderpipeline != this.previousPipeline
+             || this.scissorChanged(screenrectangle, this.previousScissorArea)
++            || renderpipeline.getVertexFormatMode().connectedPrimitives // Neo: flush elements with connected primitives individually
+             || !texturesetup.equals(this.previousTextureSetup)) {
+             if (this.bufferBuilder != null) {
+                 this.recordMesh(this.bufferBuilder, this.previousPipeline, this.previousTextureSetup, this.previousScissorArea);
 @@ -419,14 +_,31 @@
  
      private void preparePictureInPicture() {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/GuiTests.java
@@ -319,6 +319,7 @@ public class GuiTests {
             event.registerAboveAll(id, (graphics, deltaTracker) -> {
                 int centerX = graphics.guiWidth() - 20;
                 graphics.submitGuiElementRenderState(CircleGuiElementRenderState.create(centerX, 20, 15, 8, 0xFFAA0000, triStripPipeline));
+                graphics.submitGuiElementRenderState(CircleGuiElementRenderState.create(centerX, 60, 15, 8, 0xFFAA0000, triStripPipeline));
             });
         });
     }


### PR DESCRIPTION
This PR fixes UI geometry with connected primitives (triangle strip, triangle fan, line strip) not getting uploaded individually, causing separate elements using such a vertex mode to be batched together incorrectly.

Fixes #2919