### PR TITLE
Refactor AbstractWidget#getFGColor as getTextColor

### DIFF
--- a/patches/net/minecraft/client/gui/components/AbstractButton.java.patch
+++ b/patches/net/minecraft/client/gui/components/AbstractButton.java.patch
@@ -6,9 +6,9 @@
      protected void extractDefaultLabel(ActiveTextCollector output) {
 -        this.extractScrollingStringOverContents(output, this.getMessage(), 2);
 +        // Neo: Apply forced foreground color if set
-+        var message = this.getMessage();
-+        if (getFGColor() != UNSET_FG_COLOR) {
-+            message = message.copy().withStyle(style -> style.withColor(getFGColor()));
++        Component message = this.getMessage();
++        if (this.textColor != null) {
++            message = message.copy().withStyle(style -> style.withColor(this.getTextColor()));
 +        }
 +
 +        this.extractScrollingStringOverContents(output, message, 2);

--- a/patches/net/minecraft/client/gui/components/AbstractWidget.java.patch
+++ b/patches/net/minecraft/client/gui/components/AbstractWidget.java.patch
@@ -1,22 +1,44 @@
 --- a/net/minecraft/client/gui/components/AbstractWidget.java
 +++ b/net/minecraft/client/gui/components/AbstractWidget.java
-@@ -221,6 +_,19 @@
-         this.focused = focused;
+@@ -334,4 +_,41 @@
+             this.inactiveMessage = defaultInactiveMessage(message);
+         }
      }
- 
-+    public static final int UNSET_FG_COLOR = -1;
-+    protected int packedFGColor = UNSET_FG_COLOR;
-+    public int getFGColor() {
-+        if (packedFGColor != UNSET_FG_COLOR) return packedFGColor;
-+        return this.active ? -1 : -6250336; // White : Light Grey
-+    }
-+    public void setFGColor(int color) {
-+        this.packedFGColor = color;
-+    }
-+    public void clearFGColor() {
-+        this.packedFGColor = UNSET_FG_COLOR;
++
++    // Neo Begin
++    // Support for custom forced text colors. If the color is not set, it will use the vanilla defaults (white when active, light grey when inactive).
++
++    private static final net.minecraft.network.chat.TextColor WHITE = net.minecraft.network.chat.TextColor.fromRgb(0xFFFFFF);
++    private static final net.minecraft.network.chat.TextColor LIGHT_GRAY = net.minecraft.network.chat.TextColor.fromRgb(-6250336);
++
++    /**
++     * Stores the text color override. See {@link #getTextColor()} and {@link #setTextColor}.
++     */
++    protected net.minecraft.network.chat.@Nullable TextColor textColor = null;
++
++    /**
++     * Returns the widget's text color. If a custom text color has been set, that color will be used.
++     * If a custom text color has not been set, white will be used when active, and light gray otherwise.
++     * <p>
++     * Subclasses may override this to provide more advanced text color handling.
++     */
++    public net.minecraft.network.chat.TextColor getTextColor() {
++        if (this.textColor != null) {
++            return this.textColor;
++        }
++        return this.active ? WHITE : LIGHT_GRAY;
 +    }
 +
-     @Override
-     public NarratableEntry.NarrationPriority narrationPriority() {
-         if (this.isFocused()) {
++    /**
++     * Sets the text color for this widget. If null, the widget will use the vanilla default.
++     */
++    public void setTextColor(net.minecraft.network.chat.@Nullable TextColor color) {
++        this.textColor = color;
++    }
++
++    public void setTextColor(int color) {
++        this.textColor = net.minecraft.network.chat.TextColor.fromRgb(color);
++    }
++
++    // Neo End
+ }

--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedButton.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/ExtendedButton.java
@@ -46,7 +46,7 @@ public class ExtendedButton extends Button {
         guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, SPRITES.get(this.active, this.isHoveredOrFocused()), this.getX(), this.getY(), this.getWidth(), this.getHeight());
 
         final FormattedText buttonText = mc.font.ellipsize(this.getMessage(), this.width - 6); // Remove 6 pixels so that the text is always contained within the button's borders
-        guiGraphics.centeredText(mc.font, Language.getInstance().getVisualOrder(buttonText), this.getX() + this.width / 2, this.getY() + (this.height - 8) / 2, getFGColor());
+        guiGraphics.centeredText(mc.font, Language.getInstance().getVisualOrder(buttonText), this.getX() + this.width / 2, this.getY() + (this.height - 8) / 2, this.getTextColor().getValue());
 
         if (this.isHovered())
             guiGraphics.requestCursor(this.isActive() ? CursorTypes.POINTING_HAND : CursorTypes.NOT_ALLOWED);

--- a/src/client/java/net/neoforged/neoforge/client/gui/widget/UnicodeGlyphButton.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/widget/UnicodeGlyphButton.java
@@ -46,10 +46,10 @@ public class UnicodeGlyphButton extends ExtendedButton {
         guiGraphics.pose().scale(glyphScale, glyphScale);
         guiGraphics.centeredText(mc.font, Component.literal(glyph),
                 (int) (((this.getX() + (this.width / 2) - (strWidth / 2)) / glyphScale) - (glyphWidth / (2 * glyphScale)) + 2),
-                (int) (((this.getY() + ((this.height - 8) / glyphScale) / 2) - 1) / glyphScale), getFGColor());
+                (int) (((this.getY() + ((this.height - 8) / glyphScale) / 2) - 1) / glyphScale), this.getTextColor().getValue());
         guiGraphics.pose().popMatrix();
 
         guiGraphics.centeredText(mc.font, buttonText, (int) (this.getX() + (this.width / 2) + (glyphWidth / glyphScale)),
-                this.getY() + (this.height - 8) / 2, getFGColor());
+                this.getY() + (this.height - 8) / 2, this.getTextColor().getValue());
     }
 }


### PR DESCRIPTION
This PR updates `AbstractWidget#getFGColor` to be more obviously a Neo patch, as well as moving it to use modern systems (`TextColor`), renaming things to match, and updating the relevant docs.

Before it was basically just a hunk of stuff that was really really _really_ old with little to no info.

Closes #1265 
