### PR TITLE
[26.1] Fix potential memory leak in models baked with ComposedModelState

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/ComposedModelState.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/ComposedModelState.java
@@ -10,21 +10,11 @@ import net.minecraft.client.renderer.block.dispatch.ModelState;
 import net.minecraft.core.Direction;
 import org.joml.Matrix4fc;
 
-/**
- * Implementation of {@link ModelState} which prepends an additional transform onto the incoming {@link ModelState}.
- */
-public final class ComposedModelState implements ModelState {
-    private final ModelState parent;
-    private final Transformation transformation;
-
+/// Implementation of [ModelState] which prepends an additional transform onto the incoming [ModelState].
+public record ComposedModelState(ModelState parent, Transformation transformation) implements ModelState {
     public ComposedModelState(ModelState parent, Transformation transformation) {
         this.parent = parent;
         this.transformation = parent.transformation().compose(transformation);
-    }
-
-    @Override
-    public Transformation transformation() {
-        return transformation;
     }
 
     @Override


### PR DESCRIPTION
This PR converts `ComposedModelState` to a record to give it proper `equals()` and `hashCode()` implementations.
Vanilla caches model baking results in `ModelDiscovery.ModelWrapper#modelBakeCache` by the `ModelState` they were baked with. This change fixes a potential memory leak in this cache when a given model's baking is requested multiple times with `ComposedModelState`s holding the same parent `ModelState` and `Transformation`. While "dumb" models can run into this, they aren't baked nearly often enough to produce a measurable memory leak. Dynamic models which bake variations on demand during chunk meshing can however cause a severe memory relatively quickly.