### PR TITLE
Fix TagEmptyCondition working for loaded-but-empty tags

### DIFF
--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -139,6 +139,19 @@
                  } else {
                      List<Identifier> unboundTags = this.frozenTags
                          .entrySet()
+@@ -452,6 +_,12 @@
+                     return patchedHolder;
+                 }
+ 
++                // Neo: Make the underlying staged tag contents accessible for loading condition evaluation.
++                @Override
++                public Map<TagKey<T>, List<Holder<T>>> contents() {
++                    return pendingContents;
++                }
++
+                 @Override
+                 public void apply() {
+                     pendingTags.forEach((id, tag) -> {
 @@ -463,6 +_,55 @@
                  }
              };

--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -146,7 +146,7 @@
 +                // Neo: Make the underlying staged tag contents accessible for loading condition evaluation.
 +                @Override
 +                public Map<TagKey<T>, List<Holder<T>>> contents() {
-+                    return pendingContents;
++                    return Collections.unmodifiableMap(pendingContents);
 +                }
 +
                  @Override

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ConditionContext.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ConditionContext.java
@@ -5,40 +5,45 @@
 
 package net.neoforged.neoforge.common.conditions;
 
+import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.flag.FeatureFlagSet;
 
 public class ConditionContext implements ICondition.IContext {
-    private final Map<ResourceKey<? extends Registry<?>>, HolderLookup.RegistryLookup<?>> pendingTags;
+    private final Map<TagKey<?>, List<? extends Holder<?>>> pendingContents;
     private final FeatureFlagSet enabledFeatures;
     private final RegistryAccess registryAccess;
 
     public ConditionContext(List<Registry.PendingTags<?>> pendingTags, RegistryAccess registryAccess, FeatureFlagSet enabledFeatures) {
-        this.pendingTags = new IdentityHashMap<>();
+        this.pendingContents = new IdentityHashMap<>();
         this.registryAccess = registryAccess;
         this.enabledFeatures = enabledFeatures;
 
-        for (var tags : pendingTags) {
-            this.pendingTags.put(tags.key(), tags.lookup());
+        for (Registry.PendingTags<?> tags : pendingTags) {
+            this.pendingContents.putAll(tags.contents());
         }
     }
 
     public void clear() {
-        this.pendingTags.clear();
+        this.pendingContents.clear();
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public <T> boolean isTagLoaded(TagKey<T> key) {
-        var lookup = pendingTags.get(key.registry());
-        return lookup != null && lookup.get((TagKey) key).isPresent();
+        return this.pendingContents.containsKey(key);
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public <T> Collection<Holder<T>> getTag(TagKey<T> key) {
+        List<? extends Holder<?>> contents = this.pendingContents.get(key);
+        return contents != null ? (Collection) contents : List.of();
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
@@ -12,10 +12,13 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.MapCodec;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Registry.PendingTags;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.tags.TagKey;
@@ -89,12 +92,27 @@ public interface ICondition {
             public <T> boolean isTagLoaded(TagKey<T> key) {
                 throw new UnsupportedOperationException("Usage of tag-based conditions is not permitted in this context!");
             }
+
+            @Override
+            public <T> Collection<Holder<T>> getTag(TagKey<T> key) {
+                throw new UnsupportedOperationException("Usage of tag-based conditions is not permitted in this context!");
+            }
         };
 
         /**
          * Returns {@code true} if the requested tag is available.
+         * This method does not require that the loaded tag have any elements, only that it be present at all.
          */
         <T> boolean isTagLoaded(TagKey<T> key);
+
+        /**
+         * Returns the contents of the requested tag as loaded from data packs, or an empty collection if
+         * the tag is not loaded. The returned holders are safe to inspect even though the tag has not yet
+         * been bound to its registry (i.e. {@link PendingTags#apply()} has not yet run).
+         */
+        default <T> Collection<Holder<T>> getTag(TagKey<T> key) {
+            return List.of();
+        }
 
         default RegistryAccess registryAccess() {
             return RegistryAccess.EMPTY;

--- a/src/main/java/net/neoforged/neoforge/common/conditions/TagEmptyCondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/TagEmptyCondition.java
@@ -24,7 +24,7 @@ public record TagEmptyCondition<T>(TagKey<T> tag) implements ICondition {
 
     @Override
     public boolean test(ICondition.IContext context) {
-        return !context.isTagLoaded(tag);
+        return context.getTag(this.tag).isEmpty();
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IPendingTagsExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IPendingTagsExtension.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.Registry.PendingTags;
+import net.minecraft.tags.TagKey;
+
+/**
+ * Extension for {@link PendingTags} so that we can inspect tag contents before they are bound.
+ * The {@link HolderSet.Named} returned by {@link PendingTags#lookup()} is not safe to read from until {@link PendingTags#apply()}
+ * has been called. So to counteract that, we have to forward the underlying pending contents.
+ */
+public interface IPendingTagsExtension<T> {
+    /**
+     * {@return the tag contents collected during load, keyed by tag}
+     * This is the raw data before {@link PendingTags#apply()} binds it to the registry's holders.
+     */
+    Map<TagKey<T>, List<Holder<T>>> contents();
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/PendingTagsExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/PendingTagsExtension.java
@@ -17,7 +17,7 @@ import net.minecraft.tags.TagKey;
  * The {@link HolderSet.Named} returned by {@link PendingTags#lookup()} is not safe to read from until {@link PendingTags#apply()}
  * has been called. So to counteract that, we have to forward the underlying pending contents.
  */
-public interface IPendingTagsExtension<T> {
+public interface PendingTagsExtension<T> {
     /**
      * {@return the tag contents collected during load, keyed by tag}
      * This is the raw data before {@link PendingTags#apply()} binds it to the registry's holders.

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -80,6 +80,9 @@
   "net/minecraft/core/Registry": [
     "net/neoforged/neoforge/registries/IRegistryExtension<T>"
   ],
+  "net/minecraft/core/Registry$PendingTags": [
+    "net/neoforged/neoforge/common/extensions/IPendingTagsExtension<T>"
+  ],
   "net/minecraft/core/RegistrySetBuilder$UniversalLookup": [
     "net/minecraft/core/HolderLookup<java.lang.Object>"
   ],

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -81,7 +81,7 @@
     "net/neoforged/neoforge/registries/IRegistryExtension<T>"
   ],
   "net/minecraft/core/Registry$PendingTags": [
-    "net/neoforged/neoforge/common/extensions/IPendingTagsExtension<T>"
+    "net/neoforged/neoforge/common/extensions/PendingTagsExtension<T>"
   ],
   "net/minecraft/core/RegistrySetBuilder$UniversalLookup": [
     "net/minecraft/core/HolderLookup<java.lang.Object>"


### PR DESCRIPTION
This PR forwards some additional information from the tag loaded stage to `ConditionContext`, which permits us to restore the behavior of `TagEmptyCondition`. Currently the condition returns `true` if we load a tag with no contents, which is incorrect.


Closes #3104 