### PR TITLE
Clear memoized biome generation settings in FlatLevelSource

### DIFF
--- a/patches/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
@@ -1,12 +1,28 @@
 --- a/net/minecraft/world/level/levelgen/FlatLevelSource.java
 +++ b/net/minecraft/world/level/levelgen/FlatLevelSource.java
-@@ -32,7 +_,8 @@
+@@ -30,9 +_,11 @@
+         i -> i.group(FlatLevelGeneratorSettings.CODEC.fieldOf("settings").forGetter(FlatLevelSource::settings)).apply(i, i.stable(FlatLevelSource::new))
+     );
      private final FlatLevelGeneratorSettings settings;
++    // Neo: Store the memoized generation settings getter, so the cache can be cleared later
++    private final net.neoforged.neoforge.common.util.MemoizedFunction<Holder<net.minecraft.world.level.biome.Biome>, net.minecraft.world.level.biome.BiomeGenerationSettings> generationSettingsGetter;
  
      public FlatLevelSource(FlatLevelGeneratorSettings generatorSettings) {
 -        super(new FixedBiomeSource(generatorSettings.getBiome()), Util.memoize(generatorSettings::adjustGenerationSettings));
-+        // Neo: Do not memorize the generationSettingsGetter, since it may be modified by biome modifiers
-+        super(new FixedBiomeSource(generatorSettings.getBiome()), generatorSettings::adjustGenerationSettings);
++        super(new FixedBiomeSource(generatorSettings.getBiome()), this.generationSettingsGetter = net.neoforged.neoforge.common.util.MemoizedFunction.of(generatorSettings::adjustGenerationSettings));
          this.settings = generatorSettings;
      }
  
+@@ -142,5 +_,12 @@
+     @Override
+     public int getSeaLevel() {
+         return -63;
++    }
++
++    // Neo: clear the cache for the generation settings getter on refresh
++    @Override
++    public void refreshFeaturesPerStep() {
++        super.refreshFeaturesPerStep();
++        this.generationSettingsGetter.clear();
+     }
+ }

--- a/patches/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/world/level/levelgen/FlatLevelSource.java
++++ b/net/minecraft/world/level/levelgen/FlatLevelSource.java
+@@ -32,7 +_,8 @@
+     private final FlatLevelGeneratorSettings settings;
+ 
+     public FlatLevelSource(FlatLevelGeneratorSettings generatorSettings) {
+-        super(new FixedBiomeSource(generatorSettings.getBiome()), Util.memoize(generatorSettings::adjustGenerationSettings));
++        // Neo: Do not memorize the generationSettingsGetter, since it may be modified by biome modifiers
++        super(new FixedBiomeSource(generatorSettings.getBiome()), generatorSettings::adjustGenerationSettings);
+         this.settings = generatorSettings;
+     }
+ 

--- a/src/main/java/net/neoforged/neoforge/common/util/MemoizedFunction.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/MemoizedFunction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.common.util;
 
 import java.util.Map;

--- a/src/main/java/net/neoforged/neoforge/common/util/MemoizedFunction.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/MemoizedFunction.java
@@ -1,0 +1,45 @@
+package net.neoforged.neoforge.common.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/// A memoized proxy wrapping a function, with a clearable cache of values.
+///
+/// Once the function is called with a given key, the returned value is cached and reused until the cache is cleared.
+///
+/// @see net.minecraft.util.Util#memoize(Function)
+public class MemoizedFunction<T, R> implements Function<T, R> {
+    /// Wraps and memoizes the given function.
+    ///
+    /// @param function the function to be wrapped
+    /// @return the memoized function
+    public static <T, R> MemoizedFunction<T, R> of(Function<T, R> function) {
+        return new MemoizedFunction<>(function, new ConcurrentHashMap<>());
+    }
+
+    protected final Function<T, R> function;
+    protected final Map<T, R> cache;
+
+    protected MemoizedFunction(Function<T, R> function, Map<T, R> cache) {
+        this.function = function;
+        this.cache = cache;
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public R apply(T t) {
+        return cache.computeIfAbsent(t, function);
+    }
+
+    /// {@inheritDoc}
+    @Override
+    public String toString() {
+        return "memoize/1[function=" + function + ", size=" + this.cache.size() + "]";
+    }
+
+    /// Clears the cache of this memoized function.
+    public void clear() {
+        this.cache.clear();
+    }
+}


### PR DESCRIPTION
This PR fixes #2902 by modifying `FlatLevelSource` to ~~not memoize its biome generation settings~~ use a new memoized function for its biome generation settings which is cleared on refresh.

An alternative fix would be to create a system whereby a memorized function can have its cache be cleared externally. This was my original solution before I tossed it in favor of this simpler solution. **EDIT:** This fix has been implemented.