### PR TITLE
[26.1] Remove broken PoseStack from AddSectionGeometryEvent.SectionRenderingContext

### DIFF
--- a/patches/net/minecraft/client/renderer/chunk/SectionCompiler.java.patch
+++ b/patches/net/minecraft/client/renderer/chunk/SectionCompiler.java.patch
@@ -24,7 +24,7 @@
              }
          }
  
-+        net.neoforged.neoforge.client.ClientHooks.addAdditionalGeometry(additionalRenderers, layer -> this.getOrBeginLayer(startedLayers, builders, layer), region, blockRenderer, minPos);
++        net.neoforged.neoforge.client.ClientHooks.addAdditionalGeometry(additionalRenderers, layer -> this.getOrBeginLayer(startedLayers, builders, layer), region, blockRenderer);
          for (Entry<ChunkSectionLayer, BufferBuilder> entry : startedLayers.entrySet()) {
              ChunkSectionLayer layer = entry.getKey();
              MeshData mesh = entry.getValue().build();

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -810,12 +810,11 @@ public class ClientHooks {
             List<AddSectionGeometryEvent.AdditionalSectionRenderer> additionalRenderers,
             Function<ChunkSectionLayer, VertexConsumer> getOrCreateBuilder,
             RenderSectionRegion region,
-            ModelBlockRenderer blockRenderer,
-            BlockPos sectionOrigin) {
+            ModelBlockRenderer blockRenderer) {
         if (additionalRenderers.isEmpty()) {
             return;
         }
-        final var context = new AddSectionGeometryEvent.SectionRenderingContext(getOrCreateBuilder, region, blockRenderer, sectionOrigin);
+        final var context = new AddSectionGeometryEvent.SectionRenderingContext(getOrCreateBuilder, region, blockRenderer);
         for (final var renderer : additionalRenderers) {
             renderer.render(context);
         }

--- a/src/client/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/AddSectionGeometryEvent.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.client.event;
 
 import com.google.common.base.Preconditions;
-import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,25 +106,17 @@ public class AddSectionGeometryEvent extends Event {
         private final Function<ChunkSectionLayer, VertexConsumer> getOrCreateLayer;
         private final BlockAndTintGetter region;
         private final ModelBlockRenderer blockRenderer;
-        private final PoseStack poseStack;
 
         /**
          * @param getOrCreateLayer a function that, given a "chunk render type", returns the corresponding buffer and
          *                         adds it to the section if it is not already present.
          * @param region           a view of the section and some surrounding blocks
          * @param blockRenderer    the block renderer to use for rendering block models
-         * @param sectionOrigin    the origin of the chunk section being rendered
          */
-        public SectionRenderingContext(
-                Function<ChunkSectionLayer, VertexConsumer> getOrCreateLayer,
-                BlockAndTintGetter region,
-                ModelBlockRenderer blockRenderer,
-                BlockPos sectionOrigin) {
+        public SectionRenderingContext(Function<ChunkSectionLayer, VertexConsumer> getOrCreateLayer, BlockAndTintGetter region, ModelBlockRenderer blockRenderer) {
             this.getOrCreateLayer = getOrCreateLayer;
             this.region = region;
             this.blockRenderer = blockRenderer;
-            this.poseStack = new PoseStack();
-            this.poseStack.translate(sectionOrigin.getX(), sectionOrigin.getY(), sectionOrigin.getZ());
         }
 
         /**
@@ -137,11 +128,6 @@ public class AddSectionGeometryEvent extends Event {
          */
         public VertexConsumer getOrCreateChunkBuffer(ChunkSectionLayer layer) {
             return getOrCreateLayer.apply(layer);
-        }
-
-        /// Returns the [PoseStack] to use, initially set to the chunk origin at unit scaling and no rotation.
-        public PoseStack getPoseStack() {
-            return poseStack;
         }
 
         public ModelBlockRenderer getBlockRenderer() {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/client/ClientEventTests.java
@@ -101,7 +101,7 @@ public class ClientEventTests {
         });
     }
 
-    @TestHolder(description = { "Tests if adding custom geometry to chunks works", "When the message \"diamond block\" is sent in chat, this should render a fake diamond block above the player's position" })
+    @TestHolder(description = { "Tests if adding custom geometry to chunks works", "When the message \"diamond block\" is sent in chat, this should render a fake diamond block above the player's position" }, enabledByDefault = true)
     static void addSectionGeometryTest(final ClientChatEvent chatEvent, final DynamicTest test) {
         if (chatEvent.getMessage().equalsIgnoreCase("diamond block")) {
             var player = Minecraft.getInstance().player;
@@ -111,12 +111,6 @@ public class ClientEventTests {
             NeoForge.EVENT_BUS.addListener((final AddSectionGeometryEvent event) -> {
                 if (event.getSectionOrigin().equals(sectionOrigin)) {
                     event.addRenderer(context -> {
-                        var poseStack = context.getPoseStack();
-                        poseStack.pushPose();
-                        poseStack.translate(
-                                testBlockAt.getX() - sectionOrigin.getX(),
-                                testBlockAt.getY() - sectionOrigin.getY(),
-                                testBlockAt.getZ() - sectionOrigin.getZ());
                         BlockQuadOutput quadOutput = (x, y, z, quad, instance) -> {
                             VertexConsumer builder = context.getOrCreateChunkBuffer(quad.materialInfo().layer());
                             builder.putBlockBakedQuad(x, y, z, quad, instance);
@@ -131,7 +125,6 @@ public class ClientEventTests {
                                 Blocks.DIAMOND_BLOCK.defaultBlockState(),
                                 Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(Blocks.DIAMOND_BLOCK.defaultBlockState()),
                                 0);
-                        poseStack.popPose();
                     });
                 }
             });


### PR DESCRIPTION
This PR removes the broken `PoseStack` from the `AddSectionGeometryEvent.SectionRenderingContext`.
After vanilla stopped using a `PoseStack` in chunk meshing, the event was incorrectly ported to provide a `PoseStack` that is translated to the origin of the chunk section being compiled. This causes geometry rendered at section-relative coordinates with the provided `PoseStack` to render outside of the section. The `PoseStack` is being removed entirely to align with vanilla's approach of specifying the full coordinates in the `VertexConsumer#addVertex()` call instead of translating to the origin of the object to be rendered and only specifying the offsets from that origin in the `addVertex()` call.