### PR TITLE
Add enchanted loot events

### DIFF
--- a/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
+++ b/patches/net/minecraft/world/item/enchantment/EnchantmentHelper.java.patch
@@ -44,6 +44,34 @@
              if (itemEnchantments != null && !itemEnchantments.isEmpty()) {
                  EnchantedItemInUse itemInUse = new EnchantedItemInUse(piece, slot, owner);
  
+@@ -339,7 +_,12 @@
+                             if (filteredEffect.enchanted() == EnchantmentTarget.VICTIM
+                                 && filteredEffect.affected() == EnchantmentTarget.VICTIM
+                                 && filteredEffect.matches(context)) {
+-                                modifiedChance.setValue(filteredEffect.effect().process(level, random, modifiedChance.floatValue()));
++
++                                // Neo: Allow mods to modify the enchantment level for loot calculations with relevant context.
++                                int realLevel = net.neoforged.neoforge.event.EventHooks.getEntityLootEnchantmentLevel(enchantment, level, context);
++                                if (realLevel == 0) return;
++
++                                modifiedChance.setValue(filteredEffect.effect().process(realLevel, random, modifiedChance.floatValue()));
+                             }
+                         }
+                     );
+@@ -357,7 +_,12 @@
+                                 if (filteredEffect.enchanted() == EnchantmentTarget.ATTACKER
+                                     && filteredEffect.affected() == EnchantmentTarget.VICTIM
+                                     && filteredEffect.matches(context)) {
+-                                    modifiedChance.setValue(filteredEffect.effect().process(level, random, modifiedChance.floatValue()));
++
++                                    // Neo: Allow mods to modify the enchantment level for loot calculations with relevant context.
++                                    int realLevel = net.neoforged.neoforge.event.EventHooks.getEntityLootEnchantmentLevel(enchantment, level, context);
++                                    if (realLevel == 0) return;
++
++                                    modifiedChance.setValue(filteredEffect.effect().process(realLevel, random, modifiedChance.floatValue()));
+                                 }
+                             }
+                         );
 @@ -420,6 +_,12 @@
      public static boolean hasTag(ItemStack item, TagKey<Enchantment> tag) {
          ItemEnchantments enchantments = item.getOrDefault(DataComponents.ENCHANTMENTS, ItemEnchantments.EMPTY);

--- a/patches/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java
++++ b/net/minecraft/world/level/storage/loot/functions/ApplyBonusCount.java
+@@ -64,6 +_,10 @@
+         ItemInstance tool = context.getOptionalParameter(LootContextParams.TOOL);
+         if (tool != null) {
+             int level = EnchantmentHelper.getItemEnchantmentLevel(this.enchantment, tool);
++
++            // Neo: Allow mods to modify the enchantment level for loot calculations with relevant context.
++            level = net.neoforged.neoforge.event.EventHooks.getBlockLootEnchantmentLevel(tool, this.enchantment, level, context);
++
+             int newCount = this.formula.calculateNewCount(context.getRandom(), itemStack.getCount(), level);
+             itemStack.setCount(newCount);
+         }

--- a/patches/net/minecraft/world/level/storage/loot/functions/EnchantedCountIncreaseFunction.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/functions/EnchantedCountIncreaseFunction.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/storage/loot/functions/EnchantedCountIncreaseFunction.java
++++ b/net/minecraft/world/level/storage/loot/functions/EnchantedCountIncreaseFunction.java
+@@ -72,6 +_,10 @@
+         Entity killer = context.getOptionalParameter(LootContextParams.ATTACKING_ENTITY);
+         if (killer instanceof LivingEntity entity) {
+             int level = EnchantmentHelper.getEnchantmentLevel(this.enchantment, entity);
++
++            // Neo: Allow mods to modify the enchantment level for loot calculations with relevant context.
++            level = net.neoforged.neoforge.event.EventHooks.getEntityLootEnchantmentLevel(this.enchantment, level, context);
++
+             if (level == 0) {
+                 return itemStack;
+             }

--- a/patches/net/minecraft/world/level/storage/loot/predicates/BonusLevelTableCondition.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/predicates/BonusLevelTableCondition.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/storage/loot/predicates/BonusLevelTableCondition.java
++++ b/net/minecraft/world/level/storage/loot/predicates/BonusLevelTableCondition.java
+@@ -37,6 +_,10 @@
+     public boolean test(LootContext context) {
+         ItemInstance tool = context.getOptionalParameter(LootContextParams.TOOL);
+         int level = tool != null ? EnchantmentHelper.getItemEnchantmentLevel(this.enchantment, tool) : 0;
++
++        // Neo: Allow mods to modify the enchantment level for loot calculations with relevant context.
++        level = net.neoforged.neoforge.event.EventHooks.getBlockLootEnchantmentLevel(tool, this.enchantment, level, context);
++
+         float chance = this.values.get(Math.min(level, this.values.size() - 1));
+         return context.getRandom().nextFloat() < chance;
+     }

--- a/patches/net/minecraft/world/level/storage/loot/predicates/LootItemRandomChanceWithEnchantedBonusCondition.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/predicates/LootItemRandomChanceWithEnchantedBonusCondition.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/storage/loot/predicates/LootItemRandomChanceWithEnchantedBonusCondition.java
++++ b/net/minecraft/world/level/storage/loot/predicates/LootItemRandomChanceWithEnchantedBonusCondition.java
+@@ -41,6 +_,10 @@
+     public boolean test(LootContext context) {
+         Entity killerEntity = context.getOptionalParameter(LootContextParams.ATTACKING_ENTITY);
+         int enchantmentLevel = killerEntity instanceof LivingEntity livingKiller ? EnchantmentHelper.getEnchantmentLevel(this.enchantment, livingKiller) : 0;
++
++        // Neo: Allow mods to modify the enchantment level for loot calculations with relevant context.
++        enchantmentLevel = net.neoforged.neoforge.event.EventHooks.getEntityLootEnchantmentLevel(this.enchantment, enchantmentLevel, context);
++
+         float chance = enchantmentLevel > 0 ? this.enchantedChance.calculate(enchantmentLevel) : this.unenchantedChance;
+         return context.getRandom().nextFloat() < chance;
+     }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -17,7 +17,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
-import net.minecraft.client.Minecraft;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -53,6 +53,7 @@ import net.minecraft.world.Difficulty;
 import net.minecraft.world.DifficultyInstance;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
@@ -81,6 +82,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.BaseSpawner;
 import net.minecraft.world.level.BlockGetter;
@@ -110,8 +112,10 @@ import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootDataType;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.level.storage.loot.predicates.BonusLevelTableCondition;
+import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceWithEnchantedBonusCondition;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModLoader;
@@ -125,6 +129,7 @@ import net.neoforged.neoforge.common.util.InsertableLinkedOpenCustomHashSet;
 import net.neoforged.neoforge.event.brewing.PlayerBrewedPotionEvent;
 import net.neoforged.neoforge.event.brewing.PotionBrewEvent;
 import net.neoforged.neoforge.event.enchanting.EnchantedBlockLootEvent;
+import net.neoforged.neoforge.event.enchanting.EnchantedEntityLootEvent;
 import net.neoforged.neoforge.event.enchanting.EnchantmentLevelSetEvent;
 import net.neoforged.neoforge.event.enchanting.GetEnchantmentLevelEvent;
 import net.neoforged.neoforge.event.entity.EntityEvent;
@@ -1173,6 +1178,27 @@ public class EventHooks {
         Vec3 pos = ctx.getOptionalParameter(LootContextParams.ORIGIN);
         if (state != null && pos != null) {
             var event = new EnchantedBlockLootEvent(ctx.getLevel(), BlockPos.containing(pos), state, tool, ench, enchLevel);
+            NeoForge.EVENT_BUS.post(event);
+            return event.getEnchantmentLevel();
+        }
+        return enchLevel;
+    }
+
+    /**
+     * Called from {@link EnchantedCountIncreaseFunction}, {@link LootItemRandomChanceWithEnchantedBonusCondition},
+     * and {@link EnchantmentEffectComponents#EQUIPMENT_DROPS} when entity loot processing relies on enchantments for evaluating loot bonuses.
+     * <p>
+     * If the necessary context is present, this method will fire the {@link EnchantedEntityLootEvent} and return the event-modified level. Otherwise it returns the original level.
+     * 
+     * @param ench      The enchantment being queried.
+     * @param enchLevel The original enchantment level. How it gets determined depends on the particular call site. Generally it's the attacker's effective enchantment level.
+     * @param ctx       The loot context for the current entity loot evaluation.
+     */
+    public static int getEntityLootEnchantmentLevel(Holder<Enchantment> ench, int enchLevel, LootContext ctx) {
+        Entity entity = ctx.getOptionalParameter(LootContextParams.THIS_ENTITY);
+        DamageSource src = ctx.getOptionalParameter(LootContextParams.DAMAGE_SOURCE);
+        if (src != null && entity instanceof LivingEntity living) {
+            var event = new EnchantedEntityLootEvent(living, src, ench, enchLevel);
             NeoForge.EVENT_BUS.post(event);
             return event.getEnchantmentLevel();
         }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -17,6 +17,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.client.Minecraft;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -105,8 +106,12 @@ import net.minecraft.world.level.levelgen.feature.treedecorators.TreeDecorator;
 import net.minecraft.world.level.portal.PortalShape;
 import net.minecraft.world.level.portal.TeleportTransition;
 import net.minecraft.world.level.storage.ServerLevelData;
+import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootDataType;
 import net.minecraft.world.level.storage.loot.LootTable;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.BonusLevelTableCondition;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModLoader;
@@ -119,6 +124,7 @@ import net.neoforged.neoforge.common.util.ClockAdjustment;
 import net.neoforged.neoforge.common.util.InsertableLinkedOpenCustomHashSet;
 import net.neoforged.neoforge.event.brewing.PlayerBrewedPotionEvent;
 import net.neoforged.neoforge.event.brewing.PotionBrewEvent;
+import net.neoforged.neoforge.event.enchanting.EnchantedBlockLootEvent;
 import net.neoforged.neoforge.event.enchanting.EnchantmentLevelSetEvent;
 import net.neoforged.neoforge.event.enchanting.GetEnchantmentLevelEvent;
 import net.neoforged.neoforge.event.entity.EntityEvent;
@@ -1150,5 +1156,26 @@ public class EventHooks {
 
     public static <T> void onGameRuleChanged(MinecraftServer server, GameRule<T> gameRule, T newValue) {
         NeoForge.EVENT_BUS.post(new GameRuleChangedEvent(server, gameRule, newValue));
+    }
+
+    /**
+     * Called from {@link ApplyBonusCount} and {@link BonusLevelTableCondition} when blocks rely on enchantments for evaluating loot bonuses.
+     * <p>
+     * If the necessary context is present, this method will fire the {@link EnchantedBlockLootEvent} and return the event-modified level. Otherwise it returns the original level.
+     * 
+     * @param tool      The tool, from {@link LootContextParams#TOOL}.
+     * @param ench      The enchantment being queried.
+     * @param enchLevel The original enchantment level, determined from the item (or possibly {@link GetEnchantmentLevelEvent}).
+     * @param ctx       The loot context for the current block loot evaluation.
+     */
+    public static int getBlockLootEnchantmentLevel(ItemInstance tool, Holder<Enchantment> ench, int enchLevel, LootContext ctx) {
+        BlockState state = ctx.getOptionalParameter(LootContextParams.BLOCK_STATE);
+        Vec3 pos = ctx.getOptionalParameter(LootContextParams.ORIGIN);
+        if (state != null && pos != null) {
+            var event = new EnchantedBlockLootEvent(ctx.getLevel(), BlockPos.containing(pos), state, tool, ench, enchLevel);
+            NeoForge.EVENT_BUS.post(event);
+            return event.getEnchantmentLevel();
+        }
+        return enchLevel;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedBlockLootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedBlockLootEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.enchanting;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import com.google.common.base.Preconditions;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.ItemInstance;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.level.storage.loot.predicates.BonusLevelTableCondition;
+import net.neoforged.neoforge.event.level.BlockEvent;
+
+/**
+ * Fired on the server when a block's loot table queries the level of an enchantment to determine what the block will drop.
+ * <p>
+ * Notably, this fires when {@link ApplyBonusCount} or {@link BonusLevelTableCondition} check the level of an enchantment in-context.
+ * Mods that implement similar loot conditions or functions should fire this event as well.
+ * <p>
+ * If you do not need the additional context of this event, prefer {@link GetEnchantmentLevelEvent} for managing enchantment levels.
+ */
+public class EnchantedBlockLootEvent extends BlockEvent {
+    private final ItemInstance tool;
+    private final Holder<Enchantment> enchantment;
+    private int enchantmentLevel;
+
+    @ApiStatus.Internal
+    public EnchantedBlockLootEvent(ServerLevel level, BlockPos pos, BlockState state, ItemInstance tool, Holder<Enchantment> enchantment, int enchantmentLevel) {
+        super(level, pos, state);
+        this.tool = tool;
+        this.enchantment = enchantment;
+        this.enchantmentLevel = enchantmentLevel;
+    }
+
+    /**
+     * Returns the tool used to break the block, from {@link LootContextParams#TOOL}.
+     */
+    public ItemInstance getTool() {
+        return tool;
+    }
+
+    public Holder<Enchantment> getEnchantment() {
+        return this.enchantment;
+    }
+
+    public int getEnchantmentLevel() {
+        return this.enchantmentLevel;
+    }
+
+    public void setEnchantmentLevel(int enchantmentLevel) {
+        Preconditions.checkArgument(enchantmentLevel >= 0, "Enchantment level cannot be negative");
+        this.enchantmentLevel = enchantmentLevel;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedBlockLootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedBlockLootEvent.java
@@ -40,7 +40,7 @@ public class EnchantedBlockLootEvent extends BlockEvent {
     }
 
     /**
-     * Returns the tool used to break the block, from {@link LootContextParams#TOOL}.
+     * {@return the tool used to break the block, from {@link LootContextParams#TOOL}}
      */
     public ItemInstance getTool() {
         return tool;
@@ -54,6 +54,11 @@ public class EnchantedBlockLootEvent extends BlockEvent {
         return this.enchantmentLevel;
     }
 
+    /**
+     * Sets the new enchantment level.
+     * 
+     * @throws IllegalArgumentException if the enchantment level is negative.
+     */
     public void setEnchantmentLevel(int enchantmentLevel) {
         Preconditions.checkArgument(enchantmentLevel >= 0, "Enchantment level cannot be negative");
         this.enchantmentLevel = enchantmentLevel;

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedBlockLootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedBlockLootEvent.java
@@ -5,10 +5,7 @@
 
 package net.neoforged.neoforge.event.enchanting;
 
-import org.jetbrains.annotations.ApiStatus;
-
 import com.google.common.base.Preconditions;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
@@ -19,6 +16,7 @@ import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.level.storage.loot.predicates.BonusLevelTableCondition;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired on the server when a block's loot table queries the level of an enchantment to determine what the block will drop.

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedEntityLootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedEntityLootEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.enchanting;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.level.storage.loot.functions.EnchantedCountIncreaseFunction;
+import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceWithEnchantedBonusCondition;
+import net.neoforged.neoforge.event.entity.living.LivingEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Fired on the server when an entity is dropping loot and the level of a specific enchantment is being queried.
+ * <p>
+ * Notably, this fires when {@link EnchantedCountIncreaseFunction} or {@link LootItemRandomChanceWithEnchantedBonusCondition} are evaluated,
+ * as well as when {@link EnchantmentEffectComponent#EQUIPMENT_DROPS} is being processed.
+ * Mods that implement similar loot conditions or functions should fire this event as well.
+ * <p>
+ * If you do not need the additional context of this event, prefer {@link GetEnchantmentLevelEvent} for managing enchantment levels.
+ */
+public class EnchantedEntityLootEvent extends LivingEvent {
+    @Nullable
+    private final DamageSource damageSource;
+    private final Holder<Enchantment> enchantment;
+    private int enchantmentLevel;
+
+    @ApiStatus.Internal
+    public EnchantedEntityLootEvent(LivingEntity entity, DamageSource damageSource, Holder<Enchantment> enchantment, int enchantmentLevel) {
+        super(entity);
+        this.damageSource = damageSource;
+        this.enchantment = enchantment;
+        this.enchantmentLevel = enchantmentLevel;
+    }
+
+    /**
+     * Returns the entity that is dropping loot. This is generally the entity that was killed.
+     * <p>
+     * To get the attacking entity, use the {@link #getDamageSource() damage source}.
+     */
+    @Override
+    public LivingEntity getEntity() {
+        return super.getEntity();
+    }
+
+    public DamageSource getDamageSource() {
+        return this.damageSource;
+    }
+
+    public Holder<Enchantment> getEnchantment() {
+        return this.enchantment;
+    }
+
+    public int getEnchantmentLevel() {
+        return this.enchantmentLevel;
+    }
+
+    public void setEnchantmentLevel(int enchantmentLevel) {
+        this.enchantmentLevel = enchantmentLevel;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedEntityLootEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/enchanting/EnchantedEntityLootEvent.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.event.enchanting;
 
+import com.google.common.base.Preconditions;
 import net.minecraft.core.Holder;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -60,7 +61,13 @@ public class EnchantedEntityLootEvent extends LivingEvent {
         return this.enchantmentLevel;
     }
 
+    /**
+     * Sets the new enchantment level.
+     * 
+     * @throws IllegalArgumentException if the enchantment level is negative.
+     */
     public void setEnchantmentLevel(int enchantmentLevel) {
+        Preconditions.checkArgument(enchantmentLevel >= 0, "Enchantment level cannot be negative");
         this.enchantmentLevel = enchantmentLevel;
     }
 }


### PR DESCRIPTION
This PR adds two new events, `EnchantedBlockLootEvent` and `EnchantedEntityLootEvent`, which replaces the (now long gone) `LootingLevelEvent` and adds equivalent functionality for `fortune`-like enchantments.

The `EnchantedEntityLootEvent` fires whenever any of the following things are evaluated:
* `EnchantedCountIncreaseFunction`
* `LootItemRandomChanceWithEnchantedBonusCondition`
* `EnchantmentEffectComponents#EQUIPMENT_DROPS`

The `EnchantedBlockLootEvent` fires whenever any of the following things are evaluated:
* `ApplyBonusCount`
* `BonusLevelTableCondition`

As opposed to `GetEnchantmentLevelEvent`, these events are much more contextual, and allow for the creation of features that rely on the particular action being taken, rather than an out-of-context boost to a particular enchantment level.

Closes #1112