### PR TITLE
Handle exception gracefully when reading optional pack meta

### DIFF
--- a/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
@@ -127,7 +127,7 @@ public class ResourcePackLoader {
                             MOD_PACK_SELECTION_CONFIG);
 
                     if (modPack == null) {
-                        ModLoader.addLoadingIssue(ModLoadingIssue.warning("fml.modloading.brokenresources", e.getKey()).withAffectedModFile(modFile));
+                        ModLoader.addLoadingIssue(ModLoadingIssue.warning("fml.modloadingissue.brokenresources", e.getKey()).withAffectedModFile(modFile));
                         continue;
                     }
                 } else {
@@ -145,7 +145,7 @@ public class ResourcePackLoader {
                 }
             } catch (IOException exception) {
                 LOGGER.error("Failed to read pack.mcmeta file of {}", modFile, exception);
-                ModLoader.addLoadingIssue(ModLoadingIssue.warning("fml.modloading.brokenresources", e.getKey()).withAffectedModFile(modFile).withCause(exception));
+                ModLoader.addLoadingIssue(ModLoadingIssue.warning("fml.modloadingissue.brokenresources", e.getKey()).withAffectedModFile(modFile).withCause(exception));
             }
         }
 

--- a/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.resource;
 
 import com.google.common.collect.Sets;
+import com.google.gson.JsonParseException;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
@@ -196,7 +197,13 @@ public class ResourcePackLoader {
     private static Pack.Metadata readMeta(PackType type, PackLocationInfo location, Pack.ResourcesSupplier resources) throws IOException {
         final PackFormat currentVersion = SharedConstants.getCurrentVersion().packVersion(type);
         try (final PackResources primaryResources = resources.openPrimary(location)) {
-            final PackMetadataSection metadata = primaryResources.getMetadataSection(metadataTypeForPackType(type));
+            PackMetadataSection metadata;
+            try {
+                metadata = primaryResources.getMetadataSection(metadataTypeForPackType(type));
+            } catch (JsonParseException exception) {
+                LOGGER.warn("Error reading optional pack metadata for {}, attempting fallback type", location.id(), exception);
+                metadata = primaryResources.getMetadataSection(PackMetadataSection.FALLBACK_TYPE);
+            }
 
             final FeatureFlagSet flags = Optional.ofNullable(primaryResources.getMetadataSection(FeatureFlagsMetadataSection.TYPE))
                     .map(FeatureFlagsMetadataSection::flags)


### PR DESCRIPTION
This PR fixes #3051 by introducing more graceful handling for `JsonParseException`s encountered while reading optional pack metadata in `ResourcePackLoader`. This mirrors the behavior done by `Pack.readPackMetadata` when it encounters a `JsonParseException` when reading the pack metadata. See my comment in the linked issue for more details: https://github.com/neoforged/NeoForge/issues/3051#issuecomment-4189514964.

This also fixes an adjacent issue (which I found while testing out fixes for the issue): the FML translation keys used here are of an older format for mod loading issues, which FML will reject with an exception.