### PR TITLE
Fixes to ItemAccess exchange and non-partial io support

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/SimpleFluidContent.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/SimpleFluidContent.java
@@ -16,6 +16,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
 
 /**
  * Stock data component class to hold a {@link FluidStack}.
@@ -37,6 +38,10 @@ public class SimpleFluidContent implements DataComponentHolder {
 
     public static SimpleFluidContent copyOf(FluidStack fluidStack) {
         return fluidStack.isEmpty() ? EMPTY : new SimpleFluidContent(fluidStack.copy());
+    }
+
+    public static SimpleFluidContent copyOf(FluidResource resource, int amount) {
+        return resource.isEmpty() ? EMPTY : new SimpleFluidContent(resource.toStack(amount));
     }
 
     public FluidStack copy() {

--- a/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
@@ -29,10 +29,12 @@ import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 public abstract class ItemAccessResourceHandler<T extends Resource> implements ResourceHandler<T> {
     protected final ItemAccess itemAccess;
     protected final int size;
+    protected final boolean supportsPartial;
 
-    protected ItemAccessResourceHandler(ItemAccess itemAccess, int size) {
+    protected ItemAccessResourceHandler(ItemAccess itemAccess, int size, boolean supportsPartial) {
         this.itemAccess = itemAccess;
         this.size = size;
+        this.supportsPartial = supportsPartial;
     }
 
     /**
@@ -60,6 +62,7 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
      *           that will be done by the calling code based on the results of this function.
      */
     // TODO: we could allow returning null when the resource/amount should be deleted, to allow for "consumable" implementations with minimal effort
+    //  Alternatively, we could make EMPTY be the consumed result, and return the current resource as the "no-action" result
     protected abstract ItemResource update(ItemResource accessResource, int index, T newResource, int newAmount);
 
     /**
@@ -115,34 +118,47 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
         return 0;
     }
 
-    // TODO: support "all or nothing" resource handlers better by optionally changing how insert and extract round
-
     @Override
     public int insert(int index, T resource, int amount, TransactionContext transaction) {
         Objects.checkIndex(index, size());
         TransferPreconditions.checkNonEmptyNonNegative(resource, amount);
 
+        var capacity = getCapacity(index, resource);
+        if (!supportsPartial && amount < capacity) return 0;
+
         int accessAmount = itemAccess.getAmount();
-        if (accessAmount == 0) {
-            return 0;
-        }
-        int amountPerItem = amount / accessAmount;
+        if (accessAmount == 0) return 0;
 
-        ItemResource accessResource = itemAccess.getResource();
+        if (!isValid(index, resource)) return 0;
+
+        int capacityPerItem = getCapacity(index, resource);
+        ItemResource accessResource = this.itemAccess.getResource();
+
         int currentAmountPerItem = getAmountFrom(accessResource, index);
+        if (currentAmountPerItem != 0 && !resource.equals(getResourceFrom(accessResource, index))) return 0;
 
-        if ((currentAmountPerItem == 0 || resource.equals(getResourceFrom(accessResource, index))) && isValid(index, resource)) {
-            int insertedPerItem = Math.min(amountPerItem, getCapacity(index, resource) - currentAmountPerItem);
-
+        //Try filling containers fully first.
+        int numberToInsert = amount / capacityPerItem;
+        if (numberToInsert > 0) {
+            //non-partial inserting
+            int insertedPerItem = Math.min(capacityPerItem, capacityPerItem - currentAmountPerItem);
             if (insertedPerItem > 0) {
                 ItemResource filledResource = update(accessResource, index, resource, insertedPerItem + currentAmountPerItem);
-
-                if (!filledResource.isEmpty()) {
-                    return insertedPerItem * itemAccess.exchange(filledResource, accessAmount, transaction);
-                }
+                if (!filledResource.isEmpty())
+                    return insertedPerItem * itemAccess.exchange(filledResource, numberToInsert, transaction);
             }
         }
+        //If non-partial filling failed, then try partial filling if allowed
+        if (!supportsPartial) return 0;
 
+        int amountPerItem = amount / accessAmount;
+        int insertedItem = Math.min(amountPerItem, capacityPerItem - currentAmountPerItem);
+        if (insertedItem == 0) return 0;
+
+        ItemResource filledResource = update(accessResource, index, resource, insertedItem + currentAmountPerItem);
+        if (!filledResource.isEmpty()) {
+            return insertedItem * this.itemAccess.exchange(filledResource, accessAmount, transaction);
+        }
         return 0;
     }
 
@@ -151,27 +167,37 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
         Objects.checkIndex(index, size());
         TransferPreconditions.checkNonEmptyNonNegative(resource, amount);
 
-        int accessAmount = itemAccess.getAmount();
-        if (accessAmount == 0) {
-            return 0;
-        }
+        var capacity = getCapacity(index, resource);
+        if (!supportsPartial && amount < capacity) return 0;
 
-        ItemResource accessResource = itemAccess.getResource();
-        T currentResource = getResourceFrom(accessResource, index);
+        int accessAmount = this.itemAccess.getAmount();
+        if (accessAmount == 0) return 0;
 
-        if (resource.equals(currentResource)) {
-            int currentAmountPerItem = getAmountFrom(accessResource, index);
-            int extractedPerItem = Math.min(amount / accessAmount, currentAmountPerItem);
+        ItemResource accessResource = this.itemAccess.getResource();
+        if (!resource.equals(getResourceFrom(accessResource, index))) return 0;
 
+        int currentAmountPerItem = getAmountFrom(accessResource, index);
+
+        int capacityPerItem = getCapacity(index, resource);
+        int numberToDrain = amount / capacityPerItem;
+        if (numberToDrain > 0) {
+            //non-partial extracting
+            int extractedPerItem = Math.min(capacityPerItem, currentAmountPerItem);
             if (extractedPerItem > 0) {
                 ItemResource emptiedResource = update(accessResource, index, resource, currentAmountPerItem - extractedPerItem);
-
-                if (!emptiedResource.isEmpty()) {
-                    return extractedPerItem * itemAccess.exchange(emptiedResource, accessAmount, transaction);
-                }
+                if (!emptiedResource.isEmpty())
+                    return extractedPerItem * itemAccess.exchange(emptiedResource, numberToDrain, transaction);
             }
         }
 
-        return 0;
+        if (!supportsPartial) return 0;
+
+        int extractPerItem = Math.min(amount / accessAmount, currentAmountPerItem);
+        if (extractPerItem <= 0) return 0;
+
+        ItemResource emptiedResource = update(accessResource, index, resource, currentAmountPerItem - extractPerItem);
+        if (emptiedResource.isEmpty()) return 0;
+
+        return extractPerItem * this.itemAccess.exchange(emptiedResource, accessAmount, transaction);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/transfer/access/ItemAccess.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/access/ItemAccess.java
@@ -208,20 +208,31 @@ public interface ItemAccess {
     @ApiStatus.NonExtendable
     default int exchange(ItemResource newResource, int amount, TransactionContext transaction) {
         TransferPreconditions.checkNonEmptyNonNegative(newResource, amount);
-        var currentResource = getResource();
+        ItemResource currentResource = getResource();
         TransferPreconditions.checkNonEmpty(currentResource);
-
+        int inserted = 0;
         try (Transaction subTransaction = Transaction.open(transaction)) {
             int extracted = extract(currentResource, amount, subTransaction);
             if (extracted > 0) {
-                var inserted = insert(newResource, extracted, subTransaction);
+                inserted = insert(newResource, extracted, subTransaction);
                 if (inserted == extracted) {
                     subTransaction.commit();
                     return extracted;
                 }
             }
         }
+        if (inserted == 0) return 0;
+        // A scenario where this could happen is filling a stack of empty buckets with water.
+        // The inserted here would be 1, whereas the extracted would have resulted in 16.
+        // This fallback transaction serves to handle those cases and use the simulated insertion value as the extraction amount
 
+        try (Transaction fallback = Transaction.open(transaction)) {
+            int extracted = extract(currentResource, inserted, fallback);
+            if (extracted > 0 && extracted == insert(newResource, extracted, fallback)) {
+                fallback.commit();
+                return extracted;
+            }
+        }
         return 0;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/BucketResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/BucketResourceHandler.java
@@ -20,7 +20,7 @@ import net.neoforged.neoforge.transfer.item.ItemResource;
  */
 public final class BucketResourceHandler extends ItemAccessResourceHandler<FluidResource> {
     public BucketResourceHandler(ItemAccess itemAccess) {
-        super(itemAccess, 1);
+        super(itemAccess, 1, false);
     }
 
     @Override
@@ -44,12 +44,10 @@ public final class BucketResourceHandler extends ItemAccessResourceHandler<Fluid
     protected ItemResource update(ItemResource accessResource, int index, FluidResource newResource, int newAmount) {
         if (newAmount == 0) {
             return ItemResource.of(Items.BUCKET);
-        } else if (newAmount != FluidType.BUCKET_VOLUME) {
-            return ItemResource.EMPTY;
-        } else {
-            var newStack = newResource.toStack(newAmount);
-            return ItemResource.of(newStack.getFluidType().getBucket(newStack));
+        } else if (newAmount == FluidType.BUCKET_VOLUME) {
+            return ItemResource.of(newResource.getFluidType().getBucket(newResource.toStack(newAmount)));
         }
+        return ItemResource.EMPTY;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/ItemAccessFluidHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/ItemAccessFluidHandler.java
@@ -25,7 +25,11 @@ public class ItemAccessFluidHandler extends ItemAccessResourceHandler<FluidResou
     protected int capacity;
 
     public ItemAccessFluidHandler(ItemAccess itemAccess, DataComponentType<SimpleFluidContent> component, int capacity) {
-        super(itemAccess, 1);
+        this(itemAccess, component, capacity, true);
+    }
+
+    public ItemAccessFluidHandler(ItemAccess itemAccess, DataComponentType<SimpleFluidContent> component, int capacity, boolean supportsPartial) {
+        super(itemAccess, 1, supportsPartial);
         // Store the current item, such that if the item changes later we don't return any stored content from it.
         this.validItem = itemAccess.getResource().getItem();
         this.component = component;
@@ -52,7 +56,11 @@ public class ItemAccessFluidHandler extends ItemAccessResourceHandler<FluidResou
 
     @Override
     protected ItemResource update(ItemResource accessResource, int index, FluidResource newResource, int newAmount) {
-        return accessResource.with(component, SimpleFluidContent.copyOf(newResource.toStack(newAmount)));
+        if (newAmount == 0)
+            return accessResource.with(component, SimpleFluidContent.EMPTY);
+        if (supportsPartial || newAmount == capacity)
+            return accessResource.with(component, SimpleFluidContent.copyOf(newResource, newAmount));
+        return ItemResource.EMPTY;
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemAccessItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemAccessItemHandler.java
@@ -29,7 +29,11 @@ public class ItemAccessItemHandler extends ItemAccessResourceHandler<ItemResourc
     protected final DataComponentType<ItemContainerContents> component;
 
     public ItemAccessItemHandler(ItemAccess itemAccess, DataComponentType<ItemContainerContents> component, int size) {
-        super(itemAccess, size);
+        this(itemAccess, component, size, true);
+    }
+
+    public ItemAccessItemHandler(ItemAccess itemAccess, DataComponentType<ItemContainerContents> component, int size, boolean supportsPartial) {
+        super(itemAccess, size, supportsPartial);
         // Store the current item, such that if the item changes later we don't return any stored content from it.
         this.validItem = itemAccess.getResource().getItem();
         this.component = component;
@@ -74,6 +78,8 @@ public class ItemAccessItemHandler extends ItemAccessResourceHandler<ItemResourc
         }
     }
 
+    //TODO likely needs more validation that non-partial filling works for items given the backing list implementation.
+    //   See ItemAccessFluidHandler for an example
     @Override
     protected ItemResource update(ItemResource accessResource, int index, ItemResource newResource, int newAmount) {
         var contents = getContents(accessResource);

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ItemAccessHandlerTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ItemAccessHandlerTest.java
@@ -26,11 +26,12 @@ import org.junit.jupiter.api.Test;
 
 class ItemAccessHandlerTest {
     @Test
-    void testFluidItemApi() {
+    void testFluidItemApiOneByOne() {
         FluidResource water = FluidResource.of(Fluids.WATER);
         ItemResource waterBucket = ItemResource.of(Items.WATER_BUCKET);
         Container testContainer = new BucketTestContainer(ItemStack.EMPTY, new ItemStack(Items.BUCKET), new ItemStack(Items.WATER_BUCKET));
 
+        //Only fills one bucket at a time assuming there is space.
         ResourceHandler<FluidResource> slot1Handler = new BucketResourceHandler(new StackingItemAccess(testContainer, 1).oneByOne());
         ResourceHandler<FluidResource> slot2Handler = new BucketResourceHandler(new StackingItemAccess(testContainer, 2).oneByOne());
 
@@ -57,6 +58,54 @@ class ItemAccessHandlerTest {
         // Check contents after abort
         if (!testContainer.getItem(0).isEmpty()) throw new AssertionError("Failed to abort slot 0.");
         if (!sameItemSameCount(testContainer.getItem(1), Items.BUCKET, 1)) throw new AssertionError("Failed to abort slot 1.");
+        if (!sameItemSameCount(testContainer.getItem(2), Items.WATER_BUCKET, 1)) throw new AssertionError("Failed to abort slot 2.");
+    }
+
+    @Test
+    void testFluidItemApiAllAtOnce() {
+        FluidResource water = FluidResource.of(Fluids.WATER);
+        ItemResource waterBucket = ItemResource.of(Items.WATER_BUCKET);
+        Container testContainer = new BucketTestContainer(ItemStack.EMPTY, new ItemStack(Items.BUCKET, 8), new ItemStack(Items.WATER_BUCKET), ItemStack.EMPTY);
+
+        //Can fill more than one bucket at a time assuming there is space.
+        ResourceHandler<FluidResource> slot1Handler = new BucketResourceHandler(new StackingItemAccess(testContainer, 1));
+        ResourceHandler<FluidResource> slot2Handler = new BucketResourceHandler(new StackingItemAccess(testContainer, 2));
+
+        try (Transaction transaction = Transaction.openRoot()) {
+            // Test extract.
+            if (slot2Handler.extract(water, FluidType.BUCKET_VOLUME, transaction) != FluidType.BUCKET_VOLUME)
+                throw new AssertionError("Should have extracted from full bucket.");
+            // Test that an empty bucket was added.
+            if (!sameItemSameCount(testContainer.getItem(1), Items.BUCKET, 9))
+                throw new AssertionError("Buckets should have stacked.");
+            // Test that we can't extract again
+            if (slot2Handler.extract(water, FluidType.BUCKET_VOLUME, transaction) != 0)
+                throw new AssertionError("Should not have extracted a second time.");
+            // Now insert water into slot 1.
+            if (slot1Handler.insert(water, FluidType.BUCKET_VOLUME, transaction) != FluidType.BUCKET_VOLUME)
+                throw new AssertionError("Failed to insert.");
+            // Check that it filled slot 0.
+            if (!sameItemSameCount(testContainer.getItem(0), Items.WATER_BUCKET, 1))
+                throw new AssertionError("Should have filled slot 0.");
+            // Now we yeet the bucket from slot 0 just because we can.
+            if (VanillaContainerWrapper.of(testContainer).extract(0, waterBucket, 1, transaction) != 1)
+                throw new AssertionError("Failed to yeet bucket from slot 0.");
+            // Now insert should fill slot 1 with a bucket.
+            var inserted = slot1Handler.insert(water, FluidType.BUCKET_VOLUME * 3, transaction);
+            if (inserted != FluidType.BUCKET_VOLUME * 2)
+                throw new AssertionError("Failed to insert 2 buckets, inserted " + inserted);
+            // Check container contents.
+            if (!sameItemSameCount(testContainer.getItem(0), Items.WATER_BUCKET, 1))
+                throw new AssertionError("Slot 0 should have been a water bucket. Was " + testContainer.getItem(0));
+            if (!sameItemSameCount(testContainer.getItem(3), Items.WATER_BUCKET, 1))
+                throw new AssertionError("Slot 3 should have been a water bucket. Was " + testContainer.getItem(3));
+            if (!sameItemSameCount(testContainer.getItem(1), Items.BUCKET, 6))
+                throw new AssertionError("Should have filled slot 1 with a water bucket.");
+        }
+
+        // Check contents after abort
+        if (!testContainer.getItem(0).isEmpty()) throw new AssertionError("Failed to abort slot 0.");
+        if (!sameItemSameCount(testContainer.getItem(1), Items.BUCKET, 8)) throw new AssertionError("Failed to abort slot 1.");
         if (!sameItemSameCount(testContainer.getItem(2), Items.WATER_BUCKET, 1)) throw new AssertionError("Failed to abort slot 2.");
     }
 


### PR DESCRIPTION
Requested by @pupnewfster on [Discord](https://discord.com/channels/313125603924639766/1183818213134446742/1476237150377873641)

## ItemAccess.exchange
Fixes a slight hiccup that prevented actions that would result in scenarios than when the extracted and inserted amounts were different (like filling a stack of empty buckets with water) the exchange would be canceled despite having enough water and or buckets to do the operation.

## Non-partial Filling
In the previous instance of the resource handler pr, there were a few different templates that helped handle scenarios of partial and non-partial filling as well as consumable or swappable.

Non-partial filling in this case is relatively easy* to add back with the system as it is, by adding a non-partial insert/extract first, then fallback to the partial handling when flagged as allowed. This allows modders to be able to have their item fluid handlers (for instance) be an all or nothing fill. The bucket handler would normally extend the fluid inherited class, but because that one is component based, it is somewhat in an odd place since buckets are fully different items typically. It is fine, just makes it recreate some of the solution.

\*The `ItemAccessItemHandler` however, isn't currently verified to properly handle scenarios of non-partial vs partial and is most likely erroneous now in the `update` method. I imagine it works still, just with a slight degradation in performance than it was. I left a todo as a reminder for someone else to take a look sometime.

## Tests
A new test was added on top of the existing ones to ensure `oneByone` still worked, but then validates the stack filling also works. It essentially is a copy of the existing `oneByOne` test. 