### PR TITLE
[26.1] Clean up component modifier internals

### DIFF
--- a/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
@@ -1,22 +1,13 @@
 --- a/net/minecraft/core/component/DataComponentInitializers.java
 +++ b/net/minecraft/core/component/DataComponentInitializers.java
-@@ -68,6 +_,21 @@
+@@ -68,6 +_,12 @@
          Set<Holder.Reference<T>> elementsWithComponents = Sets.newIdentityHashSet();
          elementBuilders.builders.forEach((elementKey, elementBuilder) -> {
              Holder.Reference<T> element = registry.getOrThrow((ResourceKey<T>)elementKey);
 +
 +            // Neo: Support programmatic customization of the default components for items
 +            if (elementKey.isFor(net.minecraft.core.registries.Registries.ITEM)) {
-+                var item = (net.minecraft.world.item.Item) element.value();
-+                var modifier = net.neoforged.neoforge.internal.RegistrationEvents.getComponentModifiersByItem().get(item);
-+                if (modifier != null) {
-+                    modifier.accept(elementBuilder);
-+                }
-+                for (var pair : net.neoforged.neoforge.internal.RegistrationEvents.getComponentModifiersByPredicate()) {
-+                    if (pair.getFirst().test(item, elementBuilder.getComponentTypes())) {
-+                        pair.getSecond().accept(elementBuilder);
-+                    }
-+                }
++                net.neoforged.neoforge.internal.DataComponentModifiers.apply((net.minecraft.world.item.Item) element.value(), elementBuilder);
 +            }
 +
              DataComponentMap components = elementBuilder.build();

--- a/patches/net/minecraft/core/component/DataComponentMap.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentMap.java.patch
@@ -1,23 +1,15 @@
 --- a/net/minecraft/core/component/DataComponentMap.java
 +++ b/net/minecraft/core/component/DataComponentMap.java
-@@ -18,6 +_,7 @@
- import java.util.function.Predicate;
- import java.util.stream.Stream;
- import java.util.stream.StreamSupport;
-+
- import org.jspecify.annotations.Nullable;
- 
- public interface DataComponentMap extends Iterable<TypedDataComponent<?>>, DataComponentGetter {
-@@ -127,6 +_,12 @@
-         private Consumer<DataComponentMap> validator = components -> {};
- 
+@@ -129,6 +_,12 @@
          private Builder() {
-+        }
-+
+         }
+ 
 +        /// {@return an unmodifiable view of the stored component types}
 +        @org.jetbrains.annotations.ApiStatus.Internal
 +        public Set<DataComponentType<?>> getComponentTypes() {
 +            return Collections.unmodifiableSet(map.keySet());
-         }
- 
++        }
++
          public <T> DataComponentMap.Builder set(DataComponentType<T> type, @Nullable T value) {
+             this.setUnchecked(type, value);
+             return this;

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -40,8 +40,8 @@ import org.jetbrains.annotations.ApiStatus;
  *
  * // Lowest priority listener
  * public void modifyComponentsLow(ModifyDefaultComponentsEvent event) {
- *     event.modifyMatching(item -> item.components().has(DataComponents.FIRE_RESISTANT), builder -> builder
- *             .set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)); // Make all fire resistant items have a glint
+ *     event.modifyMatching((item, componentTypes) -> componentTypes.contains(DataComponents.FIRE_RESISTANT), builder -> builder
+ *             .set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true)); // Make all fire-resistant items have a glint
  * }
  * }
  */

--- a/src/main/java/net/neoforged/neoforge/internal/DataComponentModifiers.java
+++ b/src/main/java/net/neoforged/neoforge/internal/DataComponentModifiers.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.internal;
+
+import com.mojang.datafixers.util.Pair;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.world.item.Item;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
+
+public final class DataComponentModifiers {
+    private static final Map<Item, Consumer<DataComponentMap.Builder>> MODIFIERS_BY_ITEM = new HashMap<>();
+    private static final List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> MODIFIERS_BY_PREDICATE = new ArrayList<>();
+
+    static void init() {
+        ModLoader.postEvent(new ModifyDefaultComponentsEvent(MODIFIERS_BY_ITEM, MODIFIERS_BY_PREDICATE));
+    }
+
+    public static void apply(Item item, DataComponentMap.Builder builder) {
+        Consumer<DataComponentMap.Builder> modifier = MODIFIERS_BY_ITEM.get(item);
+        if (modifier != null) {
+            modifier.accept(builder);
+        }
+        for (var pair : MODIFIERS_BY_PREDICATE) {
+            if (pair.getFirst().test(item, builder.getComponentTypes())) {
+                pair.getSecond().accept(builder);
+            }
+        }
+    }
+
+    private DataComponentModifiers() {}
+}

--- a/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
+++ b/src/main/java/net/neoforged/neoforge/internal/RegistrationEvents.java
@@ -5,54 +5,19 @@
 
 package net.neoforged.neoforge.internal;
 
-import com.mojang.datafixers.util.Pair;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
-import net.minecraft.core.component.DataComponentMap;
-import net.minecraft.core.component.DataComponentType;
-import net.minecraft.world.item.Item;
-import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.capabilities.CapabilityHooks;
 import net.neoforged.neoforge.common.world.chunk.ForcedChunkManager;
 import net.neoforged.neoforge.common.world.poi.PoiTypeExtender;
-import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 import net.neoforged.neoforge.fluids.CauldronFluidContent;
 import net.neoforged.neoforge.registries.RegistryManager;
 
 public class RegistrationEvents {
-    private static Map<Item, Consumer<DataComponentMap.Builder>> componentModifiersByItem = new HashMap<>();
-    private static List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> componentModifiersByPredicate = new ArrayList<>();
-
     static void init() {
         CauldronFluidContent.init(); // must be before capability event
         CapabilityHooks.init(); // must be after cauldron event
         ForcedChunkManager.init();
         RegistryManager.initDataMaps();
-        collectComponentModifiers();
+        DataComponentModifiers.init();
         PoiTypeExtender.extendPoiTypes();
-    }
-
-    public static void collectComponentModifiers() {
-        var rawComponentModifiersByItem = new HashMap<Item, Consumer<DataComponentMap.Builder>>();
-        var rawComponentModifiersByPredicate = new ArrayList<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>>();
-
-        ModLoader.postEvent(new ModifyDefaultComponentsEvent(rawComponentModifiersByItem, rawComponentModifiersByPredicate));
-
-        componentModifiersByItem = Collections.unmodifiableMap(rawComponentModifiersByItem);
-        componentModifiersByPredicate = Collections.unmodifiableList(rawComponentModifiersByPredicate);
-    }
-
-    public static Map<Item, Consumer<DataComponentMap.Builder>> getComponentModifiersByItem() {
-        return componentModifiersByItem;
-    }
-
-    public static List<Pair<BiPredicate<? super Item, Set<DataComponentType<?>>>, Consumer<DataComponentMap.Builder>>> getComponentModifiersByPredicate() {
-        return componentModifiersByPredicate;
     }
 }


### PR DESCRIPTION
This PR is a followup to #3041, cleaning up the internals of component modifier handling.
Placing the map and list of modifiers in `RegistrationEvents` was intended as an interim solution (https://github.com/neoforged/NeoForge/pull/2927#discussion_r2701292076) just to make things work for the most part (ignoring that one of the examples wasn't functional). This PR moves the component modifier handling to a separate class and encapsulates it properly, fixes the example provided by the event docs and removes an accidental patch in the imports of `DataComponentMap`.