### PR TITLE
Add entitytype tag for item frames

### DIFF
--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -139,6 +139,7 @@
   "tag.entity_type.c.boats": "Boats",
   "tag.entity_type.c.bosses": "Bosses",
   "tag.entity_type.c.capturing_not_supported": "Capturing Not Supported",
+  "tag.entity_type.c.item_frames": "Item Frames",
   "tag.entity_type.c.minecarts": "Minecarts",
   "tag.entity_type.c.teleporting_not_supported": "Teleporting Not Supported",
   "tag.fluid.c.beetroot_soup": "Beetroot Soup",

--- a/src/generated/resources/data/c/tags/entity_type/item_frames.json
+++ b/src/generated/resources/data/c/tags/entity_type/item_frames.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:item_frame",
+    "minecraft:glow_item_frame"
+  ]
+}

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -14,6 +14,7 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -327,6 +328,9 @@ public class Tags {
         public static final TagKey<EntityType<?>> BOSSES = tag("bosses");
         public static final TagKey<EntityType<?>> MINECARTS = tag("minecarts");
         public static final TagKey<EntityType<?>> BOATS = tag("boats");
+
+        /// Tag containing entity types, generally extending {@link ItemFrame},
+        /// that can be placed on the surfaces of blocks to display an item.
         public static final TagKey<EntityType<?>> ITEM_FRAMES = tag("item_frames");
 
         /**

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -327,6 +327,7 @@ public class Tags {
         public static final TagKey<EntityType<?>> BOSSES = tag("bosses");
         public static final TagKey<EntityType<?>> MINECARTS = tag("minecarts");
         public static final TagKey<EntityType<?>> BOATS = tag("boats");
+        public static final TagKey<EntityType<?>> ITEM_FRAMES = tag("item_frames");
 
         /**
          * Entities should be included in this tag if they are not allowed to be picked up by items or grabbed in a way

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeEntityTypeTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeEntityTypeTagsProvider.java
@@ -34,6 +34,7 @@ public class NeoForgeEntityTypeTagsProvider extends EntityTypeTagsProvider {
                         EntityType.DARK_OAK_CHEST_BOAT,
                         EntityType.MANGROVE_CHEST_BOAT,
                         EntityType.BAMBOO_CHEST_RAFT);
+        tag(Tags.EntityTypes.ITEM_FRAMES).add(EntityType.ITEM_FRAME, EntityType.GLOW_ITEM_FRAME);
         tag(Tags.EntityTypes.CAPTURING_NOT_SUPPORTED);
         tag(Tags.EntityTypes.TELEPORTING_NOT_SUPPORTED);
     }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -410,6 +410,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.EntityTypes.BOSSES, "Bosses");
         add(Tags.EntityTypes.MINECARTS, "Minecarts");
         add(Tags.EntityTypes.BOATS, "Boats");
+        add(Tags.EntityTypes.ITEM_FRAMES, "Item Frames");
         add(Tags.EntityTypes.CAPTURING_NOT_SUPPORTED, "Capturing Not Supported");
         add(Tags.EntityTypes.TELEPORTING_NOT_SUPPORTED, "Teleporting Not Supported");
 


### PR DESCRIPTION
There's two entitytypes for item frames now, regular item frames and glow item frames. This puts both in one tag:

```json5
//data/c/tags/entity_type/item_frames.json
{
  "values": [
    "minecraft:item_frame",
    "minecraft:glow_item_frame"
  ]
}
```