### PR TITLE
Unhook mayFly field from controlling flight

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -79,14 +79,14 @@ public interface IPlayerExtension {
      * Determine whether a player is allowed creative flight via game mode or attribute.
      * <p>
      * Modders are discouraged from setting {@link Abilities#mayfly} directly.
+     * That {@link Abilities#mayfly} field will no longer control flight due to {@link NeoForgeMod#CREATIVE_FLIGHT} replacing it.
      *
      * @return true when creative flight is available
      * @see NeoForgeMod#CREATIVE_FLIGHT
      */
     @SuppressWarnings("deprecation")
     default boolean mayFly() {
-        // TODO 1.20.5: consider forcing mods to use the attribute
-        return self().getAbilities().mayfly || self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
+        return self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -78,8 +78,8 @@ public interface IPlayerExtension {
     /**
      * Determine whether a player is allowed creative flight via game mode or attribute.
      * <p>
-     * Modders are discouraged from setting {@link Abilities#mayfly} directly.
-     * That {@link Abilities#mayfly} field will no longer control flight due to {@link NeoForgeMod#CREATIVE_FLIGHT} replacing it.
+     * Modders are forbidden from setting {@link Abilities#mayfly} directly because it will
+     * no longer control flight due to {@link NeoForgeMod#CREATIVE_FLIGHT} replacing it.
      *
      * @return true when creative flight is available
      * @see NeoForgeMod#CREATIVE_FLIGHT


### PR DESCRIPTION
Since we had `Abilities#mayFly` field deprecated for a significant number of Minecraft versions, it is time to kill it off once and for all in favor of the NeoForge attribute `net.neoforged.neoforge.common.NeoForgeMod#CREATIVE_FLIGHT`

Anyone using the old field will now find it does not control flight at all. Forcing the usage of the attribute. The `Abilities#mayFly` field already has a javadoc pointing to the attribute so no issue there.

Closes https://github.com/neoforged/NeoForge/issues/3015