### PR TITLE
Add ModelDebugName argument to UnbakedStandaloneModel#bake

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/SimpleUnbakedStandaloneModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/SimpleUnbakedStandaloneModel.java
@@ -12,6 +12,7 @@ import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
 import net.minecraft.client.renderer.block.dispatch.ModelState;
 import net.minecraft.client.renderer.block.dispatch.SingleVariant;
 import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelDebugName;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.resources.model.ResolvedModel;
 import net.minecraft.client.resources.model.SimpleModelWrapper;
@@ -48,7 +49,7 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
     }
 
     @Override
-    public T bake(ModelBaker baker) {
+    public T bake(ModelBaker baker, ModelDebugName name) {
         return bake.apply(baker.getModel(modelId), baker);
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/SimpleUnbakedStandaloneModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/SimpleUnbakedStandaloneModel.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.client.model.standalone;
 
-import java.util.function.BiFunction;
 import net.minecraft.client.renderer.block.dispatch.BlockModelRotation;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModel;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/SimpleUnbakedStandaloneModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/SimpleUnbakedStandaloneModel.java
@@ -35,7 +35,7 @@ import net.minecraft.resources.Identifier;
  */
 public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneModel<T> {
     private final Identifier modelId;
-    private final BiFunction<ResolvedModel, ModelBaker, T> bake;
+    private final SimpleBaker<T> bake;
 
     /**
      * Construct a new {@link SimpleUnbakedStandaloneModel}.
@@ -43,14 +43,14 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      * @param modelId The id of the model to load.
      * @param bake    The function to bake the model, converting a {@link ResolvedModel} into the required type.
      */
-    public SimpleUnbakedStandaloneModel(Identifier modelId, BiFunction<ResolvedModel, ModelBaker, T> bake) {
+    public SimpleUnbakedStandaloneModel(Identifier modelId, SimpleBaker<T> bake) {
         this.modelId = modelId;
         this.bake = bake;
     }
 
     @Override
     public T bake(ModelBaker baker, ModelDebugName name) {
-        return bake.apply(baker.getModel(modelId), baker);
+        return bake.bake(baker.getModel(modelId), baker, name);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      */
     public static SimpleUnbakedStandaloneModel<BlockStateModelPart> simpleModelWrapper(Identifier modelId) {
         return new SimpleUnbakedStandaloneModel<>(
-                modelId, (model, baker) -> SimpleModelWrapper.bake(baker, model, BlockModelRotation.IDENTITY));
+                modelId, (model, baker, _) -> SimpleModelWrapper.bake(baker, model, BlockModelRotation.IDENTITY));
     }
 
     /**
@@ -71,7 +71,7 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      */
     public static SimpleUnbakedStandaloneModel<BlockStateModelPart> simpleModelWrapper(Identifier modelId, ModelState modelState) {
         return new SimpleUnbakedStandaloneModel<>(
-                modelId, (model, baker) -> SimpleModelWrapper.bake(baker, model, modelState));
+                modelId, (model, baker, _) -> SimpleModelWrapper.bake(baker, model, modelState));
     }
 
     /**
@@ -79,7 +79,7 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      */
     public static SimpleUnbakedStandaloneModel<BlockStateModel> blockStateModel(Identifier modelId) {
         return new SimpleUnbakedStandaloneModel<>(
-                modelId, (model, baker) -> new SingleVariant(SimpleModelWrapper.bake(baker, model, BlockModelRotation.IDENTITY)));
+                modelId, (model, baker, _) -> new SingleVariant(SimpleModelWrapper.bake(baker, model, BlockModelRotation.IDENTITY)));
     }
 
     /**
@@ -87,7 +87,7 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      */
     public static SimpleUnbakedStandaloneModel<BlockStateModel> blockStateModel(Identifier modelId, ModelState modelState) {
         return new SimpleUnbakedStandaloneModel<>(
-                modelId, (model, baker) -> new SingleVariant(SimpleModelWrapper.bake(baker, model, modelState)));
+                modelId, (model, baker, _) -> new SingleVariant(SimpleModelWrapper.bake(baker, model, modelState)));
     }
 
     /**
@@ -95,7 +95,7 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      */
     public static SimpleUnbakedStandaloneModel<QuadCollection> quadCollection(Identifier modelId) {
         return new SimpleUnbakedStandaloneModel<>(
-                modelId, (model, baker) -> model.bakeTopGeometry(model.getTopTextureSlots(), baker, BlockModelRotation.IDENTITY));
+                modelId, (model, baker, _) -> model.bakeTopGeometry(model.getTopTextureSlots(), baker, BlockModelRotation.IDENTITY));
     }
 
     /**
@@ -103,6 +103,11 @@ public final class SimpleUnbakedStandaloneModel<T> implements UnbakedStandaloneM
      */
     public static SimpleUnbakedStandaloneModel<QuadCollection> quadCollection(Identifier modelId, ModelState modelState) {
         return new SimpleUnbakedStandaloneModel<>(
-                modelId, (model, baker) -> model.bakeTopGeometry(model.getTopTextureSlots(), baker, modelState));
+                modelId, (model, baker, _) -> model.bakeTopGeometry(model.getTopTextureSlots(), baker, modelState));
+    }
+
+    @FunctionalInterface
+    public interface SimpleBaker<T> {
+        T bake(ResolvedModel model, ModelBaker baker, ModelDebugName name);
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/StandaloneModelLoader.java
@@ -34,7 +34,7 @@ public final class StandaloneModelLoader {
     public static CompletableFuture<BakedModels> bake(LoadedModels standaloneModels, ModelBaker baker, Executor executor) {
         return ParallelMapTransform.schedule(standaloneModels.models, (key, model) -> {
             try {
-                return model.bake(baker);
+                return model.bake(baker, key::getName);
             } catch (Exception e) {
                 LOGGER.warn("Unable to bake standalone model: '{}': {}", key.getName(), e);
                 return null;

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/UnbakedStandaloneModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/UnbakedStandaloneModel.java
@@ -31,7 +31,7 @@ public interface UnbakedStandaloneModel<T> extends ResolvableModel {
      * Bake this model.
      *
      * @param baker The current model baker.
-     * @param name The debug name of this model currently being baked.
+     * @param name  The debug name of this model currently being baked.
      * @return The fully-baked model.
      */
     T bake(ModelBaker baker, ModelDebugName name);

--- a/src/client/java/net/neoforged/neoforge/client/model/standalone/UnbakedStandaloneModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/standalone/UnbakedStandaloneModel.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.client.model.standalone;
 
 import net.minecraft.client.renderer.item.ItemModel;
 import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelDebugName;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.resources.model.ResolvableModel;
 import net.neoforged.neoforge.client.event.ModelEvent;
@@ -30,7 +31,8 @@ public interface UnbakedStandaloneModel<T> extends ResolvableModel {
      * Bake this model.
      *
      * @param baker The current model baker.
+     * @param name The debug name of this model currently being baked.
      * @return The fully-baked model.
      */
-    T bake(ModelBaker baker);
+    T bake(ModelBaker baker, ModelDebugName name);
 }


### PR DESCRIPTION
This fixes #3033. I opted to simply pass down `ModelDebugName` for simplicity. I thought about adding a default to not creat a breaking chnage but since we are that early in this current version lifspan I think it's unnecesaty.