### PR TITLE
Fix when BlockEvent.EntityPlaceEvent is canceled on server not updating client inventory

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -108,6 +108,7 @@ import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.AnvilMenu;
@@ -666,7 +667,8 @@ public class CommonHooks {
                 }
                 // inform the client that the item was not consumed
                 if (player instanceof ServerPlayer serverPlayer) {
-                    serverPlayer.connection.send(new ClientboundSetPlayerInventoryPacket(serverPlayer.getInventory().getSelectedSlot(), itemstack));
+                    int slot = context.getHand() == InteractionHand.MAIN_HAND ? serverPlayer.getInventory().getSelectedSlot() : Inventory.SLOT_OFFHAND;
+                    serverPlayer.connection.send(serverPlayer.getInventory().createInventoryUpdatePacket(slot));
                 }
             } else {
                 // Change the stack to its new content

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -71,7 +71,6 @@ import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
-import net.minecraft.network.protocol.game.ClientboundSetPlayerInventoryPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializer;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -663,6 +663,10 @@ public class CommonHooks {
                     blocksnapshot.restore(blocksnapshot.getFlags() | Block.UPDATE_CLIENTS);
                     level.restoringBlockSnapshots = false;
                 }
+                // inform the client that the item was not consumed
+                if (player instanceof ServerPlayer) {
+                    player.containerMenu.sendAllDataToRemote();
+                }
             } else {
                 // Change the stack to its new content
                 itemstack.setCount(newSize);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -71,6 +71,7 @@ import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
+import net.minecraft.network.protocol.game.ClientboundSetPlayerInventoryPacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializer;
@@ -664,8 +665,8 @@ public class CommonHooks {
                     level.restoringBlockSnapshots = false;
                 }
                 // inform the client that the item was not consumed
-                if (player instanceof ServerPlayer) {
-                    player.containerMenu.sendAllDataToRemote();
+                if (player instanceof ServerPlayer serverPlayer) {
+                    serverPlayer.connection.send(new ClientboundSetPlayerInventoryPacket(serverPlayer.getInventory().getSelectedSlot(), itemstack));
                 }
             } else {
                 // Change the stack to its new content


### PR DESCRIPTION
This is a simple fix that makes it so player inventories don't become desynced with the server when `BlockEvent.EntityPlaceEvent` is canceled only on the server side.