### PR TITLE
[26.1] Update FML to use correct GLFW init and window hints in ELS

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=11.0.3
+fancy_mod_loader_version=11.0.5-pr-403-update_window_hints
 typetools_version=0.6.3
 mixin_extras_version=0.5.3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=11.0.5-pr-403-update_window_hints
+fancy_mod_loader_version=11.0.4
 typetools_version=0.6.3
 mixin_extras_version=0.5.3
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,15 @@ dependencyResolutionManagement {
     rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
     repositories {
         mavenCentral()
+        maven {
+            name = "Maven for PR #403" // https://github.com/neoforged/FancyModLoader/pull/403
+            url = uri("https://prmaven.neoforged.net/FancyModLoader/pr403")
+            content {
+                includeModule("net.neoforged.fancymodloader", "earlydisplay")
+                includeModule("net.neoforged.fancymodloader", "junit-fml")
+                includeModule("net.neoforged.fancymodloader", "loader")
+            }
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,15 +22,6 @@ dependencyResolutionManagement {
     rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
     repositories {
         mavenCentral()
-        maven {
-            name = "Maven for PR #403" // https://github.com/neoforged/FancyModLoader/pull/403
-            url = uri("https://prmaven.neoforged.net/FancyModLoader/pr403")
-            content {
-                includeModule("net.neoforged.fancymodloader", "earlydisplay")
-                includeModule("net.neoforged.fancymodloader", "junit-fml")
-                includeModule("net.neoforged.fancymodloader", "loader")
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This PR updates FML to use the same GLFW init and window hints in ELS as vanilla does in its window init.
This may fix the ELS init crash on Linux with Nvidia and Wayland.