### PR TITLE
Skip invisible children in item_render_order of composite model

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/CompositeModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/CompositeModel.java
@@ -86,8 +86,11 @@ public class CompositeModel implements IUnbakedGeometry<CompositeModel> {
         var itemPassesBuilder = ImmutableList.<BakedModel>builder();
         for (String name : this.itemPasses) {
             var model = bakedParts.get(name);
-            if (model == null)
+            if (model == null) {
+                if (!context.isComponentVisible(name, true))
+                    continue;
                 throw new IllegalStateException("Specified \"" + name + "\" in \"item_render_order\", but that is not a child of this model.");
+            }
             itemPassesBuilder.add(model);
         }
 


### PR DESCRIPTION
This PR fixes #3007 by making `CompositeModel` skip invisible children when iterating through the model names listed in `item_render_order`.