### PR TITLE
Fail configs whose values do not accept their own defaults

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -132,6 +132,21 @@ public class ModConfigSpec implements IConfigSpec {
                 throw new IllegalArgumentException("Configuration value " + String.join(".", configValue.getPath())
                         + " defined in config " + config.getFileName() + " has restart of type " + configValue.getSpec().restartType() + " which cannot be used for configs of type " + config.getType());
             }
+            // Check that the spec's validator accepts its own default value
+            if (!configValue.getSpec().test(configValue.getDefault())) {
+                // TODO(26.2): Make this throw in dev and in production
+                if (FMLEnvironment.isProduction()) {
+                    LOGGER.warn("Configuration value {} defined in config {} has a validator that does not accept its own default value; this will be an exception in a future Minecraft version",
+                            String.join(".", configValue.getPath()),
+                            config.getFileName());
+                } else {
+                    throw new IllegalArgumentException("Configuration value "
+                            + String.join(".", configValue.getPath())
+                            + " defined in config "
+                            + config.getFileName()
+                            + " has a validator that does not accept its own default value");
+                }
+            }
         });
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -138,7 +138,8 @@ public class ModConfigSpec implements IConfigSpec {
                         + String.join(".", configValue.getPath())
                         + " defined in config "
                         + config.getFileName()
-                        + " has a validator that does not accept its own default value");
+                        + " has a validator that does not accept its own default value of "
+                        + configValue.getDefault());
             }
         });
     }

--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -134,18 +134,11 @@ public class ModConfigSpec implements IConfigSpec {
             }
             // Check that the spec's validator accepts its own default value
             if (!configValue.getSpec().test(configValue.getDefault())) {
-                // TODO(26.2): Make this throw in dev and in production
-                if (FMLEnvironment.isProduction()) {
-                    LOGGER.warn("Configuration value {} defined in config {} has a validator that does not accept its own default value; this will be an exception in a future Minecraft version",
-                            String.join(".", configValue.getPath()),
-                            config.getFileName());
-                } else {
-                    throw new IllegalArgumentException("Configuration value "
-                            + String.join(".", configValue.getPath())
-                            + " defined in config "
-                            + config.getFileName()
-                            + " has a validator that does not accept its own default value");
-                }
+                throw new IllegalArgumentException("Configuration value "
+                        + String.join(".", configValue.getPath())
+                        + " defined in config "
+                        + config.getFileName()
+                        + " has a validator that does not accept its own default value");
             }
         });
     }


### PR DESCRIPTION
This PR addresses #1768 by validating registered configs to ensure their validators accept their own default values.

This new check will throw an exception and therefore be a mod loading error (as mods register configs in their mod constructor). ~~However, to avoid breaking existing mods for end users, I've decided to make it only throw an exception in development, and log a warning in production.~~

~~If wanted, since we are in the breaking changes window, I can remove the logging and always throw an exception.~~