### PR TITLE
Added convenience overloads to set sprite/material with defaulted transparency

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/pipeline/QuadBakingVertexConsumer.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/pipeline/QuadBakingVertexConsumer.java
@@ -122,6 +122,11 @@ public class QuadBakingVertexConsumer implements VertexConsumer {
     }
 
     @SuppressWarnings("deprecation")
+    public void setSprite(Material.Baked material) {
+        setSprite(material, material.forceTranslucent() ? Transparency.TRANSLUCENT : material.sprite().transparency());
+    }
+
+    @SuppressWarnings("deprecation")
     public void setSprite(Material.Baked material, Transparency transparency) {
         RenderType itemRenderType;
         if (material.sprite().atlasLocation().equals(TextureAtlas.LOCATION_BLOCKS)) {

--- a/src/client/java/net/neoforged/neoforge/client/model/pipeline/QuadBakingVertexConsumer.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/pipeline/QuadBakingVertexConsumer.java
@@ -121,7 +121,6 @@ public class QuadBakingVertexConsumer implements VertexConsumer {
         this.direction = direction;
     }
 
-    @SuppressWarnings("deprecation")
     public void setSprite(Material.Baked material) {
         setSprite(material, material.forceTranslucent() ? Transparency.TRANSLUCENT : material.sprite().transparency());
     }

--- a/src/client/java/net/neoforged/neoforge/client/model/quad/MutableQuad.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/quad/MutableQuad.java
@@ -550,6 +550,18 @@ public class MutableQuad {
     }
 
     /**
+     * Changes the material used by this quad and sets the {@link #itemRenderType()} and {@link #chunkLayer()}
+     * based on the material.
+     *
+     * <p>Note that changing the sprite does not automatically translate the current UV coordinates within the atlas
+     * to be within this new sprite. Use {@link #setSpriteAndMoveUv(Material.Baked, Transparency)}
+     * to change sprites and remap them, {@link #bakeUvsFromPosition()} to generate texture coordinates from scratch, or set them manually.
+     */
+    public MutableQuad setSprite(Material.Baked material) {
+        return setSprite(material, getTransparency(material));
+    }
+
+    /**
      * Changes the texture atlas sprite used by this quad.
      *
      * <p>Note that changing the sprite does not automatically translate the current UV coordinates within the atlas
@@ -580,6 +592,15 @@ public class MutableQuad {
         this.chunkLayer = chunkLayer;
         this.itemRenderType = itemRenderType;
         return this;
+    }
+
+    /**
+     * Changes the sprite and remaps the UV to the new sprites position in the texture atlas.
+     *
+     * @throws IllegalStateException If no sprite is currently set. There would be nothing to remap from.
+     */
+    public MutableQuad setSpriteAndMoveUv(Material.Baked material) {
+        return setSpriteAndMoveUv(material, getTransparency(material));
     }
 
     /**
@@ -1061,5 +1082,13 @@ public class MutableQuad {
         lastSourceQuad = null;
 
         return this;
+    }
+
+    private static Transparency getTransparency(Material.Baked material) {
+        var spriteTransparency = material.sprite().contents().transparency();
+        if (material.forceTranslucent()) {
+            return Transparency.TRANSLUCENT;
+        }
+        return spriteTransparency;
     }
 }


### PR DESCRIPTION
Beats having to manually query the materials transparency yourself and pass it as the second parameter.