### PR TITLE
Fix chunk type cache being cleared too early during save

### DIFF
--- a/patches/net/minecraft/server/level/ChunkMap.java.patch
+++ b/patches/net/minecraft/server/level/ChunkMap.java.patch
@@ -8,15 +8,7 @@
              return chunk;
          }
      }
-@@ -518,12 +_,15 @@
-             } else {
-                 ChunkAccess chunk = chunkHolder.getLatestChunk();
-                 if (this.pendingUnloads.remove(pos, chunkHolder) && chunk != null) {
-+                    net.neoforged.neoforge.common.CommonHooks.onChunkUnload(this.poiManager, chunk); // Neo: Must be called for all chunk unloading. Not just LevelChunks.
-+                    this.chunkTypeCache.remove(chunk.getPos().pack()); // Neo: Prevent chunk type cache from permanently retaining data for unloaded chunks
-                     if (chunk instanceof LevelChunk levelChunk) {
-                         levelChunk.setLoaded(false);
-                     }
+@@ -524,9 +_,13 @@
  
                      this.save(chunk);
                      if (chunk instanceof LevelChunk levelChunk) {
@@ -24,6 +16,12 @@
                          this.level.unload(levelChunk);
                      }
  
++                    net.neoforged.neoforge.common.CommonHooks.onChunkUnload(this.poiManager, chunk); // Neo: Must be called for all chunk unloading. Not just LevelChunks.
++                    this.chunkTypeCache.remove(chunk.getPos().pack()); // Neo: Prevent chunk type cache from permanently retaining data for unloaded chunks
++
+                     this.lightEngine.updateChunkStatus(chunk.getPos());
+                     this.lightEngine.tryScheduleUpdate();
+                     this.nextChunkSaveTime.remove(chunk.getPos().pack());
 @@ -566,6 +_,7 @@
                  Profiler.get().incrementCounter("chunkLoad");
                  if (chunkData.isPresent()) {


### PR DESCRIPTION
`save()` reads the chunk type via `isExistingChunkFull()`. Since we were removing the entry from the cache for the chunk *before* it was saved, we forced it to use `readChunk()` to check the type instead of using the cached type as would be done in vanilla. This can cause measurable lag during chunk saves.

This PR fixes the issue by moving our hooks for clearing data to after the save completes.

The fix should also be backported to 1.21.1, as this part of the code has not changed.