### PR TITLE
Bump GradleUtils to 5.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.util.regex.Pattern
 import net.neoforged.neodev.CheckSplitSources
 
 plugins {
-    id 'net.neoforged.gradleutils' version '5.1.0'
+    id 'net.neoforged.gradleutils' version '5.1.1'
     id 'dev.lukebemish.immaculate' version '0.1.16' apply false
     id 'net.neoforged.licenser' version '0.7.5'
     id 'neoforge.formatting-conventions'


### PR DESCRIPTION
Bumps GradleUtils to `5.1.1` to fix broken changelog format (https://github.com/neoforged/GradleUtils/pull/40)