### PR TITLE
Revert "Unhook mayFly field from controlling flight"

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPlayerExtension.java
@@ -78,15 +78,15 @@ public interface IPlayerExtension {
     /**
      * Determine whether a player is allowed creative flight via game mode or attribute.
      * <p>
-     * Modders are forbidden from setting {@link Abilities#mayfly} directly because it will
-     * no longer control flight due to {@link NeoForgeMod#CREATIVE_FLIGHT} replacing it.
+     * Modders are discouraged from setting {@link Abilities#mayfly} directly.
      *
      * @return true when creative flight is available
      * @see NeoForgeMod#CREATIVE_FLIGHT
      */
     @SuppressWarnings("deprecation")
     default boolean mayFly() {
-        return self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
+        // TODO 1.20.5: consider forcing mods to use the attribute
+        return self().getAbilities().mayfly || self().getAttributeValue(NeoForgeMod.CREATIVE_FLIGHT) > 0;
     }
 
     /**


### PR DESCRIPTION
Reverts neoforged/NeoForge#3034

Apologies, it turns out the vanilla creative flight still operated through mayFly field. Which means creative flight from vanilla is also not seen by the attribute. To reconcile this, this will require more planning and work to get it all under the attribute.

also needs consideration to make packet sending use the overridden method so vanilla clients know about creative flight

Fixes https://github.com/neoforged/NeoForge/issues/3045