### PR TITLE
Remove AbstractContainerScreen#slotColor and rename getters

### DIFF
--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -167,11 +167,10 @@
                      this.slotClicked(this.hoveredSlot, this.hoveredSlot.index, i, ContainerInput.SWAP);
                      return true;
                  }
-@@ -682,6 +_,18 @@
-     @Override
+@@ -683,6 +_,13 @@
      public T getMenu() {
          return this.menu;
-+    }
+     }
 +
 +    @org.jspecify.annotations.Nullable
 +    public Slot getSlotUnderMouse() { return this.hoveredSlot; }
@@ -179,10 +178,6 @@
 +    public int getGuiTop() { return topPos; }
 +    public int getXSize() { return imageWidth; }
 +    public int getYSize() { return imageHeight; }
-+
-+    protected int slotColor = -2130706433;
-+    public int getSlotColor(int index) {
-+        return slotColor;
-     }
  
      @Override
+     public void onClose() {

--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -167,7 +167,7 @@
                      this.slotClicked(this.hoveredSlot, this.hoveredSlot.index, i, ContainerInput.SWAP);
                      return true;
                  }
-@@ -682,6 +_,28 @@
+@@ -682,6 +_,59 @@
      @Override
      public T getMenu() {
          return this.menu;
@@ -193,6 +193,37 @@
 +
 +    public int getImageHeight() {
 +        return imageHeight;
++    }
++
++    /// @deprecated Neo: Use [#getHoveredSlot()] instead.
++    @Deprecated(forRemoval = true, since = "26.1.2")
++    @org.jspecify.annotations.Nullable
++    public Slot getSlotUnderMouse() {
++        return this.getHoveredSlot();
++    }
++
++    /// @deprecated Neo: Use [#getLeftPos()] instead.
++    @Deprecated(forRemoval = true, since = "26.1.2")
++    public int getGuiLeft() {
++        return this.getLeftPos();
++    }
++
++    /// @deprecated Neo: Use [#getTopPos()] instead.
++    @Deprecated(forRemoval = true, since = "26.1.2")
++    public int getGuiTop() {
++        return this.getTopPos();
++    }
++
++    /// @deprecated Neo: Use [#getImageHeight()] instead.
++    @Deprecated(forRemoval = true, since = "26.1.2")
++    public int getXSize() {
++        return this.getImageWidth();
++    }
++
++    /// @deprecated Neo: Use [#getImageHeight()] instead.
++    @Deprecated(forRemoval = true, since = "26.1.2")
++    public int getYSize() {
++        return this.getImageHeight();
      }
  
      @Override

--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -167,18 +167,32 @@
                      this.slotClicked(this.hoveredSlot, this.hoveredSlot.index, i, ContainerInput.SWAP);
                      return true;
                  }
-@@ -683,6 +_,14 @@
+@@ -682,6 +_,28 @@
+     @Override
      public T getMenu() {
          return this.menu;
-     }
++    }
 +
 +    // Neo: Add getters for non-public fields
 +    @org.jspecify.annotations.Nullable
-+    public Slot getHoveredSlot() { return this.hoveredSlot; }
-+    public int getLeftPos() { return leftPos; }
-+    public int getTopPos() { return topPos; }
-+    public int getImageWidth() { return imageWidth; }
-+    public int getImageHeight() { return imageHeight; }
++    public Slot getHoveredSlot() {
++        return this.hoveredSlot;
++    }
++
++    public int getLeftPos() {
++        return leftPos;
++    }
++
++    public int getTopPos() {
++        return topPos;
++    }
++
++    public int getImageWidth() {
++        return imageWidth;
++    }
++
++    public int getImageHeight() {
++        return imageHeight;
+     }
  
      @Override
-     public void onClose() {

--- a/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/AbstractContainerScreen.java.patch
@@ -167,17 +167,18 @@
                      this.slotClicked(this.hoveredSlot, this.hoveredSlot.index, i, ContainerInput.SWAP);
                      return true;
                  }
-@@ -683,6 +_,13 @@
+@@ -683,6 +_,14 @@
      public T getMenu() {
          return this.menu;
      }
 +
++    // Neo: Add getters for non-public fields
 +    @org.jspecify.annotations.Nullable
-+    public Slot getSlotUnderMouse() { return this.hoveredSlot; }
-+    public int getGuiLeft() { return leftPos; }
-+    public int getGuiTop() { return topPos; }
-+    public int getXSize() { return imageWidth; }
-+    public int getYSize() { return imageHeight; }
++    public Slot getHoveredSlot() { return this.hoveredSlot; }
++    public int getLeftPos() { return leftPos; }
++    public int getTopPos() { return topPos; }
++    public int getImageWidth() { return imageWidth; }
++    public int getImageHeight() { return imageHeight; }
  
      @Override
      public void onClose() {

--- a/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen.java.patch
@@ -134,14 +134,6 @@
                  if (this.checkTabClicked(tab, xm, ym)) {
                      this.selectTab(tab);
                      return true;
-@@ -534,6 +_,7 @@
-     private void selectTab(CreativeModeTab tab) {
-         CreativeModeTab oldTab = selectedTab;
-         selectedTab = tab;
-+        slotColor = tab.getSlotColor();
-         this.quickCraftSlots.clear();
-         this.menu.items.clear();
-         this.clearDraggingState();
 @@ -610,13 +_,15 @@
              this.originalSlots = null;
          }

--- a/patches/net/minecraft/world/item/CreativeModeTab.java.patch
+++ b/patches/net/minecraft/world/item/CreativeModeTab.java.patch
@@ -9,7 +9,7 @@
      private static final Identifier DEFAULT_BACKGROUND = createTextureLocation("items");
      private final Component displayName;
      private Identifier backgroundTexture = DEFAULT_BACKGROUND;
-@@ -25,6 +_,14 @@
+@@ -25,6 +_,13 @@
      private Set<ItemStack> displayItemsSearchTab = ItemStackLinkedSet.createTypeAndComponentsSet();
      private final Supplier<ItemStack> iconGenerator;
      private final CreativeModeTab.DisplayItemsGenerator displayItemsGenerator;
@@ -18,13 +18,12 @@
 +    private final int searchBarWidth;
 +    private final net.minecraft.resources.Identifier tabsImage;
 +    private final int labelColor;
-+    private final int slotColor;
 +    public final java.util.List<net.minecraft.resources.Identifier> tabsBefore;
 +    public final java.util.List<net.minecraft.resources.Identifier> tabsAfter;
  
      private CreativeModeTab(
          CreativeModeTab.Row row,
-@@ -32,7 +_,15 @@
+@@ -32,7 +_,14 @@
          CreativeModeTab.Type type,
          Component displayName,
          Supplier<ItemStack> iconGenerator,
@@ -35,13 +34,12 @@
 +        int searchBarWidth,
 +        net.minecraft.resources.Identifier tabsImage,
 +        int labelColor,
-+        int slotColor,
 +        java.util.List<net.minecraft.resources.Identifier> tabsBefore,
 +        java.util.List<net.minecraft.resources.Identifier> tabsAfter
      ) {
          this.row = row;
          this.column = column;
-@@ -40,12 +_,29 @@
+@@ -40,12 +_,28 @@
          this.iconGenerator = iconGenerator;
          this.displayItemsGenerator = displayItemsGenerator;
          this.type = type;
@@ -50,13 +48,12 @@
 +        this.searchBarWidth = searchBarWidth;
 +        this.tabsImage = tabsImage;
 +        this.labelColor = labelColor;
-+        this.slotColor = slotColor;
 +        this.tabsBefore = java.util.List.copyOf(tabsBefore);
 +        this.tabsAfter = java.util.List.copyOf(tabsAfter);
 +    }
 +
 +    protected CreativeModeTab(CreativeModeTab.Builder builder) {
-+        this(builder.row, builder.column, builder.type, builder.displayName, builder.iconGenerator, builder.displayItemsGenerator, builder.spriteScrollerLocation, builder.hasSearchBar, builder.searchBarWidth, builder.tabsImage, builder.labelColor, builder.slotColor, builder.tabsBefore, builder.tabsAfter);
++        this(builder.row, builder.column, builder.type, builder.displayName, builder.iconGenerator, builder.displayItemsGenerator, builder.spriteScrollerLocation, builder.hasSearchBar, builder.searchBarWidth, builder.tabsImage, builder.labelColor, builder.tabsBefore, builder.tabsAfter);
 +    }
 +
 +    public static CreativeModeTab.Builder builder() {
@@ -80,7 +77,7 @@
          this.displayItems = displayList.tabContents;
          this.displayItemsSearchTab = displayList.searchTabContents;
      }
-@@ -117,8 +_,36 @@
+@@ -117,8 +_,32 @@
          return this.displayItemsSearchTab.contains(stack);
      }
  
@@ -100,10 +97,6 @@
 +        return labelColor;
 +    }
 +
-+    public int getSlotColor() {
-+        return slotColor;
-+    }
-+
 +    public net.minecraft.resources.Identifier getScrollerSprite() {
 +        if (scrollerSpriteLocation == null)
 +            return this.canScroll() ? SCROLLER_SPRITE : SCROLLER_DISABLED_SPRITE;
@@ -117,7 +110,7 @@
          private final CreativeModeTab.Row row;
          private final int column;
          private Component displayName = Component.empty();
-@@ -129,6 +_,15 @@
+@@ -129,6 +_,14 @@
          private boolean alignedRight = false;
          private CreativeModeTab.Type type = CreativeModeTab.Type.CATEGORY;
          private Identifier backgroundTexture = CreativeModeTab.DEFAULT_BACKGROUND;
@@ -126,7 +119,6 @@
 +        private int searchBarWidth = 89;
 +        private net.minecraft.resources.Identifier tabsImage = CREATIVE_INVENTORY_TABS_IMAGE;
 +        private int labelColor = -12566464;
-+        private int slotColor = -2130706433;
 +        private java.util.function.Function<CreativeModeTab.Builder, CreativeModeTab> tabFactory = CreativeModeTab::new;
 +        private final java.util.List<net.minecraft.resources.Identifier> tabsBefore = new java.util.ArrayList<>();
 +        private final java.util.List<net.minecraft.resources.Identifier> tabsAfter = new java.util.ArrayList<>();
@@ -142,7 +134,7 @@
              return this;
          }
  
-@@ -175,11 +_,109 @@
+@@ -175,11 +_,101 @@
              return this;
          }
  
@@ -187,14 +179,6 @@
 +         */
 +        public CreativeModeTab.Builder withLabelColor(int labelColor) {
 +            this.labelColor = labelColor;
-+            return this;
-+        }
-+
-+        /**
-+         * Sets the color of tab's slots.
-+         */
-+        public CreativeModeTab.Builder withSlotColor(int slotColor) {
-+            this.slotColor = slotColor;
 +            return this;
 +        }
 +


### PR DESCRIPTION
This PR closes #2889 by removing `AbstractContainerScreen#slotColor` and corresponding patches, particularly to `CreativeModeTab`. The highlight for hovered slots was changed from a drawn color overlay to nine-sliced textures.

This also renames the nearby getters (all the way from MinecraftForge/MinecraftForge#3440) to match their corresponding fields. If wanted, we can move this change to a separate PR, but I did it here because we're already making a breaking change by removing `slotColor`.



