### PR TITLE
[26.1] Add convenience method for AvatarRenderer render state modifier

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/renderstate/AvatarRenderStateModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/renderstate/AvatarRenderStateModifier.java
@@ -1,0 +1,12 @@
+package net.neoforged.neoforge.client.renderstate;
+
+import net.minecraft.client.entity.ClientAvatarEntity;
+import net.minecraft.client.renderer.entity.player.AvatarRenderer;
+import net.minecraft.client.renderer.entity.state.AvatarRenderState;
+import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.world.entity.Avatar;
+
+/// Specialized [EntityRenderState] modifier for renderers extending [AvatarRenderer]
+public abstract class AvatarRenderStateModifier {
+    public abstract <T extends Avatar & ClientAvatarEntity> void accept(T avatar, AvatarRenderState renderState);
+}

--- a/src/client/java/net/neoforged/neoforge/client/renderstate/AvatarRenderStateModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/renderstate/AvatarRenderStateModifier.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client.renderstate;
 
 import net.minecraft.client.entity.ClientAvatarEntity;

--- a/src/client/java/net/neoforged/neoforge/client/renderstate/RegisterRenderStateModifiersEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/renderstate/RegisterRenderStateModifiersEvent.java
@@ -9,11 +9,15 @@ import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
 import java.lang.reflect.ParameterizedType;
 import java.util.function.BiConsumer;
+import net.minecraft.client.entity.ClientAvatarEntity;
 import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.player.AvatarRenderer;
+import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
 import net.minecraft.client.renderer.state.MapRenderState;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.context.ContextKey;
+import net.minecraft.world.entity.Avatar;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.saveddata.maps.MapDecorationType;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
@@ -78,6 +82,27 @@ public class RegisterRenderStateModifiersEvent extends Event implements IModBusE
     public <E extends Entity, S extends EntityRenderState> void registerEntityModifier(Class<? extends EntityRenderer<? extends E, ? extends S>> baseRenderer, BiConsumer<E, S> modifier) {
         ensureParametersMatchBounds(TypeToken.of(baseRenderer));
         RenderStateExtensions.registerEntity(baseRenderer, modifier);
+    }
+
+    /// Convenience method for [AvatarRenderer]s to work around issues with generics inference and type safety with intersection types.
+    /// Registers a render state modifier for [EntityRenderState]s which are run after all vanilla data is
+    /// extracted. Can add custom data to the map using [EntityRenderState#setRenderData(ContextKey, Object)].
+    /// Any subclasses of the passed renderer class will also have this modifier applied.
+    ///
+    /// ```
+    /// event.registerAvatarEntityModifier(new AvatarRenderStateModifier() {
+    ///     @Override
+    ///     public <T extends Avatar & ClientAvatarEntity> void accept(T avatar, AvatarRenderState renderState) {
+    ///         . . .
+    ///     }
+    /// });
+    /// ```
+    public void registerAvatarEntityModifier(AvatarRenderStateModifier modifier) {
+        RenderStateExtensions.registerEntity(AvatarRenderer.class, coerce(modifier));
+    }
+
+    private static <T extends Avatar & ClientAvatarEntity> BiConsumer<?, ?> coerce(AvatarRenderStateModifier modifier) {
+        return (BiConsumer<T, AvatarRenderState>) modifier::accept;
     }
 
     /**

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
@@ -11,6 +11,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
 import java.util.Map;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.ClientAvatarEntity;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.block.BlockQuadOutput;
 import net.minecraft.client.renderer.block.model.BlockDisplayContext;
@@ -18,6 +19,8 @@ import net.minecraft.client.renderer.entity.AbstractHoglinRenderer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.MobRenderer;
 import net.minecraft.client.renderer.entity.PigRenderer;
+import net.minecraft.client.renderer.entity.player.AvatarRenderer;
+import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.client.renderer.entity.state.HoglinRenderState;
 import net.minecraft.client.renderer.entity.state.LivingEntityRenderState;
 import net.minecraft.client.renderer.item.ItemStackRenderState;
@@ -29,6 +32,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.util.context.ContextKey;
+import net.minecraft.world.entity.Avatar;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -36,6 +40,7 @@ import net.minecraft.world.entity.monster.hoglin.HoglinBase;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.AddSectionGeometryEvent;
@@ -46,6 +51,7 @@ import net.neoforged.neoforge.client.event.RenderLivingEvent;
 import net.neoforged.neoforge.client.event.RenderNameTagEvent;
 import net.neoforged.neoforge.client.event.RenderPlayerEvent;
 import net.neoforged.neoforge.client.event.SubmitCustomGeometryEvent;
+import net.neoforged.neoforge.client.renderstate.AvatarRenderStateModifier;
 import net.neoforged.neoforge.client.renderstate.RegisterRenderStateModifiersEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.testframework.DynamicTest;
@@ -157,6 +163,7 @@ public class ClientEventTests {
     static void updateRenderState(final DynamicTest test) {
         var rotationKey = new ContextKey<Float>(Identifier.fromNamespaceAndPath(test.createModId(), "rotation"));
         var numRenderAttachmentKey = new ContextKey<Integer>(Identifier.fromNamespaceAndPath(test.createModId(), "times_to_render"));
+        var avatarTestKey = new ContextKey<Vec3>(Identifier.fromNamespaceAndPath(test.createModId(), "avatar_test"));
         var testAttachment = test.registrationHelper().attachments().registerSimpleAttachment("test", () -> 3);
         test.framework().modEventBus().addListener((RegisterRenderStateModifiersEvent event) -> {
             event.registerEntityModifier(PigRenderer.class, (entity, renderState) -> {
@@ -174,6 +181,12 @@ public class ClientEventTests {
                 event.registerEntityModifier(new TestBrokenHoglinRendererTypeToken<>(), (entity, renderState) -> {});
                 test.fail("Unsafe type parameter succeeded. Cannot assume T can be ?.");
             } catch (IllegalArgumentException ignored) {}
+            event.registerAvatarEntityModifier(new AvatarRenderStateModifier() {
+                @Override
+                public <T extends Avatar & ClientAvatarEntity> void accept(T avatar, AvatarRenderState renderState) {
+                    renderState.setRenderData(avatarTestKey, avatar.avatarState().deltaMovementOnPreviousTick());
+                }
+            });
         });
         test.whenEnabled(listeners -> {
             BlockDisplayContext blockDisplayContext = BlockDisplayContext.create();
@@ -185,7 +198,11 @@ public class ClientEventTests {
                 }
                 float xRotation = event.getRenderState().getRenderDataOrDefault(rotationKey, 0f);
                 if (event.getRenderer() instanceof PigRenderer && numRender == 0) {
-                    test.fail("Custom render data not set for player");
+                    test.fail("Custom render data not set for pig");
+                    return;
+                }
+                if (event.getRenderer() instanceof AvatarRenderer<?> && event.getRenderState().getRenderData(avatarTestKey) == null) {
+                    test.fail("Avatar test data not set for player/mannequin");
                     return;
                 }
 


### PR DESCRIPTION
This PR adds a convenience method for registering render state modifiers for `AvatarRenderer`s (used by players and mannequins).

`AvatarRenderer` has an intersection type (`Avatar & ClientAvatarEntity`) as its generic bounds. This causes issues with the existing methods for registering entity render state modifiers:
- The `TypeToken` overload cannot be used with an exact generic because the type bound validation cannot ensure the provided type matches the expected type without letting through non-typesafe variants. A test exists to ensure that intersection types fail validation: https://github.com/neoforged/NeoForge/blob/a2a27d1b2bab372e249c0f89b47297de6f7b5f96/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java#L173-L175
- Using the `TypeToken` overload with a wildcard (`new TypeToken<AvatarRenderer<?>>() {}`) causes the entity parameter to be deduced as `LivingEntity`, requiring the implementor to downcast to the relevant bound which is potentially errorprone
- The `Class` overload cannot be used because `AvatarRenderer.class` does not satisfy the generic bounds

Since the `AvatarRenderer` is going to be a very frequent target for mods to hook into, an overload dedicated to it is added to hide the mess that ensues from intersection types.
Providing the full intersection type to the implementor while retaining type-safety requires using a dedicated type for the modifier and to ensure it cannot be implemented by a lambda (a lambda would break the entity parameter type again), an abstract class is used for this instead of an interface.