### PR TITLE
Add more context for ModifyDefaultComponentsEvent modifiers

### DIFF
--- a/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
@@ -7,7 +7,7 @@
 +
 +            // Neo: Support programmatic customization of the default components for items
 +            if (elementKey.isFor(net.minecraft.core.registries.Registries.ITEM)) {
-+                net.neoforged.neoforge.internal.DataComponentModifiers.apply((net.minecraft.world.item.Item) element.value(), elementBuilder);
++                net.neoforged.neoforge.internal.DataComponentModifiers.apply(context, (net.minecraft.world.item.Item) element.value(), element.key().cast(net.minecraft.core.registries.Registries.ITEM).orElseThrow(), elementBuilder);
 +            }
 +
              DataComponentMap components = elementBuilder.build();

--- a/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
+++ b/patches/net/minecraft/core/component/DataComponentInitializers.java.patch
@@ -7,7 +7,7 @@
 +
 +            // Neo: Support programmatic customization of the default components for items
 +            if (elementKey.isFor(net.minecraft.core.registries.Registries.ITEM)) {
-+                net.neoforged.neoforge.internal.DataComponentModifiers.apply(context, (net.minecraft.world.item.Item) element.value(), element.key().cast(net.minecraft.core.registries.Registries.ITEM).orElseThrow(), elementBuilder);
++                net.neoforged.neoforge.internal.DataComponentModifiers.apply(context, (net.minecraft.world.item.Item) element.value(), elementBuilder);
 +            }
 +
              DataComponentMap components = elementBuilder.build();

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -52,7 +52,7 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
         this.modifiersByPredicate = modifiersByPredicate;
     }
 
-    /// Patches the default components of the given `item`.
+    /// Patches the default components of the given item.
     ///
     /// @param item  the item to modify the default components for
     /// @param patch the patch to apply
@@ -60,7 +60,7 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
         modifiersByItem.merge(item.asItem(), patch, Initializer::andThen);
     }
 
-    /// Patches the default components of the given `item`.
+    /// Patches the default components of the given item.
     ///
     /// @param item  the item to modify the default components for
     /// @param patch the patch to apply
@@ -71,11 +71,11 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
         this.modify(item, (components, _, _) -> patch.accept(components));
     }
 
-    /// Patches the default components of all items matching the given `bipredicate`
+    /// Patches the default components of all items matching the given predicate
     /// based on item and/or its currently applied default components.
     ///
     /// If this method is used to modify components based on the item's current default components, the
-    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Initializer)] are
+    /// event listener should use the [lowest priority][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Initializer)] are
     /// already applied.
     ///
     /// @param predicate the item and its current default components filter
@@ -84,11 +84,11 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
         modifiersByPredicate.add(Pair.of(predicate, patch));
     }
 
-    /// Patches the default components of all items matching the given `bipredicate`
+    /// Patches the default components of all items matching the given predicate
     /// based on item and/or its currently applied default components.
     ///
     /// If this method is used to modify components based on the item's current default components, the
-    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Initializer)] are
+    /// event listener should use the [lowest priority][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Initializer)] are
     /// already applied.
     ///
     /// @param predicate the item and its current default components filter
@@ -116,6 +116,11 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
     /// A alternate version of [DataComponentInitializers.Initializer] which receives the item whose components being initialized.
     @FunctionalInterface
     public interface Initializer {
+        /// Initializes or modifies the default components of a given item.
+        ///
+        /// @param components the default components of the item
+        /// @param context the registry context
+        /// @param item the item
         void run(DataComponentMap.Builder components, HolderLookup.Provider context, Item item);
 
         /// {@return a composed initializer that first runs this initializer, and then runs the given initializer}

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -8,14 +8,18 @@ package net.neoforged.neoforge.event;
 import com.mojang.datafixers.util.Pair;
 import java.util.List;
 import java.util.Map;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentInitializers;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.neoforge.common.CommonHooks;
 import org.jetbrains.annotations.ApiStatus;
 
 /// The event used to modify the default [components][Item#components()] of an item.
@@ -39,12 +43,12 @@ import org.jetbrains.annotations.ApiStatus;
 ///  }
 ///  ```
 public final class ModifyDefaultComponentsEvent extends Event implements IModBusEvent {
-    private final Map<Item, DataComponentInitializers.Initializer<Item>> modifiersByItem;
-    private final List<Pair<ItemWithComponentsPredicate, DataComponentInitializers.Initializer<Item>>> modifiersByPredicate;
+    private final Map<Item, Initializer> modifiersByItem;
+    private final List<Pair<ItemWithComponentsPredicate, Initializer>> modifiersByPredicate;
 
     @ApiStatus.Internal
-    public ModifyDefaultComponentsEvent(Map<Item, DataComponentInitializers.Initializer<Item>> modifiersByItem,
-            List<Pair<ItemWithComponentsPredicate, DataComponentInitializers.Initializer<Item>>> modifiersByPredicate) {
+    public ModifyDefaultComponentsEvent(Map<Item, Initializer> modifiersByItem,
+            List<Pair<ItemWithComponentsPredicate, Initializer>> modifiersByPredicate) {
         this.modifiersByItem = modifiersByItem;
         this.modifiersByPredicate = modifiersByPredicate;
     }
@@ -53,20 +57,20 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
     ///
     /// @param item  the item to modify the default components for
     /// @param patch the patch to apply
-    public void modify(ItemLike item, DataComponentInitializers.Initializer<Item> patch) {
-        modifiersByItem.merge(item.asItem(), patch, DataComponentInitializers.Initializer::andThen);
+    public void modify(ItemLike item, Initializer patch) {
+        modifiersByItem.merge(item.asItem(), patch, Initializer::andThen);
     }
 
     /// Patches the default components of all items matching the given `bipredicate`
     /// based on item and/or its currently applied default components.
     ///
     /// If this method is used to modify components based on the item's current default components, the
-    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, DataComponentInitializers.Initializer)] are
+    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Initializer)] are
     /// already applied.
     ///
     /// @param predicate the item and its current default components filter
     /// @param patch     the patch to apply
-    public void modifyMatching(ItemWithComponentsPredicate predicate, DataComponentInitializers.Initializer<Item> patch) {
+    public void modifyMatching(ItemWithComponentsPredicate predicate, Initializer patch) {
         modifiersByPredicate.add(Pair.of(predicate, patch));
     }
 
@@ -81,5 +85,33 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
         /// @param components the data component getter for components to be bound
         /// @return Whether the condition is satisfied
         boolean test(Item item, DataComponentGetter components);
+    }
+
+    /// A alternate version of [DataComponentInitializers.Initializer] which receives the item whose components being initialized.
+    @FunctionalInterface
+    public interface Initializer {
+        void run(DataComponentMap.Builder components, HolderLookup.Provider context, Item item);
+
+        /// {@return a composed initializer that first runs this initializer, and then runs the given initializer}
+        ///
+        /// @param other the initializer to apply after this initializer is run
+        default Initializer andThen(Initializer other) {
+            return (components, context, key) -> {
+                this.run(components, context, key);
+                other.run(components, context, key);
+            };
+        }
+
+        /// {@return a composed initializer that runs this initializer and then adds the given data component and it svalue}
+        ///
+        /// @param <C> the value type of the data component
+        /// @param type the data component
+        /// @param value the value of the data component
+        ///
+        /// @see #andThen(Initializer)
+        default <C> Initializer add(DataComponentType<C> type, C value) {
+            CommonHooks.validateComponent(value);
+            return this.andThen((components, _, _) -> components.set(type, value));
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.event;
 import com.mojang.datafixers.util.Pair;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentInitializers;
@@ -59,6 +60,17 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
         modifiersByItem.merge(item.asItem(), patch, Initializer::andThen);
     }
 
+    /// Patches the default components of the given `item`.
+    ///
+    /// @param item  the item to modify the default components for
+    /// @param patch the patch to apply
+    ///
+    /// @deprecated Use [#modify(ItemLike, Initializer)] instead, which provides more contextual information.
+    @Deprecated(forRemoval = true, since = "26.1.2")
+    public void modify(ItemLike item, Consumer<DataComponentMap.Builder> patch) {
+        this.modify(item, (components, _, _) -> patch.accept(components));
+    }
+
     /// Patches the default components of all items matching the given `bipredicate`
     /// based on item and/or its currently applied default components.
     ///
@@ -70,6 +82,22 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
     /// @param patch     the patch to apply
     public void modifyMatching(ItemWithComponentsPredicate predicate, Initializer patch) {
         modifiersByPredicate.add(Pair.of(predicate, patch));
+    }
+
+    /// Patches the default components of all items matching the given `bipredicate`
+    /// based on item and/or its currently applied default components.
+    ///
+    /// If this method is used to modify components based on the item's current default components, the
+    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Initializer)] are
+    /// already applied.
+    ///
+    /// @param predicate the item and its current default components filter
+    /// @param patch     the patch to apply
+    ///
+    /// @deprecated Use [#modifyMatching(ItemWithComponentsPredicate, Initializer)] instead, which provides more contextual information.
+    @Deprecated(forRemoval = true, since = "26.1.2")
+    public void modifyMatching(ItemWithComponentsPredicate predicate, Consumer<DataComponentMap.Builder> patch) {
+        this.modifyMatching(predicate, ((components, _, _) -> patch.accept(components)));
     }
 
     /// Evaluates a condition on an `Item`

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -12,14 +12,12 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentInitializers;
 import net.minecraft.core.component.DataComponentMap;
-import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.event.IModBusEvent;
-import net.neoforged.neoforge.common.CommonHooks;
 import org.jetbrains.annotations.ApiStatus;
 
 /// The event used to modify the default [components][Item#components()] of an item.
@@ -100,18 +98,6 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
                 this.run(components, context, key);
                 other.run(components, context, key);
             };
-        }
-
-        /// {@return a composed initializer that runs this initializer and then adds the given data component and it svalue}
-        ///
-        /// @param <C> the value type of the data component
-        /// @param type the data component
-        /// @param value the value of the data component
-        ///
-        /// @see #andThen(Initializer)
-        default <C> Initializer add(DataComponentType<C> type, C value) {
-            CommonHooks.validateComponent(value);
-            return this.andThen((components, _, _) -> components.set(type, value));
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ModifyDefaultComponentsEvent.java
@@ -8,9 +8,8 @@ package net.neoforged.neoforge.event;
 import com.mojang.datafixers.util.Pair;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import net.minecraft.core.component.DataComponentGetter;
-import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponentInitializers;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.neoforged.bus.api.Event;
@@ -40,12 +39,12 @@ import org.jetbrains.annotations.ApiStatus;
 ///  }
 ///  ```
 public final class ModifyDefaultComponentsEvent extends Event implements IModBusEvent {
-    private final Map<Item, Consumer<DataComponentMap.Builder>> modifiersByItem;
-    private final List<Pair<ItemWithComponentsPredicate, Consumer<DataComponentMap.Builder>>> modifiersByPredicate;
+    private final Map<Item, DataComponentInitializers.Initializer<Item>> modifiersByItem;
+    private final List<Pair<ItemWithComponentsPredicate, DataComponentInitializers.Initializer<Item>>> modifiersByPredicate;
 
     @ApiStatus.Internal
-    public ModifyDefaultComponentsEvent(Map<Item, Consumer<DataComponentMap.Builder>> modifiersByItem,
-            List<Pair<ItemWithComponentsPredicate, Consumer<DataComponentMap.Builder>>> modifiersByPredicate) {
+    public ModifyDefaultComponentsEvent(Map<Item, DataComponentInitializers.Initializer<Item>> modifiersByItem,
+            List<Pair<ItemWithComponentsPredicate, DataComponentInitializers.Initializer<Item>>> modifiersByPredicate) {
         this.modifiersByItem = modifiersByItem;
         this.modifiersByPredicate = modifiersByPredicate;
     }
@@ -54,20 +53,20 @@ public final class ModifyDefaultComponentsEvent extends Event implements IModBus
     ///
     /// @param item  the item to modify the default components for
     /// @param patch the patch to apply
-    public void modify(ItemLike item, Consumer<DataComponentMap.Builder> patch) {
-        modifiersByItem.merge(item.asItem(), patch, Consumer::andThen);
+    public void modify(ItemLike item, DataComponentInitializers.Initializer<Item> patch) {
+        modifiersByItem.merge(item.asItem(), patch, DataComponentInitializers.Initializer::andThen);
     }
 
     /// Patches the default components of all items matching the given `bipredicate`
     /// based on item and/or its currently applied default components.
     ///
     /// If this method is used to modify components based on the item's current default components, the
-    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, Consumer)] are
+    /// event listener should use the [`lowest priority`][EventPriority#LOWEST] so that [other mods' modifications][#modify(ItemLike, DataComponentInitializers.Initializer)] are
     /// already applied.
     ///
     /// @param predicate the item and its current default components filter
     /// @param patch     the patch to apply
-    public void modifyMatching(ItemWithComponentsPredicate predicate, Consumer<DataComponentMap.Builder> patch) {
+    public void modifyMatching(ItemWithComponentsPredicate predicate, DataComponentInitializers.Initializer<Item> patch) {
         modifiersByPredicate.add(Pair.of(predicate, patch));
     }
 

--- a/src/main/java/net/neoforged/neoforge/internal/DataComponentModifiers.java
+++ b/src/main/java/net/neoforged/neoforge/internal/DataComponentModifiers.java
@@ -11,29 +11,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.component.DataComponentInitializers;
 import net.minecraft.core.component.DataComponentMap;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.Item;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 
 public final class DataComponentModifiers {
-    private static final Map<Item, DataComponentInitializers.Initializer<Item>> MODIFIERS_BY_ITEM = new HashMap<>();
-    private static final List<Pair<ModifyDefaultComponentsEvent.ItemWithComponentsPredicate, DataComponentInitializers.Initializer<Item>>> MODIFIERS_BY_PREDICATE = new ArrayList<>();
+    private static final Map<Item, ModifyDefaultComponentsEvent.Initializer> MODIFIERS_BY_ITEM = new HashMap<>();
+    private static final List<Pair<ModifyDefaultComponentsEvent.ItemWithComponentsPredicate, ModifyDefaultComponentsEvent.Initializer>> MODIFIERS_BY_PREDICATE = new ArrayList<>();
 
     static void init() {
         ModLoader.postEvent(new ModifyDefaultComponentsEvent(MODIFIERS_BY_ITEM, MODIFIERS_BY_PREDICATE));
     }
 
-    public static void apply(HolderLookup.Provider context, Item item, ResourceKey<Item> key, DataComponentMap.Builder builder) {
+    public static void apply(HolderLookup.Provider context, Item item, DataComponentMap.Builder builder) {
         var modifier = MODIFIERS_BY_ITEM.get(item);
         if (modifier != null) {
-            modifier.run(builder, context, key);
+            modifier.run(builder, context, item);
         }
         for (var pair : MODIFIERS_BY_PREDICATE) {
             if (pair.getFirst().test(item, builder)) {
-                pair.getSecond().run(builder, context, key);
+                pair.getSecond().run(builder, context, item);
             }
         }
     }

--- a/src/main/java/net/neoforged/neoforge/internal/DataComponentModifiers.java
+++ b/src/main/java/net/neoforged/neoforge/internal/DataComponentModifiers.java
@@ -10,28 +10,30 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponentInitializers;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.Item;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.event.ModifyDefaultComponentsEvent;
 
 public final class DataComponentModifiers {
-    private static final Map<Item, Consumer<DataComponentMap.Builder>> MODIFIERS_BY_ITEM = new HashMap<>();
-    private static final List<Pair<ModifyDefaultComponentsEvent.ItemWithComponentsPredicate, Consumer<DataComponentMap.Builder>>> MODIFIERS_BY_PREDICATE = new ArrayList<>();
+    private static final Map<Item, DataComponentInitializers.Initializer<Item>> MODIFIERS_BY_ITEM = new HashMap<>();
+    private static final List<Pair<ModifyDefaultComponentsEvent.ItemWithComponentsPredicate, DataComponentInitializers.Initializer<Item>>> MODIFIERS_BY_PREDICATE = new ArrayList<>();
 
     static void init() {
         ModLoader.postEvent(new ModifyDefaultComponentsEvent(MODIFIERS_BY_ITEM, MODIFIERS_BY_PREDICATE));
     }
 
-    public static void apply(Item item, DataComponentMap.Builder builder) {
-        Consumer<DataComponentMap.Builder> modifier = MODIFIERS_BY_ITEM.get(item);
+    public static void apply(HolderLookup.Provider context, Item item, ResourceKey<Item> key, DataComponentMap.Builder builder) {
+        var modifier = MODIFIERS_BY_ITEM.get(item);
         if (modifier != null) {
-            modifier.accept(builder);
+            modifier.run(builder, context, key);
         }
         for (var pair : MODIFIERS_BY_PREDICATE) {
             if (pair.getFirst().test(item, builder)) {
-                pair.getSecond().accept(builder);
+                pair.getSecond().run(builder, context, key);
             }
         }
     }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemComponentTests.java
@@ -73,7 +73,7 @@ public class ItemComponentTests {
                 .component(DataComponents.BASE_COLOR, DyeColor.BLUE))
                 .withLang("Test components item");
         test.framework().modEventBus().addListener((final ModifyDefaultComponentsEvent event) -> {
-            event.modify(testItem, builder -> builder
+            event.modify(testItem, (builder, _, _) -> builder
                     .set(DataComponents.BASE_COLOR, null)
                     .set(DataComponents.MAX_STACK_SIZE, 5));
         });
@@ -96,10 +96,10 @@ public class ItemComponentTests {
         test.framework().modEventBus().addListener((final ModifyDefaultComponentsEvent event) -> {
             event.modifyMatching(
                     (item, components) -> components.has(DataComponents.BASE_COLOR) && item == testItem.asItem(),
-                    builder -> builder.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true));
+                    (builder, _, _) -> builder.set(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true));
             event.modifyMatching(
                     (item, components) -> components.get(DataComponents.BASE_COLOR) == DyeColor.BLUE && item == testItem.asItem(),
-                    builder -> builder.set(DataComponents.RARITY, Rarity.EPIC));
+                    (builder, _, _) -> builder.set(DataComponents.RARITY, Rarity.EPIC));
         });
 
         test.onGameTest(helper -> {


### PR DESCRIPTION
This PR fixes #3121 by changing the initializer functional interface used in `ModifyDefaultComponentsEvent` from a `Consumer` to the purpose-built `DataComponentInitializers.Initializer`, which exposes both the `HolderLookup.Provider` context and the resource key of the item being modified.

That latter part is useful for those adding a modifier that depends on a predicate, so the initializer knows exactly which item it is modifying.

It seems to me that the new functional interface, added in `26.1-snapshot-3`, was overlooked during porting and our efforts to fixup the event in #3041 and #3043. I may be corrected on that, though.