### PR TITLE
Expose applied default components through ModifyDefaultComponentsEvent

### DIFF
--- a/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
@@ -13,7 +13,7 @@
 +                    modifier.accept(elementBuilder);
 +                }
 +                for (var pair : net.neoforged.neoforge.internal.RegistrationEvents.getComponentModifiersByPredicate()) {
-+                    if (pair.getFirst().test(item, elementBuilder.getAppliedDefaultComponentTypes())) {
++                    if (pair.getFirst().test(item, elementBuilder.getComponentTypes())) {
 +                        pair.getSecond().accept(elementBuilder);
 +                    }
 +                }

--- a/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
@@ -8,12 +8,12 @@
 +            // Neo: Support programmatic customization of the default components for items
 +            if (elementKey.isFor(net.minecraft.core.registries.Registries.ITEM)) {
 +                var item = (net.minecraft.world.item.Item) element.value();
-+                var modifier = net.neoforged.neoforge.internal.RegistrationEvents.componentModifiersByItem.get(item);
++                var modifier = net.neoforged.neoforge.internal.RegistrationEvents.getComponentModifiersByItem().get(item);
 +                if (modifier != null) {
 +                    modifier.accept(elementBuilder);
 +                }
-+                for (var pair : net.neoforged.neoforge.internal.RegistrationEvents.componentModifiersByPredicate) {
-+                    if (pair.getFirst().test(item)) {
++                for (var pair : net.neoforged.neoforge.internal.RegistrationEvents.getComponentModifiersByPredicate()) {
++                    if (pair.getFirst().test(item, elementBuilder.getAppliedDefaultComponentTypes())) {
 +                        pair.getSecond().accept(elementBuilder);
 +                    }
 +                }

--- a/patches/net/minecraft/core/component/DataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentMap.java.patch
@@ -8,14 +8,18 @@
  import org.jspecify.annotations.Nullable;
  
  public interface DataComponentMap extends Iterable<TypedDataComponent<?>>, DataComponentGetter {
-@@ -127,6 +_,10 @@
+@@ -127,6 +_,14 @@
          private Consumer<DataComponentMap> validator = components -> {};
  
          private Builder() {
 +        }
 +
-+        public it.unimi.dsi.fastutil.objects.ReferenceSet<DataComponentType<?>> getAppliedDefaultComponentTypes() {
-+            return map.keySet();
++        /**
++         * @return An unmodifiable set of the stored default component types
++         */
++        @org.jetbrains.annotations.ApiStatus.Internal
++        public Set<DataComponentType<?>> getAppliedDefaultComponentTypes() {
++            return Collections.unmodifiableSet(map.keySet());
          }
  
          public <T> DataComponentMap.Builder set(DataComponentType<T> type, @Nullable T value) {

--- a/patches/net/minecraft/core/component/DataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentMap.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/core/component/DataComponentMap.java
 +++ b/net/minecraft/core/component/DataComponentMap.java
-@@ -18,6 +_,8 @@
+@@ -18,6 +_,7 @@
  import java.util.function.Predicate;
  import java.util.stream.Stream;
  import java.util.stream.StreamSupport;
 +
-+import it.unimi.dsi.fastutil.objects.ReferenceSet;
  import org.jspecify.annotations.Nullable;
  
  public interface DataComponentMap extends Iterable<TypedDataComponent<?>>, DataComponentGetter {
@@ -15,7 +14,7 @@
          private Builder() {
 +        }
 +
-+        public ReferenceSet<DataComponentType<?>> getAppliedDefaultComponentTypes() {
++        public it.unimi.dsi.fastutil.objects.ReferenceSet<DataComponentType<?>> getAppliedDefaultComponentTypes() {
 +            return map.keySet();
          }
  

--- a/patches/net/minecraft/core/component/DataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentMap.java.patch
@@ -1,0 +1,22 @@
+--- a/net/minecraft/core/component/DataComponentMap.java
++++ b/net/minecraft/core/component/DataComponentMap.java
+@@ -18,6 +_,8 @@
+ import java.util.function.Predicate;
+ import java.util.stream.Stream;
+ import java.util.stream.StreamSupport;
++
++import it.unimi.dsi.fastutil.objects.ReferenceSet;
+ import org.jspecify.annotations.Nullable;
+ 
+ public interface DataComponentMap extends Iterable<TypedDataComponent<?>>, DataComponentGetter {
+@@ -127,6 +_,10 @@
+         private Consumer<DataComponentMap> validator = components -> {};
+ 
+         private Builder() {
++        }
++
++        public ReferenceSet<DataComponentType<?>> getAppliedDefaultComponentTypes() {
++            return map.keySet();
+         }
+ 
+         public <T> DataComponentMap.Builder set(DataComponentType<T> type, @Nullable T value) {

--- a/patches/net/minecraft/core/component/DataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentMap.java.patch
@@ -8,17 +8,15 @@
  import org.jspecify.annotations.Nullable;
  
  public interface DataComponentMap extends Iterable<TypedDataComponent<?>>, DataComponentGetter {
-@@ -127,6 +_,14 @@
+@@ -127,6 +_,12 @@
          private Consumer<DataComponentMap> validator = components -> {};
  
          private Builder() {
 +        }
 +
-+        /**
-+         * @return An unmodifiable set of the stored default component types
-+         */
++        /// {@return an unmodifiable view of the stored component types}
 +        @org.jetbrains.annotations.ApiStatus.Internal
-+        public Set<DataComponentType<?>> getAppliedDefaultComponentTypes() {
++        public Set<DataComponentType<?>> getComponentTypes() {
 +            return Collections.unmodifiableSet(map.keySet());
          }
  

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -6,13 +6,11 @@
 package net.neoforged.neoforge.event;
 
 import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
-
-import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
@@ -22,7 +20,6 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
-import org.jspecify.annotations.Nullable;
 
 /**
  * The event used to modify the default {@linkplain Item#components() components} of an item. <br>

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -8,9 +8,13 @@ package net.neoforged.neoforge.event;
 import com.mojang.datafixers.util.Pair;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.bus.api.Event;
@@ -18,6 +22,7 @@ import net.neoforged.bus.api.EventPriority;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.event.IModBusEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The event used to modify the default {@linkplain Item#components() components} of an item. <br>
@@ -45,11 +50,11 @@ import org.jetbrains.annotations.ApiStatus;
  */
 public final class ModifyDefaultComponentsEvent extends Event implements IModBusEvent {
     private final Map<Item, Consumer<DataComponentMap.Builder>> modifiersByItem;
-    private final List<Pair<Predicate<? super Item>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate;
+    private final List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate;
 
     @ApiStatus.Internal
     public ModifyDefaultComponentsEvent(Map<Item, Consumer<DataComponentMap.Builder>> modifiersByItem,
-            List<Pair<Predicate<? super Item>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate) {
+            List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate) {
         this.modifiersByItem = modifiersByItem;
         this.modifiersByPredicate = modifiersByPredicate;
     }
@@ -65,16 +70,17 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
     }
 
     /**
-     * Patches the default components of all items matching the given {@code predicate}.
+     * Patches the default components of all items matching the given {@code bipredicate}
+     * based on item and/or its currently applied default components.
      * <p>
      * If this method is used to modify components based on the item's current default components, the
      * event listener should use the {@link EventPriority#LOWEST lowest priority} so that {@linkplain #modify(ItemLike, Consumer) other mods' modifications} are
      * already applied.
      *
-     * @param predicate the item filter
-     * @param patch     the patch to apply
+     * @param bipredicate the item and its current default components filter
+     * @param patch       the patch to apply
      */
-    public void modifyMatching(Predicate<? super Item> predicate, Consumer<DataComponentMap.Builder> patch) {
-        modifiersByPredicate.add(Pair.of(predicate, patch));
+    public void modifyMatching(BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>> bipredicate, Consumer<DataComponentMap.Builder> patch) {
+        modifiersByPredicate.add(Pair.of(bipredicate, patch));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -6,9 +6,9 @@
 package net.neoforged.neoforge.event;
 
 import com.mojang.datafixers.util.Pair;
-import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import net.minecraft.core.component.DataComponentMap;
@@ -47,11 +47,11 @@ import org.jetbrains.annotations.ApiStatus;
  */
 public final class ModifyDefaultComponentsEvent extends Event implements IModBusEvent {
     private final Map<Item, Consumer<DataComponentMap.Builder>> modifiersByItem;
-    private final List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate;
+    private final List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate;
 
     @ApiStatus.Internal
     public ModifyDefaultComponentsEvent(Map<Item, Consumer<DataComponentMap.Builder>> modifiersByItem,
-            List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate) {
+            List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> modifiersByPredicate) {
         this.modifiersByItem = modifiersByItem;
         this.modifiersByPredicate = modifiersByPredicate;
     }
@@ -77,7 +77,7 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
      * @param bipredicate the item and its current default components filter
      * @param patch       the patch to apply
      */
-    public void modifyMatching(BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>> bipredicate, Consumer<DataComponentMap.Builder> patch) {
+    public void modifyMatching(BiPredicate<? super Item, Set<DataComponentType<?>>> bipredicate, Consumer<DataComponentMap.Builder> patch) {
         modifiersByPredicate.add(Pair.of(bipredicate, patch));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -6,17 +6,14 @@
 package net.neoforged.neoforge.internal;
 
 import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
-
-import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
@@ -27,7 +24,6 @@ import net.neoforged.neoforge.common.world.poi.PoiTypeExtender;
 import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.registries.RegistryManager;
-import org.jspecify.annotations.Nullable;
 
 public class RegistrationEvents {
     private static Map<Item, Consumer<DataComponentMap.Builder>> componentModifiersByItem = new HashMap<>();

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -7,12 +7,18 @@ package net.neoforged.neoforge.internal;
 
 import com.mojang.datafixers.util.Pair;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
@@ -21,12 +27,11 @@ import net.neoforged.neoforge.common.world.poi.PoiTypeExtender;
 import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.registries.RegistryManager;
+import org.jspecify.annotations.Nullable;
 
 public class RegistrationEvents {
-    // TODO 26.1: Find a better solution than this
-    public static Map<Item, Consumer<DataComponentMap.Builder>> componentModifiersByItem;
-    // TODO 26.1: Find a better solution than this
-    public static List<Pair<Predicate<? super Item>, Consumer<DataComponentMap.Builder>>> componentModifiersByPredicate;
+    private static Map<Item, Consumer<DataComponentMap.Builder>> componentModifiersByItem = new HashMap<>();
+    private static List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> componentModifiersByPredicate = new ArrayList<>();
 
     static void init() {
         CauldronFluidContent.init(); // must be before capability event
@@ -38,8 +43,20 @@ public class RegistrationEvents {
     }
 
     public static void collectComponentModifiers() {
-        componentModifiersByItem = new HashMap<>();
-        componentModifiersByPredicate = new ArrayList<>();
-        ModLoader.postEvent(new ModifyDefaultComponentsEvent(componentModifiersByItem, componentModifiersByPredicate));
+        var rawComponentModifiersByItem = new HashMap<Item, Consumer<DataComponentMap.Builder>>();
+        var rawComponentModifiersByPredicate = new ArrayList<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>>();
+
+        ModLoader.postEvent(new ModifyDefaultComponentsEvent(rawComponentModifiersByItem, rawComponentModifiersByPredicate));
+
+        componentModifiersByItem = Collections.unmodifiableMap(rawComponentModifiersByItem);
+        componentModifiersByPredicate = Collections.unmodifiableList(rawComponentModifiersByPredicate);
+    }
+
+    public static Map<Item, Consumer<DataComponentMap.Builder>> getComponentModifiersByItem() {
+        return componentModifiersByItem;
+    }
+
+    public static List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> getComponentModifiersByPredicate() {
+        return componentModifiersByPredicate;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -6,12 +6,12 @@
 package net.neoforged.neoforge.internal;
 
 import com.mojang.datafixers.util.Pair;
-import it.unimi.dsi.fastutil.objects.ReferenceSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import net.minecraft.core.component.DataComponentMap;
@@ -27,7 +27,7 @@ import net.neoforged.neoforge.registries.RegistryManager;
 
 public class RegistrationEvents {
     private static Map<Item, Consumer<DataComponentMap.Builder>> componentModifiersByItem = new HashMap<>();
-    private static List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> componentModifiersByPredicate = new ArrayList<>();
+    private static List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> componentModifiersByPredicate = new ArrayList<>();
 
     static void init() {
         CauldronFluidContent.init(); // must be before capability event
@@ -40,7 +40,7 @@ public class RegistrationEvents {
 
     public static void collectComponentModifiers() {
         var rawComponentModifiersByItem = new HashMap<Item, Consumer<DataComponentMap.Builder>>();
-        var rawComponentModifiersByPredicate = new ArrayList<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>>();
+        var rawComponentModifiersByPredicate = new ArrayList<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>>();
 
         ModLoader.postEvent(new ModifyDefaultComponentsEvent(rawComponentModifiersByItem, rawComponentModifiersByPredicate));
 
@@ -52,7 +52,7 @@ public class RegistrationEvents {
         return componentModifiersByItem;
     }
 
-    public static List<Pair<BiPredicate<? super Item, ReferenceSet<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> getComponentModifiersByPredicate() {
+    public static List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> getComponentModifiersByPredicate() {
         return componentModifiersByPredicate;
     }
 }

--- a/tests/src/generated/resources/assets/neotests_test_modify_default_components_event/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_test_modify_default_components_event/lang/en_us.json
@@ -1,4 +1,3 @@
 {
-  "item.neotests_test_modify_default_components_event.test_item": "Test components item",
-  "item.neotests_test_modify_default_components_event.test_item_2": "Test components item 2"
+  "item.neotests_test_modify_default_components_event.test_item": "Test components item"
 }

--- a/tests/src/generated/resources/assets/neotests_test_modify_default_components_event/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_test_modify_default_components_event/lang/en_us.json
@@ -1,3 +1,4 @@
 {
-  "item.neotests_test_modify_default_components_event.test_item": "Test components item"
+  "item.neotests_test_modify_default_components_event.test_item": "Test components item",
+  "item.neotests_test_modify_default_components_event.test_item_2": "Test components item 2"
 }

--- a/tests/src/generated/resources/assets/neotests_test_modify_default_components_event_on_default_component_matching/lang/en_us.json
+++ b/tests/src/generated/resources/assets/neotests_test_modify_default_components_event_on_default_component_matching/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "item.neotests_test_modify_default_components_event_on_default_component_matching.test_item_2": "Test components item 2"
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -94,8 +94,7 @@ public class ItemComponentTests {
 
         test.framework().modEventBus().addListener((final ModifyDefaultComponentsEvent event) -> event.modifyMatching(
                 (item, appliedDefaultComponents) -> appliedDefaultComponents.contains(DataComponents.BASE_COLOR) && item == testItem.asItem(),
-                builder -> builder.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)
-        ));
+                builder -> builder.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)));
 
         test.onGameTest(helper -> {
             helper.assertFalse(testItem.asItem().components().has(DataComponents.ENCHANTMENT_GLINT_OVERRIDE), "New default component added");

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -78,7 +78,7 @@ public class ItemComponentTests {
         });
 
         test.onGameTest(helper -> {
-            helper.assertFalse(testItem.asItem().components().has(DataComponents.BASE_COLOR), "Default component was not removed");
+            helper.assertFalse(testItem.asItem().components().has(DataComponents.BASE_COLOR), "Default component was removed");
             helper.assertValueEqual(testItem.asItem().getDefaultMaxStackSize(), 5, "max stack size");
             helper.succeed();
         });
@@ -97,8 +97,8 @@ public class ItemComponentTests {
                 builder -> builder.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)));
 
         test.onGameTest(helper -> {
-            helper.assertFalse(testItem.asItem().components().has(DataComponents.ENCHANTMENT_GLINT_OVERRIDE), "New default component added");
-            helper.assertFalse(testItem.asItem().components().has(DataComponents.BASE_COLOR), "Default component was not removed");
+            helper.assertTrue(testItem.asItem().components().has(DataComponents.ENCHANTMENT_GLINT_OVERRIDE), "New default component added");
+            helper.assertTrue(testItem.asItem().components().has(DataComponents.BASE_COLOR), "Default component was not removed");
             helper.assertValueEqual(testItem.asItem().getDefaultMaxStackSize(), 5, "max stack size");
             helper.succeed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -83,4 +83,25 @@ public class ItemComponentTests {
             helper.succeed();
         });
     }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if the ModifyDefaultComponentsEvent can modify based on another default component", groups = EventTests.GROUP)
+    static void testModifyDefaultComponentsEventOnDefaultComponentMatching(DynamicTest test, RegistrationHelper reg) {
+        final var testItem = reg.items().registerSimpleItem("test_item_2", props -> props
+                .component(DataComponents.BASE_COLOR, DyeColor.BLUE))
+                .withLang("Test components item 2");
+
+        test.framework().modEventBus().addListener((final ModifyDefaultComponentsEvent event) -> event.modifyMatching(
+                (item, appliedDefaultComponents) -> appliedDefaultComponents.contains(DataComponents.BASE_COLOR) && item == testItem.asItem(),
+                builder -> builder.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)
+        ));
+
+        test.onGameTest(helper -> {
+            helper.assertFalse(testItem.asItem().components().has(DataComponents.ENCHANTMENT_GLINT_OVERRIDE), "New default component added");
+            helper.assertFalse(testItem.asItem().components().has(DataComponents.BASE_COLOR), "Default component was not removed");
+            helper.assertValueEqual(testItem.asItem().getDefaultMaxStackSize(), 5, "max stack size");
+            helper.succeed();
+        });
+    }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -99,7 +99,6 @@ public class ItemComponentTests {
         test.onGameTest(helper -> {
             helper.assertTrue(testItem.asItem().components().has(DataComponents.ENCHANTMENT_GLINT_OVERRIDE), "New default component added");
             helper.assertTrue(testItem.asItem().components().has(DataComponents.BASE_COLOR), "Default component was not removed");
-            helper.assertValueEqual(testItem.asItem().getDefaultMaxStackSize(), 5, "max stack size");
             helper.succeed();
         });
     }


### PR DESCRIPTION
I figured I would add a patch to allow retrieving the list of current default components from the current builder and then feed that to `ModifyDefaultComponentsEvent` (The `Set` is unmodifiable so should be fine to expose). I decided not to keep an item only predicate because it seems alright to just pass the current item's list of applied default components along with the item and signal to people that it is now available to use. Making it less likely that someone will accidentally use `item.components()` when they can see the component list right there in their face. Downside is it is a breaking change but should be fine this early into 26.1. 

Also locks down `componentModifiersByItem` and `componentModifiersByPredicate` so no mod can reassign or modify those collections, allowing it to remain safe within NeoForge's domain.

Unit test added to ensure this does not face regression in future.

Resolves https://github.com/neoforged/NeoForge/issues/3006