### PR TITLE
Reset flat generator settings layers on refresh

### DIFF
--- a/patches/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/FlatLevelSource.java.patch
@@ -13,7 +13,7 @@
          this.settings = generatorSettings;
      }
  
-@@ -142,5 +_,12 @@
+@@ -142,5 +_,13 @@
      @Override
      public int getSeaLevel() {
          return -63;
@@ -24,5 +24,6 @@
 +    public void refreshFeaturesPerStep() {
 +        super.refreshFeaturesPerStep();
 +        this.generationSettingsGetter.clear();
++        this.settings.updateLayers();
      }
  }


### PR DESCRIPTION
This PR fixes #3115 by refreshing the mutable layer state in `FlatLevelGeneratorSettings` during a refresh of the `FlatLevelSource`.

The generator settings stores some mutable state related to the configured flat layers, that is modified when adjusting generation settings for a given biome.

As of 82a051279c4cbc2701701754fc5ce912dbb0d829 (#3086), we now clear the cache of per-biome generation settings during refresh, in order for biome modifiers to work on flat level sources. That left the mutable state unchanged, which causes a crash when generating new chunks.

Tested by flying around a superflat void world to generate chunks, and observing no crashes.