### PR TITLE
feat: do not try to sync data attachments to vanilla clients

### DIFF
--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
@@ -105,7 +105,7 @@ public final class AttachmentSync {
         var packet = new SyncAttachmentsPayload(syncTarget(holder), List.of(type), data).toVanillaClientbound();
         for (var player : players) {
             if (type.syncHandler.sendToPlayer(holder.getExposedHolder(), player)) {
-                if (player.connection.hasChannel(SyncAttachmentsPayload.TYPE.id())) {
+                if (player.connection.hasChannel(SyncAttachmentsPayload.TYPE)) {
                     player.connection.send(packet);
                 }
             }
@@ -163,7 +163,7 @@ public final class AttachmentSync {
         if (holder.attachments == null) {
             return null;
         }
-        if (!to.connection.hasChannel(SyncAttachmentsPayload.TYPE.id())) {
+        if (!to.connection.hasChannel(SyncAttachmentsPayload.TYPE)) {
             return null;
         }
         boolean anySyncableAttachment = false;

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
@@ -30,7 +30,6 @@ import net.neoforged.neoforge.common.util.FriendlyByteBufUtil;
 import net.neoforged.neoforge.event.level.ChunkWatchEvent;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.payload.SyncAttachmentsPayload;
-import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.RegistryBuilder;
 import net.neoforged.neoforge.registries.callback.AddCallback;

--- a/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/AttachmentSync.java
@@ -30,6 +30,7 @@ import net.neoforged.neoforge.common.util.FriendlyByteBufUtil;
 import net.neoforged.neoforge.event.level.ChunkWatchEvent;
 import net.neoforged.neoforge.network.connection.ConnectionType;
 import net.neoforged.neoforge.network.payload.SyncAttachmentsPayload;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import net.neoforged.neoforge.registries.RegistryBuilder;
 import net.neoforged.neoforge.registries.callback.AddCallback;
@@ -105,7 +106,9 @@ public final class AttachmentSync {
         var packet = new SyncAttachmentsPayload(syncTarget(holder), List.of(type), data).toVanillaClientbound();
         for (var player : players) {
             if (type.syncHandler.sendToPlayer(holder.getExposedHolder(), player)) {
-                player.connection.send(packet);
+                if (player.connection.hasChannel(SyncAttachmentsPayload.TYPE.id())) {
+                    player.connection.send(packet);
+                }
             }
         }
     }
@@ -159,6 +162,9 @@ public final class AttachmentSync {
     @Nullable
     private static SyncAttachmentsPayload syncInitialAttachments(AttachmentHolder holder, ServerPlayer to) {
         if (holder.attachments == null) {
+            return null;
+        }
+        if (!to.connection.hasChannel(SyncAttachmentsPayload.TYPE.id())) {
             return null;
         }
         boolean anySyncableAttachment = false;


### PR DESCRIPTION
This was discussed on Discord: https://discord.com/channels/313125603924639766/852298000042164244/1470546865438068808

We want to not break the vanilla compat when using data attachments auto synced. We add some checks in AttachmentsSync to see if we have the channel for the packet, if not, we simply don't send the sync packet.