### PR TITLE
Add client config for skipping modded splashes when vanilla is modified

### DIFF
--- a/patches/net/minecraft/client/resources/SplashManager.java.patch
+++ b/patches/net/minecraft/client/resources/SplashManager.java.patch
@@ -5,7 +5,7 @@
      protected List<Component> prepare(ResourceManager manager, ProfilerFiller profiler) {
          try {
 +            var splashes = Minecraft.getInstance().getResourceManager().getResourceOrThrow(SPLASHES_LOCATION);
-+            if (splashes.sourcePackId().equals("vanilla"))
++            if (splashes.sourcePackId().equals("vanilla") || !net.neoforged.neoforge.client.config.NeoForgeClientConfig.INSTANCE.skipModdedSplashesIfVanillaModified.getAsBoolean())
 +                return net.neoforged.neoforge.client.resources.NeoForgeSplashHooks.loadSplashes(manager);
 +
              List var4;

--- a/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
+++ b/src/client/java/net/neoforged/neoforge/client/config/NeoForgeClientConfig.java
@@ -39,6 +39,8 @@ public final class NeoForgeClientConfig {
 
     public final ModConfigSpec.BooleanValue enableB3DValidationLayer;
 
+    public final ModConfigSpec.BooleanValue skipModdedSplashesIfVanillaModified;
+
     private NeoForgeClientConfig(ModConfigSpec.Builder builder) {
         enhancedLighting = builder
                 .comment("Enable the enhanced block model lighting pipeline - fixes the lighting of custom models, as well as many vanilla bugs.")
@@ -74,6 +76,11 @@ public final class NeoForgeClientConfig {
                 .comment("When enabled, all usage of Blaze3D will be validated against allowed usage")
                 .translation("neoforge.configgui.enableB3DValidationLayer")
                 .define("enableB3DValidationLayer", !FMLEnvironment.isProduction());
+
+        skipModdedSplashesIfVanillaModified = builder
+                .comment("When enabled, modded splashes will not be loaded if the vanilla splash text is modified.")
+                .translation("neoforge.configgui.skipModdedSplashesIfVanillaModified")
+                .define("skipModdedSplashesIfVanillaModified", true);
     }
 
     @SubscribeEvent

--- a/src/client/java/net/neoforged/neoforge/client/resources/NeoForgeSplashHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/resources/NeoForgeSplashHooks.java
@@ -14,7 +14,9 @@ import net.minecraft.client.resources.SplashManager;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
+import org.jetbrains.annotations.ApiStatus;
 
+@ApiStatus.Internal
 public class NeoForgeSplashHooks {
     public static List<Component> loadSplashes(ResourceManager resourceManager) {
         List<Component> list = Lists.newArrayList();

--- a/src/main/resources/assets/neoforge/lang/en_us.json
+++ b/src/main/resources/assets/neoforge/lang/en_us.json
@@ -218,6 +218,8 @@
   "neoforge.configgui.showLoadWarnings.tooltip": "When enabled, NeoForge will show any warnings that occurred during loading.",
   "neoforge.configgui.useCombinedDepthStencilAttachment": "Use combined DEPTH_STENCIL Attachment",
   "neoforge.configgui.useCombinedDepthStencilAttachment.tooltip": "Set to true to use a combined DEPTH_STENCIL attachment instead of two separate ones.",
+  "neoforge.configgui.skipModdedSplashesIfVanillaModified": "Skip modded splashes if vanilla splashes are modified",
+  "neoforge.configgui.skipModdedSplashesIfVanillaModified.tooltip": "When enabled, modded splash texts are skipped from loading if the vanilla splash text file is modified.",
 
   "neoforge.controlsgui.shift": "SHIFT + %s",
   "neoforge.controlsgui.control": "CTRL + %s",


### PR DESCRIPTION
This PR implements and closes #2893 by adding a new client config for whether to skip loading modded splash texts when the vanilla splash text file is modified.

By default, modded splashes are skipped when the vanilla splash text file is modified by a resource pack. This config allows modded splashes to be loaded regardless.

This PR also marks the `NeoForgeSplashHooks` class as an internal API, since mods have no reason to call it ever.