### PR TITLE
Fire the BreakBlockEvent on the client and server

### DIFF
--- a/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -1,5 +1,27 @@
 --- a/net/minecraft/client/multiplayer/MultiPlayerGameMode.java
 +++ b/net/minecraft/client/multiplayer/MultiPlayerGameMode.java
+@@ -114,12 +_,20 @@
+     }
+ 
+     public boolean destroyBlock(BlockPos pos) {
++        // Neo: Fire the BlockBreakEvent. Unlike the server path, ignoring ItemStack#canDestroyBlock is done below because the vanilla code checks things in a different order here.
++        BlockState state = this.minecraft.level.getBlockState(pos);
++        var event = net.neoforged.neoforge.common.CommonHooks.fireBlockBreak(this.minecraft.level, this.localPlayerMode, this.minecraft.player, pos, state);
++        if (event.isCanceled()) {
++            return false;
++        }
++
+         if (this.minecraft.player.blockActionRestricted(this.minecraft.level, pos, this.localPlayerMode)) {
+             return false;
+         } else {
+             Level level = this.minecraft.level;
+             BlockState oldState = level.getBlockState(pos);
+-            if (!this.minecraft.player.getMainHandItem().canDestroyBlock(oldState, level, pos, this.minecraft.player)) {
++            // Neo: Ignore this condition, as it is handled by fireBlockBreak and the event is expected to be able to override it.
++            if (false && !this.minecraft.player.getMainHandItem().canDestroyBlock(oldState, level, pos, this.minecraft.player)) {
+                 return false;
+             } else {
+                 Block oldBlock = oldState.getBlock();
 @@ -128,11 +_,12 @@
                  } else if (oldState.isAir()) {
                      return false;

--- a/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -30,9 +30,11 @@
                      blockState.attack(this.level, pos, this.player);
                      progress = blockState.getDestroyProgress(this.player, this.player.level(), pos);
                  }
-@@ -259,7 +_,8 @@
+@@ -258,8 +_,10 @@
+     }
  
      public boolean destroyBlock(BlockPos pos) {
++        // Neo: Fire the BlockBreakEvent, and ignore the original ItemStack#canDestroyBlock check since the break event manages the status of it.
          BlockState state = this.level.getBlockState(pos);
 -        if (!this.player.getMainHandItem().canDestroyBlock(state, this.level, pos, this.player)) {
 +        var event = net.neoforged.neoforge.common.CommonHooks.fireBlockBreak(level, gameModeForPlayer, player, pos, state);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -211,6 +211,7 @@ import net.neoforged.neoforge.event.entity.player.SweepAttackEvent;
 import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.NoteBlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import net.neoforged.neoforge.event.level.block.CropGrowEvent;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.internal.NeoForgeProxy;
@@ -572,7 +573,7 @@ public class CommonHooks {
      * @param state    The state of the block being broken
      * @return The event
      */
-    public static BlockEvent.BreakEvent fireBlockBreak(Level level, GameType gameType, ServerPlayer player, BlockPos pos, BlockState state) {
+    public static BreakBlockEvent fireBlockBreak(Level level, GameType gameType, Player player, BlockPos pos, BlockState state) {
         boolean preCancelEvent = false;
 
         ItemStack itemstack = player.getMainHandItem();
@@ -588,14 +589,13 @@ public class CommonHooks {
             preCancelEvent = true;
         }
 
-        // Post the block break event
-        BlockEvent.BreakEvent event = new BlockEvent.BreakEvent(level, pos, state, player);
+        var event = new BreakBlockEvent(level, pos, state, player);
         event.setCanceled(preCancelEvent);
         NeoForge.EVENT_BUS.post(event);
 
-        // If the event is canceled, let the client know the block still exists
-        if (event.isCanceled()) {
-            player.connection.send(new ClientboundBlockUpdatePacket(pos, state));
+        // If the event is canceled on the server, let the client know the block still exists
+        if (event.isCanceled() && event.shouldNotifyClient() && player instanceof ServerPlayer sp) {
+            sp.connection.send(new ClientboundBlockUpdatePacket(pos, state));
         }
 
         return event;

--- a/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/BlockEvent.java
@@ -12,13 +12,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.BaseFireBlock;
-import net.minecraft.world.level.block.GameMasterBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.PortalShape;
 import net.neoforged.bus.api.Event;
@@ -51,43 +49,6 @@ public abstract class BlockEvent extends Event {
 
     public BlockState getState() {
         return state;
-    }
-
-    /**
-     * This event is fired on the server when a player attempts to break a block, upon receipt of a block break packet.
-     *
-     * The following conditions may cause this event to fire in a cancelled state:
-     * <ul>
-     * <li>If {@link Player#blockActionRestricted} is true.</li>
-     * <li>If the target block is a {@link GameMasterBlock} and {@link Player#canUseGameMasterBlocks()} is false.</li>
-     * <li>If the the player is holding an item, and {@link Item#canAttackBlock} is false.</li>
-     * </ul>
-     *
-     * In the first two cases, un-cancelling the event will not permit the block to be broken.
-     * In the third case, un-cancelling will allow the break, bypassing the behavior of {@link Item#canAttackBlock}.
-     */
-    public static class BreakEvent extends BlockEvent implements ICancellableEvent {
-        private final Player player;
-
-        public BreakEvent(Level level, BlockPos pos, BlockState state, Player player) {
-            super(level, pos, state);
-            this.player = player;
-        }
-
-        /**
-         * {@return the player who is attempting to break the block}
-         */
-        public Player getPlayer() {
-            return player;
-        }
-
-        /**
-         * Cancelling this event will prevent the block from being broken, and notifies the client of the refusal.
-         */
-        @Override
-        public void setCanceled(boolean canceled) {
-            ICancellableEvent.super.setCanceled(canceled);
-        }
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/level/block/BreakBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/block/BreakBlockEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.level.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.GameMasterBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.neoforge.event.level.BlockEvent;
+
+/**
+ * This event is fired when a player attempts to break a block, on both the client and server.
+ *
+ * The following conditions may cause this event to fire in a cancelled state:
+ * <ul>
+ * <li>If {@link Player#blockActionRestricted} is true.</li>
+ * <li>If the target block is a {@link GameMasterBlock} and {@link Player#canUseGameMasterBlocks()} is false.</li>
+ * <li>If the the player is holding an item, and {@link Item#canAttackBlock} is false.</li>
+ * </ul>
+ *
+ * In the first two cases, un-cancelling the event will not permit the block to be broken.
+ * In the third case, un-cancelling will allow the break, bypassing the behavior of {@link Item#canAttackBlock}.
+ */
+public class BreakBlockEvent extends BlockEvent implements ICancellableEvent {
+    private final Player player;
+    private boolean notifyClient = false;
+
+    public BreakBlockEvent(Level level, BlockPos pos, BlockState state, Player player) {
+        super(level, pos, state);
+        this.player = player;
+    }
+
+    /**
+     * {@return the player who is attempting to break the block}
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Canceling this event will prevent the block from being broken.
+     * <p>
+     * When canceled on the server, the client will receive
+     */
+    @Override
+    public void setCanceled(boolean canceled) {
+        ICancellableEvent.super.setCanceled(canceled);
+    }
+
+    /**
+     * Whether or not the client should receive a {@link ClientboundBlockUpdatePacket} when this event is canceled on the server.
+     */
+    public boolean shouldNotifyClient() {
+        return notifyClient;
+    }
+
+    /**
+     * Used to enable (or disable) notifying the client.
+     * <p>
+     * This should be set when canceling the event only on the server, without a matching client-side event handler.
+     * <p>
+     * However, in general, prefer to run your event handler on both sides, rather than relying on the notifying path.
+     */
+    public void setNotifyClient(boolean notify) {
+        this.notifyClient = notify;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/level/block/BreakBlockEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/block/BreakBlockEvent.java
@@ -47,7 +47,7 @@ public class BreakBlockEvent extends BlockEvent implements ICancellableEvent {
     /**
      * Canceling this event will prevent the block from being broken.
      * <p>
-     * When canceled on the server, the client will receive
+     * When canceled on the server, If {@link #shouldNotifyClient()}, the client will receive a {@link ClientboundBlockUpdatePacket}.
      */
     @Override
     public void setCanceled(boolean canceled) {


### PR DESCRIPTION
This PR includes two changes:
1. It moves `BlockEvent.BreakEvent` to a standalone top-level class `BreakBlockEvent`, following prior decisions to migrate away from inner-class events.
2. It updates the firing logic to fire `BreakBlockEvent` on the client, instead of only firing it on the server.

The first change is straightforward. The second change means we have a new firing site for this event in `MultiPlayerGameMode#destroyBlock`, mirroring the one in `ServerPlayerGameMode#destroyBlock`. 

As a result, the automatic behavior to dispatch a `ClientboundBlockUpdatePacket` when the event was canceled was made conditional, requiring `BreakBlockEvent#setNotifyClient(true)` to be called to invoke that behavior. A suggestion is made for users to not rely on this method and ensure their event handlers run on both sides properly instead.

Closes #2189 