### PR TITLE
[26.1] Fix visual item cloning bug

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -57,7 +57,7 @@
          } else {
 -            boolean cloning = this.minecraft.options.keyPickItem.matchesMouse(event) && this.minecraft.player.hasInfiniteMaterials();
 +            var mouseKey = com.mojang.blaze3d.platform.InputConstants.Type.MOUSE.getOrCreate(event.button());
-+            boolean cloning = this.minecraft.options.keyPickItem.isActiveAndMatches(mouseKey);
++            boolean cloning = this.minecraft.options.keyPickItem.isActiveAndMatches(mouseKey) && this.minecraft.player.hasInfiniteMaterials();
              Slot slot = this.getHoveredSlot(event.x(), event.y());
              this.doubleclick = this.lastClickSlot == slot && doubleClick;
              this.skipNextRelease = false;


### PR DESCRIPTION
This PR fixes #3009 by adding the missing `this.minecraft.player.hasInfiniteMaterials()` check that vanilla does to our `keyPickItem.isActiveAndMatches(mouseKey)` patch

Without this fix survival players can middle mouse drag to visually clone them item in hand, releasing the mouse button does not actually clone the items.