### PR TITLE
Add CustomClickActionEvent

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -155,3 +155,15 @@
      }
  
      @Override
+@@ -2169,5 +_,11 @@
+     @FunctionalInterface
+     interface EntityInteraction {
+         InteractionResult run(ServerPlayer p_143695_, Entity p_143696_, InteractionHand p_143697_);
++    }
++
++    @Override
++    public void handleCustomClickAction(net.minecraft.network.protocol.common.ServerboundCustomClickActionPacket packet) {
++        super.handleCustomClickAction(packet);
++        net.neoforged.neoforge.common.CommonHooks.onCustomClickAction(player, packet);
+     }
+ }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -70,6 +70,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.ServerboundCustomClickActionPacket;
 import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
 import net.minecraft.network.protocol.game.ServerboundPlayerActionPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
@@ -209,6 +210,7 @@ import net.neoforged.neoforge.event.entity.living.MobEffectEvent;
 import net.neoforged.neoforge.event.entity.player.AnvilCraftEvent;
 import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
 import net.neoforged.neoforge.event.entity.player.CriticalHitEvent;
+import net.neoforged.neoforge.event.entity.player.CustomClickActionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEnchantItemEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
@@ -1780,5 +1782,9 @@ public class CommonHooks {
         } else {
             LOGGER.warn(message);
         }
+    }
+
+    public static void onCustomClickAction(ServerPlayer player, ServerboundCustomClickActionPacket packet) {
+        NeoForge.EVENT_BUS.post(new CustomClickActionEvent(player, packet.id(), packet.payload().orElse(null)));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/CustomClickActionEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/CustomClickActionEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.player;
+
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.protocol.common.ServerboundCustomClickActionPacket;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.Event;
+import net.neoforged.neoforge.common.CommonHooks;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * This event is fired when a player sends a {@link ServerboundCustomClickActionPacket} to the server.
+ * <p>
+ * This packet is sent by the client when a {@link ClickEvent.Custom} is clicked, be it from a component or a dialog.
+ * <p>
+ * This event is fired only on the logical server.
+ */
+public class CustomClickActionEvent extends Event {
+    private final ServerPlayer player;
+    private final Identifier identifier;
+    private final Tag payload;
+
+    /**
+     * Fired via {@link CommonHooks#onCustomClickAction(ServerPlayer, ServerboundCustomClickActionPacket)}
+     */
+    public CustomClickActionEvent(ServerPlayer player, Identifier identifier, @Nullable Tag payload) {
+        this.player = player;
+        this.identifier = identifier;
+        this.payload = payload;
+    }
+
+    /**
+     * @return the player who clicked this custom click event
+     */
+    public ServerPlayer getPlayer() {
+        return player;
+    }
+
+    /**
+     * @return the custom click event's identifier
+     */
+    public Identifier getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * @return the custom click event's payload
+     */
+    @Nullable
+    public Tag getPayload() {
+        return payload;
+    }
+}


### PR DESCRIPTION
Minecraft semi-recently (in 1.21.6) introduced `ClickEvent.Custom` (aka the [`minecraft:custom` click event](https://minecraft.wiki/w/Text_component_format#custom)) which allows you to define a click event in a component (or in a [dialog](https://minecraft.wiki/w/Dialog) action button) that sends a packet with an identifier and a payload to the server when clicked. The server does nothing with this packet.

This PR adds a new event, `CustomClickActionEvent`. This event is invoked whenever the server receives this packet.

### Some decisions to note
- Because a `ClickEvent.Custom` may or may not have a payload attached, I have opted to have the payload tag field be nullable to match other events in NeoForge using null values rather than Java's `Optional`.
- I only made the event trigger on the logical server. Theoretically this event could be altered to have it execute on the client as well when the client sends the packet. This may be desirable, and if it is, I can amend this.