### PR TITLE
Backport to 1.20.6: Make Boat.Type enum extensible

### DIFF
--- a/patches/net/minecraft/client/model/geom/LayerDefinitions.java.patch
+++ b/patches/net/minecraft/client/model/geom/LayerDefinitions.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/model/geom/LayerDefinitions.java
 +++ b/net/minecraft/client/model/geom/LayerDefinitions.java
+@@ -315,7 +_,7 @@
+         LayerDefinition layerdefinition22 = ChestRaftModel.createBodyModel();
+ 
+         for (Boat.Type boat$type : Boat.Type.values()) {
+-            if (boat$type == Boat.Type.BAMBOO) {
++            if (boat$type.isRaft()) {
+                 builder.put(ModelLayers.createBoatModelName(boat$type), layerdefinition21);
+                 builder.put(ModelLayers.createChestBoatModelName(boat$type), layerdefinition22);
+             } else {
 @@ -328,6 +_,7 @@
          WoodType.values().forEach(p_171114_ -> builder.put(ModelLayers.createSignModelName(p_171114_), layerdefinition23));
          LayerDefinition layerdefinition24 = HangingSignRenderer.createHangingSignLayer();

--- a/patches/net/minecraft/client/model/geom/ModelLayers.java.patch
+++ b/patches/net/minecraft/client/model/geom/ModelLayers.java.patch
@@ -1,6 +1,30 @@
 --- a/net/minecraft/client/model/geom/ModelLayers.java
 +++ b/net/minecraft/client/model/geom/ModelLayers.java
-@@ -228,11 +_,13 @@
+@@ -212,27 +_,33 @@
+     }
+ 
+     public static ModelLayerLocation createRaftModelName(Boat.Type p_252002_) {
+-        return createLocation("raft/" + p_252002_.getName(), "main");
++        ResourceLocation location = new ResourceLocation(p_252002_.getName());
++        return new ModelLayerLocation(location.withPrefix("raft/"), "main");
+     }
+ 
+     public static ModelLayerLocation createChestRaftModelName(Boat.Type p_248520_) {
+-        return createLocation("chest_raft/" + p_248520_.getName(), "main");
++        ResourceLocation location = new ResourceLocation(p_248520_.getName());
++        return new ModelLayerLocation(location.withPrefix("chest_raft/"), "main");
+     }
+ 
+     public static ModelLayerLocation createBoatModelName(Boat.Type p_171290_) {
+-        return createLocation("boat/" + p_171290_.getName(), "main");
++        ResourceLocation location = new ResourceLocation(p_171290_.getName());
++        return new ModelLayerLocation(location.withPrefix("boat/"), "main");
+     }
+ 
+     public static ModelLayerLocation createChestBoatModelName(Boat.Type p_233551_) {
+-        return createLocation("chest_boat/" + p_233551_.getName(), "main");
++        ResourceLocation location = new ResourceLocation(p_233551_.getName());
++        return new ModelLayerLocation(location.withPrefix("chest_boat/"), "main");
      }
  
      public static ModelLayerLocation createSignModelName(WoodType p_171292_) {

--- a/patches/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/BoatRenderer.java.patch
@@ -1,5 +1,32 @@
 --- a/net/minecraft/client/renderer/entity/BoatRenderer.java
 +++ b/net/minecraft/client/renderer/entity/BoatRenderer.java
+@@ -37,7 +_,7 @@
+             .collect(
+                 ImmutableMap.toImmutableMap(
+                     p_173938_ -> (Boat.Type)p_173938_,
+-                    p_247941_ -> Pair.of(new ResourceLocation(getTextureLocation(p_247941_, p_234564_)), this.createBoatModel(p_234563_, p_247941_, p_234564_))
++                    p_247941_ -> Pair.of(new ResourceLocation(p_247941_.getName()).withPrefix(getTextureLocation(p_247941_, p_234564_)).withSuffix(".png"), this.createBoatModel(p_234563_, p_247941_, p_234564_))
+                 )
+             );
+     }
+@@ -45,7 +_,7 @@
+     private ListModel<Boat> createBoatModel(EntityRendererProvider.Context p_248834_, Boat.Type p_249317_, boolean p_250093_) {
+         ModelLayerLocation modellayerlocation = p_250093_ ? ModelLayers.createChestBoatModelName(p_249317_) : ModelLayers.createBoatModelName(p_249317_);
+         ModelPart modelpart = p_248834_.bakeLayer(modellayerlocation);
+-        if (p_249317_ == Boat.Type.BAMBOO) {
++        if (p_249317_.isRaft()) {
+             return (ListModel<Boat>)(p_250093_ ? new ChestRaftModel(modelpart) : new RaftModel(modelpart));
+         } else {
+             return (ListModel<Boat>)(p_250093_ ? new ChestBoatModel(modelpart) : new BoatModel(modelpart));
+@@ -53,7 +_,7 @@
+     }
+ 
+     private static String getTextureLocation(Boat.Type p_234566_, boolean p_234567_) {
+-        return p_234567_ ? "textures/entity/chest_boat/" + p_234566_.getName() + ".png" : "textures/entity/boat/" + p_234566_.getName() + ".png";
++        return p_234567_ ? "textures/entity/chest_boat/" : "textures/entity/boat/";
+     }
+ 
+     public void render(Boat p_113929_, float p_113930_, float p_113931_, PoseStack p_113932_, MultiBufferSource p_113933_, int p_113934_) {
 @@ -75,7 +_,7 @@
              p_113932_.mulPose(new Quaternionf().setAngleAxis(p_113929_.getBubbleAngle(p_113931_) * (float) (Math.PI / 180.0), 1.0F, 0.0F, 1.0F));
          }
@@ -9,7 +36,7 @@
          ResourceLocation resourcelocation = pair.getFirst();
          ListModel<Boat> listmodel = pair.getSecond();
          p_113932_.scale(-1.0F, -1.0F, 1.0F);
-@@ -94,7 +_,10 @@
+@@ -94,7 +_,12 @@
          super.render(p_113929_, p_113930_, p_113931_, p_113932_, p_113933_, p_113934_);
      }
  
@@ -17,7 +44,9 @@
      public ResourceLocation getTextureLocation(Boat p_113927_) {
 -        return this.boatResources.get(p_113927_.getVariant()).getFirst();
 +        return getModelWithLocation(p_113927_).getFirst();
-     }
++    }
 +
-+    public Pair<ResourceLocation, ListModel<Boat>> getModelWithLocation(Boat boat) { return this.boatResources.get(boat.getVariant()); }
++    public Pair<ResourceLocation, ListModel<Boat>> getModelWithLocation(Boat boat) {
++        return this.boatResources.get(boat.getVariant());
+     }
  }

--- a/patches/net/minecraft/world/entity/vehicle/Boat.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/Boat.java.patch
@@ -9,6 +9,25 @@
      private static final EntityDataAccessor<Integer> DATA_ID_TYPE = SynchedEntityData.defineId(Boat.class, EntityDataSerializers.INT);
      private static final EntityDataAccessor<Boolean> DATA_ID_PADDLE_LEFT = SynchedEntityData.defineId(Boat.class, EntityDataSerializers.BOOLEAN);
      private static final EntityDataAccessor<Boolean> DATA_ID_PADDLE_RIGHT = SynchedEntityData.defineId(Boat.class, EntityDataSerializers.BOOLEAN);
+@@ -154,7 +_,7 @@
+             }
+         }
+ 
+-        return new Vec3(0.0, this.getVariant() == Boat.Type.BAMBOO ? (double)(p_295933_.height() * 0.8888889F) : (double)(p_295933_.height() / 3.0F), (double)f)
++        return new Vec3(0.0, this.getVariant().isRaft() ? (double)(p_295933_.height() * 0.8888889F) : (double)(p_295933_.height() / 3.0F), (double)f)
+             .yRot(-this.getYRot() * (float) (Math.PI / 180.0));
+     }
+ 
+@@ -209,7 +_,8 @@
+             case DARK_OAK -> Items.DARK_OAK_BOAT;
+             case MANGROVE -> Items.MANGROVE_BOAT;
+             case BAMBOO -> Items.BAMBOO_RAFT;
+-            default -> Items.OAK_BOAT;
++            case OAK -> Items.OAK_BOAT;
++            default -> this.getVariant().boatItem.get();
+         };
+     }
+ 
 @@ -471,7 +_,7 @@
                  for (int i2 = i1; i2 < j1; i2++) {
                      blockpos$mutableblockpos.set(l1, k1, i2);
@@ -45,7 +64,16 @@
                          && d0 < (double)((float)blockpos$mutableblockpos.getY() + fluidstate.getHeight(this.level(), blockpos$mutableblockpos))) {
                          if (!fluidstate.isSource()) {
                              return Boat.Status.UNDER_FLOWING_WATER;
-@@ -794,7 +_,7 @@
+@@ -787,14 +_,15 @@
+                             }
+ 
+                             for (int j = 0; j < 2; j++) {
+-                                this.spawnAtLocation(Items.STICK);
++                                // Neo: allow dropping material-specific sticks instead of just generic wooden sticks
++                                this.spawnAtLocation(this.getVariant().getSticks());
+                             }
+                         }
+                     }
                  }
  
                  this.resetFallDistance();
@@ -63,3 +91,92 @@
      }
  
      protected int getMaxPassengers() {
+@@ -869,7 +_,7 @@
+         IN_AIR;
+     }
+ 
+-    public static enum Type implements StringRepresentable {
++    public static enum Type implements StringRepresentable, net.neoforged.neoforge.common.IExtensibleEnum {
+         OAK(Blocks.OAK_PLANKS, "oak"),
+         SPRUCE(Blocks.SPRUCE_PLANKS, "spruce"),
+         BIRCH(Blocks.BIRCH_PLANKS, "birch"),
+@@ -878,16 +_,57 @@
+         CHERRY(Blocks.CHERRY_PLANKS, "cherry"),
+         DARK_OAK(Blocks.DARK_OAK_PLANKS, "dark_oak"),
+         MANGROVE(Blocks.MANGROVE_PLANKS, "mangrove"),
+-        BAMBOO(Blocks.BAMBOO_PLANKS, "bamboo");
++        BAMBOO(Blocks.BAMBOO_PLANKS, "bamboo", true);
+ 
+         private final String name;
++        /** @deprecated Neo: Will be {@link Blocks#AIR} for modded boat types, use {@link #planksSupplier} instead */
++        @Deprecated
+         private final Block planks;
++        private final java.util.function.Supplier<Block> planksSupplier;
++        final java.util.function.Supplier<Item> boatItem;
++        final java.util.function.Supplier<Item> chestBoatItem;
++        private final java.util.function.Supplier<Item> stickItem;
++        private final boolean raft;
+         public static final StringRepresentable.EnumCodec<Boat.Type> CODEC = StringRepresentable.fromEnum(Boat.Type::values);
+         private static final IntFunction<Boat.Type> BY_ID = ByIdMap.continuous(Enum::ordinal, values(), ByIdMap.OutOfBoundsStrategy.ZERO);
+ 
+         private Type(Block p_38427_, String p_38428_) {
++            this(p_38427_, p_38428_, false);
++        }
++
++        private Type(Block p_38427_, String p_38428_, boolean raft) {
+             this.name = p_38428_;
+             this.planks = p_38427_;
++            this.planksSupplier = () -> p_38427_;
++            this.boatItem = () -> Items.AIR;
++            this.chestBoatItem = () -> Items.AIR;
++            this.stickItem = () -> Items.STICK;
++            this.raft = raft;
++        }
++
++        /**
++        * @param planks A supplier of the block to be dropped when the boat is destroyed by fall damage
++        * @param name The name of this boat type
++        * @param boatItem A supplier of the item to be dropped when a normal boat or raft of this type is picked up
++        * @param chestBoatItem A supplier of the item to be dropped when a chest boat or raft of this type is picked up
++        * @param stickItem A supplier of the stick item to be dropped when the boat is destroyed by fall damage
++        * @param raft Whether this boat type is a "standard" boat or a raft
++        */
++        private Type(
++            java.util.function.Supplier<Block> planks,
++            String name,
++            java.util.function.Supplier<Item> boatItem,
++            java.util.function.Supplier<Item> chestBoatItem,
++            java.util.function.Supplier<Item> stickItem,
++            boolean raft
++        ) {
++            this.name = name;
++            this.planks = Blocks.AIR;
++            this.planksSupplier = planks;
++            this.boatItem = boatItem;
++            this.chestBoatItem = chestBoatItem;
++            this.stickItem = stickItem;
++            this.raft = raft;
+         }
+ 
+         @Override
+@@ -900,7 +_,19 @@
+         }
+ 
+         public Block getPlanks() {
+-            return this.planks;
++            return this.planksSupplier.get();
++        }
++
++        public Item getSticks() {
++            return this.stickItem.get();
++        }
++
++        public boolean isRaft() {
++            return this.raft;
++        }
++
++        public static Boat.Type create(String id, java.util.function.Supplier<Block> planks, String name, java.util.function.Supplier<Item> boatItem, java.util.function.Supplier<Item> chestBoatItem, java.util.function.Supplier<Item> stickItem, boolean raft) {
++            throw new IllegalStateException("Enum not extended");
+         }
+ 
+         @Override

--- a/patches/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/ChestBoat.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/world/entity/vehicle/ChestBoat.java
++++ b/net/minecraft/world/entity/vehicle/ChestBoat.java
+@@ -115,7 +_,8 @@
+             case DARK_OAK -> Items.DARK_OAK_CHEST_BOAT;
+             case MANGROVE -> Items.MANGROVE_CHEST_BOAT;
+             case BAMBOO -> Items.BAMBOO_CHEST_RAFT;
+-            default -> Items.OAK_CHEST_BOAT;
++            case OAK -> Items.OAK_CHEST_BOAT;
++            default -> this.getVariant().chestBoatItem.get();
+         };
+     }
+ 


### PR DESCRIPTION
Backport https://github.com/neoforged/NeoForge/commit/c857071c5c6dfe3400fd339bf021ac551c7fe8fc

The only thing that needs to be fixed is that there is a circular dependency with boat.type.create and boatitem
How could I fix this?

Like this:
```
DeferredItem<Item> CUSTOM_BOAT_ITEM = REGISTRY.register("custom_boat", () -> new BoatItem(false, ACACIA_TYPE, new Item.Properties().stacksTo(1)))

Boat.Type ACACIA_TYPE = Boat.Type.create("CUSTOMBOAT_ACACIA", () -> Blocks.OAK_PLANKS, "testboat:acacia",
				CUSTOM_BOAT_ITEM, () -> Items.AIR, () -> Items.STICK, false);
```

Does this PR look good enough?
