### PR TITLE
PoiStateSet: Support lazily-evaluated states (e.g. tags)

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
@@ -17,100 +17,99 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class PoiStateSet implements Set<BlockState> {
-	/** Contains possibly lazily-evaluated states. */
-	private final Set<BlockState> backingSet;
-	/** Actual elements are added to this through {@link #addCustomStates}. */
-	private final Set<BlockState> ownElements = new ReferenceOpenHashSet<>();
-	
-	public PoiStateSet(Set<BlockState> states) {
-		// `states` may contain lazily-evaluated elements, so don't make a defensive copy.
-		this.backingSet = states;
-	}
-	
-	@Override
-	public int size() {
-		return this.backingSet.size() + this.ownElements.size();
-	}
-	
-	@Override
-	public boolean isEmpty() {
-		return this.backingSet.isEmpty() && this.ownElements.isEmpty();
-	}
-	
-	@Override
-	public boolean contains(Object o) {
-		return this.backingSet.contains(o) || this.ownElements.contains(o);
-	}
-	
-	@SuppressWarnings("SuspiciousMethodCalls")
-	@Override
-	public boolean containsAll(Collection<?> c) {
-		for (var el : c) {
-			if (!this.backingSet.contains(el) && !this.ownElements.contains(el))
-				return false;
-		}
-		return true;
-	}
-	
-	@Override
-	public Iterator<BlockState> iterator() {
-		return Iterators.unmodifiableIterator(Iterators.concat(this.backingSet.iterator(), this.ownElements.iterator()));
-	}
-	
-	private ArrayList<BlockState> toList() {
-		ArrayList<BlockState> outList = new ArrayList<>(this.backingSet.size() + this.ownElements.size());
-		outList.addAll(this.backingSet);
-		outList.addAll(this.ownElements);
-		return outList;
-	}
-	
-	@Override
-	public Object[] toArray() {
-		return toList().toArray();
-	}
-	
-	@Override
-	public <T> T[] toArray(T[] a) {
-		return toList().toArray(a);
-	}
-	
-	@Override
-	public boolean add(BlockState state) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public boolean remove(Object o) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public boolean addAll(Collection<? extends BlockState> c) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public boolean retainAll(Collection<?> c) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public boolean removeAll(Collection<?> c) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public boolean removeIf(Predicate<? super BlockState> filter) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public void clear() {
-		throw new UnsupportedOperationException();
-	}
-	
-	void addCustomStates(Set<BlockState> states) {
-		this.backingSet.addAll(states);
-	}
-}
+    /** Contains possibly lazily-evaluated states. */
+    private final Set<BlockState> backingSet;
+    /** Actual elements are added to this through {@link #addCustomStates}. */
+    private final Set<BlockState> ownElements = new ReferenceOpenHashSet<>();
 
+    public PoiStateSet(Set<BlockState> states) {
+        // `states` may contain lazily-evaluated elements, so don't make a defensive copy.
+        this.backingSet = states;
+    }
+
+    @Override
+    public int size() {
+        return this.backingSet.size() + this.ownElements.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.backingSet.isEmpty() && this.ownElements.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return this.backingSet.contains(o) || this.ownElements.contains(o);
+    }
+
+    @SuppressWarnings("SuspiciousMethodCalls")
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        for (var el : c) {
+            if (!this.backingSet.contains(el) && !this.ownElements.contains(el))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Iterator<BlockState> iterator() {
+        return Iterators.unmodifiableIterator(Iterators.concat(this.backingSet.iterator(), this.ownElements.iterator()));
+    }
+
+    private ArrayList<BlockState> toList() {
+        ArrayList<BlockState> outList = new ArrayList<>(this.backingSet.size() + this.ownElements.size());
+        outList.addAll(this.backingSet);
+        outList.addAll(this.ownElements);
+        return outList;
+    }
+
+    @Override
+    public Object[] toArray() {
+        return toList().toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return toList().toArray(a);
+    }
+
+    @Override
+    public boolean add(BlockState state) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends BlockState> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super BlockState> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    void addCustomStates(Set<BlockState> states) {
+        this.backingSet.addAll(states);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
@@ -110,6 +110,6 @@ public final class PoiStateSet implements Set<BlockState> {
     }
 
     void addCustomStates(Set<BlockState> states) {
-        this.backingSet.addAll(states);
+        this.ownElements.addAll(states);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
+++ b/src/main/java/net/neoforged/neoforge/common/world/poi/PoiStateSet.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.common.world.poi;
 
 import com.google.common.collect.Iterators;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -16,83 +17,100 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class PoiStateSet implements Set<BlockState> {
-    private final Set<BlockState> backingSet = new ReferenceOpenHashSet<>();
-
-    public PoiStateSet(Set<BlockState> states) {
-        this.backingSet.addAll(states);
-    }
-
-    @Override
-    public int size() {
-        return this.backingSet.size();
-    }
-
-    @Override
-    public boolean isEmpty() {
-        return this.backingSet.isEmpty();
-    }
-
-    @Override
-    public boolean contains(Object o) {
-        return this.backingSet.contains(o);
-    }
-
-    @Override
-    public boolean containsAll(Collection<?> c) {
-        return this.backingSet.containsAll(c);
-    }
-
-    @Override
-    public Iterator<BlockState> iterator() {
-        return Iterators.unmodifiableIterator(this.backingSet.iterator());
-    }
-
-    @Override
-    public Object[] toArray() {
-        return this.backingSet.toArray();
-    }
-
-    @Override
-    public <T> T[] toArray(T[] a) {
-        return this.backingSet.toArray(a);
-    }
-
-    @Override
-    public boolean add(BlockState state) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean remove(Object o) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends BlockState> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean retainAll(Collection<?> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean removeAll(Collection<?> c) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean removeIf(Predicate<? super BlockState> filter) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void clear() {
-        throw new UnsupportedOperationException();
-    }
-
-    void addCustomStates(Set<BlockState> states) {
-        this.backingSet.addAll(states);
-    }
+	/** Contains possibly lazily-evaluated states. */
+	private final Set<BlockState> backingSet;
+	/** Actual elements are added to this through {@link #addCustomStates}. */
+	private final Set<BlockState> ownElements = new ReferenceOpenHashSet<>();
+	
+	public PoiStateSet(Set<BlockState> states) {
+		// `states` may contain lazily-evaluated elements, so don't make a defensive copy.
+		this.backingSet = states;
+	}
+	
+	@Override
+	public int size() {
+		return this.backingSet.size() + this.ownElements.size();
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return this.backingSet.isEmpty() && this.ownElements.isEmpty();
+	}
+	
+	@Override
+	public boolean contains(Object o) {
+		return this.backingSet.contains(o) || this.ownElements.contains(o);
+	}
+	
+	@SuppressWarnings("SuspiciousMethodCalls")
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		for (var el : c) {
+			if (!this.backingSet.contains(el) && !this.ownElements.contains(el))
+				return false;
+		}
+		return true;
+	}
+	
+	@Override
+	public Iterator<BlockState> iterator() {
+		return Iterators.unmodifiableIterator(Iterators.concat(this.backingSet.iterator(), this.ownElements.iterator()));
+	}
+	
+	private ArrayList<BlockState> toList() {
+		ArrayList<BlockState> outList = new ArrayList<>(this.backingSet.size() + this.ownElements.size());
+		outList.addAll(this.backingSet);
+		outList.addAll(this.ownElements);
+		return outList;
+	}
+	
+	@Override
+	public Object[] toArray() {
+		return toList().toArray();
+	}
+	
+	@Override
+	public <T> T[] toArray(T[] a) {
+		return toList().toArray(a);
+	}
+	
+	@Override
+	public boolean add(BlockState state) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean remove(Object o) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean addAll(Collection<? extends BlockState> c) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean removeIf(Predicate<? super BlockState> filter) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public void clear() {
+		throw new UnsupportedOperationException();
+	}
+	
+	void addCustomStates(Set<BlockState> states) {
+		this.backingSet.addAll(states);
+	}
 }
+


### PR DESCRIPTION
## Summary
Oftentimes, you need to read block types that may not be known when your mod is initialized: having entities flee from deterrent blocks configurable through a tag, for example.  

Without being able to use a PoI, the only way to do this is to scan every single block in range to see if it belongs to a tag.  This is, to put it lightly, _extremely_ laggy.

This PR just makes `PoiStateSet` hold a direct reference to the set given to it instead of creating a defensive copy, allowing any lazily-generated sets - such as tags - to function as intended.

## Changes
- `#backingSet` no longer creates a defensive copy. Instead, it holds a reference to the original set to avoid evaluating any lazy sets.
- New elements are now added to `#ownElements`, another set contained in the class.
- All implemented methods (e.g. `size`, `contains`, `isEmpty`) have been updated to act with respect to the contents of both sets, preserving the contract.


Note that this PR **does NOT implement** any Tag-based or lazy PoI sets, since I'm not sure if you'd want those as part of the standard API.  I just want to make it possible for devs to implement themselves.