### PR TITLE
[26.1] Re-enable changelog publishing

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -20,6 +20,11 @@ evaluationDependsOn(":neoforge-coremods")
 
 gradleutils.setupSigning(project: project, signAllPublications: true)
 
+changelog {
+    from '21.6'
+    disableAutomaticPublicationRegistration()
+}
+
 sourceSets {
     main {
         java {
@@ -463,6 +468,18 @@ configurations {
         }
         javaComponent.addVariantsFromConfiguration(it) {}
     }
+    changelog {
+        canBeDeclared = false
+        canBeResolved = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "changelog"))
+        }
+        // Publish it, but only for release versions
+        if (!rootProject.isPreReleaseVersion) {
+            javaComponent.addVariantsFromConfiguration(it) {}
+        }
+    }
 }
 
 sourcesJar {
@@ -484,6 +501,11 @@ artifacts {
     }
     installerJar(installerJar) {
         setClassifier("installer")
+    }
+    changelog(createChangelog.outputFile) {
+        builtBy(createChangelog)
+        setClassifier("changelog")
+        setExtension("txt")
     }
 }
 

--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -21,7 +21,7 @@ evaluationDependsOn(":neoforge-coremods")
 gradleutils.setupSigning(project: project, signAllPublications: true)
 
 changelog {
-    from '21.6'
+    from '26.1.0'
     disableAutomaticPublicationRegistration()
 }
 


### PR DESCRIPTION
This PR simply re-enables changelog publishing which was disabled during the unobfuscated / 26.1 development 
This is done this by reverting the commit which disabled changelog publishing (https://github.com/neoforged/NeoForge/commit/30062dab567b0aae0c9ab448b295b1d256c50455)