### PR TITLE
LivingEntity Freeze event

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -28,16 +28,19 @@
      private final Set<TagKey<Fluid>> fluidOnEyes = new HashSet<>();
      public int invulnerableTime;
      protected boolean firstTick = true;
-@@ -287,6 +_,8 @@
-     private final InsideBlockEffectApplier.StepBasedCollector insideEffectCollector = new InsideBlockEffectApplier.StepBasedCollector();
-     private CustomData customData = CustomData.EMPTY;
- 
-+    private int ticksRequiredToFreeze = 140;
-+
-     public Entity(EntityType<?> p_19870_, Level p_19871_) {
-         this.type = p_19870_;
-         this.level = p_19871_;
-@@ -306,7 +_,10 @@
+@@ -256,6 +_,7 @@
+     private static final EntityDataAccessor<Boolean> DATA_NO_GRAVITY = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.BOOLEAN);
+     protected static final EntityDataAccessor<Pose> DATA_POSE = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.POSE);
+     private static final EntityDataAccessor<Integer> DATA_TICKS_FROZEN = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.INT);
++    private static final EntityDataAccessor<Integer> DATA_TICKS_REQUIRED_TO_FREEZE = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.INT);
+     private EntityInLevelCallback levelCallback = EntityInLevelCallback.NULL;
+     private final VecDeltaCodec packetPositionCodec = new VecDeltaCodec();
+     public boolean needsSync;
+@@ -303,10 +_,14 @@
+         synchedentitydata$builder.define(DATA_NO_GRAVITY, false);
+         synchedentitydata$builder.define(DATA_POSE, Pose.STANDING);
+         synchedentitydata$builder.define(DATA_TICKS_FROZEN, 0);
++        synchedentitydata$builder.define(DATA_TICKS_REQUIRED_TO_FREEZE, 140);
          this.defineSynchedData(synchedentitydata$builder);
          this.entityData = synchedentitydata$builder.build();
          this.setPos(0.0, 0.0, 0.0);
@@ -298,11 +301,11 @@
  
      public int getTicksRequiredToFreeze() {
 -        return 140;
-+        return this.ticksRequiredToFreeze;
++        return this.entityData.get(DATA_TICKS_REQUIRED_TO_FREEZE);
 +    }
 +
 +    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
-+        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
++        this.entityData.set(DATA_TICKS_REQUIRED_TO_FREEZE, ticksRequiredToFreeze);
      }
  
      public void thunderHit(ServerLevel p_19927_, LightningBolt p_19928_) {

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -28,6 +28,15 @@
      private final Set<TagKey<Fluid>> fluidOnEyes = new HashSet<>();
      public int invulnerableTime;
      protected boolean firstTick = true;
+@@ -287,6 +_,8 @@
+     private final InsideBlockEffectApplier.StepBasedCollector insideEffectCollector = new InsideBlockEffectApplier.StepBasedCollector();
+     private CustomData customData = CustomData.EMPTY;
+ 
++    private int ticksRequiredToFreeze = 140;
++
+     public Entity(EntityType<?> p_19870_, Level p_19871_) {
+         this.type = p_19870_;
+         this.level = p_19871_;
 @@ -306,7 +_,10 @@
          this.defineSynchedData(synchedentitydata$builder);
          this.entityData = synchedentitydata$builder.build();
@@ -284,6 +293,19 @@
      }
  
      public void setSwimming(boolean p_20283_) {
+@@ -2719,7 +_,11 @@
+     }
+ 
+     public int getTicksRequiredToFreeze() {
+-        return 140;
++        return this.ticksRequiredToFreeze;
++    }
++
++    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
++        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
+     }
+ 
+     public void thunderHit(ServerLevel p_19927_, LightningBolt p_19928_) {
 @@ -2728,7 +_,7 @@
              this.igniteForSeconds(8.0F);
          }

--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -28,19 +28,7 @@
      private final Set<TagKey<Fluid>> fluidOnEyes = new HashSet<>();
      public int invulnerableTime;
      protected boolean firstTick = true;
-@@ -256,6 +_,7 @@
-     private static final EntityDataAccessor<Boolean> DATA_NO_GRAVITY = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.BOOLEAN);
-     protected static final EntityDataAccessor<Pose> DATA_POSE = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.POSE);
-     private static final EntityDataAccessor<Integer> DATA_TICKS_FROZEN = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.INT);
-+    private static final EntityDataAccessor<Integer> DATA_TICKS_REQUIRED_TO_FREEZE = SynchedEntityData.defineId(Entity.class, EntityDataSerializers.INT);
-     private EntityInLevelCallback levelCallback = EntityInLevelCallback.NULL;
-     private final VecDeltaCodec packetPositionCodec = new VecDeltaCodec();
-     public boolean needsSync;
-@@ -303,10 +_,14 @@
-         synchedentitydata$builder.define(DATA_NO_GRAVITY, false);
-         synchedentitydata$builder.define(DATA_POSE, Pose.STANDING);
-         synchedentitydata$builder.define(DATA_TICKS_FROZEN, 0);
-+        synchedentitydata$builder.define(DATA_TICKS_REQUIRED_TO_FREEZE, 140);
+@@ -306,7 +_,10 @@
          this.defineSynchedData(synchedentitydata$builder);
          this.entityData = synchedentitydata$builder.build();
          this.setPos(0.0, 0.0, 0.0);
@@ -301,11 +289,11 @@
  
      public int getTicksRequiredToFreeze() {
 -        return 140;
-+        return this.entityData.get(DATA_TICKS_REQUIRED_TO_FREEZE);
++        return this.getData(net.neoforged.neoforge.common.NeoForgeMod.TICKS_REQUIRED_TO_FREEZE);
 +    }
 +
 +    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
-+        this.entityData.set(DATA_TICKS_REQUIRED_TO_FREEZE, ticksRequiredToFreeze);
++        this.setData(net.neoforged.neoforge.common.NeoForgeMod.TICKS_REQUIRED_TO_FREEZE, ticksRequiredToFreeze);
      }
  
      public void thunderHit(ServerLevel p_19927_, LightningBolt p_19928_) {

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -619,7 +619,7 @@
          profilerfiller.pop();
          if (this.level() instanceof ServerLevel serverlevel) {
              profilerfiller.push("freezing");
-+            net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, this.level());
++            net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, serverlevel);
 +            if (false) {
              if (!this.isInPowderSnow || !this.canFreeze()) {
                  this.setTicksFrozen(Math.max(0, this.getTicksFrozen() - 2));

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -615,25 +615,23 @@
              }
          } else {
              this.noJumpDelay = 0;
-@@ -2992,6 +_,9 @@
-         }
- 
+@@ -2994,6 +_,8 @@
          profilerfiller.pop();
-+        profilerfiller.push("freezing");
-+        net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, this.level());
-+        if (false) {
          if (this.level() instanceof ServerLevel serverlevel) {
              profilerfiller.push("freezing");
++            net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, this.level());
++            if (false) {
              if (!this.isInPowderSnow || !this.canFreeze()) {
-@@ -3006,6 +_,8 @@
+                 this.setTicksFrozen(Math.max(0, this.getTicksFrozen() - 2));
+             }
+@@ -3003,6 +_,7 @@
+             if (this.tickCount % 40 == 0 && this.isFullyFrozen() && this.canFreeze()) {
+                 this.hurtServer(serverlevel, this.damageSources().freeze(), 1.0F);
+             }
++            }
  
              profilerfiller.pop();
          }
-+        }
-+        profilerfiller.pop();
- 
-         profilerfiller.push("push");
-         if (this.autoSpinAttackTicks > 0) {
 @@ -3280,8 +_,11 @@
  
      private void updatingUsingItem() {

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -615,6 +615,24 @@
              }
          } else {
              this.noJumpDelay = 0;
+@@ -2994,6 +_,8 @@
+         profilerfiller.pop();
+         if (this.level() instanceof ServerLevel serverlevel) {
+             profilerfiller.push("freezing");
++            net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, serverlevel);
++            if (false) {
+             if (!this.isInPowderSnow || !this.canFreeze()) {
+                 this.setTicksFrozen(Math.max(0, this.getTicksFrozen() - 2));
+             }
+@@ -3003,7 +_,7 @@
+             if (this.tickCount % 40 == 0 && this.isFullyFrozen() && this.canFreeze()) {
+                 this.hurtServer(serverlevel, this.damageSources().freeze(), 1.0F);
+             }
+-
++            }
+             profilerfiller.pop();
+         }
+ 
 @@ -3280,8 +_,11 @@
  
      private void updatingUsingItem() {

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -615,24 +615,25 @@
              }
          } else {
              this.noJumpDelay = 0;
-@@ -2994,6 +_,8 @@
-         profilerfiller.pop();
-         if (this.level() instanceof ServerLevel serverlevel) {
-             profilerfiller.push("freezing");
-+            net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, serverlevel);
-+            if (false) {
-             if (!this.isInPowderSnow || !this.canFreeze()) {
-                 this.setTicksFrozen(Math.max(0, this.getTicksFrozen() - 2));
-             }
-@@ -3003,7 +_,7 @@
-             if (this.tickCount % 40 == 0 && this.isFullyFrozen() && this.canFreeze()) {
-                 this.hurtServer(serverlevel, this.damageSources().freeze(), 1.0F);
-             }
--
-+            }
-             profilerfiller.pop();
+@@ -2992,6 +_,9 @@
          }
  
+         profilerfiller.pop();
++        profilerfiller.push("freezing");
++        net.neoforged.neoforge.common.CommonHooks.onLivingFreeze(this, this.level());
++        if (false) {
+         if (this.level() instanceof ServerLevel serverlevel) {
+             profilerfiller.push("freezing");
+             if (!this.isInPowderSnow || !this.canFreeze()) {
+@@ -3006,6 +_,8 @@
+ 
+             profilerfiller.pop();
+         }
++        }
++        profilerfiller.pop();
+ 
+         profilerfiller.push("push");
+         if (this.autoSpinAttackTicks > 0) {
 @@ -3280,8 +_,11 @@
  
      private void updatingUsingItem() {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -102,7 +102,10 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
 import net.minecraft.world.entity.ai.village.poi.PoiManager;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -200,6 +203,7 @@ import net.neoforged.neoforge.event.entity.living.LivingDropsEvent;
 import net.neoforged.neoforge.event.entity.living.LivingDrownEvent;
 import net.neoforged.neoforge.event.entity.living.LivingEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFallEvent;
+import net.neoforged.neoforge.event.entity.living.LivingFreezeEvent;
 import net.neoforged.neoforge.event.entity.living.LivingGetProjectileEvent;
 import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 import net.neoforged.neoforge.event.entity.living.LivingKnockBackEvent;
@@ -1468,6 +1472,54 @@ public class CommonHooks {
 
         if (!isAir && !entity.level().isClientSide() && entity.isPassenger() && entity.getVehicle() != null && !entity.getVehicle().canBeRiddenUnderFluidType(entity.getEyeInFluidType(), entity)) {
             entity.stopRiding();
+        }
+    }
+
+    public static void onLivingFreeze(LivingEntity entity, ServerLevel serverLevel) {
+        boolean isFreezing = entity.isInPowderSnow && entity.canFreeze();
+
+        LivingFreezeEvent freezeEvent = new LivingFreezeEvent(entity, isFreezing);
+        NeoForge.EVENT_BUS.post(freezeEvent);
+
+        if (freezeEvent.isCanceled()) { // Do not freeze if canceled
+            return;
+        }
+
+        if (!freezeEvent.isFreezing()) {
+            entity.setTicksFrozen(Math.max(0, entity.getTicksFrozen() - 2));
+        }
+
+        Identifier speedModifierPowderSnowId = Identifier.withDefaultNamespace("powder_snow");
+        // LivingEntity#removeFrost
+        {
+            AttributeInstance attributeinstance = entity.getAttribute(Attributes.MOVEMENT_SPEED);
+            if (attributeinstance != null) {
+                if (attributeinstance.getModifier(speedModifierPowderSnowId) != null) {
+                    attributeinstance.removeModifier(speedModifierPowderSnowId);
+                }
+            }
+        }
+
+        // LivingEntity#tryAddFrost
+        {
+            BlockState blockStateOnLegacy = entity.level().getBlockState(entity.getOnPosLegacy());
+            if (!blockStateOnLegacy.isAir()) {
+                int i = entity.getTicksFrozen();
+                if (i > 0) {
+                    AttributeInstance attributeinstance = entity.getAttribute(Attributes.MOVEMENT_SPEED);
+                    if (attributeinstance == null) {
+                        return;
+                    }
+
+                    float f = freezeEvent.getSlowAmount() * entity.getPercentFrozen();
+                    attributeinstance.addTransientModifier(new AttributeModifier(speedModifierPowderSnowId, f, AttributeModifier.Operation.ADD_VALUE));
+                }
+            }
+        }
+
+        boolean isFullyFrozen = entity.getTicksFrozen() >= freezeEvent.getTicksRequiredToFreeze();
+        if (entity.tickCount % freezeEvent.getDamageTickRate() == 0 && isFullyFrozen && entity.canFreeze()) {
+            entity.hurtServer(serverLevel, entity.damageSources().freeze(), freezeEvent.getDamageAmount());
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1476,7 +1476,7 @@ public class CommonHooks {
         }
     }
 
-    public static void onLivingFreeze(LivingEntity entity, Level level) {
+    public static void onLivingFreeze(LivingEntity entity, ServerLevel level) {
         boolean isFreezing = entity.isInPowderSnow && entity.canFreeze();
 
         LivingFreezeEvent freezeEvent = new LivingFreezeEvent(entity, isFreezing);
@@ -1519,13 +1519,9 @@ public class CommonHooks {
             LivingFrozenEvent frozenEvent = new LivingFrozenEvent(entity);
             NeoForge.EVENT_BUS.post(frozenEvent);
 
-            if (!level.isClientSide()) {
-                if (!frozenEvent.isCanceled()) {
-                    if (entity.tickCount % frozenEvent.getDamageTickInterval() == 0) {
-                        if (frozenEvent.getDamageAmount() > 0) {
-                            entity.hurtServer((ServerLevel) level, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
-                        }
-                    }
+            if (!frozenEvent.isCanceled() || frozenEvent.getDamageAmount() > 0) {
+                if (entity.tickCount % frozenEvent.getDamageTickInterval() == 0) {
+                    entity.hurtServer(level, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
                 }
             }
         }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1504,13 +1504,11 @@ public class CommonHooks {
                 int i = entity.getTicksFrozen();
                 if (i > 0) {
                     AttributeInstance attributeinstance = entity.getAttribute(Attributes.MOVEMENT_SPEED);
-                    if (attributeinstance == null) {
-                        return;
+                    if (attributeinstance != null) {
+                        entity.setTicksRequiredToFreeze(freezeEvent.getTicksRequiredToFreeze());
+                        float f = freezeEvent.getSlowAmount() * entity.getPercentFrozen();
+                        attributeinstance.addTransientModifier(new AttributeModifier(speedModifierPowderSnowId, f, AttributeModifier.Operation.ADD_VALUE));
                     }
-
-                    entity.setTicksRequiredToFreeze(freezeEvent.getTicksRequiredToFreeze());
-                    float f = freezeEvent.getSlowAmount() * entity.getPercentFrozen();
-                    attributeinstance.addTransientModifier(new AttributeModifier(speedModifierPowderSnowId, f, AttributeModifier.Operation.ADD_VALUE));
                 }
             }
         }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1476,7 +1476,7 @@ public class CommonHooks {
         }
     }
 
-    public static void onLivingFreeze(LivingEntity entity, ServerLevel serverLevel) {
+    public static void onLivingFreeze(LivingEntity entity, Level level) {
         boolean isFreezing = entity.isInPowderSnow && entity.canFreeze();
 
         LivingFreezeEvent freezeEvent = new LivingFreezeEvent(entity, isFreezing);
@@ -1508,6 +1508,7 @@ public class CommonHooks {
                         return;
                     }
 
+                    entity.setTicksRequiredToFreeze(freezeEvent.getTicksRequiredToFreeze());
                     float f = freezeEvent.getSlowAmount() * entity.getPercentFrozen();
                     attributeinstance.addTransientModifier(new AttributeModifier(speedModifierPowderSnowId, f, AttributeModifier.Operation.ADD_VALUE));
                 }
@@ -1518,10 +1519,12 @@ public class CommonHooks {
             LivingFrozenEvent frozenEvent = new LivingFrozenEvent(entity);
             NeoForge.EVENT_BUS.post(frozenEvent);
 
-            if (!frozenEvent.isCanceled()) {
-                if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
-                    if (frozenEvent.getDamageAmount() > 0) {
-                        entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+            if (!level.isClientSide()) {
+                if (!frozenEvent.isCanceled()) {
+                    if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
+                        if (frozenEvent.getDamageAmount() > 0) {
+                            entity.hurtServer((ServerLevel) level, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                        }
                     }
                 }
             }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1481,10 +1481,6 @@ public class CommonHooks {
         LivingFreezeEvent freezeEvent = new LivingFreezeEvent(entity, isFreezing);
         NeoForge.EVENT_BUS.post(freezeEvent);
 
-        if (freezeEvent.isCanceled()) { // Do not freeze if canceled
-            return;
-        }
-
         if (!freezeEvent.isFreezing()) {
             entity.setTicksFrozen(Math.max(0, entity.getTicksFrozen() - 2));
         }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -204,6 +204,7 @@ import net.neoforged.neoforge.event.entity.living.LivingDrownEvent;
 import net.neoforged.neoforge.event.entity.living.LivingEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFallEvent;
 import net.neoforged.neoforge.event.entity.living.LivingFreezeEvent;
+import net.neoforged.neoforge.event.entity.living.LivingFrozenEvent;
 import net.neoforged.neoforge.event.entity.living.LivingGetProjectileEvent;
 import net.neoforged.neoforge.event.entity.living.LivingIncomingDamageEvent;
 import net.neoforged.neoforge.event.entity.living.LivingKnockBackEvent;
@@ -1513,9 +1514,15 @@ public class CommonHooks {
             }
         }
 
-        boolean isFullyFrozen = entity.getTicksFrozen() >= freezeEvent.getTicksRequiredToFreeze();
-        if (entity.tickCount % freezeEvent.getDamageTickRate() == 0 && isFullyFrozen && entity.canFreeze()) {
-            entity.hurtServer(serverLevel, entity.damageSources().freeze(), freezeEvent.getDamageAmount());
+        if (entity.isFullyFrozen() && entity.canFreeze()) {
+            LivingFrozenEvent frozenEvent = new LivingFrozenEvent(entity);
+            NeoForge.EVENT_BUS.post(frozenEvent);
+
+            if (!frozenEvent.isCanceled()) {
+                if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
+                    entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                }
+            }
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1520,7 +1520,9 @@ public class CommonHooks {
 
             if (!frozenEvent.isCanceled()) {
                 if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
-                    entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                    if (frozenEvent.getDamageAmount() > 0) {
+                        entity.hurtServer(serverLevel, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
+                    }
                 }
             }
         }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1521,7 +1521,7 @@ public class CommonHooks {
 
             if (!level.isClientSide()) {
                 if (!frozenEvent.isCanceled()) {
-                    if (entity.tickCount % frozenEvent.getDamageTickRate() == 0) {
+                    if (entity.tickCount % frozenEvent.getDamageTickInterval() == 0) {
                         if (frozenEvent.getDamageAmount() > 0) {
                             entity.hurtServer((ServerLevel) level, entity.damageSources().freeze(), frozenEvent.getDamageAmount());
                         }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Supplier;
+
 import net.minecraft.SharedConstants;
 import net.minecraft.advancements.criterion.EntitySubPredicate;
 import net.minecraft.commands.Commands;
@@ -26,6 +28,7 @@ import net.minecraft.core.RegistryCodecs;
 import net.minecraft.core.component.predicates.DataComponentPredicate;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
@@ -84,6 +87,7 @@ import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
+import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
 import net.neoforged.neoforge.common.advancements.critereon.ItemAbilityPredicate;
 import net.neoforged.neoforge.common.advancements.critereon.PiglinCurrencyItemPredicate;
@@ -188,6 +192,7 @@ public class NeoForgeMod {
     private static final DeferredRegister<HolderSetType> HOLDER_SET_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.HOLDER_SET_TYPES, MOD_ID);
     private static final DeferredRegister<AttributeType<?>> ATTRIBUTE_TYPES = DeferredRegister.create(Registries.ATTRIBUTE_TYPE, MOD_ID);
     private static final DeferredRegister<EnvironmentAttribute<?>> ENVIRONMENT_ATTRIBUTES = DeferredRegister.create(Registries.ENVIRONMENT_ATTRIBUTE, MOD_ID);
+    private static final DeferredRegister<AttachmentType<?>> ATTACHMENT_TYPES = DeferredRegister.create(NeoForgeRegistries.ATTACHMENT_TYPES, MOD_ID);
 
     @SuppressWarnings({ "unchecked", "rawtypes" }) // Uses Holder instead of DeferredHolder as the type due to weirdness between ECJ and javac.
     private static final Holder<ArgumentTypeInfo<?, ?>> ENUM_COMMAND_ARGUMENT_TYPE = COMMAND_ARGUMENT_TYPES.register("enum", () -> ArgumentTypeInfos.registerByClass(EnumArgument.class, new EnumArgument.Info()));
@@ -351,6 +356,10 @@ public class NeoForgeMod {
      * Can be used in a holderset object with {@code { "type": "neoforge:not", "value": holderset }}</p>
      */
     public static final Holder<HolderSetType> NOT_HOLDER_SET = HOLDER_SET_TYPES.register("not", NotHolderSet.Type::new);
+
+    public static final Supplier<AttachmentType<Integer>> TICKS_REQUIRED_TO_FREEZE = ATTACHMENT_TYPES.register(
+            "ticks_required_to_freeze", () -> AttachmentType.builder(() -> Entity.BASE_TICKS_REQUIRED_TO_FREEZE).serialize(Codec.INT.fieldOf("ticks_required_to_freeze")).sync(ByteBufCodecs.INT).build()
+    );
 
     private static final DeferredRegister<SlotDisplay.Type<?>> SLOT_DISPLAY_TYPES = DeferredRegister.create(Registries.SLOT_DISPLAY, MOD_ID);
 
@@ -584,6 +593,7 @@ public class NeoForgeMod {
         GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
         ATTRIBUTE_TYPES.register(modEventBus);
         ENVIRONMENT_ATTRIBUTES.register(modEventBus);
+        ATTACHMENT_TYPES.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
         ConfigSync.registerEventListeners();
         container.registerConfig(ModConfig.Type.SERVER, NeoForgeServerConfig.SPEC);

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -22,23 +22,17 @@ import net.neoforged.neoforge.common.NeoForge;
  */
 public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
-    private int ticksRequiredToFreeze;
     private float slowAmount;
-    private float damageAmount;
-    private int damageTickRate; // In ticks
 
     public LivingFreezeEvent(LivingEntity entity, boolean isFreezing) {
         super(entity);
         this.isFreezing = isFreezing;
-        this.ticksRequiredToFreeze = entity.getTicksRequiredToFreeze();
         this.slowAmount = -0.05F;
-        this.damageAmount = 1.0F;
-        this.damageTickRate = 40;
     }
 
     /**
      * If the entity is freezing, its freezing counter will be increased. If it's over the
-     * {@link #getTicksRequiredToFreeze()} threshold, the entity will take damage.<br>
+     * {@link LivingEntity#getTicksRequiredToFreeze()} threshold, the entity will take damage.<br>
      * If the entity is not freezing, its freezing counter will be decreased.
      *
      * @return True if the entity is freezing
@@ -56,38 +50,11 @@ public class LivingFreezeEvent extends LivingEvent {
         isFreezing = freezing;
     }
 
-    /**
-     * @return The number of ticks needed to fully freeze (start applying damage) while freezing.
-     */
-    public int getTicksRequiredToFreeze() {
-        return ticksRequiredToFreeze;
-    }
-
-    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
-        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
-    }
-
     public float getSlowAmount() {
         return slowAmount;
     }
 
     public void setSlowAmount(float slowAmount) {
         this.slowAmount = slowAmount;
-    }
-
-    public float getDamageAmount() {
-        return damageAmount;
-    }
-
-    public void setDamageAmount(float damageAmount) {
-        this.damageAmount = damageAmount;
-    }
-
-    public int getDamageTickRate() {
-        return damageTickRate;
-    }
-
-    public void setDamageTickRate(int damageTickRate) {
-        this.damageTickRate = damageTickRate;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -53,6 +53,7 @@ public class LivingFreezeEvent extends LivingEvent {
 
     /**
      * Get the slow attribute value applied to the entity as it's freezing. It's applied as {@link AttributeModifier.Operation#ADD_VALUE}.
+     * 
      * @return The current value
      */
     public float getSlowAmount() {
@@ -61,6 +62,7 @@ public class LivingFreezeEvent extends LivingEvent {
 
     /**
      * Sets the slow attribute value that will be applied to the entity as it's freezing.
+     * 
      * @param slowAmount The new value.
      */
     public void setSlowAmount(float slowAmount) {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -8,7 +8,7 @@ package net.neoforged.neoforge.event.entity.living;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
 
-public class LivingFreezeEvent extends LivingEvent implements ICancellableEvent {
+public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
     private int ticksRequiredToFreeze;
     private float slowAmount;

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -24,11 +24,13 @@ import net.neoforged.neoforge.common.NeoForge;
 public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
     private float slowAmount;
+    private int ticksRequiredToFreeze;
 
     public LivingFreezeEvent(LivingEntity entity, boolean isFreezing) {
         super(entity);
         this.isFreezing = isFreezing;
         this.slowAmount = -0.05F;
+        this.ticksRequiredToFreeze = entity.getTicksRequiredToFreeze();
     }
 
     /**
@@ -67,5 +69,23 @@ public class LivingFreezeEvent extends LivingEvent {
      */
     public void setSlowAmount(float slowAmount) {
         this.slowAmount = slowAmount;
+    }
+
+    /**
+     * Get the amount of ticks required to fully freeze (start taking damage).
+     *
+     * @return The current value
+     */
+    public int getTicksRequiredToFreeze() {
+        return ticksRequiredToFreeze;
+    }
+
+    /**
+     * Sets the amount of ticks required to fully freeze (start taking damage).
+     *
+     * @param ticksRequiredToFreeze The new value
+     */
+    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
+        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -5,9 +5,21 @@
 
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.common.NeoForge;
 
+/**
+ * LivingFreezeEvent is fired whenever a living entity ticks.<br>
+ * <br>
+ * This event is fired via {@link CommonHooks#onLivingFreeze(LivingEntity, ServerLevel)}.<br>
+ * <br>
+ * This event is {@link ICancellableEvent}.<br>
+ * <br>
+ * This event is fired on {@link NeoForge#EVENT_BUS}, on the logical server only.
+ */
 public class LivingFreezeEvent extends LivingEvent {
     private boolean isFreezing;
     private int ticksRequiredToFreeze;
@@ -24,14 +36,29 @@ public class LivingFreezeEvent extends LivingEvent {
         this.damageTickRate = 40;
     }
 
+    /**
+     * If the entity is freezing, its freezing counter will be increased. If it's over the
+     * {@link #getTicksRequiredToFreeze()} threshold, the entity will take damage.<br>
+     * If the entity is not freezing, its freezing counter will be decreased.
+     *
+     * @return True if the entity is freezing
+     */
     public boolean isFreezing() {
         return isFreezing;
     }
 
+    /**
+     * Sets if the entity is freezing or not.
+     *
+     * @param freezing The new value.
+     */
     public void setFreezing(boolean freezing) {
         isFreezing = freezing;
     }
 
+    /**
+     * @return The number of ticks needed to fully freeze (start applying damage) while freezing.
+     */
     public int getTicksRequiredToFreeze() {
         return ticksRequiredToFreeze;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.event.entity.living;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
@@ -50,10 +51,18 @@ public class LivingFreezeEvent extends LivingEvent {
         isFreezing = freezing;
     }
 
+    /**
+     * Get the slow attribute value applied to the entity as it's freezing. It's applied as {@link AttributeModifier.Operation#ADD_VALUE}.
+     * @return The current value
+     */
     public float getSlowAmount() {
         return slowAmount;
     }
 
+    /**
+     * Sets the slow attribute value that will be applied to the entity as it's freezing.
+     * @param slowAmount The new value.
+     */
     public void setSlowAmount(float slowAmount) {
         this.slowAmount = slowAmount;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFreezeEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.living;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.ICancellableEvent;
+
+public class LivingFreezeEvent extends LivingEvent implements ICancellableEvent {
+    private boolean isFreezing;
+    private int ticksRequiredToFreeze;
+    private float slowAmount;
+    private float damageAmount;
+    private int damageTickRate; // In ticks
+
+    public LivingFreezeEvent(LivingEntity entity, boolean isFreezing) {
+        super(entity);
+        this.isFreezing = isFreezing;
+        this.ticksRequiredToFreeze = entity.getTicksRequiredToFreeze();
+        this.slowAmount = -0.05F;
+        this.damageAmount = 1.0F;
+        this.damageTickRate = 40;
+    }
+
+    public boolean isFreezing() {
+        return isFreezing;
+    }
+
+    public void setFreezing(boolean freezing) {
+        isFreezing = freezing;
+    }
+
+    public int getTicksRequiredToFreeze() {
+        return ticksRequiredToFreeze;
+    }
+
+    public void setTicksRequiredToFreeze(int ticksRequiredToFreeze) {
+        this.ticksRequiredToFreeze = ticksRequiredToFreeze;
+    }
+
+    public float getSlowAmount() {
+        return slowAmount;
+    }
+
+    public void setSlowAmount(float slowAmount) {
+        this.slowAmount = slowAmount;
+    }
+
+    public float getDamageAmount() {
+        return damageAmount;
+    }
+
+    public void setDamageAmount(float damageAmount) {
+        this.damageAmount = damageAmount;
+    }
+
+    public int getDamageTickRate() {
+        return damageTickRate;
+    }
+
+    public void setDamageTickRate(int damageTickRate) {
+        this.damageTickRate = damageTickRate;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -1,5 +1,7 @@
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.world.damagesource.DamageSources;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
@@ -26,18 +28,40 @@ public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent 
         this.damageTickRate = 40;
     }
 
+    /**
+     * Gets the amount of {@linkplain DamageSources#freeze() drowning damage} the entity would take.<br>
+     * For vanilla entities, the default amount of damage is 1 (half a heart).
+     * <p>
+     * If the damage amount is less than or equal to zero, {@link Entity#hurtServer} will not be called.
+     *
+     * @return The amount of damage that will be dealt to the entity when actively drowning.
+     */
     public float getDamageAmount() {
         return damageAmount;
     }
 
+    /**
+     * Sets the amount of freezing damage that may be inflicted.
+     *
+     * @param damageAmount The new value.
+     * @see #getDamageAmount()
+     */
     public void setDamageAmount(float damageAmount) {
         this.damageAmount = damageAmount;
     }
 
+    /**
+     * @return The amount of ticks between two damages instances.
+     */
     public int getDamageTickRate() {
         return damageTickRate;
     }
 
+    /**
+     * Sets the amount of ticks between two damages instances.
+     *
+     * @param damageTickRate The new value.
+     */
     public void setDamageTickRate(int damageTickRate) {
         this.damageTickRate = damageTickRate;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -1,0 +1,53 @@
+package net.neoforged.neoforge.event.entity.living;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.common.NeoForge;
+import net.minecraft.server.level.ServerLevel;
+
+/**
+ * LivingDrownEvent is fired whenever a living entity is fully frozen and is taking damage.
+ * <p>
+ * This event is fired via {@link CommonHooks#onLivingFreeze(LivingEntity, ServerLevel)}.
+ * <p>
+ * This event is {@link ICancellableEvent}. Effects of cancellation are noted in {@link #setCanceled(boolean)}.
+ * <p>
+ * This event does not {@linkplain HasResult have a result}.
+ * This event is fired on {@link NeoForge#EVENT_BUS}
+ **/
+public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent {
+    private float damageAmount;
+    private int damageTickRate;
+
+    public LivingFrozenEvent(LivingEntity entity) {
+        super(entity);
+        this.damageAmount = 1.0F;
+        this.damageTickRate = 40;
+    }
+
+    public float getDamageAmount() {
+        return damageAmount;
+    }
+
+    public void setDamageAmount(float damageAmount) {
+        this.damageAmount = damageAmount;
+    }
+
+    public int getDamageTickRate() {
+        return damageTickRate;
+    }
+
+    public void setDamageTickRate(int damageTickRate) {
+        this.damageTickRate = damageTickRate;
+    }
+
+    /**
+     * Cancelling the event will cancel the damage to the entity.
+     * @param canceled
+     */
+    @Override
+    public void setCanceled(boolean canceled) {
+        ICancellableEvent.super.setCanceled(canceled);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -1,12 +1,17 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.event.entity.living;
 
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.damagesource.DamageSources;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.NeoForge;
-import net.minecraft.server.level.ServerLevel;
 
 /**
  * LivingDrownEvent is fired whenever a living entity is fully frozen and is taking damage.
@@ -68,6 +73,7 @@ public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent 
 
     /**
      * Cancelling the event will cancel the damage to the entity.
+     * 
      * @param canceled
      */
     @Override

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingFrozenEvent.java
@@ -25,12 +25,12 @@ import net.neoforged.neoforge.common.NeoForge;
  **/
 public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent {
     private float damageAmount;
-    private int damageTickRate;
+    private int damageTickInterval;
 
     public LivingFrozenEvent(LivingEntity entity) {
         super(entity);
         this.damageAmount = 1.0F;
-        this.damageTickRate = 40;
+        this.damageTickInterval = 40;
     }
 
     /**
@@ -58,17 +58,17 @@ public class LivingFrozenEvent extends LivingEvent implements ICancellableEvent 
     /**
      * @return The amount of ticks between two damages instances.
      */
-    public int getDamageTickRate() {
-        return damageTickRate;
+    public int getDamageTickInterval() {
+        return damageTickInterval;
     }
 
     /**
      * Sets the amount of ticks between two damages instances.
      *
-     * @param damageTickRate The new value.
+     * @param damageTickInterval The new value.
      */
-    public void setDamageTickRate(int damageTickRate) {
-        this.damageTickRate = damageTickRate;
+    public void setDamageTickInterval(int damageTickInterval) {
+        this.damageTickInterval = damageTickInterval;
     }
 
     /**

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/LivingFreezeEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/LivingFreezeEventTest.java
@@ -30,7 +30,7 @@ public class LivingFreezeEventTest {
 
     public static void onFrozenEvent(LivingFrozenEvent event) {
         //event.setCanceled(true);
-        event.setDamageTickRate(1);
+        event.setDamageTickInterval(1);
         event.setDamageAmount(4);
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/LivingFreezeEventTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/entity/LivingFreezeEventTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.oldtest.entity;
+
+import com.mojang.logging.LogUtils;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.living.LivingFreezeEvent;
+import net.neoforged.neoforge.event.entity.living.LivingFrozenEvent;
+import org.slf4j.Logger;
+
+@Mod("living_freeze_event_test")
+public class LivingFreezeEventTest {
+    public static final boolean ENABLE = true;
+    public static final Logger LOGGER = LogUtils.getLogger();
+
+    public LivingFreezeEventTest() {
+        if (ENABLE) {
+            NeoForge.EVENT_BUS.addListener(LivingFreezeEventTest::onFreezeEvent);
+            NeoForge.EVENT_BUS.addListener(LivingFreezeEventTest::onFrozenEvent);
+        }
+    }
+
+    public static void onFreezeEvent(LivingFreezeEvent event) {
+        event.setTicksRequiredToFreeze(10);
+    }
+
+    public static void onFrozenEvent(LivingFrozenEvent event) {
+        //event.setCanceled(true);
+        event.setDamageTickRate(1);
+        event.setDamageAmount(4);
+    }
+}

--- a/tests/src/main/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/main/resources/META-INF/neoforge.mods.toml
@@ -247,5 +247,7 @@ modId="custom_feature_flags_pack_test"
 featureFlags="game_test_feature_flags.json"
 [[mods]]
 modId="recipe_sync_test"
+[[mods]]
+modId="living_freeze_event_test"
 
 # ADD ABOVE THIS LINE


### PR DESCRIPTION
This pull request adds a `LivingFreezeEvent` analogous to the existing `LivingBreatheEvent`. It allows control (and query) on:
- if a living entity is freezing or not
- the amount of slow applied when freezing
- the amount if ticks required to be fully frozen (start taking damage, having the blue hearts)

There is also the `LivingFrozenEvent` which is analogous to `LivingDrownEvent`. It allows control (and query) on:
- the damage amount per tick
- and the tick interval for the damage (period between instances of damage)

This is my first Neo PR, I would be happy to have feedback!