### PR TITLE
Allow Item Layer Models to be emissive

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -152,6 +152,16 @@
      ) {
          final Multimap<String, Identifier> missingSprites = Multimaps.synchronizedMultimap(HashMultimap.create());
          final Multimap<String, String> missingReferences = Multimaps.synchronizedMultimap(HashMultimap.create());
+@@ -250,7 +_,8 @@
+ 
+             private Material.@Nullable Baked bakeForAtlas(Material material, SpriteLoader.Preparations atlas) {
+                 TextureAtlasSprite sprite = atlas.getSprite(material.sprite());
+-                return sprite != null ? new Material.Baked(sprite, material.forceTranslucent()) : null;
++                // Neo: Forward the extra face data from Material to Material$Baked
++                return sprite != null ? new Material.Baked(sprite, material.forceTranslucent(), material.extraFaceData()) : null;
+             }
+ 
+             @Override
 @@ -261,7 +_,7 @@
          };
          CompletableFuture<ModelBakery.BakingResult> bakedStateResults = bakery.bakeModels(materialBaker, taskExecutor);

--- a/patches/net/minecraft/client/resources/model/cuboid/ItemModelGenerator.java.patch
+++ b/patches/net/minecraft/client/resources/model/cuboid/ItemModelGenerator.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/client/resources/model/cuboid/ItemModelGenerator.java
++++ b/net/minecraft/client/resources/model/cuboid/ItemModelGenerator.java
+@@ -210,8 +_,10 @@
+     public record ItemLayerKey(Material.Baked material, ModelState modelState, int layerIndex) implements ModelBaker.SharedOperationKey<QuadCollection> {
+         public QuadCollection compute(ModelBaker modelBakery) {
+             QuadCollection.Builder builder = new QuadCollection.Builder();
++            var faceData = this.material.extraFaceData();
+             BakedQuad.MaterialInfo materialInfo = modelBakery.interner()
+-                .materialInfo(BakedQuad.MaterialInfo.of(this.material, this.material.sprite().transparency(), this.layerIndex, true, 0));
++                    // Neo: Forward additional face data properties to the BakedQuad$MaterialInfo for generated item models.
++                .materialInfo(BakedQuad.MaterialInfo.of(this.material, this.material.sprite().transparency(), this.layerIndex, true, faceData.lightEmission(), faceData.ambientOcclusion()));
+             ItemModelGenerator.bakeExtrudedSprite(builder, modelBakery.interner(), this.modelState, materialInfo);
+             return builder.build();
+         }

--- a/patches/net/minecraft/client/resources/model/sprite/Material.java.patch
+++ b/patches/net/minecraft/client/resources/model/sprite/Material.java.patch
@@ -1,0 +1,51 @@
+--- a/net/minecraft/client/resources/model/sprite/Material.java
++++ b/net/minecraft/client/resources/model/sprite/Material.java
+@@ -9,27 +_,43 @@
+ import net.neoforged.api.distmarker.OnlyIn;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public record Material(Identifier sprite, boolean forceTranslucent) {
++public record Material(Identifier sprite, boolean forceTranslucent, net.neoforged.neoforge.client.model.ExtraFaceData extraFaceData) {
+     private static final Codec<Material> SIMPLE_CODEC = Identifier.CODEC.xmap(Material::new, Material::sprite);
+     private static final Codec<Material> FULL_CODEC = RecordCodecBuilder.create(
+         i -> i.group(
+                 Identifier.CODEC.fieldOf("sprite").forGetter(Material::sprite),
+-                Codec.BOOL.optionalFieldOf("force_translucent", false).forGetter(Material::forceTranslucent)
++                Codec.BOOL.optionalFieldOf("force_translucent", false).forGetter(Material::forceTranslucent),
++                net.neoforged.neoforge.client.model.ExtraFaceData.CODEC.optionalFieldOf("neoforge_data", net.neoforged.neoforge.client.model.ExtraFaceData.DEFAULT).forGetter(Material::extraFaceData)
+             )
+             .apply(i, Material::new)
+     );
+     public static final Codec<Material> CODEC = Codec.either(SIMPLE_CODEC, FULL_CODEC)
+-        .xmap(Either::unwrap, material -> material.forceTranslucent ? Either.right(material) : Either.left(material));
++        .xmap(Either::unwrap, material -> (material.forceTranslucent || !net.neoforged.neoforge.client.model.ExtraFaceData.DEFAULT.equals(material.extraFaceData)) ? Either.right(material) : Either.left(material));
+ 
+     public Material(Identifier sprite) {
+         this(sprite, false);
+     }
+ 
++    // Neo: Backwards-compatible constructor supplying a default face data.
++    public Material(Identifier sprite, boolean forceTranslucent) {
++        this(sprite, forceTranslucent, net.neoforged.neoforge.client.model.ExtraFaceData.DEFAULT);
++    }
++
+     public Material withForceTranslucent(boolean forceTranslucent) {
+-        return new Material(this.sprite, forceTranslucent);
++        // Neo: Augment this method to forward face data to the cloned Material
++        return new Material(this.sprite, forceTranslucent, this.extraFaceData);
++    }
++
++    /// Creates a copy of this Material with the same sprite and forced translucency, but with the given face data.
++    public Material withExtraFaceData(net.neoforged.neoforge.client.model.ExtraFaceData extraFaceData) {
++        return new Material(this.sprite, this.forceTranslucent, extraFaceData);
+     }
+ 
+     @OnlyIn(Dist.CLIENT)
+-    public record Baked(TextureAtlasSprite sprite, boolean forceTranslucent) {
++    public record Baked(TextureAtlasSprite sprite, boolean forceTranslucent, net.neoforged.neoforge.client.model.ExtraFaceData extraFaceData) {
++        // Neo: Backwards-compatible constructor supplying a default face data.
++        public Baked(TextureAtlasSprite sprite, boolean forceTranslucent) {
++            this(sprite, forceTranslucent, net.neoforged.neoforge.client.model.ExtraFaceData.DEFAULT);
++        }
+     }
+ }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/client/EmissiveElementsTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/client/EmissiveElementsTest.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.oldtest.client;
 
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.material.MapColor;
 import net.neoforged.bus.api.IEventBus;
@@ -17,7 +18,7 @@ import net.neoforged.neoforge.registries.DeferredItem;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 /**
- * Test mod that demos emissivity on "elements" models.
+ * Test mod that demos emissivity on "elements" models and on item layer textures.
  */
 @Mod(EmissiveElementsTest.MOD_ID)
 public class EmissiveElementsTest {
@@ -27,6 +28,8 @@ public class EmissiveElementsTest {
 
     public static final DeferredBlock<Block> TEST_BLOCK = BLOCKS.registerSimpleBlock("emissive", props -> props.mapColor(MapColor.STONE));
     public static final DeferredItem<BlockItem> TEST_BLOCK_ITEM = ITEMS.registerSimpleBlockItem(TEST_BLOCK);
+    // Exercises ItemLayerKey#compute with a non-default ExtraFaceData: light_emission=15 on layer0.
+    public static final DeferredItem<Item> TEST_GLOW_ITEM = ITEMS.registerSimpleItem("glow_item");
 
     public EmissiveElementsTest(IEventBus modEventBus) {
         BLOCKS.register(modEventBus);
@@ -35,7 +38,9 @@ public class EmissiveElementsTest {
     }
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
-        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS)
+        if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) {
             event.accept(TEST_BLOCK_ITEM);
+            event.accept(TEST_GLOW_ITEM);
+        }
     }
 }

--- a/tests/src/main/resources/assets/emissive_elements_test/items/glow_item.json
+++ b/tests/src/main/resources/assets/emissive_elements_test/items/glow_item.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "emissive_elements_test:item/glow_item"
+  }
+}

--- a/tests/src/main/resources/assets/emissive_elements_test/models/item/glow_item.json
+++ b/tests/src/main/resources/assets/emissive_elements_test/models/item/glow_item.json
@@ -1,0 +1,11 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": {
+      "sprite": "minecraft:item/redstone",
+      "neoforge_data": {
+        "light_emission": 15
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the ability to specify an `ExtraFaceData` for Item Layer models, alongside their sprite texture, and hooks up everything such that the additional data is forwarded to the quads that get created (except for Color, because that would be more involved, so I'll do that later).

## Json Syntax
Old (1.21.1)
```js
"neoforge_data": {
    "0": { // Corresponding layer number
        "color": "FFFF00FF",
        "block_light": 15,
        "sky_light": 15
    }
}
```

New (26.1.2)
```js
    "layer0": { // Embedded directly in the layer. Fortunately Material was already an object.
      "sprite": "minecraft:item/redstone",
      "neoforge_data": {
        "light_emission": 15
      }
    }
```

This restores the ability to make items that utilize `item/generated` ("Item Layer Models") emissive, without resorting to custom models. Screenshot of the item from the test below.

![](https://i.imgur.com/F1iQeuW.png)

___
This is basically a re-implementation of a feature from https://github.com/MinecraftForge/MinecraftForge/pull/9106 that was lost somewhere between 1.21.1 and 26.1.2.