### PR TITLE
Capture final target position for EnderMan & item teleport hook

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -642,6 +642,45 @@
          if (!this.level().isClientSide()) {
              boolean wasUsingItem = this.isUsingItem();
              this.recentKineticEnemies = null;
+@@ -3573,6 +_,8 @@
+         boolean ok = false;
+         BlockPos pos = BlockPos.containing(xx, yy, zz);
+         Level level = this.level();
++        // Neo: Store whether we actually did a teleport to the target, to know when not to teleport back to the same back
++        boolean teleported = false;
+         if (level.hasChunkAt(pos)) {
+             boolean landed = false;
+ 
+@@ -3588,15 +_,29 @@
+             }
+ 
+             if (landed) {
++                // Neo: Hook here for EnderMan's teleport, to get the actual final position being teleported to
++                var doTeleport = true;
++                if (this instanceof net.minecraft.world.entity.monster.EnderMan) {
++                    var event = net.neoforged.neoforge.event.EventHooks.onEnderTeleport(this, xx, y, zz);
++                    doTeleport = !event.isCanceled();
++                    xx = event.getTargetX();
++                    y = event.getTargetY();
++                    zz = event.getTargetZ();
++                }
++                if (doTeleport) {
++                teleported = true;
+                 this.teleportTo(xx, y, zz);
+                 if (level.noCollision(this) && !level.containsAnyLiquid(this.getBoundingBox())) {
+                     ok = true;
+                 }
++                }
+             }
+         }
+ 
+         if (!ok) {
++            if (teleported) { // Neo: Teleport back to original only if we teleported away and need to revert
+             this.teleportTo(xo, yo, zo);
++            }
+             return false;
+         } else {
+             if (showParticles) {
 @@ -3676,8 +_,8 @@
          }
  

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -642,6 +642,18 @@
          if (!this.level().isClientSide()) {
              boolean wasUsingItem = this.isUsingItem();
              this.recentKineticEnemies = null;
+@@ -3566,6 +_,11 @@
+     }
+ 
+     public boolean randomTeleport(double xx, double yy, double zz, boolean showParticles) {
++        return randomTeleport(xx, yy, zz, showParticles, ItemStack.EMPTY);
++    }
++
++    // Neo: Add overload with the consumed item causing the random teleport
++    public boolean randomTeleport(double xx, double yy, double zz, boolean showParticles, ItemStack consumedStack) {
+         double xo = this.getX();
+         double yo = this.getY();
+         double zo = this.getZ();
 @@ -3573,6 +_,8 @@
          boolean ok = false;
          BlockPos pos = BlockPos.containing(xx, yy, zz);
@@ -651,20 +663,23 @@
          if (level.hasChunkAt(pos)) {
              boolean landed = false;
  
-@@ -3588,15 +_,29 @@
+@@ -3588,15 +_,32 @@
              }
  
              if (landed) {
-+                // Neo: Hook here for EnderMan's teleport, to get the actual final position being teleported to
-+                var doTeleport = true;
-+                if (this instanceof net.minecraft.world.entity.monster.EnderMan) {
-+                    var event = net.neoforged.neoforge.event.EventHooks.onEnderTeleport(this, xx, y, zz);
-+                    doTeleport = !event.isCanceled();
++                // Neo: Fire event for either item consumption or EnderMan teleport, to get the actual final position being teleported to
++                net.neoforged.neoforge.event.entity.EntityTeleportEvent event = null;
++                if (!consumedStack.isEmpty()) {
++                    event = net.neoforged.neoforge.event.EventHooks.onItemConsumptionTeleport(this, consumedStack, xx, y, zz);
++                } else if (this instanceof net.minecraft.world.entity.monster.EnderMan) {
++                    event = net.neoforged.neoforge.event.EventHooks.onEnderTeleport(this, xx, y, zz);
++                }
++                if (event != null) {
 +                    xx = event.getTargetX();
 +                    y = event.getTargetY();
 +                    zz = event.getTargetZ();
 +                }
-+                if (doTeleport) {
++                if (event == null || !event.isCanceled()) {
 +                teleported = true;
                  this.teleportTo(xx, y, zz);
                  if (level.noCollision(this) && !level.containsAnyLiquid(this.getBoundingBox())) {

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -658,7 +658,7 @@
          boolean ok = false;
          BlockPos pos = BlockPos.containing(xx, yy, zz);
          Level level = this.level();
-+        // Neo: Store whether we actually did a teleport to the target, to know when not to teleport back to the same back
++        // Neo: Store whether we actually did a teleport to the target, to avoid teleporting the entity back to its original position if it didn't teleport away
 +        boolean teleported = false;
          if (level.hasChunkAt(pos)) {
              boolean landed = false;

--- a/patches/net/minecraft/world/entity/monster/EnderMan.java.patch
+++ b/patches/net/minecraft/world/entity/monster/EnderMan.java.patch
@@ -25,18 +25,6 @@
      }
  
      @Override
-@@ -285,8 +_,10 @@
-         boolean couldStandOn = blockState.blocksMotion();
-         boolean isWet = blockState.getFluidState().is(FluidTags.WATER);
-         if (couldStandOn && !isWet) {
-+            net.neoforged.neoforge.event.entity.EntityTeleportEvent.EnderEntity event = net.neoforged.neoforge.event.EventHooks.onEnderTeleport(this, x, y, z);
-+            if (event.isCanceled()) return false;
-             Vec3 oldPos = this.position();
--            boolean result = this.randomTeleport(x, y, z, true);
-+            boolean result = this.randomTeleport(event.getTargetX(), event.getTargetY(), event.getTargetZ(), true);
-             if (result) {
-                 this.level().gameEvent(GameEvent.TELEPORT, oldPos, GameEvent.Context.of(this));
-                 if (!this.isSilent()) {
 @@ -441,7 +_,7 @@
              if (this.enderman.getCarriedBlock() == null) {
                  return false;

--- a/patches/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
+++ b/patches/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java.patch
@@ -1,13 +1,12 @@
 --- a/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
 +++ b/net/minecraft/world/item/consume_effects/TeleportRandomlyConsumeEffect.java
-@@ -54,7 +_,9 @@
+@@ -54,7 +_,8 @@
              }
  
              Vec3 oldPos = user.position();
 -            if (user.randomTeleport(xx, yy, zz, true)) {
-+            var event = net.neoforged.neoforge.event.EventHooks.onItemConsumptionTeleport(user, stack, xx, yy, zz);
-+            if (event.isCanceled()) return false;
-+            if (user.randomTeleport(event.getTargetX(), event.getTargetY(), event.getTargetZ(), true)) {
++            // Neo: Pass on the consumed stack to fire the appropriate sub-event of EntityTeleportEvent
++            if (user.randomTeleport(xx, yy, zz, true, stack)) {
                  level.gameEvent(GameEvent.TELEPORT, oldPos, GameEvent.Context.of(user));
                  SoundSource soundSource;
                  SoundEvent soundEvent;

--- a/src/main/java/net/neoforged/neoforge/event/entity/EntityTeleportEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/EntityTeleportEvent.java
@@ -9,6 +9,8 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.monster.EnderMan;
+import net.minecraft.world.entity.monster.Shulker;
 import net.minecraft.world.entity.projectile.throwableitemprojectile.ThrownEnderpearl;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.HitResult;
@@ -130,18 +132,14 @@ public class EntityTeleportEvent extends EntityEvent implements ICancellableEven
         }
     }
 
-    /**
-     * EntityTeleportEvent.EnderEntity is fired before an Enderman or Shulker randomly teleports.
-     * <br>
-     * This event is {@link ICancellableEvent}.<br>
-     * If the event is not canceled, the entity will be teleported.
-     * <br>
-     * This event is fired on the {@link NeoForge#EVENT_BUS}.<br>
-     * <br>
-     * This event is only fired on the {@link LogicalSide#SERVER} side.<br>
-     * <br>
-     * If this event is canceled, the entity will not be teleported.
-     */
+    /// Fired before an [EnderMan] or [Shulker] randomly teleports.
+    ///
+    /// For [EnderMan] entities: if the target position is modified to a location where it could not
+    /// normally teleport to, such as by reason of being obstructed with blocks, it will not teleport there even if this event is not canceled.
+    ///
+    /// This event is fired on the [game event bus][NeoForge#EVENT_BUS], only on the [logical server][LogicalSide#SERVER].
+    ///
+    /// This event is [cancellable][ICancellableEvent]. If this event is canceled, the entity will not be teleported.
     public static class EnderEntity extends EntityTeleportEvent implements ICancellableEvent {
         private final LivingEntity entityLiving;
 


### PR DESCRIPTION
This PR fixes #3113 by moving the `EntityTeleportEvent.EnderEntity` and `EntityTeleportEvent.ItemConsumption` hooks to `LivingEntity#randomTeleport`, which captures the proper final Y level.

The original locations of the teleport hooks do not provide the final Y level of the target position; for example, `EnderMan#teleport` only had a potential target position that isn't occupied by blocks. It is `LivingEntity#randomTeleport` which finds the Y level the entity can stand on and occupy, so the hook is moved there.

To move the `EntityTeleportEvent.ItemConsumption` hook, a new overload of `LivingEntity#teleport` was added with an additional context of the consumed item stack. If that is supplied, the event fired is `ItemConsumption`; otherwise, if the entity is an `Enderman`, the event fired is `EnderEntity`.

Partially tested by spawning endermen in the rain and seeing them teleport while breakpointing at the event hook, and seeing them teleport and scatter like normal.