### PR TITLE
[26.1] Add support for per-quad render types to BlockModelRenderState and block model submits

### DIFF
--- a/patches/net/minecraft/client/renderer/SubmitNodeCollection.java.patch
+++ b/patches/net/minecraft/client/renderer/SubmitNodeCollection.java.patch
@@ -1,0 +1,52 @@
+--- a/net/minecraft/client/renderer/SubmitNodeCollection.java
++++ b/net/minecraft/client/renderer/SubmitNodeCollection.java
+@@ -38,6 +_,7 @@
+     private final List<SubmitNodeStorage.LeashSubmit> leashSubmits = new ArrayList<>();
+     private final List<SubmitNodeStorage.MovingBlockSubmit> movingBlockSubmits = new ArrayList<>();
+     private final List<SubmitNodeStorage.BlockModelSubmit> blockModelSubmits = new ArrayList<>();
++    private final List<SubmitNodeStorage.MultiLayerBlockModelSubmit> multiLayerBlockModelSubmits = new ArrayList<>();
+     private final List<SubmitNodeStorage.BreakingBlockModelSubmit> breakingBlockModelSubmits = new ArrayList<>();
+     private final List<SubmitNodeStorage.ItemSubmit> itemSubmits = new ArrayList<>();
+     private final List<SubmitNodeCollector.ParticleGroupRenderer> particleGroupRenderers = new ArrayList<>();
+@@ -173,6 +_,21 @@
+     }
+ 
+     @Override
++    public void submitMultiLayerBlockModel(
++        PoseStack poseStack,
++        List<BlockStateModelPart> modelParts,
++        boolean translucent,
++        int[] tintLayers,
++        int lightCoords,
++        int overlayCoords,
++        int outlineColor
++    ) {
++        this.wasUsed = true;
++        this.multiLayerBlockModelSubmits
++            .add(new SubmitNodeStorage.MultiLayerBlockModelSubmit(poseStack.last().copy(), modelParts, translucent, tintLayers, lightCoords, overlayCoords, outlineColor));
++    }
++
++    @Override
+     public void submitBreakingBlockModel(PoseStack poseStack, BlockStateModel model, long seed, int progress) {
+         this.wasUsed = true;
+         this.breakingBlockModelSubmits.add(new SubmitNodeStorage.BreakingBlockModelSubmit(poseStack.last().copy(), model, seed, progress));
+@@ -236,6 +_,11 @@
+         return this.blockModelSubmits;
+     }
+ 
++    /// Neo: expose multi-layer block model submits with support for per-quad render types
++    public List<SubmitNodeStorage.MultiLayerBlockModelSubmit> getMultiLayerBlockModelSubmits() {
++        return this.multiLayerBlockModelSubmits;
++    }
++
+     public List<SubmitNodeStorage.BreakingBlockModelSubmit> getBreakingBlockModelSubmits() {
+         return this.breakingBlockModelSubmits;
+     }
+@@ -272,6 +_,7 @@
+         this.leashSubmits.clear();
+         this.movingBlockSubmits.clear();
+         this.blockModelSubmits.clear();
++        this.multiLayerBlockModelSubmits.clear();
+         this.breakingBlockModelSubmits.clear();
+         this.itemSubmits.clear();
+         this.particleGroupRenderers.clear();

--- a/patches/net/minecraft/client/renderer/block/BlockModelRenderState.java.patch
+++ b/patches/net/minecraft/client/renderer/block/BlockModelRenderState.java.patch
@@ -1,0 +1,55 @@
+--- a/net/minecraft/client/renderer/block/BlockModelRenderState.java
++++ b/net/minecraft/client/renderer/block/BlockModelRenderState.java
+@@ -29,8 +_,10 @@
+     private @Nullable Matrix4fc specialRendererTransformation;
+     private @Nullable IntList tintLayers;
+     private @Nullable RandomSource randomSource;
++    private boolean hasTranslucency;
+ 
+     public void clear() {
++        this.hasTranslucency = false;
+         this.modelParts = null;
+         this.transformation = null;
+         this.renderType = null;
+@@ -57,6 +_,7 @@
+     public List<BlockStateModelPart> setupModel(Matrix4fc transformation, boolean hasTranslucency) {
+         this.transformation = identityToNull(transformation);
+         this.renderType = hasTranslucency ? Sheets.translucentBlockSheet() : Sheets.cutoutBlockSheet();
++        this.hasTranslucency = hasTranslucency;
+         if (this.modelParts == null) {
+             this.modelParts = new ObjectArrayList<>();
+         } else {
+@@ -68,6 +_,33 @@
+ 
+     public void submit(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, int overlayCoords, int outlineColor) {
+         this.submitModel(this.renderType, poseStack, submitNodeCollector, lightCoords, overlayCoords, outlineColor);
++        this.submitSpecialRenderer(poseStack, submitNodeCollector, lightCoords, overlayCoords, outlineColor);
++    }
++
++    /// Neo: submit this render state with full support for per-quad render types
++    ///
++    /// @param poseStack           The transformations to apply to the model
++    /// @param submitNodeCollector The collector to submit this render state to
++    /// @param lightCoords         The packed light coordinates to render the model with
++    /// @param overlayCoords       The overlay texture coordinates to render the model with
++    /// @param outlineColor        The outline color to render the model with, or `0` to render no outline
++    public void submitMultiLayer(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, int overlayCoords, int outlineColor) {
++        if (this.modelParts != null && !this.modelParts.isEmpty()) {
++            List<BlockStateModelPart> modelPartsCopy = new ObjectArrayList<>(this.modelParts);
++            int[] tints = this.tintLayers != null ? this.tintLayers.toArray(EMPTY_TINTS) : EMPTY_TINTS;
++            if (this.transformation != null) {
++                poseStack.pushPose();
++                poseStack.mulPose(this.transformation);
++                submitNodeCollector.submitMultiLayerBlockModel(poseStack, modelPartsCopy, hasTranslucency, tints, lightCoords, overlayCoords, outlineColor);
++                poseStack.popPose();
++            } else {
++                submitNodeCollector.submitMultiLayerBlockModel(poseStack, modelPartsCopy, hasTranslucency, tints, lightCoords, overlayCoords, outlineColor);
++            }
++        }
++        this.submitSpecialRenderer(poseStack, submitNodeCollector, lightCoords, overlayCoords, outlineColor);
++    }
++
++    private void submitSpecialRenderer(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, int overlayCoords, int outlineColor) {
+         if (this.specialRenderer != null) {
+             if (this.specialRendererTransformation != null) {
+                 poseStack.pushPose();

--- a/patches/net/minecraft/client/renderer/feature/BlockFeatureRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/feature/BlockFeatureRenderer.java.patch
@@ -1,5 +1,21 @@
 --- a/net/minecraft/client/renderer/feature/BlockFeatureRenderer.java
 +++ b/net/minecraft/client/renderer/feature/BlockFeatureRenderer.java
+@@ -47,6 +_,7 @@
+     ) {
+         this.renderMovingBlockSubmits(nodeCollection, bufferSource, blockStateModelSet, optionsState, false);
+         this.renderBlockModelSubmits(nodeCollection, bufferSource, outlineBufferSource, false);
++        net.neoforged.neoforge.client.submit.ExtendedBlockFeatureRenderer.renderMultiLayerBlockModelSubmits(nodeCollection, bufferSource, outlineBufferSource, this.quadInstance, false);
+     }
+ 
+     public void renderTranslucent(
+@@ -59,6 +_,7 @@
+     ) {
+         this.renderMovingBlockSubmits(nodeCollection, bufferSource, blockStateModelSet, optionsState, true);
+         this.renderBlockModelSubmits(nodeCollection, bufferSource, outlineBufferSource, true);
++        net.neoforged.neoforge.client.submit.ExtendedBlockFeatureRenderer.renderMultiLayerBlockModelSubmits(nodeCollection, bufferSource, outlineBufferSource, this.quadInstance, true);
+         this.renderBreakingBlockModelSubmits(nodeCollection, crumblingBufferSource);
+     }
+ 
 @@ -81,7 +_,7 @@
              MovingBlockRenderState movingBlockRenderState = submit.movingBlockRenderState();
              BlockState blockState = movingBlockRenderState.blockState;

--- a/src/client/java/net/neoforged/neoforge/client/NeoForgeRenderTypes.java
+++ b/src/client/java/net/neoforged/neoforge/client/NeoForgeRenderTypes.java
@@ -12,6 +12,7 @@ import com.mojang.blaze3d.textures.GpuSampler;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.rendertype.OutputTarget;
 import net.minecraft.client.renderer.rendertype.RenderSetup;
 import net.minecraft.client.renderer.rendertype.RenderType;
@@ -35,6 +36,9 @@ public enum NeoForgeRenderTypes {
     ITEM_UNSORTED_TRANSLUCENT(() -> getUnsortedTranslucent(TextureAtlas.LOCATION_ITEMS)),
     ITEM_UNLIT_TRANSLUCENT(() -> getUnlitTranslucent(TextureAtlas.LOCATION_ITEMS)),
     ITEM_UNSORTED_UNLIT_TRANSLUCENT(() -> getUnlitUnsortedTranslucent(TextureAtlas.LOCATION_ITEMS));
+
+    /// Solid equivalent to [Sheets#cutoutBlockSheet()] and [Sheets#translucentBlockSheet()]
+    public static final RenderType SOLID_BLOCK_SHEET = RenderTypes.entitySolid(TextureAtlas.LOCATION_BLOCKS);
 
     // TODO 1.21.11: Some render types previously enabled linear filtering, this intends to be equivalent, but was not checked. Also check the mipmap flag.
     private static final Supplier<GpuSampler> LINEAR_FILTERING_SAMPLER = () -> RenderSystem.getSamplerCache()

--- a/src/client/java/net/neoforged/neoforge/client/extensions/OrderedSubmitNodeCollectorExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/OrderedSubmitNodeCollectorExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.List;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.block.BlockModelRenderState;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+
+public interface OrderedSubmitNodeCollectorExtension {
+    /// Submit the provided [BlockStateModelPart]s with full support for per-quad render types.
+    ///
+    /// Primarily intended to be used via [BlockModelRenderState#submitMultiLayer(PoseStack, SubmitNodeCollector, int, int, int)].
+    ///
+    /// @param poseStack           The transformations to apply to the parts
+    /// @param modelParts          The model parts to submit
+    /// @param translucent         Whether the parts contain any translucent quads
+    /// @param lightCoords         The packed light coordinates to render the parts with
+    /// @param overlayCoords       The overlay texture coordinates to render the parts with
+    /// @param outlineColor        The outline color to render the parts with, or `0` to render no outline
+    default void submitMultiLayerBlockModel(
+            PoseStack poseStack,
+            List<BlockStateModelPart> modelParts,
+            boolean translucent,
+            int[] tintLayers,
+            int lightCoords,
+            int overlayCoords,
+            int outlineColor) {}
+}

--- a/src/client/java/net/neoforged/neoforge/client/extensions/SubmitNodeStorageExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/SubmitNodeStorageExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.List;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.SubmitNodeStorage;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+
+public interface SubmitNodeStorageExtension extends SubmitNodeCollector {
+    private SubmitNodeStorage self() {
+        return (SubmitNodeStorage) this;
+    }
+
+    @Override
+    default void submitMultiLayerBlockModel(
+            PoseStack poseStack,
+            List<BlockStateModelPart> modelParts,
+            boolean translucent,
+            int[] tintLayers,
+            int lightCoords,
+            int overlayCoords,
+            int outlineColor) {
+        self().order(0).submitMultiLayerBlockModel(poseStack, modelParts, translucent, tintLayers, lightCoords, overlayCoords, outlineColor);
+    }
+
+    record MultiLayerBlockModelSubmit(
+            PoseStack.Pose pose,
+            List<BlockStateModelPart> modelParts,
+            boolean translucent,
+            int[] tintLayers,
+            int lightCoords,
+            int overlayCoords,
+            int outlineColor) {}
+}

--- a/src/client/java/net/neoforged/neoforge/client/submit/ExtendedBlockFeatureRenderer.java
+++ b/src/client/java/net/neoforged/neoforge/client/submit/ExtendedBlockFeatureRenderer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.submit;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.QuadInstance;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.OutlineBufferSource;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.renderer.SubmitNodeCollection;
+import net.minecraft.client.renderer.SubmitNodeStorage;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.feature.BlockFeatureRenderer;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.resources.model.geometry.BakedQuad;
+import net.minecraft.core.Direction;
+import net.neoforged.neoforge.client.NeoForgeRenderTypes;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+@ApiStatus.Internal
+public final class ExtendedBlockFeatureRenderer extends BlockFeatureRenderer {
+    private static final Direction[] DIRECTIONS = Direction.values();
+
+    public static void renderMultiLayerBlockModelSubmits(
+            SubmitNodeCollection nodeCollection,
+            MultiBufferSource.BufferSource bufferSource,
+            OutlineBufferSource outlineBufferSource,
+            QuadInstance quadInstance,
+            boolean translucent) {
+        for (SubmitNodeStorage.MultiLayerBlockModelSubmit submit : nodeCollection.getMultiLayerBlockModelSubmits()) {
+            if (submit.translucent() != translucent) {
+                continue;
+            }
+
+            int outlineColor = submit.outlineColor();
+            VertexConsumer outlineBuffer = null;
+            if (outlineColor != 0) {
+                outlineBufferSource.setColor(outlineColor);
+                outlineBuffer = outlineBufferSource.getBuffer(RenderTypes.outline(TextureAtlas.LOCATION_BLOCKS));
+            }
+
+            quadInstance.setLightCoords(submit.lightCoords());
+            quadInstance.setOverlayCoords(submit.overlayCoords());
+
+            PoseStack.Pose pose = submit.pose();
+            int[] tintLayers = submit.tintLayers();
+            for (BlockStateModelPart part : submit.modelParts()) {
+                putMultiLayerPartQuads(pose, part, quadInstance, tintLayers, bufferSource, outlineBuffer);
+            }
+        }
+    }
+
+    private static void putMultiLayerPartQuads(
+            PoseStack.Pose pose,
+            BlockStateModelPart part,
+            QuadInstance quadInstance,
+            int[] tintLayers,
+            MultiBufferSource.BufferSource bufferSource,
+            @Nullable VertexConsumer outlineBuffer) {
+        for (Direction direction : DIRECTIONS) {
+            for (BakedQuad quad : part.getQuads(direction)) {
+                putQuad(pose, quad, quadInstance, tintLayers, getQuadBuffer(bufferSource, quad), outlineBuffer);
+            }
+        }
+
+        for (BakedQuad quad : part.getQuads(null)) {
+            putQuad(pose, quad, quadInstance, tintLayers, getQuadBuffer(bufferSource, quad), outlineBuffer);
+        }
+    }
+
+    private static VertexConsumer getQuadBuffer(MultiBufferSource.BufferSource bufferSource, BakedQuad quad) {
+        return bufferSource.getBuffer(switch (quad.materialInfo().layer()) {
+            case SOLID -> NeoForgeRenderTypes.SOLID_BLOCK_SHEET;
+            case CUTOUT -> Sheets.cutoutBlockSheet();
+            case TRANSLUCENT -> Sheets.translucentBlockSheet();
+        });
+    }
+
+    private ExtendedBlockFeatureRenderer() {}
+}

--- a/src/client/java/net/neoforged/neoforge/client/submit/package-info.java
+++ b/src/client/java/net/neoforged/neoforge/client/submit/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@NullMarked
+package net.neoforged.neoforge.client.submit;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -64,6 +64,7 @@ public net.minecraft.client.renderer.blockentity.SkullBlockRenderer SKIN_BY_TYPE
 public net.minecraft.client.renderer.entity.EntityRenderers register(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/client/renderer/entity/EntityRendererProvider;)V # register
 public net.minecraft.client.renderer.entity.LivingEntityRenderer addLayer(Lnet/minecraft/client/renderer/entity/layers/RenderLayer;)Z # addLayer
 public net.minecraft.client.renderer.entity.layers.EquipmentLayerRenderer getColorForLayer(Lnet/minecraft/client/resources/model/EquipmentClientInfo$Layer;I)I
+protected net.minecraft.client.renderer.feature.BlockFeatureRenderer putQuad(Lcom/mojang/blaze3d/vertex/PoseStack$Pose;Lnet/minecraft/client/resources/model/geometry/BakedQuad;Lcom/mojang/blaze3d/vertex/QuadInstance;[ILcom/mojang/blaze3d/vertex/VertexConsumer;Lcom/mojang/blaze3d/vertex/VertexConsumer;)V
 public net.minecraft.client.renderer.item.CuboidItemModelWrapper <init>(Ljava/util/List;Lnet/minecraft/client/resources/model/geometry/QuadCollection;Lnet/minecraft/client/renderer/item/ModelRenderProperties;Lorg/joml/Matrix4fc;)V
 public net.minecraft.client.renderer.texture.SpriteContents byMipLevel # byMipLevel
 default net.minecraft.client.renderer.texture.SpriteContents animatedTexture # animatedTexture

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -23,6 +23,12 @@
   "net/minecraft/client/gui/GuiGraphicsExtractor": [
     "net/neoforged/neoforge/client/extensions/IGuiGraphicsExtension"
   ],
+  "net/minecraft/client/renderer/OrderedSubmitNodeCollector": [
+    "net/neoforged/neoforge/client/extensions/OrderedSubmitNodeCollectorExtension"
+  ],
+  "net/minecraft/client/renderer/SubmitNodeStorage": [
+    "net/neoforged/neoforge/client/extensions/SubmitNodeStorageExtension"
+  ],
   "net/minecraft/client/renderer/block/dispatch/BlockStateModel": [
     "net/neoforged/neoforge/client/extensions/BlockStateModelExtension"
   ],


### PR DESCRIPTION
This PR adds support for submitting `BlockModelRenderState`s and the associated "block model submit" with full support for per-quad render types.

Vanilla's block model submit forces the entire model into either the cutout or the translucent layer depending on presence of *any* translucent quads in the model. This causes visual issues with certain models, one of which is even observable in vanilla when putting leaves onto a display entity with "see-through leaves" disabled.
The submit method added by this PR allows rendering multi-layer block models correctly when they deliberately put quads into "lower" layers than their sprites would dictate (i.e. putting leaves into `SOLID` when "see-through leaves" are disabled). To make this work, NeoForge needs to reintroduce the "entity solid" render type which vanilla removed in a recent snapshot (`Sheets.solidBlockSheet()`).