### PR TITLE
FML Support for JST enum extension

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,13 +34,13 @@ asm_version=9.9.1
 mergetool_version=2.0.0
 accesstransformers_version=11.0.1
 eventbus_version=8.0.2
-mixin_version=0.17.0+mixin.0.8.7
+mixin_version=0.17.1+mixin.0.8.7
 terminalconsoleappender_version=1.3.0
 nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=11.0.5
+fancy_mod_loader_version=11.0.18-pr-412-strip-jst-injected-enum-entries
 typetools_version=0.6.3
 mixin_extras_version=0.5.3
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,15 @@ dependencyResolutionManagement {
     rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
     repositories {
         mavenCentral()
+        maven {
+            name = "Maven for PR #412" // https://github.com/neoforged/FancyModLoader/pull/412
+            url = uri("https://prmaven.neoforged.net/FancyModLoader/pr412")
+            content {
+                includeModule("net.neoforged.fancymodloader", "earlydisplay")
+                includeModule("net.neoforged.fancymodloader", "junit-fml")
+                includeModule("net.neoforged.fancymodloader", "loader")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR just bumps FML to the PR-published version, for the sake of testing.

**MAINTAINER'S NOTE**: See https://github.com/neoforged/FancyModLoader/pull/412.