### PR TITLE
[26.1] Introduce `FluidInstance` and `FluidStackTemplate`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/FluidInstance.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidInstance.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.fluids;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import net.minecraft.core.Holder;
+import net.minecraft.core.TypedInstance;
+import net.minecraft.core.component.DataComponentGetter;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemInstance;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+
+public interface FluidInstance extends TypedInstance<Fluid>, DataComponentGetter {
+    String FIELD_ID = ItemInstance.FIELD_ID;
+    String FIELD_AMOUNT = "amount";
+    String FIELD_COMPONENTS = ItemInstance.FIELD_COMPONENTS;
+
+    Codec<Holder<Fluid>> FLUID_HOLDER_CODEC = BuiltInRegistries.FLUID
+            .holderByNameCodec()
+            .validate(fluid -> fluid.is(Fluids.EMPTY.builtInRegistryHolder()) ? DataResult.error(() -> "Fluid must not be minecraft:empty") : DataResult.success(fluid));
+
+    StreamCodec<RegistryFriendlyByteBuf, Holder<Fluid>> FLUID_HOLDER_STREAM_CODEC = ByteBufCodecs.holderRegistry(Registries.FLUID);
+
+    Codec<Holder<Fluid>> FLUID_HOLDER_CODEC_WITH_BOUND_COMPONENTS = FLUID_HOLDER_CODEC.validate(
+            fluid -> !fluid.areComponentsBound()
+                    ? DataResult.error(() -> "Fluid " + fluid.getRegisteredName() + " does not have components yet")
+                    : DataResult.success(fluid));
+
+    int amount();
+
+    /// Returns the fluid type of this instance.
+    default FluidType getFluidType() {
+        return typeHolder().value().getFluidType();
+    }
+
+    /// Check if the fluid type of this instance is equal to the given fluid type.
+    default boolean is(FluidType fluidType) {
+        return getFluidType() == fluidType;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.fluids;
 
 import com.google.common.collect.Lists;
-import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -23,6 +22,7 @@ import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.component.PatchedDataComponentMap;
+import net.minecraft.core.component.TypedDataComponent;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -38,7 +38,6 @@ import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.MutableDataComponentHolder;
 import net.neoforged.neoforge.event.EventHooks;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
 
 /**
  * {@link ItemStack} equivalent for fluids.
@@ -136,15 +135,18 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
             }
         }
     };
-    private static final Logger LOGGER = LogUtils.getLogger();
     public static final FluidStack EMPTY = new FluidStack(null);
     private int amount;
     private final @Nullable Holder<Fluid> fluid;
     private final PatchedDataComponentMap components;
 
     @Override
-    public PatchedDataComponentMap getComponents() {
-        return components;
+    public DataComponentMap getComponents() {
+        return isEmpty() ? DataComponentMap.EMPTY : components;
+    }
+
+    public DataComponentMap getPrototype() {
+        return isEmpty() ? DataComponentMap.EMPTY : typeHolder().components();
     }
 
     public DataComponentPatch getComponentsPatch() {
@@ -153,6 +155,10 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
 
     public DataComponentMap immutableComponents() {
         return !this.isEmpty() ? this.components.toImmutableMap() : DataComponentMap.EMPTY;
+    }
+
+    public boolean hasNonDefault(DataComponentType<?> type) {
+        return !isEmpty() && components.hasNonDefault(type);
     }
 
     public boolean isComponentsPatchEmpty() {
@@ -190,14 +196,14 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
      * Checks if this fluid stack is empty.
      */
     public boolean isEmpty() {
-        return this == EMPTY || this.fluid == Fluids.EMPTY || this.amount <= 0;
+        return this == EMPTY || fluid.value().isSame(Fluids.EMPTY) || this.amount <= 0;
     }
 
     /**
      * Splits off a stack of the given amount of this stack and reduces this stack by the amount.
      */
     public FluidStack split(int amount) {
-        int i = Math.min(amount, this.amount);
+        int i = Math.min(amount, getAmount());
         FluidStack fluidStack = this.copyWithAmount(i);
         this.shrink(i);
         return fluidStack;
@@ -220,12 +226,12 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
      * Returns the fluid in this stack, or {@link Fluids#EMPTY} if this stack is empty.
      */
     public Fluid getFluid() {
-        return this.isEmpty() ? Fluids.EMPTY : this.fluid.value();
+        return typeHolder().value();
     }
 
     @Override
     public Holder<Fluid> typeHolder() {
-        return this.getFluid().builtInRegistryHolder();
+        return isEmpty() ? Fluids.EMPTY.builtInRegistryHolder() : fluid;
     }
 
     public boolean is(Predicate<Holder<Fluid>> holderPredicate) {
@@ -239,7 +245,7 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
         if (this.isEmpty()) {
             return EMPTY;
         } else {
-            return new FluidStack(this.fluid, this.amount, this.components.copy());
+            return new FluidStack(typeHolder(), amount(), this.components.copy());
         }
     }
 
@@ -254,6 +260,18 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
             fluidStack.setAmount(amount);
             return fluidStack;
         }
+    }
+
+    public FluidStack transmuteCopy(Fluid newFluid) {
+        return transmuteCopy(newFluid, amount());
+    }
+
+    public FluidStack transmuteCopy(Fluid newFluid, int newAmount) {
+        return isEmpty() ? EMPTY : transmuteCopyIgnoreEmpty(newFluid, newAmount);
+    }
+
+    private FluidStack transmuteCopyIgnoreEmpty(Fluid newFluid, int newAmount) {
+        return new FluidStack(newFluid, newAmount, components.asPatch());
     }
 
     /**
@@ -398,6 +416,10 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
     @Override
     public <T> T set(DataComponentType<T> type, @Nullable T component) {
         return this.components.set(type, component);
+    }
+
+    public <T> @Nullable T set(TypedDataComponent<T> value) {
+        return components.set(value);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.fluids;
 import com.google.common.collect.Lists;
 import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.netty.handler.codec.DecoderException;
@@ -19,17 +18,14 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
-import net.minecraft.core.TypedInstance;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.component.PatchedDataComponentMap;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.entity.player.Player;
@@ -51,12 +47,10 @@ import org.slf4j.Logger;
  *
  * <p>Most methods in this class are adapted from {@link ItemStack}.
  */
-public final class FluidStack implements MutableDataComponentHolder, TypedInstance<Fluid> {
-    public static final Codec<Holder<Fluid>> FLUID_NON_EMPTY_CODEC = BuiltInRegistries.FLUID.holderByNameCodec().validate(holder -> {
-        return holder.is(Fluids.EMPTY.builtInRegistryHolder()) ? DataResult.error(() -> {
-            return "Fluid must not be minecraft:empty";
-        }) : DataResult.success(holder);
-    });
+public final class FluidStack implements MutableDataComponentHolder, FluidInstance {
+    /// @deprecated Use {@linkplain #FLUID_HOLDER_CODEC}
+    @Deprecated
+    public static final Codec<Holder<Fluid>> FLUID_NON_EMPTY_CODEC = FLUID_HOLDER_CODEC;
     /**
      * A standard map codec for fluid stacks that does not accept empty stacks.
      */
@@ -64,9 +58,9 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
             "FluidStack",
             c -> RecordCodecBuilder.mapCodec(
                     instance -> instance.group(
-                            FLUID_NON_EMPTY_CODEC.fieldOf("id").forGetter(FluidStack::typeHolder),
-                            ExtraCodecs.POSITIVE_INT.fieldOf("amount").forGetter(FluidStack::getAmount), // note: no .orElse(1) compared to ItemStack
-                            DataComponentPatch.CODEC.optionalFieldOf("components", DataComponentPatch.EMPTY)
+                            FLUID_HOLDER_CODEC_WITH_BOUND_COMPONENTS.fieldOf(FIELD_ID).forGetter(FluidStack::typeHolder),
+                            ExtraCodecs.POSITIVE_INT.fieldOf(FIELD_AMOUNT).forGetter(FluidStack::getAmount), // note: no .orElse(1) compared to ItemStack
+                            DataComponentPatch.CODEC.optionalFieldOf(FIELD_COMPONENTS, DataComponentPatch.EMPTY)
                                     .forGetter(stack -> stack.components.asPatch()))
                             .apply(instance, FluidStack::new)));
     /**
@@ -84,8 +78,8 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
         return Codec.lazyInitialized(
                 () -> RecordCodecBuilder.create(
                         instance -> instance.group(
-                                FLUID_NON_EMPTY_CODEC.fieldOf("id").forGetter(FluidStack::typeHolder),
-                                DataComponentPatch.CODEC.optionalFieldOf("components", DataComponentPatch.EMPTY)
+                                FLUID_HOLDER_CODEC.fieldOf(FIELD_ID).forGetter(FluidStack::typeHolder),
+                                DataComponentPatch.CODEC.optionalFieldOf(FIELD_COMPONENTS, DataComponentPatch.EMPTY)
                                         .forGetter(stack -> stack.components.asPatch()))
                                 .apply(instance, (holder, patch) -> new FluidStack(holder, amount, patch))));
     }
@@ -99,15 +93,13 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
      * A stream codec for fluid stacks that accepts empty stacks.
      */
     public static final StreamCodec<RegistryFriendlyByteBuf, FluidStack> OPTIONAL_STREAM_CODEC = new StreamCodec<>() {
-        private static final StreamCodec<RegistryFriendlyByteBuf, Holder<Fluid>> FLUID_STREAM_CODEC = ByteBufCodecs.holderRegistry(Registries.FLUID);
-
         @Override
         public FluidStack decode(RegistryFriendlyByteBuf buf) {
             int amount = buf.readVarInt();
             if (amount <= 0) {
                 return FluidStack.EMPTY;
             } else {
-                Holder<Fluid> holder = FLUID_STREAM_CODEC.decode(buf);
+                Holder<Fluid> holder = FLUID_HOLDER_STREAM_CODEC.decode(buf);
                 DataComponentPatch patch = DataComponentPatch.STREAM_CODEC.decode(buf);
                 return new FluidStack(holder, amount, patch);
             }
@@ -119,7 +111,7 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
                 buf.writeVarInt(0);
             } else {
                 buf.writeVarInt(stack.getAmount());
-                FLUID_STREAM_CODEC.encode(buf, stack.typeHolder());
+                FLUID_HOLDER_STREAM_CODEC.encode(buf, stack.typeHolder());
                 DataComponentPatch.STREAM_CODEC.encode(buf, stack.components.asPatch());
             }
         }
@@ -280,6 +272,15 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
         }
     }
 
+    /// Compares an fluidstack with an [FluidStackTemplate] as per [#matches(FluidStack, FluidStack)].
+    public static boolean matches(FluidStack a, @Nullable FluidStackTemplate b) {
+        if (b == null) {
+            return a.isEmpty();
+        }
+
+        return a.amount() == b.amount() && isSameFluidSameComponents(a, b);
+    }
+
     /**
      * Checks if the two fluid stacks have the same fluid. Ignores amount and components.
      *
@@ -299,6 +300,22 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
             return false;
         } else {
             return first.isEmpty() && second.isEmpty() ? true : Objects.equals(first.components, second.components);
+        }
+    }
+
+    /// {@return true if a and b refer to the same fluid, or if a is empty and b is null}
+    public static boolean isSameItem(FluidStack a, @Nullable FluidStackTemplate b) {
+        return b == null ? a.isEmpty() : a.is(b.fluid());
+    }
+
+    /// Compares the fluid and components of this stack against an [FluidStackTemplate].
+    ///
+    /// @return True if either this stack is empty and the template is null, or they reference the same fluid and have equivalent component patches.
+    public static boolean isSameFluidSameComponents(FluidStack a, @Nullable FluidStackTemplate b) {
+        if (a.isEmpty() || b == null) {
+            return a.isEmpty() == (b == null);
+        } else {
+            return a.is(b.fluid()) && a.components.patchEquals(b.components());
         }
     }
 
@@ -418,11 +435,16 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
         return getFluidType().getDescription(this);
     }
 
+    @Override
+    public int amount() {
+        return this.isEmpty() ? 0 : this.amount;
+    }
+
     /**
      * Returns the amount of this stack.
      */
     public int getAmount() {
-        return this.isEmpty() ? 0 : this.amount;
+        return amount();
     }
 
     /**
@@ -456,18 +478,4 @@ public final class FluidStack implements MutableDataComponentHolder, TypedInstan
     }
 
     // Extra methods that are not directly adapted from ItemStack go below
-
-    /**
-     * Returns the fluid type of this stack.
-     */
-    public FluidType getFluidType() {
-        return getFluid().getFluidType();
-    }
-
-    /**
-     * Check if the fluid type of this stack is equal to the given fluid type.
-     */
-    public boolean is(FluidType fluidType) {
-        return getFluidType() == fluidType;
-    }
 }

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -304,7 +304,7 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
     }
 
     /// {@return true if a and b refer to the same fluid, or if a is empty and b is null}
-    public static boolean isSameItem(FluidStack a, @Nullable FluidStackTemplate b) {
+    public static boolean isSameFluid(FluidStack a, @Nullable FluidStackTemplate b) {
         return b == null ? a.isEmpty() : a.is(b.fluid());
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -165,20 +165,20 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
         return !this.isEmpty() ? this.components.isPatchEmpty() : true;
     }
 
-    public FluidStack(Holder<Fluid> fluid, int amount, DataComponentPatch patch) {
-        this(fluid, amount, PatchedDataComponentMap.fromPatch(fluid.components(), patch));
-    }
-
     public FluidStack(Fluid fluid, int amount, DataComponentPatch patch) {
         this(fluid.builtInRegistryHolder(), amount, patch);
+    }
+
+    public FluidStack(Fluid fluid, int amount) {
+        this(fluid, amount, DataComponentPatch.EMPTY);
     }
 
     public FluidStack(Holder<Fluid> fluid, int amount) {
         this(fluid, amount, DataComponentPatch.EMPTY);
     }
 
-    public FluidStack(Fluid fluid, int amount) {
-        this(fluid, amount, DataComponentPatch.EMPTY);
+    public FluidStack(Holder<Fluid> fluid, int amount, DataComponentPatch patch) {
+        this(fluid, amount, PatchedDataComponentMap.fromPatch(fluid.components(), patch));
     }
 
     private FluidStack(Holder<Fluid> fluid, int amount, PatchedDataComponentMap components) {

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -48,9 +48,6 @@ import org.slf4j.Logger;
  * <p>Most methods in this class are adapted from {@link ItemStack}.
  */
 public final class FluidStack implements MutableDataComponentHolder, FluidInstance {
-    /// @deprecated Use {@linkplain #FLUID_HOLDER_CODEC}
-    @Deprecated
-    public static final Codec<Holder<Fluid>> FLUID_NON_EMPTY_CODEC = FLUID_HOLDER_CODEC;
     /**
      * A standard map codec for fluid stacks that does not accept empty stacks.
      */

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -142,7 +142,7 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
     private static final Logger LOGGER = LogUtils.getLogger();
     public static final FluidStack EMPTY = new FluidStack(null);
     private int amount;
-    private final Fluid fluid;
+    private final @Nullable Holder<Fluid> fluid;
     private final PatchedDataComponentMap components;
 
     @Override
@@ -163,22 +163,22 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
     }
 
     public FluidStack(Holder<Fluid> fluid, int amount, DataComponentPatch patch) {
-        this(fluid.value(), amount, patch);
+        this(fluid, amount, PatchedDataComponentMap.fromPatch(fluid.components(), patch));
     }
 
     public FluidStack(Fluid fluid, int amount, DataComponentPatch patch) {
-        this(fluid, amount, PatchedDataComponentMap.fromPatch(DataComponentMap.EMPTY, patch));
+        this(fluid.builtInRegistryHolder(), amount, patch);
     }
 
     public FluidStack(Holder<Fluid> fluid, int amount) {
-        this(fluid.value(), amount);
+        this(fluid, amount, DataComponentPatch.EMPTY);
     }
 
     public FluidStack(Fluid fluid, int amount) {
-        this(fluid, amount, new PatchedDataComponentMap(DataComponentMap.EMPTY));
+        this(fluid, amount, DataComponentPatch.EMPTY);
     }
 
-    private FluidStack(Fluid fluid, int amount, PatchedDataComponentMap components) {
+    private FluidStack(Holder<Fluid> fluid, int amount, PatchedDataComponentMap components) {
         this.fluid = fluid;
         this.amount = amount;
         this.components = components;
@@ -223,7 +223,7 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
      * Returns the fluid in this stack, or {@link Fluids#EMPTY} if this stack is empty.
      */
     public Fluid getFluid() {
-        return this.isEmpty() ? Fluids.EMPTY : this.fluid;
+        return this.isEmpty() ? Fluids.EMPTY : this.fluid.value();
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStack.java
@@ -287,7 +287,7 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
         }
     }
 
-    /// Compares an fluidstack with an [FluidStackTemplate] as per [#matches(FluidStack, FluidStack)].
+    /// Compares a fluidstack with a [FluidStackTemplate] as per [#matches(FluidStack, FluidStack)].
     public static boolean matches(FluidStack a, @Nullable FluidStackTemplate b) {
         if (b == null) {
             return a.isEmpty();
@@ -323,7 +323,7 @@ public final class FluidStack implements MutableDataComponentHolder, FluidInstan
         return b == null ? a.isEmpty() : a.is(b.fluid());
     }
 
-    /// Compares the fluid and components of this stack against an [FluidStackTemplate].
+    /// Compares the fluid and components of this stack against a [FluidStackTemplate].
     ///
     /// @return True if either this stack is empty and the template is null, or they reference the same fluid and have equivalent component patches.
     public static boolean isSameFluidSameComponents(FluidStack a, @Nullable FluidStackTemplate b) {

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
@@ -35,7 +35,7 @@ public record FluidStackTemplate(Holder<Fluid> fluid, int amount, DataComponentP
 
     public FluidStackTemplate {
         if (fluid.is(Fluids.EMPTY.builtInRegistryHolder()) || amount <= 0) {
-            throw new IllegalStateException("Fluid mst be non-empty");
+            throw new IllegalStateException("Fluid must be non-empty");
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
@@ -15,10 +15,16 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import org.jspecify.annotations.Nullable;
 
+/// {@link Fluid} variant of {@link ItemStackTemplate}.
+///
+/// The main difference is that fluid templates are required to have an {@code amount}, while item templates default to {@code 1}.
+///
+/// Most methods in this class are adopted from {@link ItemStackTemplate}.
 public record FluidStackTemplate(Holder<Fluid> fluid, int amount, DataComponentPatch components) implements FluidInstance {
     public static final MapCodec<FluidStackTemplate> MAP_CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
             FLUID_HOLDER_CODEC.fieldOf(FIELD_ID).forGetter(FluidStackTemplate::fluid),

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.fluids;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import org.jspecify.annotations.Nullable;
+
+public record FluidStackTemplate(Holder<Fluid> fluid, int amount, DataComponentPatch components) implements FluidInstance {
+    public static final MapCodec<FluidStackTemplate> MAP_CODEC = RecordCodecBuilder.mapCodec(i -> i.group(
+            FLUID_HOLDER_CODEC.fieldOf(FIELD_ID).forGetter(FluidStackTemplate::fluid),
+            ExtraCodecs.POSITIVE_INT.fieldOf(FIELD_AMOUNT).forGetter(FluidStackTemplate::amount),
+            DataComponentPatch.CODEC.optionalFieldOf(FIELD_COMPONENTS, DataComponentPatch.EMPTY).forGetter(FluidStackTemplate::components)).apply(i, FluidStackTemplate::new));
+
+    public static final Codec<FluidStackTemplate> CODEC = Codec.withAlternative(MAP_CODEC.codec(), FLUID_HOLDER_CODEC, fluid -> new FluidStackTemplate(fluid.value(), FluidType.BUCKET_VOLUME));
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, FluidStackTemplate> STREAM_CODEC = StreamCodec.composite(
+            FLUID_HOLDER_STREAM_CODEC, FluidStackTemplate::fluid,
+            ByteBufCodecs.VAR_INT, FluidStackTemplate::amount,
+            DataComponentPatch.STREAM_CODEC, FluidStackTemplate::components,
+            FluidStackTemplate::new);
+
+    public FluidStackTemplate {
+        if (fluid.is(Fluids.EMPTY.builtInRegistryHolder()) || amount <= 0) {
+            throw new IllegalStateException("Fluid mst be non-empty");
+        }
+    }
+
+    public FluidStackTemplate(Holder<Fluid> fluid, int amount) {
+        this(fluid, amount, DataComponentPatch.EMPTY);
+    }
+
+    public FluidStackTemplate(Fluid fluid, int amount, DataComponentPatch components) {
+        this(fluid.builtInRegistryHolder(), amount, components);
+    }
+
+    public FluidStackTemplate(Fluid fluid, int amount) {
+        this(fluid, amount, DataComponentPatch.EMPTY);
+    }
+
+    public FluidStackTemplate withAmount(int amount) {
+        return this.amount == amount ? this : new FluidStackTemplate(fluid, amount, components);
+    }
+
+    public FluidStack create() {
+        return new FluidStack(fluid, amount, components);
+    }
+
+    public FluidStack apply(DataComponentPatch additionalPatch) {
+        return apply(amount, additionalPatch);
+    }
+
+    public FluidStack apply(int amount, DataComponentPatch additionalPatch) {
+        var stack = new FluidStack(fluid, amount, additionalPatch);
+        stack.applyComponents(components);
+        return stack;
+    }
+
+    @Override
+    public Holder<Fluid> typeHolder() {
+        return fluid;
+    }
+
+    @Override
+    public @Nullable <T> T get(DataComponentType<? extends T> type) {
+        return components.get(fluid.components(), type);
+    }
+
+    public static FluidStackTemplate fromNonEmptyStack(FluidStack stack) {
+        if (stack.isEmpty()) {
+            throw new IllegalStateException("Stack must be non-empty");
+        }
+
+        return new FluidStackTemplate(stack.typeHolder(), stack.getAmount(), stack.getComponentsPatch());
+    }
+
+    public static Codec<FluidStackTemplate> fixedAmountCodec(int amount) {
+        return Codec.lazyInitialized(() -> RecordCodecBuilder.create(i -> i.group(
+                FLUID_HOLDER_CODEC.fieldOf(FIELD_ID).forGetter(FluidStackTemplate::fluid),
+                DataComponentPatch.CODEC.optionalFieldOf(FIELD_COMPONENTS, DataComponentPatch.EMPTY).forGetter(FluidStackTemplate::components)).apply(i, (holder, patch) -> new FluidStackTemplate(holder, amount, patch))));
+    }
+
+    public static StreamCodec<RegistryFriendlyByteBuf, FluidStackTemplate> fixedAmountStreamCodec(int amount) {
+        return StreamCodec.composite(
+                FLUID_HOLDER_STREAM_CODEC, FluidStackTemplate::fluid,
+                DataComponentPatch.STREAM_CODEC, FluidStackTemplate::components,
+                (holder, patch) -> new FluidStackTemplate(holder, amount, patch));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidStackTemplate.java
@@ -51,6 +51,14 @@ public record FluidStackTemplate(Holder<Fluid> fluid, int amount, DataComponentP
         this(fluid, amount, DataComponentPatch.EMPTY);
     }
 
+    public static FluidStackTemplate fromNonEmptyStack(FluidStack stack) {
+        if (stack.isEmpty()) {
+            throw new IllegalStateException("Stack must be non-empty");
+        }
+
+        return new FluidStackTemplate(stack.typeHolder(), stack.getAmount(), stack.getComponentsPatch());
+    }
+
     public FluidStackTemplate withAmount(int amount) {
         return this.amount == amount ? this : new FluidStackTemplate(fluid, amount, components);
     }
@@ -77,14 +85,6 @@ public record FluidStackTemplate(Holder<Fluid> fluid, int amount, DataComponentP
     @Override
     public @Nullable <T> T get(DataComponentType<? extends T> type) {
         return components.get(fluid.components(), type);
-    }
-
-    public static FluidStackTemplate fromNonEmptyStack(FluidStack stack) {
-        if (stack.isEmpty()) {
-            throw new IllegalStateException("Stack must be non-empty");
-        }
-
-        return new FluidStackTemplate(stack.typeHolder(), stack.getAmount(), stack.getComponentsPatch());
     }
 
     public static Codec<FluidStackTemplate> fixedAmountCodec(int amount) {

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/SimpleFluidIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/SimpleFluidIngredient.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.crafting.display.SlotDisplay;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.fluids.FluidInstance;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.crafting.display.FluidTagSlotDisplay;
 
@@ -31,7 +32,7 @@ import net.neoforged.neoforge.fluids.crafting.display.FluidTagSlotDisplay;
  */
 public class SimpleFluidIngredient extends FluidIngredient {
     private static final Codec<HolderSet<Fluid>> HOLDER_SET_NO_EMPTY_FLUID = HolderSetCodec.create(
-            Registries.FLUID, FluidStack.FLUID_NON_EMPTY_CODEC, false);
+            Registries.FLUID, FluidInstance.FLUID_HOLDER_CODEC, false);
 
     static final Codec<SimpleFluidIngredient> CODEC = ExtraCodecs.nonEmptyHolderSet(HOLDER_SET_NO_EMPTY_FLUID)
             .xmap(SimpleFluidIngredient::new, SimpleFluidIngredient::fluidSet);

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -73,7 +73,7 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
         return new FluidResource(stack.copyWithAmount(FluidType.BUCKET_VOLUME));
     }
 
-    /// Creates an FluidResource using the default or copy of the passed in fluid stack. Note the count is lost.
+    /// Creates a FluidResource using the default or copy of the passed in fluid stack. Note the amount is lost.
     ///
     /// @param template stack to copy with a size of 1
     /// @return If null was given, an empty resource is returned.

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -85,7 +85,10 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
         if (template.components().isEmpty()) {
             return of(template.fluid());
         }
-        return new FluidResource(template.withAmount(FluidType.BUCKET_VOLUME).create());
+
+        var stack = template.create();
+        stack.setAmount(FluidType.BUCKET_VOLUME);
+        return new FluidResource(stack);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -14,18 +14,19 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidInstance;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidStackTemplate;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.transfer.TransferPreconditions;
 import net.neoforged.neoforge.transfer.resource.DataComponentHolderResource;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Immutable combination of a {@link Fluid} and data components.
@@ -55,7 +56,7 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
      * Stream codec for a fluid resource. Accepts empty resources.
      */
     public static final StreamCodec<RegistryFriendlyByteBuf, FluidResource> STREAM_CODEC = StreamCodec.composite(
-            ByteBufCodecs.holderRegistry(Registries.FLUID), FluidResource::typeHolder,
+            FluidInstance.FLUID_HOLDER_STREAM_CODEC, FluidResource::typeHolder,
             DataComponentPatch.STREAM_CODEC, FluidResource::getComponentsPatch,
             FluidResource::of);
 
@@ -70,6 +71,21 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
             return of(stack.getFluid());
         }
         return new FluidResource(stack.copyWithAmount(FluidType.BUCKET_VOLUME));
+    }
+
+    /// Creates an FluidResource using the default or copy of the passed in fluid stack. Note the count is lost.
+    ///
+    /// @param template stack to copy with a size of 1
+    /// @return If null was given, an empty resource is returned.
+    ///         If there were no patches on the stack's data components, the fluid's default resource will be returned, otherwise a new instance with the copied stack.
+    public static FluidResource of(@Nullable FluidStackTemplate template) {
+        if (template == null) {
+            return EMPTY;
+        }
+        if (template.components().isEmpty()) {
+            return of(template.fluid());
+        }
+        return new FluidResource(new FluidStack(template.fluid(), FluidType.BUCKET_VOLUME, template.components()));
     }
 
     /**
@@ -253,6 +269,13 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
      */
     public boolean matches(FluidStack stack) {
         return FluidStack.isSameFluidSameComponents(stack, innerStack);
+    }
+
+    /// {@return true if this resource matches the fluid and components of the passed template}
+    ///
+    /// @param template the fluid stack template to check
+    public boolean matches(@Nullable FluidStackTemplate template) {
+        return FluidStack.isSameFluidSameComponents(innerStack, template);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -85,7 +85,7 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
         if (template.components().isEmpty()) {
             return of(template.fluid());
         }
-        return new FluidResource(new FluidStack(template.fluid(), FluidType.BUCKET_VOLUME, template.components()));
+        return new FluidResource(template.withAmount(FluidType.BUCKET_VOLUME).create());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
@@ -151,10 +151,15 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
             return of(holder.value());
         }
 
-        return ItemStack.validateStrict(new ItemStack(holder, 1, patch)).mapOrElse(ItemResource::new, err -> {
-            LOGGER.warn("Can't create item resource '{}' with components {}, error: {}", holder.getRegisteredName(), patch, err.message());
+        var stack = new ItemStack(holder, 1, patch);
+        var err = ItemStack.validateStrict(stack).error();
+
+        if (err.isPresent()) {
+            LOGGER.warn("Can't create item resource '{}' with components {}, error: {}", holder.getRegisteredName(), patch, err.get().message());
             return EMPTY;
-        });
+        }
+
+        return new ItemResource(stack);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
@@ -96,7 +96,10 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
         if (template.components().isEmpty()) {
             return of(template.item());
         }
-        return new ItemResource(template.withCount(1).create());
+
+        var stack = template.create();
+        stack.setCount(1);
+        return new ItemResource(stack);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.transfer.item;
 
+import com.mojang.logging.LogUtils;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.Objects;
@@ -29,12 +30,14 @@ import net.minecraft.world.level.ItemLike;
 import net.neoforged.neoforge.transfer.TransferPreconditions;
 import net.neoforged.neoforge.transfer.resource.DataComponentHolderResource;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
 
 /**
  * Immutable combination of an {@link Item} and data components.
  * Similar to an {@link ItemStack}, but immutable and without a count.
  */
 public final class ItemResource implements DataComponentHolderResource<Item> {
+    private static final Logger LOGGER = LogUtils.getLogger();
     /**
      * The empty resource instance of a {@link ItemResource}
      */
@@ -93,7 +96,7 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
         if (template.components().isEmpty()) {
             return of(template.item());
         }
-        return new ItemResource(new ItemStack(template.item(), 1, template.components()));
+        return new ItemResource(template.withCount(1).create());
     }
 
     /**
@@ -144,7 +147,11 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
         if (holder.value() == Items.AIR || patch.isEmpty()) {
             return of(holder.value());
         }
-        return new ItemResource(new ItemStack(holder, 1, patch));
+
+        return ItemStack.validateStrict(new ItemStack(holder, 1, patch)).mapOrElse(ItemResource::new, err -> {
+            LOGGER.warn("Can't create item resource '{}' with components {}, error: {}", holder.getRegisteredName(), patch, err.message());
+            return EMPTY;
+        });
     }
 
     /**


### PR DESCRIPTION
With 26.1-snapshot-3 mojang introduced 2 new types `ItemStackTemplate` and `ItemInstance`, this PR introduces fluid variants of these for our `FluidStack`

`FluidStackTemplate` an immutable representation of `FluidStack`
`FluidInstance` super type of both `FluidStack` and `FluidStackTemplate`


This PR also does the following
- modifies `ItemResource#of(ItemStackTemplate)` and `FluidResource#of(FluidStackTemplate)` methods slightly to ensure resources are only created using validated stacks, mostly where a new stack (with components) is created passing a existing stacks is assumed to be valid
- updates `FluidStack` to track `Holder<Fluid>` instead of raw `Fluid` objects