### PR TITLE
[26.1] Update RenderLevelStageEvent for vanilla changes and add SubmitCustomGeometryEvent

### DIFF
--- a/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/LevelRenderer.java.patch
@@ -66,45 +66,54 @@
          if (transparencyChain != null) {
              transparencyChain.addToFrame(frame, screenWidth, screenHeight, this.targets);
          }
-@@ -663,6 +_,9 @@
+@@ -663,6 +_,8 @@
  
                  ChunkSectionsToRender chunkSectionsToRender = this.prepareChunkRenders(modelViewMatrix, camX, camY, camZ);
                  chunkSectionsToRender.renderGroup(ChunkSectionLayerGroup.OPAQUE, this.chunkLayerSampler);
-+                profiler.push("neoforge_render_after_opaque_blocks");
++                profiler.popPush("neoforge_render_after_opaque_blocks");
 +                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterOpaqueBlocks(this, this.levelRenderState, null, modelViewMatrix, this.getRenderableSections()));
-+                profiler.pop();
                  this.minecraft.gameRenderer.getLighting().setupFor(Lighting.Entry.LEVEL);
                  if (this.shouldShowEntityOutlines() && entityOutlineTarget != null) {
                      RenderTarget outlineTarget = entityOutlineTarget.get();
-@@ -680,6 +_,9 @@
+@@ -680,9 +_,13 @@
                  this.submitBlockEntities(poseStack, levelRenderState, this.submitNodeStorage);
                  profiler.popPush("submitParticles");
                  this.particlesRenderState.submit(this.submitNodeStorage, levelRenderState.cameraRenderState);
-+                Profiler.get().push("neoforge_render_after_particles");
-+                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterParticles(this, this.levelRenderState, null, modelViewMatrix, this.getRenderableSections()));
-+                Profiler.get().pop();
++                profiler.popPush("neoforge_submit_custom");
++                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.SubmitCustomGeometryEvent(this.levelRenderState, this.submitNodeStorage, poseStack, this.getRenderableSections()));
                  profiler.popPush("solidFeatures");
                  this.featureRenderDispatcher.renderSolidFeatures();
                  bufferSource.endBatch();
-@@ -705,6 +_,8 @@
-                 crumblingBufferSource.endBatch();
++                profiler.popPush("neoforge_render_after_opaque_features");
++                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterOpaqueFeatures(this, this.levelRenderState, poseStack, modelViewMatrix, this.getRenderableSections()));
                  profiler.pop();
-                 this.renderBuffers.outlineBufferSource().endOutlineBatch();
-+                profiler.popPush("neoforge_render_after_entities");
-+                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterEntities(this, this.levelRenderState, poseStack, modelViewMatrix, this.getRenderableSections()));
-                 if (renderOutline) {
-                     this.renderBlockOutline(bufferSource, poseStack, false, levelRenderState);
-                     bufferSource.endBatch();
+                 this.checkPoseStack(poseStack);
+                 if (translucentTarget != null) {
+@@ -700,6 +_,8 @@
+                 profiler.push("translucentFeatures");
+                 this.featureRenderDispatcher.renderTranslucentFeatures();
+                 bufferSource.endBatch();
++                profiler.popPush("neoforge_render_after_translucent_features");
++                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterTranslucentFeatures(this, this.levelRenderState, poseStack, modelViewMatrix, this.getRenderableSections()));
+                 profiler.popPush("destroyProgress");
+                 this.renderBlockDestroyAnimation(poseStack, crumblingBufferSource, levelRenderState);
+                 crumblingBufferSource.endBatch();
 @@ -716,6 +_,8 @@
                  this.checkPoseStack(poseStack);
                  profiler.push("translucentTerrain");
                  chunkSectionsToRender.renderGroup(ChunkSectionLayerGroup.TRANSLUCENT, this.chunkLayerSampler);
 +                profiler.popPush("neoforge_render_after_translucent_blocks");
-+                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterTranslucentBlocks(this, this.levelRenderState, null, modelViewMatrix, this.getRenderableSections()));
++                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterTranslucentBlocks(this, this.levelRenderState, poseStack, modelViewMatrix, this.getRenderableSections()));
                  if (renderOutline) {
                      this.renderBlockOutline(bufferSource, poseStack, true, levelRenderState);
                  }
-@@ -730,9 +_,18 @@
+@@ -726,13 +_,24 @@
+                 bufferSource.endBatch();
+                 this.featureRenderDispatcher.clearSubmitNodes();
+                 this.particlesRenderState.reset();
++                profiler.push("neoforge_render_after_translucent_particles");
++                net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterTranslucentParticles(this, this.levelRenderState, poseStack, modelViewMatrix, this.getRenderableSections()));
+             }
          );
      }
  
@@ -147,10 +156,12 @@
          int renderDistance = this.minecraft.options.getEffectiveRenderDistance() * 16;
          float depthFar = this.minecraft.gameRenderer.getDepthFar();
          FramePass pass = frame.addPass("weather");
-@@ -757,6 +_,9 @@
+@@ -756,7 +_,10 @@
+         pass.executes(() -> {
              RenderSystem.setShaderFog(fog);
              CameraRenderState cameraState = this.levelRenderState.cameraRenderState;
-             this.weatherEffectRenderer.render(cameraState.pos, this.levelRenderState.weatherRenderState);
+-            this.weatherEffectRenderer.render(cameraState.pos, this.levelRenderState.weatherRenderState);
++            this.weatherEffectRenderer.render(cameraState.pos, this.levelRenderState.weatherRenderState, this.levelRenderState);
 +            Profiler.get().push("neoforge_render_after_weather");
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterWeather(this, this.levelRenderState, null, modelViewMatrix, this.getRenderableSections()));
 +            Profiler.get().pop();

--- a/src/client/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
+++ b/src/client/java/net/neoforged/neoforge/client/BlockEntityRenderBoundsDebugRenderer.java
@@ -63,7 +63,7 @@ public final class BlockEntityRenderBoundsDebugRenderer {
     }
 
     @SubscribeEvent
-    public static void onRenderLevelStage(RenderLevelStageEvent.AfterEntities event) {
+    public static void onRenderLevelStage(RenderLevelStageEvent.AfterOpaqueFeatures event) {
         if (!enabled) {
             return;
         }

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
@@ -9,6 +9,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import java.util.function.Consumer;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.state.LevelRenderState;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -22,6 +23,9 @@ import org.jspecify.annotations.Nullable;
  * Fires at various times during {@linkplain LevelRenderer#renderLevel} and {@linkplain GameRenderer#renderLevel}.
  * Custom render state used in the various stages must be extracted in {@link ExtractLevelRenderStateEvent} and
  * stored in the provided {@link LevelRenderState}
+ *
+ *
+ * <p>To submit custom geometry to the {@link SubmitNodeCollector} system, use {@link SubmitCustomGeometryEvent} instead.
  *
  * <p>The sub-events are not {@linkplain ICancellableEvent cancellable}. </p>
  *

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderLevelStageEvent.java
@@ -31,10 +31,10 @@ import org.jspecify.annotations.Nullable;
  * <p>The sub-events are fired in the following order:
  * {@link AfterSky},
  * {@link AfterOpaqueBlocks},
- * {@link AfterEntities},
+ * {@link AfterOpaqueFeatures},
+ * {@link AfterTranslucentFeatures}
  * {@link AfterTranslucentBlocks},
- * {@link AfterTripwireBlocks},
- * {@link AfterParticles},
+ * {@link AfterTranslucentParticles},
  * {@link AfterWeather},
  * {@link AfterLevel}
  */
@@ -110,10 +110,19 @@ public abstract class RenderLevelStageEvent extends Event {
     }
 
     /**
-     * Fired within {@linkplain LevelRenderer#addMainPass} after entities and block entities have been rendered.
+     * Fired within {@linkplain LevelRenderer#addMainPass} after opaque "features" from entities, block entities and particles have been rendered.
      */
-    public static class AfterEntities extends RenderLevelStageEvent {
-        public AfterEntities(LevelRenderer levelRenderer, LevelRenderState levelRenderState, @Nullable PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
+    public static class AfterOpaqueFeatures extends RenderLevelStageEvent {
+        public AfterOpaqueFeatures(LevelRenderer levelRenderer, LevelRenderState levelRenderState, PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
+            super(levelRenderer, levelRenderState, poseStack, modelViewMatrix, renderableSections);
+        }
+    }
+
+    /**
+     * Fired within {@linkplain LevelRenderer#addMainPass} after translucent "features" from entities and block entities have been rendered.
+     */
+    public static class AfterTranslucentFeatures extends RenderLevelStageEvent {
+        public AfterTranslucentFeatures(LevelRenderer levelRenderer, LevelRenderState levelRenderState, PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
             super(levelRenderer, levelRenderState, poseStack, modelViewMatrix, renderableSections);
         }
     }
@@ -122,16 +131,16 @@ public abstract class RenderLevelStageEvent extends Event {
      * Fired within {@linkplain LevelRenderer#addMainPass} after translucent chunk geometry has been rendered.
      */
     public static class AfterTranslucentBlocks extends RenderLevelStageEvent {
-        public AfterTranslucentBlocks(LevelRenderer levelRenderer, LevelRenderState levelRenderState, @Nullable PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
+        public AfterTranslucentBlocks(LevelRenderer levelRenderer, LevelRenderState levelRenderState, PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
             super(levelRenderer, levelRenderState, poseStack, modelViewMatrix, renderableSections);
         }
     }
 
     /**
-     * Fired at the end of {@linkplain LevelRenderer#addParticlesPass} after particles have been rendered.
+     * Fired within {@linkplain LevelRenderer#addMainPass} after translucent "features" from particles have been rendered.
      */
-    public static class AfterParticles extends RenderLevelStageEvent {
-        public AfterParticles(LevelRenderer levelRenderer, LevelRenderState levelRenderState, @Nullable PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
+    public static class AfterTranslucentParticles extends RenderLevelStageEvent {
+        public AfterTranslucentParticles(LevelRenderer levelRenderer, LevelRenderState levelRenderState, PoseStack poseStack, Matrix4f modelViewMatrix, Iterable<? extends IRenderableSection> renderableSections) {
             super(levelRenderer, levelRenderState, poseStack, modelViewMatrix, renderableSections);
         }
     }

--- a/src/client/java/net/neoforged/neoforge/client/event/SubmitCustomGeometryEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/SubmitCustomGeometryEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.function.Consumer;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.state.LevelRenderState;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.client.IRenderableSection;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * This event can be used to submit custom geometry outside of {@link BlockEntityRenderer}s,
+ * {@link EntityRenderer}s and {@link Particle}s.
+ *
+ * <p>This event is fired between particle submission and rendering of opaque submits.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
+ *
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}, only on the
+ * {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public final class SubmitCustomGeometryEvent extends Event {
+    private final LevelRenderState levelRenderState;
+    private final SubmitNodeCollector submitNodeCollector;
+    private final PoseStack poseStack;
+    private final Iterable<? extends IRenderableSection> renderableSections;
+
+    @ApiStatus.Internal
+    public SubmitCustomGeometryEvent(LevelRenderState levelRenderState, SubmitNodeCollector submitNodeCollector, PoseStack poseStack, Iterable<? extends IRenderableSection> renderableSections) {
+        this.levelRenderState = levelRenderState;
+        this.submitNodeCollector = submitNodeCollector;
+        this.poseStack = poseStack;
+        this.renderableSections = renderableSections;
+    }
+
+    /**
+     * {@return the level render state}
+     */
+    public LevelRenderState getLevelRenderState() {
+        return levelRenderState;
+    }
+
+    /**
+     * {@return the submit node collector to submit the geometry to}
+     */
+    public SubmitNodeCollector getSubmitNodeCollector() {
+        return submitNodeCollector;
+    }
+
+    /**
+     * {@return the pose stack to use for geometry submission}
+     */
+    public PoseStack getPoseStack() {
+        return poseStack;
+    }
+
+    /**
+     * Returns an iterable of all visible sections.
+     * <p>
+     * Calling {@link Iterable#forEach(Consumer)} on the returned iterable allows the underlying renderer
+     * to optimize how it fetches the visible sections, and is recommended.
+     */
+    public Iterable<? extends IRenderableSection> getRenderableSections() {
+        return renderableSections;
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/event/SubmitCustomGeometryEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/SubmitCustomGeometryEvent.java
@@ -22,12 +22,14 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * This event can be used to submit custom geometry outside of {@link BlockEntityRenderer}s,
  * {@link EntityRenderer}s and {@link Particle}s.
+ * Custom render state used by the submits must be extracted in {@link ExtractLevelRenderStateEvent} and
+ * stored in the provided {@link LevelRenderState}
  *
  * <p>This event is fired between particle submission and rendering of opaque submits.
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
  *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}, only on the
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main NeoForge event bus}, only on the
  * {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
 public final class SubmitCustomGeometryEvent extends Event {


### PR DESCRIPTION
This PR updates `RenderLevelStageEvent` to match the different phases of level rendering in vanilla and adds `SubmitCustomGeometryEvent` to allow using the `SubmitNodeCollector` system for arbitrary geometry which does not originate from a `BlockEntityRenderer`, `EntityRenderer` or `Particle`.