### PR TITLE
Work around decompile issues associated with #2956

### DIFF
--- a/patches/net/minecraft/resources/Identifier.java.patch
+++ b/patches/net/minecraft/resources/Identifier.java.patch
@@ -1,15 +1,15 @@
 --- a/net/minecraft/resources/Identifier.java
 +++ b/net/minecraft/resources/Identifier.java
-@@ -140,6 +_,12 @@
-     public int hashCode() {
+@@ -141,6 +_,12 @@
          return 31 * this.namespace.hashCode() + this.path.hashCode();
      }
-+
+ 
 +    // Normal compare sorts by path first, this compares namespace first.
 +    public int compareNamespaced(Identifier o) {
 +        int ret = this.namespace.compareTo(o.namespace);
 +        return ret != 0 ? ret : this.path.compareTo(o.path);
 +    }
- 
++
      public int compareTo(Identifier o) {
          int result = this.path.compareTo(o.path);
+         if (result == 0) {

--- a/patches/net/minecraft/resources/Identifier.java.patch
+++ b/patches/net/minecraft/resources/Identifier.java.patch
@@ -1,15 +1,15 @@
 --- a/net/minecraft/resources/Identifier.java
 +++ b/net/minecraft/resources/Identifier.java
-@@ -150,6 +_,12 @@
-         return result;
+@@ -140,6 +_,12 @@
+     public int hashCode() {
+         return 31 * this.namespace.hashCode() + this.path.hashCode();
      }
- 
++
 +    // Normal compare sorts by path first, this compares namespace first.
 +    public int compareNamespaced(Identifier o) {
 +        int ret = this.namespace.compareTo(o.namespace);
 +        return ret != 0 ? ret : this.path.compareTo(o.path);
 +    }
-+
-     public Path resolveAgainst(Path root) {
-         return root.resolve(this.getNamespace(), new String[]{this.getPath()});
-     }
+ 
+     public int compareTo(Identifier o) {
+         int result = this.path.compareTo(o.path);


### PR DESCRIPTION
It appears that, potentially due to different JDKs or using Java 21 vs Java 25, it's possible for the decompilation of `Identifier` to produce different output, specifically when decompiling references to `Path::resolve`.

The patch itself is generated against a version that decompiled this to `String first, String[] more`.

Users on the NeoForge discord/GitHub have reported issues where this patch failed to apply as their development environment decompiled `Path::resolve` to `String first, String ... more` and lack the explicit array creation.

Someone on the NeoForge discord suggested moving the patch as a temporary solution until JDK versions can be properly enforced for vineflower decompilation, thus this PR.