### PR TITLE
Fix NPE when getting an Attachment from a fake player

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
@@ -64,6 +64,7 @@ import net.minecraft.network.protocol.game.ServerboundSwingPacket;
 import net.minecraft.network.protocol.game.ServerboundTeleportToEntityPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ClientInformation;
 import net.minecraft.server.level.ServerLevel;
@@ -306,6 +307,11 @@ public class FakePlayer extends ServerPlayer {
 
         @Override
         public void handleChatSessionUpdate(ServerboundChatSessionUpdatePacket packet) {}
+
+        @Override
+        public boolean hasChannel(Identifier payloadId) {
+            return false;
+        }
     }
 
     private static final class FakeConnection extends net.minecraft.network.Connection {


### PR DESCRIPTION
This PR short circuits `hasChannel` on the FakePlayerNetHandler to return false because the connection has no channel and would cause a NPE on the super method.