### PR TITLE
Tighten `getEnchantPowerBonus` to `BlockGetter`

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -517,7 +517,7 @@ public interface IBlockExtension {
      * @param pos   Block position in level
      * @return The amount of enchanting power this block produces.
      */
-    default float getEnchantPowerBonus(BlockState state, LevelReader level, BlockPos pos) {
+    default float getEnchantPowerBonus(BlockState state, BlockGetter level, BlockPos pos) {
         return state.is(BlockTags.ENCHANTMENT_POWER_PROVIDER) ? 1 : 0;
     }
 


### PR DESCRIPTION
This adjusts the signature of `getEnchantPowerBonus` to use `BlockGetter` instead of `LevelReader`, which makes it much easier to use in contexts like tooltips.

Closes #1453 