### PR TITLE
Allow ItemModelOutput to datagen ClientItems for arbitrary identifiers

### DIFF
--- a/patches/net/minecraft/client/data/models/ItemModelOutput.java.patch
+++ b/patches/net/minecraft/client/data/models/ItemModelOutput.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/data/models/ItemModelOutput.java
 +++ b/net/minecraft/client/data/models/ItemModelOutput.java
-@@ -15,4 +_,10 @@
+@@ -15,4 +_,16 @@
      void accept(Item p_456234_, ItemModel.Unbaked p_454728_, ClientItem.Properties p_455827_);
  
      void copy(Item p_387316_, Item p_387995_);
@@ -9,5 +9,11 @@
 +     * Neo: Pulled up from {@link ModelProvider.ItemInfoCollector} to give modders full control over the {@link net.minecraft.client.renderer.item.ClientItem} instead of just the {@link ItemModel.Unbaked} in {@link #accept(Item, ItemModel.Unbaked)
 +     */
 +    default void register(Item item, net.minecraft.client.renderer.item.ClientItem clientItem) {
++    }
++
++    /**
++     * Neo: Pulled up from {@link ModelProvider.ItemInfoCollector} to allow for arbitrarily named model files to be generated
++     */
++    default void register(net.minecraft.resources.Identifier identifier, net.minecraft.client.renderer.item.ClientItem clientItem) {
 +    }
  }

--- a/patches/net/minecraft/client/data/models/ItemModelOutput.java.patch
+++ b/patches/net/minecraft/client/data/models/ItemModelOutput.java.patch
@@ -12,7 +12,7 @@
 +    }
 +
 +    /**
-+     * Neo: Pulled up from {@link ModelProvider.ItemInfoCollector} to allow for arbitrarily named model files to be generated
++     * Neo: Allow generating arbitrarily named client item files
 +     */
 +    default void register(net.minecraft.resources.Identifier identifier, net.minecraft.client.renderer.item.ClientItem clientItem) {
 +    }

--- a/patches/net/minecraft/client/data/models/ModelProvider.java.patch
+++ b/patches/net/minecraft/client/data/models/ModelProvider.java.patch
@@ -117,18 +117,18 @@
  
          @Override
          public void accept(Item p_387063_, ItemModel.Unbaked p_388578_, ClientItem.Properties p_455547_) {
-@@ -110,15 +_,22 @@
-             }
+@@ -111,14 +_,22 @@
          }
  
+         @Override
 +        public void register(Identifier identifier, ClientItem clientItem) {
-+            ClientItem existing = this.idItemInfos.put(identifier, clientItem);
++            ClientItem existing = this.idItemInfos.putIfAbsent(identifier, clientItem);
 +            if (existing != null) {
 +                throw new IllegalStateException("Duplicate item model definition for " + identifier);
 +            }
 +        }
 +
-         @Override
++        @Override
          public void copy(Item p_386920_, Item p_386789_) {
              this.copies.put(p_386789_, p_386920_);
          }

--- a/patches/net/minecraft/client/data/models/ModelProvider.java.patch
+++ b/patches/net/minecraft/client/data/models/ModelProvider.java.patch
@@ -99,11 +99,12 @@
                  .toList();
              if (!list.isEmpty()) {
                  throw new IllegalStateException("Missing blockstate definitions for: " + list);
-@@ -97,6 +_,16 @@
+@@ -97,6 +_,17 @@
      static class ItemInfoCollector implements ItemModelOutput {
          private final Map<Item, ClientItem> itemInfos = new HashMap<>();
          private final Map<Item, Item> copies = new HashMap<>();
 +        private final Supplier<Stream<? extends Holder<Item>>> knownItems;
++        private final Map<Identifier, ClientItem> idItemInfos = new HashMap<>();
 +
 +        public ItemInfoCollector(Supplier<Stream<? extends Holder<Item>>> knownItems) {
 +            this.knownItems = knownItems;
@@ -116,7 +117,20 @@
  
          @Override
          public void accept(Item p_387063_, ItemModel.Unbaked p_388578_, ClientItem.Properties p_455547_) {
-@@ -116,9 +_,9 @@
+@@ -110,15 +_,22 @@
+             }
+         }
+ 
++        public void register(Identifier identifier, ClientItem clientItem) {
++            ClientItem existing = this.idItemInfos.put(identifier, clientItem);
++            if (existing != null) {
++                throw new IllegalStateException("Duplicate item model definition for " + identifier);
++            }
++        }
++
+         @Override
+         public void copy(Item p_386920_, Item p_386789_) {
+             this.copies.put(p_386789_, p_386920_);
          }
  
          public void finalizeAndValidate() {
@@ -142,3 +156,17 @@
                  .toList();
              if (!list.isEmpty()) {
                  throw new IllegalStateException("Missing item model definitions for: " + list);
+@@ -143,9 +_,11 @@
+         }
+ 
+         public CompletableFuture<?> save(CachedOutput p_387552_, PackOutput.PathProvider p_388501_) {
+-            return DataProvider.saveAll(
++            return CompletableFuture.allOf(DataProvider.saveAll(
+                 p_387552_, ClientItem.CODEC, p_465443_ -> p_388501_.json(p_465443_.builtInRegistryHolder().key().identifier()), this.itemInfos
+-            );
++            ), DataProvider.saveAll(
++                    p_387552_, ClientItem.CODEC, p_388501_::json, this.idItemInfos
++            ));
+         }
+     }
+ 


### PR DESCRIPTION
This proposed change allows datagen of arbitrarily named `ClientItem`s. Vanilla loads every `ClientItem` JSON (in `assets/<mod_id>/items/...`) whether an item with the same ID exists or not. These models can be used in the `item_model` item component to make items appear differently.

This functionality is particularly helpful when developing server sided mods that include a resource pack.

Relevant discord conversation in `#neoforge-github` can be seen [here](https://discord.com/channels/313125603924639766/852298000042164244/1462950747648954492).