### PR TITLE
Broaden acceptable return types for Level.dragonParts()

### DIFF
--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -200,7 +200,7 @@
      }
  
 -    public abstract Collection<EnderDragonPart> dragonParts();
-+    public abstract Collection<net.neoforged.neoforge.entity.PartEntity<?>> dragonParts();
++    public abstract Collection<? extends net.neoforged.neoforge.entity.PartEntity<?>> dragonParts();
  
      public void blockEntityChanged(BlockPos p_151544_) {
          if (this.hasChunkAt(p_151544_)) {


### PR DESCRIPTION
When subclassing `Level` in common code under a 1.21.11 multiloader project, `Level.dragonParts()`, as an abstract method, must be implemented. However, the original return type is not actually valid under NeoForge. 

In vanilla:
```java
public abstract Collection<EnderDragonPart> dragonParts()
```

In Neo:
```java
public abstract Collection<net.neoforged.neoforge.entity.PartEntity<?>> dragonParts();
```

Naturally, this neo-only class cannot be accessed in common code, and while `EnderDragonPart` extends `PartEntity<EnderDragon>`, it cannot be used in the return type due to the strict requirement of `PartEntity<?>`. This requires either the use of a raw `Collection` return type, or modifying the NeoForge definition to accept _subclasses_ of `PartEntity<?>`, such that `Collection<EnderDragonPart>` is valid under NeoForge.

Current grossness:
```java
	@Override
	public Collection dragonParts() {
		return List.of();
	}
```

I'd like to change this to:
```java
public abstract Collection<? extends net.neoforged.neoforge.entity.PartEntity<?>> dragonParts();
```
Such that:
```java
	@Override
	public Collection<EnderDragonPart> dragonParts() {
		return List.of();
	}
```
is valid.

This will allow `Collection<EnderDragonPart>` to be used regardless of loader - under the vanilla declaration, nothing changes, and under Neo, `EnderDragonPart` already subclasses `PartEntity`.

Relatively meaningless? Perhaps. Still, it'd be nice to maintain compatibility and not disallow the vanilla return type.
