### PR TITLE
Various fixes to damage pipeline events

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -441,7 +441,7 @@
                  }
  
                  return damage;
-@@ -1896,21 +_,36 @@
+@@ -1896,21 +_,37 @@
  
      protected void actuallyHurt(ServerLevel level, DamageSource source, float dmg) {
          if (!this.isInvulnerableTo(level, source)) {
@@ -450,6 +450,7 @@
 -            float var10 = Math.max(dmg - this.getAbsorptionAmount(), 0.0F);
 -            this.setAbsorptionAmount(this.getAbsorptionAmount() - (dmg - var10));
 -            float absorbedDamage = dmg - var10;
++            // Neo (ImplNote): Keep this in-sync with the equivalent patches in Player#actuallyHurt.
 +            // Neo: Primary damage pipeline hooks. Compute the armor and enchantment reductions against the "original" damage, and then fire LivingDamageEvent.Pre
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ARMOR, this.damageContainers.peek().getNewDamage() - this.getDamageAfterArmorAbsorb(source, this.damageContainers.peek().getNewDamage()));
 +            this.getDamageAfterMagicAbsorb(source, this.damageContainers.peek().getNewDamage());

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -235,10 +235,11 @@
              this.resolveMobResponsibleForDamage(source);
              this.resolvePlayerResponsibleForDamage(source);
              if (tookFullDamage) {
-@@ -1267,6 +_,7 @@
+@@ -1267,6 +_,8 @@
                  CriteriaTriggers.PLAYER_HURT_ENTITY.trigger(sourcePlayer, this, source, damage, damage, blocked);
              }
  
++            net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek());
 +            this.damageContainers.pop();
              return success;
          }
@@ -448,7 +449,7 @@
                  this.gameEvent(GameEvent.ENTITY_DAMAGE);
 +                this.onDamageTaken(this.damageContainers.peek());
              }
-+            net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek());
++            // Neo: Note that the LivingDamageEvent.Post is fired from LivingEntity#hurtServer later in the call stack.
          }
      }
  

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -190,55 +190,73 @@
          float health = this.getHealth();
          if (health > 0.0F) {
              this.setHealth(health + heal);
-@@ -1156,11 +_,14 @@
+@@ -1156,11 +_,18 @@
          } else if (source.is(DamageTypeTags.IS_FIRE) && this.hasEffect(MobEffects.FIRE_RESISTANCE)) {
              return false;
          } else {
 +            this.damageContainers.push(new net.neoforged.neoforge.common.damagesource.DamageContainer(source, damage));
-+            if (net.neoforged.neoforge.common.CommonHooks.onEntityIncomingDamage(this, this.damageContainers.peek())) return false;
++            if (net.neoforged.neoforge.common.CommonHooks.onEntityIncomingDamage(this, this.damageContainers.peek())) {
++                this.damageContainers.pop();
++                return false;
++            }
++
              if (this.isSleeping()) {
                  this.stopSleeping();
              }
  
              this.noActionTime = 0;
-+            damage = this.damageContainers.peek().getNewDamage(); //Neo: enforce damage container as source of truth for damage amount
++            damage = this.damageContainers.peek().getNewDamage(); // Neo: enforce damage container as source of truth for damage amount
              if (damage < 0.0F) {
                  damage = 0.0F;
              }
-@@ -1181,24 +_,28 @@
+@@ -1181,24 +_,38 @@
              if (Float.isNaN(damage) || Float.isInfinite(damage)) {
                  damage = Float.MAX_VALUE;
              }
-+            this.damageContainers.peek().setNewDamage(damage); //update container with vanilla changes
++            this.damageContainers.peek().setNewDamage(damage); // Update container with vanilla changes
  
              boolean tookFullDamage = true;
              if (this.invulnerableTime > 10.0F && !source.is(DamageTypeTags.BYPASSES_COOLDOWN)) {
                  if (damage <= this.lastHurt) {
++                    // Neo: Pop the container when vanilla would abort the incoming damage due to the invulnerability ticks.
 +                    this.damageContainers.pop();
                      return false;
                  }
  
++                // If we are going to do damage despite invulnerability (due to the damage being higher than prior), we need to setup the container differently.
++                this.damageContainers.peek().setPostAttackInvulnerabilityTicks(this.invulnerableTime);
 +                this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.INVULNERABILITY, this.lastHurt);
                  this.actuallyHurt(level, source, damage - this.lastHurt);
-                 this.lastHurt = damage;
+-                this.lastHurt = damage;
++                // Vanilla updates lastHurt to the local var `damage`, but we throw an event in actuallyHurt that might mess with the damage.
++                // Also, since we're in the "damage while invuln is active" block, we need to make sure we don't reduce the lastHurt amount.
++                this.lastHurt = java.lang.Math.max(this.lastHurt, this.damageContainers.peek().getInflictedDamage());
++                this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
                  tookFullDamage = false;
              } else {
-                 this.lastHurt = damage;
+-                this.lastHurt = damage;
 -                this.invulnerableTime = 20;
-+                this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
                  this.actuallyHurt(level, source, damage);
++                this.lastHurt = this.damageContainers.peek().getInflictedDamage();
++                this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
                  this.hurtDuration = 10;
                  this.hurtTime = this.hurtDuration;
              }
  
-+            damage = this.damageContainers.peek().getNewDamage(); //update local with container value
++            // Neo: Note that we don't update the local tookFullDamage.
++            //      Its name doesn't really mean that, and it is instead used to track if we're inside the invuln block above.
++            //      Also, we need to update the `damage` local with the post-Pre-event value.
++            damage = this.damageContainers.peek().getInflictedDamage();
++
              this.resolveMobResponsibleForDamage(source);
              this.resolvePlayerResponsibleForDamage(source);
              if (tookFullDamage) {
-@@ -1267,6 +_,8 @@
+@@ -1267,6 +_,10 @@
                  CriteriaTriggers.PLAYER_HURT_ENTITY.trigger(sourcePlayer, this, source, damage, damage, blocked);
              }
  
++            // Neo: Fire our post-damage event hooks. As usual, fire the extension method first, then the event version.
++            this.onDamageTaken(this.damageContainers.peek());
 +            net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek());
 +            this.damageContainers.pop();
              return success;
@@ -290,14 +308,15 @@
                      protectionItem = itemStack.copy();
                      itemStack.shrink(1);
                      break;
-@@ -1415,6 +_,7 @@
-     }
+@@ -1416,6 +_,8 @@
  
      public void die(DamageSource source) {
-+        if (net.neoforged.neoforge.common.CommonHooks.onLivingDeath(this, source)) return;
          if (!this.isRemoved() && !this.dead) {
++            // Neo: Fire the LivingDeathEvent after validating that the entity isn't already dead, but before trying to kill it.
++            if (net.neoforged.neoforge.common.CommonHooks.onLivingDeath(this, source)) return;
              Entity sourceEntity = source.getEntity();
              LivingEntity killer = this.getKillCredit();
+             if (killer != null) {
 @@ -1451,7 +_,7 @@
          if (this.level() instanceof ServerLevel serverLevel) {
              boolean var6 = false;
@@ -422,7 +441,7 @@
                  }
  
                  return damage;
-@@ -1896,11 +_,13 @@
+@@ -1896,21 +_,36 @@
  
      protected void actuallyHurt(ServerLevel level, DamageSource source, float dmg) {
          if (!this.isInvulnerableTo(level, source)) {
@@ -431,9 +450,20 @@
 -            float var10 = Math.max(dmg - this.getAbsorptionAmount(), 0.0F);
 -            this.setAbsorptionAmount(this.getAbsorptionAmount() - (dmg - var10));
 -            float absorbedDamage = dmg - var10;
++            // Neo: Primary damage pipeline hooks. Compute the armor and enchantment reductions against the "original" damage, and then fire LivingDamageEvent.Pre
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ARMOR, this.damageContainers.peek().getNewDamage() - this.getDamageAfterArmorAbsorb(source, this.damageContainers.peek().getNewDamage()));
 +            this.getDamageAfterMagicAbsorb(source, this.damageContainers.peek().getNewDamage());
++
++            // LivingDamageEvent.Pre is then able to mutate the container to change the reductions and change the "real" damage that will be inflicted.
 +            float damage = net.neoforged.neoforge.common.CommonHooks.onLivingDamagePre(this, this.damageContainers.peek());
++            // Throw an exception if someone kills the entity during Pre. Vanilla is going to kill any entity which isDeadOrDying() when it bubbles back up to hurtServer, so it dying early is invalid.
++            com.google.common.base.Preconditions.checkArgument(!this.dead, "It is invalid to have killed an entity during LivingDamageEvent.Pre. Use LivingIncomingDamageEvent or LivingDamageEvent.Post instead.");
++
++            // Store a copy of the "true" inflicted damage so we can propagate it back to hurtServer.
++            this.damageContainers.peek().captureInflictedDamage();
++
++            // Next we attribute damage to absorption hearts. We record the amount blocked by absorption in the container for later calculations.
++            // Mods reduction functions may adjust the split of damage between absorption and health, so we need to first apply the reductions and then compute the amounts that go to each pool.
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ABSORPTION, Math.min(this.getAbsorptionAmount(), damage));
 +            float absorbedDamage = Math.min(damage, this.damageContainers.peek().getReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ABSORPTION));
 +            this.setAbsorptionAmount(Math.max(0, this.getAbsorptionAmount() - absorbedDamage));
@@ -441,15 +471,16 @@
              if (absorbedDamage > 0.0F && absorbedDamage < 3.4028235E37F && source.getEntity() instanceof ServerPlayer serverPlayer) {
                  serverPlayer.awardStat(Stats.DAMAGE_DEALT_ABSORBED, Math.round(absorbedDamage * 10.0F));
              }
-@@ -1908,9 +_,10 @@
+ 
++            // Last thing here, inflict damage to the entity's health, based on how much damage is remaining after absorption has been processes.
              if (var10 != 0.0F) {
                  this.getCombatTracker().recordDamage(source, var10);
                  this.setHealth(this.getHealth() - var10);
 -                this.setAbsorptionAmount(this.getAbsorptionAmount() - var10);
                  this.gameEvent(GameEvent.ENTITY_DAMAGE);
-+                this.onDamageTaken(this.damageContainers.peek());
              }
-+            // Neo: Note that the LivingDamageEvent.Post is fired from LivingEntity#hurtServer later in the call stack.
++
++            // Neo: Now we go back to hurtServer, where we'll update various metadata fields, process the side effects of damage (i.e. killing the entity), and firing LivingDamageEvent.Post
          }
      }
  

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -143,16 +143,14 @@
              if (absorbedDamage > 0.0F && absorbedDamage < 3.4028235E37F) {
                  this.awardStat(Stats.DAMAGE_ABSORBED, Math.round(absorbedDamage * 10.0F));
              }
-@@ -760,7 +_,9 @@
+@@ -760,6 +_,7 @@
                  }
  
                  this.gameEvent(GameEvent.ENTITY_DAMAGE);
 +                this.onDamageTaken(this.damageContainers.peek());
              }
-+            net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek());
          }
      }
- 
 @@ -816,6 +_,8 @@
  
              return InteractionResult.PASS;

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -123,7 +123,7 @@
                      if (level.getDifficulty() == Difficulty.PEACEFUL) {
                          damage = 0.0F;
                      }
-@@ -742,11 +_,14 @@
+@@ -742,15 +_,31 @@
      @Override
      protected void actuallyHurt(ServerLevel level, DamageSource source, float dmg) {
          if (!this.isInvulnerableTo(level, source)) {
@@ -132,9 +132,21 @@
 -            float var8 = Math.max(dmg - this.getAbsorptionAmount(), 0.0F);
 -            this.setAbsorptionAmount(this.getAbsorptionAmount() - (dmg - var8));
 -            float absorbedDamage = dmg - var8;
++            // Neo (ImplNote): Keep this in-sync with the equivalent patches in LivingEntity#actuallyHurt.
++            // Neo: Primary damage pipeline hooks. Compute the armor and enchantment reductions against the "original" damage, and then fire LivingDamageEvent.Pre
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ARMOR, this.damageContainers.peek().getNewDamage() - this.getDamageAfterArmorAbsorb(source, this.damageContainers.peek().getNewDamage()));
 +            this.getDamageAfterMagicAbsorb(source, this.damageContainers.peek().getNewDamage());
++
++            // LivingDamageEvent.Pre is then able to mutate the container to change the reductions and change the "real" damage that will be inflicted.
 +            float damage = net.neoforged.neoforge.common.CommonHooks.onLivingDamagePre(this, this.damageContainers.peek());
++            // Throw an exception if someone kills the entity during Pre. Vanilla is going to kill any entity which isDeadOrDying() when it bubbles back up to hurtServer, so it dying early is invalid.
++            com.google.common.base.Preconditions.checkArgument(!this.dead, "It is invalid to have killed an entity during LivingDamageEvent.Pre. Use LivingIncomingDamageEvent or LivingDamageEvent.Post instead.");
++
++            // Store a copy of the "true" inflicted damage so we can propagate it back to hurtServer.
++            this.damageContainers.peek().captureInflictedDamage();
++
++            // Next we attribute damage to absorption hearts. We record the amount blocked by absorption in the container for later calculations.
++            // Mods reduction functions may adjust the split of damage between absorption and health, so we need to first apply the reductions and then compute the amounts that go to each pool.
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ABSORPTION, Math.min(this.getAbsorptionAmount(), damage));
 +            float absorbed = Math.min(damage, this.damageContainers.peek().getReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.ABSORPTION));
 +            this.setAbsorptionAmount(Math.max(0, this.getAbsorptionAmount() - absorbed));
@@ -143,14 +155,20 @@
              if (absorbedDamage > 0.0F && absorbedDamage < 3.4028235E37F) {
                  this.awardStat(Stats.DAMAGE_ABSORBED, Math.round(absorbedDamage * 10.0F));
              }
-@@ -760,6 +_,7 @@
-                 }
+ 
++            // Last thing here, inflict damage to the entity's health, based on how much damage is remaining after absorption has been processes.
+             if (var8 != 0.0F) {
+                 this.causeFoodExhaustion(source.getFoodExhaustion());
+                 this.getCombatTracker().recordDamage(source, var8);
+@@ -761,6 +_,8 @@
  
                  this.gameEvent(GameEvent.ENTITY_DAMAGE);
-+                this.onDamageTaken(this.damageContainers.peek());
              }
++
++            // Neo: Now we go back to hurtServer, where we'll update various metadata fields, process the side effects of damage (i.e. killing the entity), and firing LivingDamageEvent.Post
          }
      }
+ 
 @@ -816,6 +_,8 @@
  
              return InteractionResult.PASS;

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common;
 
 import com.google.common.base.CaseFormat;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -301,10 +302,12 @@ public class CommonHooks {
      * @param entity    the entity to receive damage
      * @param container the newly instantiated container for damage to be dealt. Most properties of
      *                  the container will be empty at this stage.
-     * @return if the event is cancelled and no damage will be applied to the entity
+     * @return if the event is cancelled or the entity was killed during the event. If true, further processing stops and no damage will be applied to the entity
      */
     public static boolean onEntityIncomingDamage(LivingEntity entity, DamageContainer container) {
-        return NeoForge.EVENT_BUS.post(new LivingIncomingDamageEvent(entity, container)).isCanceled();
+        Preconditions.checkArgument(!entity.isDeadOrDying(), "The LivingIncomingDamageEvent cannot be fired with a dead entity.");
+        var event = NeoForge.EVENT_BUS.post(new LivingIncomingDamageEvent(entity, container));
+        return event.isCanceled() || entity.isDeadOrDying();
     }
 
     public static LivingKnockBackEvent onLivingKnockBack(LivingEntity target, float strength, double ratioX, double ratioZ) {

--- a/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
+++ b/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
@@ -5,10 +5,12 @@
 
 package net.neoforged.neoforge.common.damagesource;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.neoforge.event.entity.EntityInvulnerabilityCheckEvent;
 import net.neoforged.neoforge.event.entity.living.LivingDamageEvent;
@@ -60,6 +62,7 @@ public class DamageContainer {
     private float blockedDamage = 0f;
     private float shieldDamage = 0;
     private int invulnerabilityTicksAfterAttack = 20;
+    private float inflictedDamage = 0;
 
     public DamageContainer(DamageSource source, float originalDamage) {
         this.source = source;
@@ -85,6 +88,7 @@ public class DamageContainer {
      * @param damage the amount to harm this entity at the end of the damage sequence
      */
     public void setNewDamage(float damage) {
+        Preconditions.checkArgument(damage >= 0.0F, "Damage cannot be negative.");
         this.newDamage = damage;
     }
 
@@ -128,6 +132,7 @@ public class DamageContainer {
      * @param ticks Ticks of invulnerability after this damage sequence
      */
     public void setPostAttackInvulnerabilityTicks(int ticks) {
+        Preconditions.checkArgument(ticks > 0, "Ticks cannot be negative.");
         this.invulnerabilityTicksAfterAttack = ticks;
     }
 
@@ -155,7 +160,7 @@ public class DamageContainer {
         if (event.getBlocked()) {
             this.blockedDamage = event.getBlockedDamage();
             this.shieldDamage = event.shieldDamage();
-            this.newDamage -= this.blockedDamage;
+            this.newDamage = Math.max(this.newDamage - this.blockedDamage, 0);
         }
     }
 
@@ -163,7 +168,27 @@ public class DamageContainer {
     public void setReduction(Reduction reduction, float amount) {
         float modifiedReduction = modifyReduction(reduction, amount);
         this.reductions.put(reduction, modifiedReduction);
-        this.newDamage -= modifiedReduction;
+        this.newDamage = Math.max(this.newDamage - modifiedReduction, 0);
+    }
+
+    /**
+     * Captures the "true" inflicted damage, which is the authoritative amount of damage dealt after {@link LivingDamageEvent.Pre}.
+     * <p>
+     * This will never be called if the entity is invulnerable to the damage, which leaves the inflicted damage (correctly) at zero.
+     */
+    @ApiStatus.Internal
+    public void captureInflictedDamage() {
+        this.inflictedDamage = this.getNewDamage();
+    }
+
+    /**
+     * Returns the "true" inflicted damage so we can bubble it back up to {@link LivingEntity#lastHurt} after actuallyHurt() completes.
+     * <p>
+     * Not doing a capture of the value means we have to try and reverse engineer the value from the new damage and the amount that was soaked by absorption hearts.
+     */
+    @ApiStatus.Internal
+    public float getInflictedDamage() {
+        return this.inflictedDamage;
     }
 
     private float modifyReduction(Reduction type, float reduction) {

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java
@@ -97,7 +97,8 @@ public abstract class LivingDamageEvent extends LivingEvent {
     public static class Post extends LivingDamageEvent {
         private final float originalDamage;
         private final DamageSource source;
-        private final float newDamage;
+        private final float inflictedDamage;
+        private final float healthDamage;
         private final float blockedDamage;
         private final float shieldDamage;
         private final int postAttackInvulnerabilityTicks;
@@ -107,7 +108,8 @@ public abstract class LivingDamageEvent extends LivingEvent {
             super(entity);
             this.originalDamage = container.getOriginalDamage();
             this.source = container.getSource();
-            this.newDamage = container.getNewDamage();
+            this.inflictedDamage = container.getInflictedDamage();
+            this.healthDamage = container.getNewDamage();
             this.blockedDamage = container.getBlockedDamage();
             this.shieldDamage = container.getShieldDamage();
             this.postAttackInvulnerabilityTicks = container.getPostAttackInvulnerabilityTicks();
@@ -126,9 +128,14 @@ public abstract class LivingDamageEvent extends LivingEvent {
             return source;
         }
 
+        /** {@return the amount of damage inflicted to the entity, after all modifications} */
+        public float getInflictedDamage() {
+            return this.inflictedDamage;
+        }
+
         /** {@return the amount of health this entity lost during this sequence} */
-        public float getNewDamage() {
-            return newDamage;
+        public float getHealthDamage() {
+            return this.healthDamage;
         }
 
         /** {@return the amount of damage reduced by a blocking action} */

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/living/LivingEntityEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/living/LivingEntityEventTests.java
@@ -305,7 +305,7 @@ public class LivingEntityEventTests {
         AttachmentType<Float> VALUE_ABSORPTION = reg.attachments().registerSimpleAttachment("absorption_reduction", () -> 0f);
         AttachmentType<Float> VALUE_MOB_EFFECTS = reg.attachments().registerSimpleAttachment("effect_reduction", () -> 0f);
         AttachmentType<Float> VALUE_PRE_POST_DAMAGE = reg.attachments().registerSimpleAttachment("pre_post_damage", () -> 0f);
-        AttachmentType<Float> VALUE_NEW_DAMAGE = reg.attachments().registerSimpleAttachment("new_damage", () -> 0f);
+        AttachmentType<Float> VALUE_HEALTH_DAMAGE = reg.attachments().registerSimpleAttachment("health_damage", () -> 0f);
 
         /* This event listener watches for the first event in the damage sequence.  At this stage we expect to  add our
          * reduction functions and replace the incoming damage amount with a new value. */
@@ -340,7 +340,7 @@ public class LivingEntityEventTests {
         test.eventListeners().forge().addListener((final LivingDamageEvent.Post event) -> {
             if (event.getEntity() instanceof GameTestPlayer player && Objects.equals(player.getCustomName(), NAME)) {
                 player.setData(VALUE_ABSORPTION, event.getReduction(DamageContainer.Reduction.ABSORPTION));
-                player.setData(VALUE_NEW_DAMAGE, event.getNewDamage());
+                player.setData(VALUE_HEALTH_DAMAGE, event.getHealthDamage());
             }
         });
 
@@ -371,8 +371,8 @@ public class LivingEntityEventTests {
                     String playerHealth = formatter.format(player.getHealth());
                     helper.assertTrue(playerHealth.equals("11"), "player health expected 11, actually " + playerHealth);
 
-                    String valueNewDamage = formatter.format(player.getData(VALUE_NEW_DAMAGE));
-                    helper.assertTrue(valueNewDamage.equals("9"), "new damage expected 9, actually " + valueNewDamage);
+                    String valueNewDamage = formatter.format(player.getData(VALUE_HEALTH_DAMAGE));
+                    helper.assertTrue(valueNewDamage.equals("9"), "health damage expected 9, actually " + valueNewDamage);
 
                     String valuePrePostDamage = formatter.format(player.getData(VALUE_PRE_POST_DAMAGE));
                     helper.assertTrue(valuePrePostDamage.equals("9.451"), "damage from sequence before change expected 9.451, actually " + valuePrePostDamage);


### PR DESCRIPTION
## Overview
This PR is composed of various individual fixes to parts of the damage pipeline, due to issues that were discovered in review of the original PR. The original PR text is at the bottom.

## Fixes
1. Moves the firing point of `LivingDamageEvent.Post` and `ILivingEntityExtension#onDamageTaken` to the end of `LivingEntity#hurtServer` instead of `LivingEntity#actuallyHurt`.
    a. This fixes a bug where dealing follow-up damage will try to kill the entity twice.
2. Prevents the `LivingDeathEvent` from re-firing when the target entity is already `this.dead` or `this.removed`. Prior to that it was possible to call `die()` and have an event fire for an invalid entity.
3. Fixes a memory leak in `LivingEntity#hurtServer` caused by returning without popping the latest damage container.
4. Fixes `DamageContainer#setPostAttackInvulnerabilityTicks` not working when dealing follow-up invulnerability tick damage (i.e. when dealing more damage than a previous hit in a 1s window)
5. Fixes `LivingEntity#lastHurt` not reflecting `LivingDamageEvent.Pre`-modified damage.
6. Fixes follow up calculations in `LivingEntity#hurtServer` not reflecting `LivingDamageEvent.Pre`-modified damage. This required adding a new `inflictedDamage` field to `DamageContainer`.
7. Requires that the entity not be killed during `LivingDamageEvent.Pre`. Trying to kill the entity here will screw up the code that is about to run, so we explicitly forbid it. Users can pick the event that runs earlier or later.
8. Fixes `DamageContainer` permitting a negative damage value.
9. Requires that `CommonHooks.onEntityIncomingDamage` not be called with a dead entity.
10. Updates the comments in `actuallyHurt` due to the patch complexity.


___
This PR moves the firing point for the `LivingDamageEvent.Post` from the tail of `LivingEntity#actuallyHurt` to the tail of `LivingEntity#hurtServer`.

The rationale for this is that currently we fire the `Post` event after damage has been dealt, but before the effect of resolving that damage has occurred. Meaning that if you, for example, deal follow-up damage in the `Post` event, you will place the entity into an invalid state and trigger it to `die()` twice and re-run various side effects of taking damage after the entity has died.

The alternative was to add an early bail out in `hurtServer` if `this.dead`, but it makes more sense to move the firing point. Per the event's documentation:

> The fields in this event represent the FINAL values of what was applied to the entity.

At the current firing point (before this change) this isn't even necessarily true, because modifications to the damage container in this step will have actual impacts to the entity's further processing. Even worse, things like `resolveMobResponsibleForDamage` and `resolvePlayerResponsibleForDamage` haven't been called yet, meaning context you would expect to be present in a post-damage hook isn't there.