### PR TITLE
Backport vanilla tag as `c:loom_patterns`

### DIFF
--- a/src/generated/resources/assets/c/lang/en_us.json
+++ b/src/generated/resources/assets/c/lang/en_us.json
@@ -285,6 +285,7 @@
   "tag.item.c.ingots.iron": "Iron Ingots",
   "tag.item.c.ingots.netherite": "Netherite Ingots",
   "tag.item.c.leathers": "Leathers",
+  "tag.item.c.loom_patterns": "Loom Patterns",
   "tag.item.c.mushrooms": "Mushrooms",
   "tag.item.c.music_discs": "Music Discs",
   "tag.item.c.nether_stars": "Nether Stars",

--- a/src/generated/resources/data/c/tags/item/loom_patterns.json
+++ b/src/generated/resources/data/c/tags/item/loom_patterns.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "minecraft:flower_banner_pattern",
+    "minecraft:creeper_banner_pattern",
+    "minecraft:skull_banner_pattern",
+    "minecraft:mojang_banner_pattern",
+    "minecraft:globe_banner_pattern",
+    "minecraft:piglin_banner_pattern",
+    "minecraft:flow_banner_pattern",
+    "minecraft:guster_banner_pattern"
+  ]
+}

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -604,7 +604,7 @@ public class Tags {
         public static final TagKey<Item> MUSIC_DISCS = tag("music_discs");
         /**
          * For banner patterns to be used in recipes.
-         * This is a backport of 21.6 Minecraft's #minecraft:loom_patterns item tag.
+         * This is a backport of 26.1 Minecraft's #minecraft:loom_patterns item tag.
          */
         public static final TagKey<Item> LOOM_PATTERNS = tag("loom_patterns");
         public static final TagKey<Item> NETHER_STARS = tag("nether_stars");

--- a/src/main/java/net/neoforged/neoforge/common/Tags.java
+++ b/src/main/java/net/neoforged/neoforge/common/Tags.java
@@ -602,6 +602,11 @@ public class Tags {
          * A pancake with a JUKEBOX_PLAYABLE component attached to play in Jukeboxes as an Easter Egg is not a music disc and would not go in this tag.
          */
         public static final TagKey<Item> MUSIC_DISCS = tag("music_discs");
+        /**
+         * For banner patterns to be used in recipes.
+         * This is a backport of 21.6 Minecraft's #minecraft:loom_patterns item tag.
+         */
+        public static final TagKey<Item> LOOM_PATTERNS = tag("loom_patterns");
         public static final TagKey<Item> NETHER_STARS = tag("nether_stars");
         public static final TagKey<Item> NETHERRACKS = tag("netherracks");
         public static final TagKey<Item> NUGGETS = tag("nuggets");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeItemTagsProvider.java
@@ -178,6 +178,9 @@ public final class NeoForgeItemTagsProvider extends ItemTagsProvider {
                 Items.MUSIC_DISC_WARD, Items.MUSIC_DISC_11, Items.MUSIC_DISC_WAIT, Items.MUSIC_DISC_OTHERSIDE, Items.MUSIC_DISC_5,
                 Items.MUSIC_DISC_PIGSTEP, Items.MUSIC_DISC_RELIC, Items.MUSIC_DISC_CREATOR, Items.MUSIC_DISC_CREATOR_MUSIC_BOX,
                 Items.MUSIC_DISC_PRECIPICE);
+        tag(Tags.Items.LOOM_PATTERNS).add(Items.FLOWER_BANNER_PATTERN, Items.CREEPER_BANNER_PATTERN, Items.SKULL_BANNER_PATTERN,
+                Items.MOJANG_BANNER_PATTERN, Items.GLOBE_BANNER_PATTERN, Items.PIGLIN_BANNER_PATTERN,
+                Items.FLOW_BANNER_PATTERN, Items.GUSTER_BANNER_PATTERN);
         tag(Tags.Items.NETHER_STARS).add(Items.NETHER_STAR);
         copy(Tags.Blocks.NETHERRACKS, Tags.Items.NETHERRACKS);
         tag(Tags.Items.NUGGETS).addTags(Tags.Items.NUGGETS_GOLD, Tags.Items.NUGGETS_IRON);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeLanguageProvider.java
@@ -260,6 +260,7 @@ public final class NeoForgeLanguageProvider extends LanguageProvider {
         add(Tags.Items.INGOTS_NETHERITE, "Netherite Ingots");
         add(Tags.Items.LEATHERS, "Leathers");
         add(Tags.Items.MUSIC_DISCS, "Music Discs");
+        add(Tags.Items.LOOM_PATTERNS, "Loom Patterns");
         add(Tags.Items.MUSHROOMS, "Mushrooms");
         add(Tags.Items.NETHER_STARS, "Nether Stars");
         add(Tags.Items.NETHERRACKS, "Netherracks");


### PR DESCRIPTION
I need a collection of banner pattern for a trade system in my mod in 1.21.1. Vanilla has a tag of banner patterns as `minecraft:loom_patterns` in 26.1. So it seems like a good idea to backport it to 1.21.1 as `c:loom_patterns`.

I don't think the other mc versions need a backport to as 1.21.1 is the dominate 1.21.x version afaik

Fabric PR: https://github.com/FabricMC/fabric-api/pull/5290