### PR TITLE
Fix MC-271761: Resource filter namespace leak

### DIFF
--- a/patches/net/minecraft/server/packs/resources/MultiPackResourceManager.java.patch
+++ b/patches/net/minecraft/server/packs/resources/MultiPackResourceManager.java.patch
@@ -1,5 +1,15 @@
 --- a/net/minecraft/server/packs/resources/MultiPackResourceManager.java
 +++ b/net/minecraft/server/packs/resources/MultiPackResourceManager.java
+@@ -28,7 +_,8 @@
+         for (PackResources pack : packs) {
+             ResourceFilterSection filterSection = this.getPackFilterSection(pack);
+             Set<String> providedNamespaces = pack.getNamespaces(type);
+-            Predicate<Identifier> pathFilter = filterSection != null ? location -> filterSection.isPathFiltered(location.getPath()) : null;
++            // Neo: Fix MC-271761 by properly coupling namespace and path checks
++            Predicate<Identifier> pathFilter = filterSection != null ? filterSection::isFiltered : null;
+ 
+             for (String namespace : namespaces) {
+                 boolean packContainsNamespace = providedNamespaces.contains(namespace);
 @@ -58,6 +_,7 @@
          try {
              return pack.getMetadataSection(ResourceFilterSection.TYPE);

--- a/patches/net/minecraft/server/packs/resources/ResourceFilterSection.java.patch
+++ b/patches/net/minecraft/server/packs/resources/ResourceFilterSection.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/server/packs/resources/ResourceFilterSection.java
++++ b/net/minecraft/server/packs/resources/ResourceFilterSection.java
+@@ -24,4 +_,11 @@
+     public boolean isPathFiltered(String path) {
+         return this.blockList.stream().anyMatch(p -> p.pathPredicate().test(path));
+     }
++
++    // Neo: Fix MC-271761 by properly coupling namespace and path in a single predicate check
++    public boolean isFiltered(net.minecraft.resources.Identifier id) {
++        return this.blockList.stream().anyMatch(pattern ->
++                pattern.namespacePredicate().test(id.getNamespace()) && pattern.pathPredicate().test(id.getPath())
++        );
++    }
+ }


### PR DESCRIPTION
Fixes [MC-271761](https://bugs.mojang.com/browse/MC-271761), where resource filter blocks for different namespaces incorrectly leak into one another. 

Tested by loading the datapack in the linked issue, and verified that advancements are all successfully removed, while `/recipe give @s *` gives all the expected Vanilla recipes.