### PR TITLE
Replace leather in vanilla recipes with c:leathers

### DIFF
--- a/src/generated/resources/data/minecraft/recipe/black_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/black_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:black_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:black_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/blue_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/blue_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:blue_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:blue_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/book.json
+++ b/src/generated/resources/data/minecraft/recipe/book.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    "minecraft:paper",
+    "minecraft:paper",
+    "minecraft:paper",
+    "#c:leathers"
+  ],
+  "result": {
+    "id": "minecraft:book"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/brown_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/brown_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:brown_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:brown_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/bundle.json
+++ b/src/generated/resources/data/minecraft/recipe/bundle.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shaped",
   "category": "equipment",
   "key": {
-    "#": "minecraft:leather",
+    "#": "#c:leathers",
     "-": "#c:strings"
   },
   "pattern": [

--- a/src/generated/resources/data/minecraft/recipe/cyan_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/cyan_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:cyan_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:cyan_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/gray_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/gray_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:gray_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:gray_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/green_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/green_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:green_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:green_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/leather_boots.json
+++ b/src/generated/resources/data/minecraft/recipe/leather_boots.json
@@ -1,16 +1,14 @@
 {
   "type": "minecraft:crafting_shaped",
-  "category": "misc",
+  "category": "equipment",
   "key": {
-    "#": "#c:rods/wooden",
     "X": "#c:leathers"
   },
   "pattern": [
-    "###",
-    "#X#",
-    "###"
+    "X X",
+    "X X"
   ],
   "result": {
-    "id": "minecraft:item_frame"
+    "id": "minecraft:leather_boots"
   }
 }

--- a/src/generated/resources/data/minecraft/recipe/leather_chestplate.json
+++ b/src/generated/resources/data/minecraft/recipe/leather_chestplate.json
@@ -1,16 +1,15 @@
 {
   "type": "minecraft:crafting_shaped",
-  "category": "misc",
+  "category": "equipment",
   "key": {
-    "#": "#c:rods/wooden",
     "X": "#c:leathers"
   },
   "pattern": [
-    "###",
-    "#X#",
-    "###"
+    "X X",
+    "XXX",
+    "XXX"
   ],
   "result": {
-    "id": "minecraft:item_frame"
+    "id": "minecraft:leather_chestplate"
   }
 }

--- a/src/generated/resources/data/minecraft/recipe/leather_helmet.json
+++ b/src/generated/resources/data/minecraft/recipe/leather_helmet.json
@@ -1,16 +1,14 @@
 {
   "type": "minecraft:crafting_shaped",
-  "category": "misc",
+  "category": "equipment",
   "key": {
-    "#": "#c:rods/wooden",
     "X": "#c:leathers"
   },
   "pattern": [
-    "###",
-    "#X#",
-    "###"
+    "XXX",
+    "X X"
   ],
   "result": {
-    "id": "minecraft:item_frame"
+    "id": "minecraft:leather_helmet"
   }
 }

--- a/src/generated/resources/data/minecraft/recipe/leather_horse_armor.json
+++ b/src/generated/resources/data/minecraft/recipe/leather_horse_armor.json
@@ -2,15 +2,14 @@
   "type": "minecraft:crafting_shaped",
   "category": "misc",
   "key": {
-    "#": "#c:rods/wooden",
     "X": "#c:leathers"
   },
   "pattern": [
-    "###",
-    "#X#",
-    "###"
+    "X X",
+    "XXX",
+    "X X"
   ],
   "result": {
-    "id": "minecraft:item_frame"
+    "id": "minecraft:leather_horse_armor"
   }
 }

--- a/src/generated/resources/data/minecraft/recipe/leather_leggings.json
+++ b/src/generated/resources/data/minecraft/recipe/leather_leggings.json
@@ -1,16 +1,15 @@
 {
   "type": "minecraft:crafting_shaped",
-  "category": "misc",
+  "category": "equipment",
   "key": {
-    "#": "#c:rods/wooden",
     "X": "#c:leathers"
   },
   "pattern": [
-    "###",
-    "#X#",
-    "###"
+    "XXX",
+    "X X",
+    "X X"
   ],
   "result": {
-    "id": "minecraft:item_frame"
+    "id": "minecraft:leather_leggings"
   }
 }

--- a/src/generated/resources/data/minecraft/recipe/light_blue_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/light_blue_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:light_blue_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:light_blue_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/light_gray_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/light_gray_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:light_gray_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:light_gray_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/lime_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/lime_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:lime_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:lime_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/magenta_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/magenta_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:magenta_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:magenta_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/orange_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/orange_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:orange_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:orange_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/pink_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/pink_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:pink_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:pink_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/purple_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/purple_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:purple_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:purple_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/red_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/red_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:red_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:red_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/saddle.json
+++ b/src/generated/resources/data/minecraft/recipe/saddle.json
@@ -3,7 +3,7 @@
   "category": "equipment",
   "key": {
     "#": "#c:ingots/iron",
-    "X": "minecraft:leather"
+    "X": "#c:leathers"
   },
   "pattern": [
     " X ",

--- a/src/generated/resources/data/minecraft/recipe/white_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/white_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:white_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:white_harness"
+  }
+}

--- a/src/generated/resources/data/minecraft/recipe/yellow_harness.json
+++ b/src/generated/resources/data/minecraft/recipe/yellow_harness.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "harness",
+  "key": {
+    "#": "minecraft:yellow_wool",
+    "G": "minecraft:glass",
+    "L": "#c:leathers"
+  },
+  "pattern": [
+    "LLL",
+    "G#G"
+  ],
+  "result": {
+    "id": "minecraft:yellow_harness"
+  }
+}

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeRecipeProvider.java
@@ -96,6 +96,7 @@ public final class NeoForgeRecipeProvider extends VanillaRecipeProvider {
         replace(Items.EGG, Tags.Items.EGGS);
         replace(Items.STRING, Tags.Items.STRINGS);
         exclude(getConversionRecipeName(Blocks.WHITE_WOOL, Items.STRING));
+        replace(Items.LEATHER, Tags.Items.LEATHERS);
 
         exclude(Blocks.GOLD_BLOCK);
         exclude(Items.GOLD_NUGGET);


### PR DESCRIPTION
This PR implements and closes #2852 by replacing uses of `minecraft:leather` in vanilla recipes with `c:leathers`.