### PR TITLE
[26.1] Fix crash when freezing after applying registry sync with entries unknown to the client

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/network/ClientPayloadHandler.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/ClientPayloadHandler.java
@@ -103,6 +103,7 @@ final class ClientPayloadHandler {
             Set<ResourceKey<?>> keysUnknownToClient = RegistryManager.applySnapshot(synchronizedRegistries, false);
             if (!keysUnknownToClient.isEmpty()) {
                 context.disconnect(Component.translatable("neoforge.network.registries.sync.server-with-unknown-keys", keysUnknownToClient.stream().map(Object::toString).collect(Collectors.joining(", "))));
+                RegistryManager.revertToFrozen();
                 return;
             }
 
@@ -112,6 +113,7 @@ final class ClientPayloadHandler {
         } catch (Throwable t) {
             LOGGER.error("Failed to handle registry sync from server.", t);
             context.disconnect(Component.translatable("neoforge.network.registries.sync.failed", t.toString()));
+            RegistryManager.revertToFrozen();
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/registries/RegistryManager.java
+++ b/src/main/java/net/neoforged/neoforge/registries/RegistryManager.java
@@ -173,11 +173,15 @@ public class RegistryManager {
 
         if (backup == null) {
             forgeRegistry.clear(false);
+            boolean foundMissing = false;
             for (var entry : snapshot.getIds().int2ObjectEntrySet()) {
                 ResourceKey<T> key = ResourceKey.create(registryKey, entry.getValue());
                 if (!registry.containsKey(key)) {
                     missing.add(key);
-                } else {
+                    foundMissing = true;
+                } else if (!foundMissing) {
+                    // ID mappings must only be added if this registry didn't encounter missing entries before, otherwise certain operations such
+                    // as iterating the registry will crash due to the ID->value list being filled up with nulls to add the next known entry
                     forgeRegistry.registerIdMapping(key, entry.getIntKey());
                 }
             }

--- a/src/main/java/net/neoforged/neoforge/registries/RegistryManager.java
+++ b/src/main/java/net/neoforged/neoforge/registries/RegistryManager.java
@@ -181,7 +181,9 @@ public class RegistryManager {
                     foundMissing = true;
                 } else if (!foundMissing) {
                     // ID mappings must only be added if this registry didn't encounter missing entries before, otherwise certain operations such
-                    // as iterating the registry will crash due to the ID->value list being filled up with nulls to add the next known entry
+                    // as iterating the registry will crash due to the ID->value list being filled up with nulls to add the next known entry.
+                    // Encountering entries unknown to the client in the snapshot sent by the server guarantees that the player will be disconnected
+                    // and the registry reverted to the frozen state, so the incomplete ID mapping registration cannot cause issues later.
                     forgeRegistry.registerIdMapping(key, entry.getIntKey());
                 }
             }


### PR DESCRIPTION
This PR fixes a crash when freezing a registry after applying a registry sync with entries unknown to the client.

If the registry snapshot sent by the server contains at least one entry which is unknown to the client, followed by at least one additional entry that is known to the client, then the `MappedRegistry#byId` list (i.e. the int ID -> value mapping) is filled with nulls up to the required size to insert the known value following the unknown one, causing null values to remain at the indexes to which the server assigned the elements the client does not have.
After registering the ID mapping for all known entries, the registry is frozen, invoking its bake callbacks. The bake callback added to the block registry by NeoForge iterates over the registry to populate the `Block.BLOCK_STATE_REGISTRY`. `MappedRegistry#iterator()` uses the aforementioned ID->value mapping via `Iterators.transform(this.byId.iterator(), Holder::value)`. When this iterator reaches the null entries in the list, the `Holder#value()` call throws an NPE, killing the registry snapshot application and disconnecting the player with a confusing error instead of disconnecting them with a message about the missing entries.
To fix this, ID mappings for known elements in a given registry are only added if the snapshot application for this registry did not yet encounter unknown elements.

Additionally this "dirty" disconnect as well as the "clean" disconnect with unknown elements leave the registries in a broken state which can then cause further errors or outright crash the game when trying to enter another server or singleplayer world, especially in the "dirty" disconnect case.
To fix this, both cases revert the registry to the frozen state. Contrary to the description in #2950, the first possible disconnect that happens when the client did not receive all snapshots (i.e. `ClientPayloadHandler.toSynchronize` is not empty) does not need to revert to frozen because no snapshot application has happened yet at that point.

Fixes #2806
Fixes #2950