### PR TITLE
Fix ECJ compile errors w/ Eclipse 2026-03

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/util/ConcatenatedListView.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/ConcatenatedListView.java
@@ -104,12 +104,12 @@ public class ConcatenatedListView<T> implements List<T> {
 
     @Override
     public Iterator<T> iterator() {
-        return Iterables.unmodifiableIterable(Iterables.concat(lists)).iterator();
+        return Iterables.<T>unmodifiableIterable(Iterables.concat(lists)).iterator();
     }
 
     @Override
     public Spliterator<T> spliterator() {
-        return Iterables.unmodifiableIterable(Iterables.concat(lists)).spliterator();
+        return Iterables.<T>unmodifiableIterable(Iterables.concat(lists)).spliterator();
     }
 
     // Delegate to a concatenated collection


### PR DESCRIPTION
Eclipse fails type inference of these two methods without the explicit `<T>` marker because it fails to coerce the `Iterable<? extends T>`  from `Iterables.concat` into `Iterator<T>` / `Spliterator<T>`. Making the generic explicit to `Iterables.unmodifiableIterable` repairs the inference.