### PR TITLE
[26.1] Add support for dynamic block tint values

### DIFF
--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -130,3 +130,18 @@
      private boolean shouldRenderFace(BlockAndTintGetter level, BlockState state, Direction direction, BlockPos neighborPos) {
          if (!this.cull) {
              return true;
+@@ -204,6 +_,14 @@
+         if (!this.tintSourcesInitialized) {
+             this.configureTintCache(state);
+             this.tintSourcesInitialized = true;
++            if (this.tintSources.isEmpty()) {
++                var extensions = net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions.of(state);
++                if (extensions.collectDynamicTintValues(state, level, pos, this.computedTintValues)) {
++                    for (int i = 0; i < this.computedTintValues.size(); i++) {
++                        this.tintSources.add(null);
++                    }
++                }
++            }
+         }
+ 
+         if (tintIndex >= this.tintSources.size()) {

--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -130,13 +130,14 @@
      private boolean shouldRenderFace(BlockAndTintGetter level, BlockState state, Direction direction, BlockPos neighborPos) {
          if (!this.cull) {
              return true;
-@@ -204,6 +_,14 @@
+@@ -204,6 +_,15 @@
          if (!this.tintSourcesInitialized) {
              this.configureTintCache(state);
              this.tintSourcesInitialized = true;
 +            if (this.tintSources.isEmpty()) {
-+                var extensions = net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions.of(state);
-+                if (extensions.collectDynamicTintValues(state, level, pos, this.computedTintValues)) {
++                net.neoforged.neoforge.client.extensions.common.IClientBlockExtensions.of(state)
++                        .collectDynamicTintValues(state, level, pos, this.computedTintValues);
++                if (!this.computedTintValues.isEmpty()) {
 +                    for (int i = 0; i < this.computedTintValues.size(); i++) {
 +                        this.tintSources.add(null);
 +                    }

--- a/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
@@ -138,6 +138,9 @@ public interface IClientBlockExtensions {
 
     /// Collect tint values for blocks with a dynamic tint layer count.
     ///
+    /// Tint values must be appended to the provided list such that their index in the list matches the tint index
+    /// specified by the quad(s) that should be affected by them.
+    ///
     /// Intended to be used by blocks which imitate other blocks and pull their tint values from the imitated block.
     /// This method is only called when [BlockColors#getTintSources(BlockState)] returns an empty list for the block
     /// these extensions are associated to.

--- a/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
@@ -5,7 +5,10 @@
 
 package net.neoforged.neoforge.client.extensions.common;
 
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.particle.ParticleEngine;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
 import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -131,5 +134,20 @@ public interface IClientBlockExtensions {
             return new Vector3d(0.6F, 0.1F, 0.0F);
         }
         return originalColor;
+    }
+
+    /// Collect tint values for blocks with a dynamic tint layer count.
+    ///
+    /// Intended to be used by blocks which imitate other blocks and pull their tint values from the imitated block.
+    /// This method is only called when [BlockColors#getTintSources(BlockState)] returns an empty list for the block
+    /// these extensions are associated to.
+    ///
+    /// @param state      The block state whose tint values are being queried
+    /// @param level      The level in which the block is being rendered
+    /// @param pos        The position at which the block is being rendered
+    /// @param tintValues The list to append the tint values to
+    /// @return true to enable the dynamic tint values to be used
+    default boolean collectDynamicTintValues(BlockState state, BlockAndTintGetter level, BlockPos pos, IntList tintValues) {
+        return false;
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientBlockExtensions.java
@@ -146,8 +146,5 @@ public interface IClientBlockExtensions {
     /// @param level      The level in which the block is being rendered
     /// @param pos        The position at which the block is being rendered
     /// @param tintValues The list to append the tint values to
-    /// @return true to enable the dynamic tint values to be used
-    default boolean collectDynamicTintValues(BlockState state, BlockAndTintGetter level, BlockPos pos, IntList tintValues) {
-        return false;
-    }
+    default void collectDynamicTintValues(BlockState state, BlockAndTintGetter level, BlockPos pos, IntList tintValues) {}
 }


### PR DESCRIPTION
This PR adds a hook to allow blocks with dynamic tint layer counts to provide tint values to `ModelBlockRenderer`.

Before the introduction of `BlockTintSource`, chunk meshing did not care about the amount of tint layers used by any given block and `BlockColor` implementations could provide values for any arbitrary amount of tint indices (including negative tint indices lower than -1). With the introduction of `BlockTintSource`, every block intending to be tinted is required to provide a fixed list of sources, one source per tint index.
This works fine for the vast majority of relevant blocks but fails catastrophically on blocks which imitate other blocks and pull the tint values from the imitated blocks. Registering an arbitrarily sized list of tint sources is not realistic, particularly when the block may consist of multiple parts, each with unknown tint counts.

This PR only implements support for this hook in `ModelBlockRenderer`. The new `BlockModel` system (and `BlockStateModelWrapper` in particular) does not support level-aware tints out of the box. Level context could be provided through a custom `BlockDisplayContext` but this needs further thought and can be implemented in a seperate PR at a later time.