### PR TITLE
[26.1] Add optional player context to Item.TooltipContext

### DIFF
--- a/patches/net/minecraft/client/gui/screens/Screen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/Screen.java.patch
@@ -17,9 +17,12 @@
      }
  
      protected <T extends GuiEventListener & Renderable & NarratableEntry> T addRenderableWidget(T widget) {
-@@ -239,7 +_,7 @@
+@@ -237,9 +_,9 @@
+ 
+     public static List<Component> getTooltipFromItem(Minecraft minecraft, ItemStack itemStack) {
          return itemStack.getTooltipLines(
-             Item.TooltipContext.of(minecraft.level),
+-            Item.TooltipContext.of(minecraft.level),
++            Item.TooltipContext.of(minecraft.level, minecraft.player),
              minecraft.player,
 -            minecraft.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL
 +            net.neoforged.neoforge.client.ClientTooltipFlag.of(minecraft.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL)

--- a/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -185,7 +185,7 @@
          TooltipFlag.Default originalTooltipStyle = this.minecraft.options.advancedItemTooltips ? TooltipFlag.Default.ADVANCED : TooltipFlag.Default.NORMAL;
          TooltipFlag tooltipStyle = isCreativeSlot ? originalTooltipStyle.asCreative() : originalTooltipStyle;
 -        List<Component> originalLines = itemStack.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, tooltipStyle);
-+        List<Component> originalLines = itemStack.getTooltipLines(Item.TooltipContext.of(this.minecraft.level), this.minecraft.player, net.neoforged.neoforge.client.ClientTooltipFlag.of(tooltipStyle));
++        List<Component> originalLines = itemStack.getTooltipLines(Item.TooltipContext.of(this.minecraft.level, this.minecraft.player), this.minecraft.player, net.neoforged.neoforge.client.ClientTooltipFlag.of(tooltipStyle));
          if (originalLines.isEmpty()) {
              return originalLines;
          } else if (isSingleCategoryTab && isCreativeSlot) {

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -126,7 +126,7 @@
              return this;
          }
  
-@@ -709,6 +_,14 @@
+@@ -709,7 +_,25 @@
  
          boolean isPeaceful();
  
@@ -138,10 +138,21 @@
 +            return null;
 +        }
 +
++        /// Neo: Returns the player for whom tooltips are being generated, if known
++        @Nullable
++        default Player player() {
++            return null;
++        }
++
          static Item.TooltipContext of(@Nullable Level level) {
++            return of(level, null);
++        }
++
++        static Item.TooltipContext of(@Nullable Level level, @Nullable Player player) {
              return level == null ? EMPTY : new Item.TooltipContext() {
                  @Override
-@@ -729,6 +_,11 @@
+                 public HolderLookup.Provider registries() {
+@@ -729,6 +_,17 @@
                  @Override
                  public boolean isPeaceful() {
                      return level.getDifficulty() == Difficulty.PEACEFUL;
@@ -150,6 +161,12 @@
 +                @Override
 +                public Level level() {
 +                    return level;
++                }
++
++                @Nullable
++                @Override
++                public Player player() {
++                    return player;
                  }
              };
          }

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -126,7 +126,7 @@
              return this;
          }
  
-@@ -709,7 +_,25 @@
+@@ -709,7 +_,33 @@
  
          boolean isPeaceful();
  
@@ -148,7 +148,15 @@
 +            return of(level, null);
 +        }
 +
-+        static Item.TooltipContext of(@Nullable Level level, @Nullable Player player) {
++        static Item.TooltipContext of(@Nullable Level pLevel, @Nullable Player player) {
++            Level level;
++            if (pLevel != null) {
++                level = pLevel;
++            } else if (player != null) {
++                level = player.level();
++            } else {
++                level = null;
++            }
              return level == null ? EMPTY : new Item.TooltipContext() {
                  @Override
                  public HolderLookup.Provider registries() {

--- a/patches/net/minecraft/world/item/Item.java.patch
+++ b/patches/net/minecraft/world/item/Item.java.patch
@@ -126,7 +126,7 @@
              return this;
          }
  
-@@ -709,7 +_,33 @@
+@@ -709,7 +_,26 @@
  
          boolean isPeaceful();
  
@@ -149,14 +149,7 @@
 +        }
 +
 +        static Item.TooltipContext of(@Nullable Level pLevel, @Nullable Player player) {
-+            Level level;
-+            if (pLevel != null) {
-+                level = pLevel;
-+            } else if (player != null) {
-+                level = player.level();
-+            } else {
-+                level = null;
-+            }
++            Level level = pLevel == null && player != null ? player.level() : pLevel;
              return level == null ? EMPTY : new Item.TooltipContext() {
                  @Override
                  public HolderLookup.Provider registries() {

--- a/src/main/java/net/neoforged/neoforge/common/util/AttributeTooltipContext.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/AttributeTooltipContext.java
@@ -21,12 +21,6 @@ import org.jspecify.annotations.Nullable;
  */
 public interface AttributeTooltipContext extends Item.TooltipContext {
     /**
-     * {@return the player for whom tooltips are being generated for, if known}
-     */
-    @Nullable
-    Player player();
-
-    /**
      * {@return the tooltip display}
      */
     TooltipDisplay tooltipDisplay();


### PR DESCRIPTION
This PR adds the player for whom tooltip contents are being collected, if available, to `Item.TooltipContext`, moving it up from Neo's `AttributeTooltipContext` to the vanilla context. This allows items to display data that is specific to them but stored on the player (i.e. via a player data attachment) for whatever technical reason.