### PR TITLE
API for blocks to declare whether they're relocatable from a given area

### DIFF
--- a/patches/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/BedBlock.java.patch
@@ -5,19 +5,19 @@
          return new int[][]{{0, 0}, {-forward.getStepX(), -forward.getStepZ()}};
      }
 +
-+    // Neoforge: beds are relocatable if and only if both halves are being relocated
++    // Neo: beds are relocatable if and only if both halves are being relocated
 +    @Override
-+    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
-+        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos pos, BlockState state) {
++        if (state.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.No.INSTANCE;
 +        }
 +        // verify the other half exists; if not, don't deny relocation
-+        BedPart thisPart = thisState.getValue(PART);
-+        BlockPos neighborPos = thisPos.relative(getConnectedDirection(thisState)); // getConnectedDirection points to the other half
++        BedPart thisPart = state.getValue(PART);
++        BlockPos neighborPos = pos.relative(getConnectedDirection(state)); // getConnectedDirection points to the other half
 +        BlockState neighborState = level.getBlockState(neighborPos);
-+        BlockState expectedState = thisState.setValue(PART, thisPart == BedPart.HEAD ? BedPart.FOOT : BedPart.HEAD);
++        BlockState expectedState = state.setValue(PART, thisPart == BedPart.HEAD ? BedPart.FOOT : BedPart.HEAD);
 +        if (neighborState != expectedState)
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
++            return net.neoforged.neoforge.common.util.BlockRelocability.Yes.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(pos, neighborPos));
 +    }
  }

--- a/patches/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/BedBlock.java.patch
@@ -18,6 +18,6 @@
 +        BlockState expectedState = thisState.setValue(PART, thisPart == BedPart.HEAD ? BedPart.FOOT : BedPart.HEAD);
 +        if (neighborState != expectedState)
 +            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
 +    }
  }

--- a/patches/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/BedBlock.java.patch
@@ -7,17 +7,17 @@
 +
 +    // Neoforge: beds are relocatable if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
-+            return false;
-+        Direction facing = thisState.getValue(FACING);
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
++        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++        }
++        // verify the other half exists; if not, don't deny relocation
 +        BedPart thisPart = thisState.getValue(PART);
 +        BlockPos neighborPos = thisPos.relative(getConnectedDirection(thisState)); // getConnectedDirection points to the other half
 +        BlockState neighborState = level.getBlockState(neighborPos);
 +        BlockState expectedState = thisState.setValue(PART, thisPart == BedPart.HEAD ? BedPart.FOOT : BedPart.HEAD);
-+        // if this is only half a bed / the other half doesn't exist, no point in denying the relocation
 +        if (neighborState != expectedState)
-+            return true;
-+        return containsPosition.test(neighborPos);
++            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
 +    }
  }

--- a/patches/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/BedBlock.java.patch
@@ -7,8 +7,8 @@
 +
 +    // Neoforge: beds are relocatable if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
-+        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
-+            && relocatingPositions.contains(thisPos.relative(getConnectedDirection(thisState))); // getConnectedDirection points to the other half
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
++        return super.isRelocatable(level, thisPos, thisState, containsPosition)
++            && containsPosition.test(thisPos.relative(getConnectedDirection(thisState))); // getConnectedDirection points to the other half
 +    }
  }

--- a/patches/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/BedBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/BedBlock.java
 +++ b/net/minecraft/world/level/block/BedBlock.java
-@@ -334,4 +_,11 @@
+@@ -334,4 +_,20 @@
      private static int[][] bedAboveStandUpOffsets(Direction forward) {
          return new int[][]{{0, 0}, {-forward.getStepX(), -forward.getStepZ()}};
      }
@@ -8,7 +8,16 @@
 +    // Neoforge: beds are relocatable if and only if both halves are being relocated
 +    @Override
 +    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        return super.isRelocatable(level, thisPos, thisState, containsPosition)
-+            && containsPosition.test(thisPos.relative(getConnectedDirection(thisState))); // getConnectedDirection points to the other half
++        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
++            return false;
++        Direction facing = thisState.getValue(FACING);
++        BedPart thisPart = thisState.getValue(PART);
++        BlockPos neighborPos = thisPos.relative(getConnectedDirection(thisState)); // getConnectedDirection points to the other half
++        BlockState neighborState = level.getBlockState(neighborPos);
++        BlockState expectedState = thisState.setValue(PART, thisPart == BedPart.HEAD ? BedPart.FOOT : BedPart.HEAD);
++        // if this is only half a bed / the other half doesn't exist, no point in denying the relocation
++        if (neighborState != expectedState)
++            return true;
++        return containsPosition.test(neighborPos);
 +    }
  }

--- a/patches/net/minecraft/world/level/block/BedBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/BedBlock.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/block/BedBlock.java
++++ b/net/minecraft/world/level/block/BedBlock.java
+@@ -334,4 +_,11 @@
+     private static int[][] bedAboveStandUpOffsets(Direction forward) {
+         return new int[][]{{0, 0}, {-forward.getStepX(), -forward.getStepZ()}};
+     }
++
++    // Neoforge: beds are relocatable if and only if both halves are being relocated
++    @Override
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
++        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
++            && relocatingPositions.contains(thisPos.relative(getConnectedDirection(thisState))); // getConnectedDirection points to the other half
++    }
+ }

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -28,6 +28,6 @@
 +        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
 +        if (neighborState != expectedState)
 +            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -9,7 +9,7 @@
              DoublePlantBlock.preventDropFromBottomPart(level, pos, state, player);
          }
  
-@@ -270,5 +_,13 @@
+@@ -270,5 +_,20 @@
  
      public static boolean isWoodenDoor(BlockState state) {
          return state.getBlock() instanceof DoorBlock door && door.type().canOpenByHand();
@@ -18,8 +18,15 @@
 +    // Neoforge: Doors are relocatable if and only if both halves are being relocated
 +    @Override
 +    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        return super.isRelocatable(level, thisPos, thisState, containsPosition)
-+            && containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
-+
++        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
++            return false;
++        // verify the other half exists; if not, don't deny relocation
++        DoubleBlockHalf thisHalf = thisState.getValue(HALF);
++        BlockPos neighborPos = thisPos.relative(thisHalf.getDirectionToOther());
++        BlockState neighborState = level.getBlockState(neighborPos);
++        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
++        if (neighborState != expectedState)
++            return true;
++        return containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -9,7 +9,7 @@
              DoublePlantBlock.preventDropFromBottomPart(level, pos, state, player);
          }
  
-@@ -270,5 +_,20 @@
+@@ -270,5 +_,21 @@
  
      public static boolean isWoodenDoor(BlockState state) {
          return state.getBlock() instanceof DoorBlock door && door.type().canOpenByHand();
@@ -17,16 +17,17 @@
 +
 +    // Neoforge: Doors are relocatable if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
-+            return false;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
++        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++        }
 +        // verify the other half exists; if not, don't deny relocation
 +        DoubleBlockHalf thisHalf = thisState.getValue(HALF);
 +        BlockPos neighborPos = thisPos.relative(thisHalf.getDirectionToOther());
 +        BlockState neighborState = level.getBlockState(neighborPos);
 +        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
 +        if (neighborState != expectedState)
-+            return true;
-+        return containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
++            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -17,9 +17,9 @@
 +
 +    // Neoforge: Doors are relocatable if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
-+        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
-+            && relocatingPositions.contains(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
++        return super.isRelocatable(level, thisPos, thisState, containsPosition)
++            && containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
 +
      }
  }

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -15,19 +15,19 @@
          return state.getBlock() instanceof DoorBlock door && door.type().canOpenByHand();
 +    }
 +
-+    // Neoforge: Doors are relocatable if and only if both halves are being relocated
++    // Neo: Doors are relocatable if and only if both halves are being relocated
 +    @Override
-+    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
-+        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos pos, BlockState state) {
++        if (state.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.No.INSTANCE;
 +        }
 +        // verify the other half exists; if not, don't deny relocation
-+        DoubleBlockHalf thisHalf = thisState.getValue(HALF);
-+        BlockPos neighborPos = thisPos.relative(thisHalf.getDirectionToOther());
++        DoubleBlockHalf thisHalf = state.getValue(HALF);
++        BlockPos neighborPos = pos.relative(thisHalf.getDirectionToOther());
 +        BlockState neighborState = level.getBlockState(neighborPos);
-+        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
++        BlockState expectedState = state.setValue(HALF, thisHalf.getOtherHalf());
 +        if (neighborState != expectedState)
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
++            return net.neoforged.neoforge.common.util.BlockRelocability.Yes.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(pos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoorBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoorBlock.java.patch
@@ -9,3 +9,17 @@
              DoublePlantBlock.preventDropFromBottomPart(level, pos, state, player);
          }
  
+@@ -270,5 +_,13 @@
+ 
+     public static boolean isWoodenDoor(BlockState state) {
+         return state.getBlock() instanceof DoorBlock door && door.type().canOpenByHand();
++    }
++
++    // Neoforge: Doors are relocatable if and only if both halves are being relocated
++    @Override
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
++        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
++            && relocatingPositions.contains(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
++
+     }
+ }

--- a/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
@@ -8,7 +8,7 @@
              return belowState.is(this) && belowState.getValue(HALF) == DoubleBlockHalf.LOWER;
          }
      }
-@@ -132,5 +_,12 @@
+@@ -132,5 +_,20 @@
      @Override
      protected long getSeed(BlockState state, BlockPos pos) {
          return Mth.getSeed(pos.getX(), pos.below(state.getValue(HALF) == DoubleBlockHalf.LOWER ? 0 : 1).getY(), pos.getZ());
@@ -17,7 +17,15 @@
 +    // Neoforge: Relocatable if and only if both halves are being relocated
 +    @Override
 +    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        return super.isRelocatable(level, thisPos, thisState, containsPosition)
-+            && containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
++        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
++            return false;
++        // verify the other half exists; if not, don't deny relocation
++        DoubleBlockHalf thisHalf = thisState.getValue(HALF);
++        BlockPos neighborPos = thisPos.relative(thisHalf.getDirectionToOther());
++        BlockState neighborState = level.getBlockState(neighborPos);
++        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
++        if (neighborState != expectedState)
++            return true;
++        return containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
@@ -14,19 +14,19 @@
          return Mth.getSeed(pos.getX(), pos.below(state.getValue(HALF) == DoubleBlockHalf.LOWER ? 0 : 1).getY(), pos.getZ());
 +    }
 +
-+    // Neoforge: Relocatable if and only if both halves are being relocated
++    // Neo: Relocatable if and only if both halves are being relocated
 +    @Override
-+    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
-+        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos pos, BlockState state) {
++        if (state.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.No.INSTANCE;
 +        }
 +        // verify the other half exists; if not, don't deny relocation
-+        DoubleBlockHalf thisHalf = thisState.getValue(HALF);
-+        BlockPos neighborPos = thisPos.relative(thisHalf.getDirectionToOther());
++        DoubleBlockHalf thisHalf = state.getValue(HALF);
++        BlockPos neighborPos = pos.relative(thisHalf.getDirectionToOther());
 +        BlockState neighborState = level.getBlockState(neighborPos);
-+        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
++        BlockState expectedState = state.setValue(HALF, thisHalf.getOtherHalf());
 +        if (neighborState != expectedState)
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
++            return net.neoforged.neoforge.common.util.BlockRelocability.Yes.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(pos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
@@ -27,6 +27,6 @@
 +        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
 +        if (neighborState != expectedState)
 +            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
@@ -8,3 +8,16 @@
              return belowState.is(this) && belowState.getValue(HALF) == DoubleBlockHalf.LOWER;
          }
      }
+@@ -132,5 +_,12 @@
+     @Override
+     protected long getSeed(BlockState state, BlockPos pos) {
+         return Mth.getSeed(pos.getX(), pos.below(state.getValue(HALF) == DoubleBlockHalf.LOWER ? 0 : 1).getY(), pos.getZ());
++    }
++
++    // Neoforge: Relocatable if and only if both halves are being relocated
++    @Override
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
++        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
++            && relocatingPositions.contains(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
+     }
+ }

--- a/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
@@ -16,8 +16,8 @@
 +
 +    // Neoforge: Relocatable if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
-+        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
-+            && relocatingPositions.contains(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
++        return super.isRelocatable(level, thisPos, thisState, containsPosition)
++            && containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
      }
  }

--- a/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/DoublePlantBlock.java.patch
@@ -8,7 +8,7 @@
              return belowState.is(this) && belowState.getValue(HALF) == DoubleBlockHalf.LOWER;
          }
      }
-@@ -132,5 +_,20 @@
+@@ -132,5 +_,21 @@
      @Override
      protected long getSeed(BlockState state, BlockPos pos) {
          return Mth.getSeed(pos.getX(), pos.below(state.getValue(HALF) == DoubleBlockHalf.LOWER ? 0 : 1).getY(), pos.getZ());
@@ -16,16 +16,17 @@
 +
 +    // Neoforge: Relocatable if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
-+            return false;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
++        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++        }
 +        // verify the other half exists; if not, don't deny relocation
 +        DoubleBlockHalf thisHalf = thisState.getValue(HALF);
 +        BlockPos neighborPos = thisPos.relative(thisHalf.getDirectionToOther());
 +        BlockState neighborState = level.getBlockState(neighborPos);
 +        BlockState expectedState = thisState.setValue(HALF, thisHalf.getOtherHalf());
 +        if (neighborState != expectedState)
-+            return true;
-+        return containsPosition.test(thisPos.relative(thisState.getValue(HALF).getDirectionToOther()));
++            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -65,6 +65,6 @@
 +        // if this is extended but somebody already cut the block in half, no point in denying the relocation
 +        if (!(neighborState.getBlock() instanceof PistonHeadBlock && neighborState.getValue(PistonHeadBlock.FACING) == facing))
 +            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -53,8 +53,8 @@
 +
 +    // Neoforge: If piston is extended, can be relocated if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
-+        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
-+            && (!thisState.getValue(EXTENDED) || relocatingPositions.contains(thisPos.relative(thisState.getValue(FACING))));
++    public boolean isRelocatable(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
++        return super.isRelocatable(level, thisPos, thisState, containsPosition)
++            && (!thisState.getValue(EXTENDED) || containsPosition.test(thisPos.relative(thisState.getValue(FACING))));
      }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -51,20 +51,20 @@
          return false;
 +    }
 +
-+    // Neoforge: Extended piston multiblock can be relocated if and only if both halves are being relocated
++    // Neo: Extended piston multiblock can be relocated if and only if both halves are being relocated
 +    @Override
-+    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState) {
-+        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(net.minecraft.world.level.LevelReader level, BlockPos pos, BlockState state) {
++        if (state.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.No.INSTANCE;
 +        }
-+        if (!thisState.getValue(EXTENDED))
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        Direction facing = thisState.getValue(FACING);
-+        BlockPos neighborPos = thisPos.relative(facing);
++        if (!state.getValue(EXTENDED))
++            return net.neoforged.neoforge.common.util.BlockRelocability.Yes.INSTANCE;
++        Direction facing = state.getValue(FACING);
++        BlockPos neighborPos = pos.relative(facing);
 +        BlockState neighborState = level.getBlockState(neighborPos);
++        if (neighborState.getBlock() instanceof PistonHeadBlock && neighborState.getValue(PistonHeadBlock.FACING) == facing)
++            return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(pos, neighborPos));
 +        // if this is extended but somebody already cut the block in half, no point in denying the relocation
-+        if (!(neighborState.getBlock() instanceof PistonHeadBlock && neighborState.getValue(PistonHeadBlock.FACING) == facing))
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
++        return net.neoforged.neoforge.common.util.BlockRelocability.Yes.INSTANCE;
      }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -45,16 +45,25 @@
      @Override
      protected BlockState mirror(BlockState state, Mirror mirror) {
          return state.rotate(mirror.getRotation(state.getValue(FACING)));
-@@ -380,5 +_,12 @@
+@@ -380,5 +_,21 @@
      @Override
      protected boolean isPathfindable(BlockState state, PathComputationType type) {
          return false;
 +    }
 +
-+    // Neoforge: If piston is extended, can be relocated if and only if both halves are being relocated
++    // Neoforge: Extended piston multiblock can be relocated if and only if both halves are being relocated
 +    @Override
 +    public boolean isRelocatable(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        return super.isRelocatable(level, thisPos, thisState, containsPosition)
-+            && (!thisState.getValue(EXTENDED) || containsPosition.test(thisPos.relative(thisState.getValue(FACING))));
++        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
++            return false;
++        if (!thisState.getValue(EXTENDED))
++            return true;
++        Direction facing = thisState.getValue(FACING);
++        BlockPos neighborPos = thisPos.relative(facing);
++        BlockState neighborState = level.getBlockState(neighborPos);
++        // if this is extended but somebody already cut the block in half, no point in denying the relocation
++        if (!(neighborState.getBlock() instanceof PistonHeadBlock && neighborState.getValue(PistonHeadBlock.FACING) == facing))
++            return true;
++        return containsPosition.test(neighborPos);
      }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -34,14 +34,27 @@
                  toUpdate[updateIndex++] = state;
              }
  
-@@ -360,6 +_,10 @@
-     @Override
-     protected BlockState rotate(BlockState state, Rotation rotation) {
+@@ -362,6 +_,10 @@
          return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
-+    }
-+
-+    public BlockState rotate(BlockState state, net.minecraft.world.level.LevelAccessor world, BlockPos pos, Rotation direction) {
-+         return state.getValue(EXTENDED) ? state : super.rotate(state, world, pos, direction);
      }
  
++    public BlockState rotate(BlockState state, net.minecraft.world.level.LevelAccessor world, BlockPos pos, Rotation direction) {
++         return state.getValue(EXTENDED) ? state : super.rotate(state, world, pos, direction);
++    }
++
      @Override
+     protected BlockState mirror(BlockState state, Mirror mirror) {
+         return state.rotate(mirror.getRotation(state.getValue(FACING)));
+@@ -380,5 +_,12 @@
+     @Override
+     protected boolean isPathfindable(BlockState state, PathComputationType type) {
+         return false;
++    }
++
++    // Neoforge: If piston is extended, can be relocated if and only if both halves are being relocated
++    @Override
++    public boolean isRelocatable(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
++        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
++            && (!thisState.getValue(EXTENDED) || relocatingPositions.contains(thisPos.relative(thisState.getValue(FACING))));
+     }
+ }

--- a/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonBaseBlock.java.patch
@@ -45,7 +45,7 @@
      @Override
      protected BlockState mirror(BlockState state, Mirror mirror) {
          return state.rotate(mirror.getRotation(state.getValue(FACING)));
-@@ -380,5 +_,21 @@
+@@ -380,5 +_,22 @@
      @Override
      protected boolean isPathfindable(BlockState state, PathComputationType type) {
          return false;
@@ -53,17 +53,18 @@
 +
 +    // Neoforge: Extended piston multiblock can be relocated if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
-+            return false;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(net.minecraft.world.level.LevelReader level, BlockPos thisPos, BlockState thisState) {
++        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++        }
 +        if (!thisState.getValue(EXTENDED))
-+            return true;
++            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
 +        Direction facing = thisState.getValue(FACING);
 +        BlockPos neighborPos = thisPos.relative(facing);
 +        BlockState neighborState = level.getBlockState(neighborPos);
 +        // if this is extended but somebody already cut the block in half, no point in denying the relocation
 +        if (!(neighborState.getBlock() instanceof PistonHeadBlock && neighborState.getValue(PistonHeadBlock.FACING) == facing))
-+            return true;
-+        return containsPosition.test(neighborPos);
++            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
      }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/level/block/piston/PistonHeadBlock.java
++++ b/net/minecraft/world/level/block/piston/PistonHeadBlock.java
+@@ -143,4 +_,11 @@
+     protected boolean isPathfindable(BlockState state, PathComputationType type) {
+         return false;
+     }
++
++    // Neoforge: Can be relocated if and only if both halves are being relocated
++    @Override
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
++        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
++            && (relocatingPositions.contains(thisPos.relative(thisState.getValue(FACING).getOpposite()))); // facing points toward head, opposite points toward base
++    }
+ }

--- a/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
@@ -1,21 +1,22 @@
 --- a/net/minecraft/world/level/block/piston/PistonHeadBlock.java
 +++ b/net/minecraft/world/level/block/piston/PistonHeadBlock.java
-@@ -143,4 +_,18 @@
+@@ -143,4 +_,19 @@
      protected boolean isPathfindable(BlockState state, PathComputationType type) {
          return false;
      }
 +
 +    // Neoforge: Extended piston multiblock be relocated if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
-+            return false;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
++        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++        }
 +        Direction facing = thisState.getValue(FACING);
 +        BlockPos neighborPos = thisPos.relative(facing.getOpposite()); // facing points to head, opposite points to base
 +        BlockState neighborState = level.getBlockState(neighborPos);
 +        // if this is extended but somebody already cut the block in half, no point in denying the relocation
 +        if (!(neighborState.getBlock() instanceof PistonBaseBlock && neighborState.getValue(FACING) == facing && neighborState.getValue(PistonBaseBlock.EXTENDED)))
-+            return true;
-+        return containsPosition.test(neighborPos);
++            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
++        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
 +    }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
@@ -5,18 +5,18 @@
          return false;
      }
 +
-+    // Neoforge: Extended piston multiblock be relocated if and only if both halves are being relocated
++    // Neo: Extended piston multiblock be relocated if and only if both halves are being relocated
 +    @Override
-+    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
-+        if (thisState.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Never.INSTANCE;
++    public net.neoforged.neoforge.common.util.BlockRelocability getRelocability(LevelReader level, BlockPos pos, BlockState state) {
++        if (state.is(net.neoforged.neoforge.common.Tags.Blocks.RELOCATION_NOT_SUPPORTED)) {
++            return net.neoforged.neoforge.common.util.BlockRelocability.No.INSTANCE;
 +        }
-+        Direction facing = thisState.getValue(FACING);
-+        BlockPos neighborPos = thisPos.relative(facing.getOpposite()); // facing points to head, opposite points to base
++        Direction facing = state.getValue(FACING);
++        BlockPos neighborPos = pos.relative(facing.getOpposite()); // facing points to head, opposite points to base
 +        BlockState neighborState = level.getBlockState(neighborPos);
++        if (neighborState.getBlock() instanceof PistonBaseBlock && neighborState.getValue(FACING) == facing && neighborState.getValue(PistonBaseBlock.EXTENDED))
++            return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(pos, neighborPos));
 +        // if this is extended but somebody already cut the block in half, no point in denying the relocation
-+        if (!(neighborState.getBlock() instanceof PistonBaseBlock && neighborState.getValue(FACING) == facing && neighborState.getValue(PistonBaseBlock.EXTENDED)))
-+            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
++        return net.neoforged.neoforge.common.util.BlockRelocability.Yes.INSTANCE;
 +    }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
@@ -7,8 +7,8 @@
 +
 +    // Neoforge: Can be relocated if and only if both halves are being relocated
 +    @Override
-+    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.Set<BlockPos> relocatingPositions) {
-+        return super.isRelocatable(level, thisPos, thisState, relocatingPositions)
-+            && (relocatingPositions.contains(thisPos.relative(thisState.getValue(FACING).getOpposite()))); // facing points toward head, opposite points toward base
++    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
++        return super.isRelocatable(level, thisPos, thisState, containsPosition)
++            && (containsPosition.test(thisPos.relative(thisState.getValue(FACING).getOpposite()))); // facing points toward head, opposite points toward base
 +    }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
@@ -1,14 +1,21 @@
 --- a/net/minecraft/world/level/block/piston/PistonHeadBlock.java
 +++ b/net/minecraft/world/level/block/piston/PistonHeadBlock.java
-@@ -143,4 +_,11 @@
+@@ -143,4 +_,18 @@
      protected boolean isPathfindable(BlockState state, PathComputationType type) {
          return false;
      }
 +
-+    // Neoforge: Can be relocated if and only if both halves are being relocated
++    // Neoforge: Extended piston multiblock be relocated if and only if both halves are being relocated
 +    @Override
 +    public boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, java.util.function.Predicate<BlockPos> containsPosition) {
-+        return super.isRelocatable(level, thisPos, thisState, containsPosition)
-+            && (containsPosition.test(thisPos.relative(thisState.getValue(FACING).getOpposite()))); // facing points toward head, opposite points toward base
++        if (!super.isRelocatable(level, thisPos, thisState, containsPosition))
++            return false;
++        Direction facing = thisState.getValue(FACING);
++        BlockPos neighborPos = thisPos.relative(facing.getOpposite()); // facing points to head, opposite points to base
++        BlockState neighborState = level.getBlockState(neighborPos);
++        // if this is extended but somebody already cut the block in half, no point in denying the relocation
++        if (!(neighborState.getBlock() instanceof PistonBaseBlock && neighborState.getValue(FACING) == facing && neighborState.getValue(PistonBaseBlock.EXTENDED)))
++            return true;
++        return containsPosition.test(neighborPos);
 +    }
  }

--- a/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/piston/PistonHeadBlock.java.patch
@@ -17,6 +17,6 @@
 +        // if this is extended but somebody already cut the block in half, no point in denying the relocation
 +        if (!(neighborState.getBlock() instanceof PistonBaseBlock && neighborState.getValue(FACING) == facing && neighborState.getValue(PistonBaseBlock.EXTENDED)))
 +            return net.neoforged.neoforge.common.util.BlockRelocability.Always.INSTANCE;
-+        return new net.neoforged.neoforge.common.util.BlockRelocability.CuboidMultiblock(net.minecraft.world.level.levelgen.structure.BoundingBox.fromCorners(thisPos, neighborPos));
++        return new net.neoforged.neoforge.common.util.BlockRelocability.Multiblock(java.util.Set.of(thisPos, neighborPos));
 +    }
  }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -79,6 +80,7 @@ import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.common.DataMapHooks;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
+import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.EventHooks;
@@ -1076,5 +1078,24 @@ public interface IBlockExtension {
      */
     default boolean shouldHideAdjacentFluidFace(BlockState state, Direction selfFace, FluidState adjacentFluid) {
         return state.getFluidState().getType().isSame(adjacentFluid.getType());
+    }
+
+    /// Determines whether a block can be relocated, given some region of one or more blocks being relocated.
+    /// "Relocation" here means a region of blocks being cut or copied,
+    /// and then pasted in a different area, possibly with a translation, rotation, and/or mirror.
+    ///
+    /// A multiblock which is relocatable if and only if the entire multiblock is being relocated
+    /// (such as a bed or a door) may override this method to define such restrictions.
+    ///
+    /// Blocks which are not relocatable under any circumstances should be added to
+    /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case this method does not need to be overridden.
+    ///
+    /// @param level LevelReader where blocks are being relocated from.
+    /// @param thisPos BlockPos of this specific block being relocated.
+    /// @param thisState BlockState of this specific block being relocated. Must exist at thisPos in the given level.
+    /// @param relocatingPositions Set of all BlockPos where blocks are being relocated from.
+    /// Must include thisPos, and implementors may assume thisPos is contained within relocatingPositions.
+    default boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, Set<BlockPos> relocatingPositions) {
+        return !thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -1097,7 +1097,7 @@ public interface IBlockExtension {
     /// @return BlockRelocability declaring whether the block may be relocated
     default BlockRelocability getRelocability(LevelReader level, BlockPos pos, BlockState state) {
         return state.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED)
-                ? BlockRelocability.Never.INSTANCE
-                : BlockRelocability.Always.INSTANCE;
+                ? BlockRelocability.No.INSTANCE
+                : BlockRelocability.Yes.INSTANCE;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -6,8 +6,8 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -1093,9 +1093,9 @@ public interface IBlockExtension {
     /// @param level LevelReader where blocks are being relocated from.
     /// @param thisPos BlockPos of this specific block being relocated.
     /// @param thisState BlockState of this specific block being relocated. Must exist at thisPos in the given level.
-    /// @param relocatingPositions Set of all BlockPos where blocks are being relocated from.
-    /// Must include thisPos, and implementors may assume thisPos is contained within relocatingPositions.
-    default boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, Set<BlockPos> relocatingPositions) {
+    /// @param containsPosition Predicate for testing whether some other blockpos is being relocated.
+    /// Must be true for thisPos.
+    default boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, Predicate<BlockPos> containsPosition) {
         return !thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -1092,10 +1092,11 @@ public interface IBlockExtension {
     /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case this method does not need to be overridden.
     ///
     /// @param level LevelReader which the block is being relocated from
-    /// @param thisPos BlockPos which the block is being relocated from
-    /// @param thisState BlockState of the block being relocated
-    default BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
-        return thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED)
+    /// @param pos BlockPos which the block is being relocated from
+    /// @param state BlockState of the block being relocated
+    /// @return BlockRelocability declaring whether the block may be relocated
+    default BlockRelocability getRelocability(LevelReader level, BlockPos pos, BlockState state) {
+        return state.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED)
                 ? BlockRelocability.Never.INSTANCE
                 : BlockRelocability.Always.INSTANCE;
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
@@ -84,6 +85,7 @@ import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
+import net.neoforged.neoforge.common.util.BlockRelocability;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.EventHooks;
 import net.neoforged.neoforge.model.data.ModelData;
@@ -1082,23 +1084,23 @@ public interface IBlockExtension {
         return state.getFluidState().getType().isSame(adjacentFluid.getType());
     }
 
-    /// Determines whether a block can be relocated, given some region of one or more blocks being relocated.
+    /// Declares whether a block may be relocated and under what circumstances.
     /// "Relocation" here means a region of blocks being cut or copied,
-    /// and then pasted in a different area, possibly with a translation, rotation, and/or mirror.
+    /// and pasted somewhere else, with a translation and possibly a rotation or mirror,
+    /// also copying any blockentity data to the new position(s).
     ///
     /// A multiblock which is relocatable if and only if the entire multiblock is being relocated
-    /// (such as a bed or a door) may override this method to define such restrictions.
+    /// (e.g. a bed, a door, a 3x3 machine) may override this method to define such behavior.
     ///
-    /// Blocks which are not relocatable under any circumstances should be added to
+    /// Blocks which may never be relocated should be added to
     /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case this method does not need to be overridden.
     ///
-    /// @param level LevelReader where blocks are being relocated from.
-    /// @param thisPos BlockPos of this specific block being relocated.
-    /// @param thisState BlockState of this specific block being relocated. Must exist at thisPos in the given level.
-    /// @param containsPosition Predicate for testing whether some other blockpos is being relocated,
-    /// e.g. {@link BoundingBox#isInside(Vec3i)} for cuboid regions.
-    /// Must be true for thisPos.
-    default boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, Predicate<BlockPos> containsPosition) {
-        return !thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED);
+    /// @param level LevelReader which the block is being relocated from
+    /// @param thisPos BlockPos which the block is being relocated from
+    /// @param thisState BlockState of the block being relocated
+    default BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
+        return thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED)
+            ? BlockRelocability.Never.INSTANCE
+            : BlockRelocability.Always.INSTANCE;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -6,12 +6,9 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
@@ -72,7 +69,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
-import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
@@ -1100,7 +1096,7 @@ public interface IBlockExtension {
     /// @param thisState BlockState of the block being relocated
     default BlockRelocability getRelocability(LevelReader level, BlockPos thisPos, BlockState thisState) {
         return thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED)
-            ? BlockRelocability.Never.INSTANCE
-            : BlockRelocability.Always.INSTANCE;
+                ? BlockRelocability.Never.INSTANCE
+                : BlockRelocability.Always.INSTANCE;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -10,6 +10,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
@@ -70,6 +71,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.level.material.PushReaction;
@@ -1093,7 +1095,8 @@ public interface IBlockExtension {
     /// @param level LevelReader where blocks are being relocated from.
     /// @param thisPos BlockPos of this specific block being relocated.
     /// @param thisState BlockState of this specific block being relocated. Must exist at thisPos in the given level.
-    /// @param containsPosition Predicate for testing whether some other blockpos is being relocated.
+    /// @param containsPosition Predicate for testing whether some other blockpos is being relocated,
+    /// e.g. {@link BoundingBox#isInside(Vec3i)} for cuboid regions.
     /// Must be true for thisPos.
     default boolean isRelocatable(LevelReader level, BlockPos thisPos, BlockState thisState, Predicate<BlockPos> containsPosition) {
         return !thisState.is(Tags.Blocks.RELOCATION_NOT_SUPPORTED);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -47,6 +47,7 @@ import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
+import net.neoforged.neoforge.common.util.BlockRelocability;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.EventHooks;
 import org.jspecify.annotations.Nullable;
@@ -814,20 +815,20 @@ public interface IBlockStateExtension {
         return self().getBlock().shouldHideAdjacentFluidFace(self(), selfFace, adjacentFluid);
     }
 
-    /// Determines whether a block can be relocated, given some region of one or more blocks being relocated.
+    /// Declares whether a block may be relocated and under what circumstances.
     /// "Relocation" here means a region of blocks being cut or copied,
-    /// and then pasted in a different area, possibly with a translation, rotation, and/or mirror.
+    /// and pasted somewhere else, with a translation and possibly a rotation or mirror,
+    /// also copying any blockentity data to the new position(s).
     ///
     /// A multiblock which is relocatable if and only if the entire multiblock is being relocated
-    /// (such as a bed or a door) may override {@link IBlockExtension#isRelocatable} to define such restrictions.
+    /// (e.g. a bed, a door, a 3x3 machine) may override {@link IBlockExtension#getRelocability} to define such behavior.
     ///
-    /// Blocks which are not relocatable under any circumstances should be added to
-    /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case isRelocatable does not need to be overridden.
+    /// Blocks which may never be relocated should be added to
+    /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case getRelocability does not need to be overridden.
     ///
-    /// @param level LevelReader where blocks are being relocated from.
-    /// @param thisPos BlockPos of this specific blockstate being relocated.
-    /// @param containsPosition Predicate for testing whether other positions are being relocated; must be true for thisPos.
-    default boolean isRelocatable(LevelReader level, BlockPos thisPos, Predicate<BlockPos> containsPosition) {
-        return self().getBlock().isRelocatable(level, thisPos, self(), containsPosition);
+    /// @param level LevelReader where this blockstate is being relocated from
+    /// @param thisPos BlockPos of this blockstate being relocated
+    default BlockRelocability getRelocability(LevelReader level, BlockPos thisPos) {
+        return self().getBlock().getRelocability(level, thisPos, self());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -6,6 +6,7 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -44,6 +45,7 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
+import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;
 import net.neoforged.neoforge.event.EventHooks;
@@ -810,5 +812,22 @@ public interface IBlockStateExtension {
      */
     default boolean shouldHideAdjacentFluidFace(Direction selfFace, FluidState adjacentFluid) {
         return self().getBlock().shouldHideAdjacentFluidFace(self(), selfFace, adjacentFluid);
+    }
+
+    /// Determines whether a block can be relocated, given some region of one or more blocks being relocated.
+    /// "Relocation" here means a region of blocks being cut or copied,
+    /// and then pasted in a different area, possibly with a translation, rotation, and/or mirror.
+    ///
+    /// A multiblock which is relocatable if and only if the entire multiblock is being relocated
+    /// (such as a bed or a door) may override {@link IBlockExtension#isRelocatable} to define such restrictions.
+    ///
+    /// Blocks which are not relocatable under any circumstances should be added to
+    /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case isRelocatable does not need to be overridden.
+    ///
+    /// @param level LevelReader where blocks are being relocated from.
+    /// @param thisPos BlockPos of this specific blockstate being relocated.
+    /// @param relocatingPositions Set of all BlockPos where blocks are being relocated from, which must include thisPos.
+    default boolean isRelocatable(LevelReader level, BlockPos thisPos, Set<BlockPos> relocatingPositions) {
+        return self().getBlock().isRelocatable(level, thisPos, self(), relocatingPositions);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -6,8 +6,8 @@
 package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -826,8 +826,8 @@ public interface IBlockStateExtension {
     ///
     /// @param level LevelReader where blocks are being relocated from.
     /// @param thisPos BlockPos of this specific blockstate being relocated.
-    /// @param relocatingPositions Set of all BlockPos where blocks are being relocated from, which must include thisPos.
-    default boolean isRelocatable(LevelReader level, BlockPos thisPos, Set<BlockPos> relocatingPositions) {
-        return self().getBlock().isRelocatable(level, thisPos, self(), relocatingPositions);
+    /// @param containsPosition Predicate for testing whether other positions are being relocated; must be true for thisPos.
+    default boolean isRelocatable(LevelReader level, BlockPos thisPos, Predicate<BlockPos> containsPosition) {
+        return self().getBlock().isRelocatable(level, thisPos, self(), containsPosition);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -7,7 +7,6 @@ package net.neoforged.neoforge.common.extensions;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -815,19 +815,12 @@ public interface IBlockStateExtension {
     }
 
     /// Declares whether a block may be relocated and under what circumstances.
-    /// "Relocation" here means a region of blocks being cut or copied,
-    /// and pasted somewhere else, with a translation and possibly a rotation or mirror,
-    /// also copying any blockentity data to the new position(s).
-    ///
-    /// A multiblock which is relocatable if and only if the entire multiblock is being relocated
-    /// (e.g. a bed, a door, a 3x3 machine) may override {@link IBlockExtension#getRelocability} to define such behavior.
-    ///
-    /// Blocks which may never be relocated should be added to
-    /// {@link Tags.Blocks#RELOCATION_NOT_SUPPORTED}, in which case getRelocability does not need to be overridden.
     ///
     /// @param level LevelReader where this blockstate is being relocated from
-    /// @param thisPos BlockPos of this blockstate being relocated
-    default BlockRelocability getRelocability(LevelReader level, BlockPos thisPos) {
-        return self().getBlock().getRelocability(level, thisPos, self());
+    /// @param pos BlockPos of this blockstate being relocated
+    /// @return BlockRelocability declaring whether the block may be relocated
+    /// @see IBlockExtension#getRelocability
+    default BlockRelocability getRelocability(LevelReader level, BlockPos pos) {
+        return self().getBlock().getRelocability(level, pos, self());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -44,7 +44,6 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.capabilities.BlockCapabilityCache;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
-import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.enums.BubbleColumnDirection;
 import net.neoforged.neoforge.common.util.BlockRelocability;
 import net.neoforged.neoforge.common.world.AuxiliaryLightManager;

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -5,11 +5,9 @@
 
 package net.neoforged.neoforge.common.util;
 
-
+import java.util.Set;
 import net.minecraft.core.BlockPos;
 import net.neoforged.neoforge.common.extensions.IBlockStateExtension;
-
-import java.util.Set;
 
 /// Declares whether some block is relocatable by mechanics which cut/copy and paste blocks,
 /// typically with some translation and possibly a rotation and/or mirror,
@@ -17,54 +15,54 @@ import java.util.Set;
 ///
 /// Relocator mechanics may query {@link IBlockStateExtension#getRelocability} for each block in some area being moved.
 public sealed interface BlockRelocability permits BlockRelocability.Never, BlockRelocability.Always, BlockRelocability.Multiblock {
+    /// {@return true if the block is relocatable from a given Set of block positions, false otherwise}
+    /// @param relocatingPositions Set of positions blocks are being relocated from
+    public abstract boolean isRelocatable(Set<BlockPos> relocatingPositions);
 
-	/// {@return true if the block is relocatable from a given Set of block positions, false otherwise}
-	/// @param relocatingPositions Set of positions blocks are being relocated from
-	public abstract boolean isRelocatable(Set<BlockPos> relocatingPositions);
+    /// BlockRelocability indicating some block may never be relocated.
+    /// "Never" only indicates that this BlockRelocability instance produced by some context
+    /// will always return false for isRelocatable; it does not imply that the relevant block
+    /// will always produce a Never instance in any context.
+    public static enum Never implements BlockRelocability {
+        /** Singleton instance **/
+        INSTANCE;
 
-	/// BlockRelocability indicating some block may never be relocated.
-	/// "Never" only indicates that this BlockRelocability instance produced by some context
-	/// will always return false for isRelocatable; it does not imply that the relevant block
-	/// will always produce a Never instance in any context.
-	public static enum Never implements BlockRelocability {
-		/// Singleton instance.
-		INSTANCE;
+        @Override
+        public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+            return false;
+        }
+    }
 
-		@Override
-		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
-			return false;
-		}
-	}
+    /// BlockRelocability indicating some block is movable from any position.
+    /// "Always" only indicates that this BlockRelocability instance produced by some context
+    /// will always return true for isRelocatable; it does not imply that the relevant block
+    /// will always produce an Always instance in any context.
+    public static enum Always implements BlockRelocability {
+        /** Singleton instance **/
+        INSTANCE;
 
-	/// BlockRelocability indicating some block is movable from any position.
-	/// "Always" only indicates that this BlockRelocability instance produced by some context
-	/// will always return true for isRelocatable; it does not imply that the relevant block
-	/// will always produce an Always instance in any context.
-	public static enum Always implements BlockRelocability {
-		/// Singleton instance.
-		INSTANCE;
+        @Override
+        public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+            return true;
+        }
+    }
 
-		@Override
-		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
-			return true;
-		}
-	}
-	/// BlockRelocability indicating a block may be moved if and only if some set of other block positions is being
-	/// moved with it.
-	///
-	/// Large multiblocks with a "core" block may reduce the number of necessary checks by having the non-core blocks
-	/// only require themselves and the core, and having the core block require all non-core positions.
-	///
-	/// @param requiredPositions Set of block positions which must be moved with this block to allow moving it.
-	public static record Multiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
-		@Override
-		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
-			for (BlockPos pos : requiredPositions) {
-				if (!relocatingPositions.contains(pos)) {
-					return false;
-				}
-			}
-			return true;
-		}
-	}
+    /// BlockRelocability indicating a block may be moved if and only if some set of other block positions is being
+    /// moved with it.
+    ///
+    /// Large multiblocks with a "core" block may reduce the number of necessary checks by having the non-core blocks
+    /// only require themselves and the core, and having the core block require all non-core positions.
+    ///
+    /// @param requiredPositions Set of block positions which must be moved with this block to allow moving it.
+    public static record Multiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
+        @Override
+        public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+            for (BlockPos pos : requiredPositions) {
+                if (!relocatingPositions.contains(pos)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -1,0 +1,111 @@
+package net.neoforged.neoforge.common.util;
+
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.neoforged.neoforge.common.extensions.IBlockStateExtension;
+
+import java.util.Set;
+
+/// Declares whether some block is relocatable by mechanics which cut/copy and paste blocks,
+/// typically with some translation and possibly a rotation and/or mirror,
+/// and including any blockentity data.
+///
+/// Relocator mechanics may query {@link IBlockStateExtension#getRelocability} for each block in some area being moved.
+public sealed interface BlockRelocability permits BlockRelocability.Never, BlockRelocability.Always, BlockRelocability.CuboidMultiblock, BlockRelocability.AmorphousMultiblock {
+
+	/// {@return true if the block is relocatable from a given BoundingBox, false otherwise}
+	/// @param relocatingArea BoundingBox of the block positions being relocated
+	public abstract boolean isRelocatable(BoundingBox relocatingArea);
+
+	/// {@return true if the block is relocatable from a given Set of block positions, false otherwise}
+	public abstract boolean isRelocatable(Set<BlockPos> relocatingPositions);
+
+	/// BlockRelocability indicating some block may never be relocated.
+	/// "Never" only indicates that this BlockRelocability instance produced by some context
+	/// will always return false for isRelocatable; it does not imply that the relevant block
+	/// will always produce a Never instance in any context.
+	public static enum Never implements BlockRelocability {
+		/// singleton instance
+		INSTANCE;
+
+		@Override
+		public boolean isRelocatable(BoundingBox relocatingArea) {
+			return false;
+		}
+
+		@Override
+		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+			return false;
+		}
+	}
+
+	/// BlockRelocability indicating some block is movable from any position.
+	/// "Always" only indicates that this BlockRelocability instance produced by some context
+	/// will always return true for isRelocatable; it does not imply that the relevant block
+	/// will always produce an Always instance in any context.
+	public static enum Always implements BlockRelocability {
+		/// singleton instance
+		INSTANCE;
+
+		@Override
+		public boolean isRelocatable(BoundingBox relocatingArea) {
+			return true;
+		}
+
+		@Override
+		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+			return true;
+		}
+	}
+
+	/// BlockRelocability indicating some block is movable if and only if a given region of blocks is being moved with it.
+	/// This may be provided by blocks such as beds, doors, 3x3 furnaces, etc.
+	///
+	/// @param requiredArea BoundingBox of block positions which must be moved with this block to allow moving it.
+	public static record CuboidMultiblock(BoundingBox requiredArea) implements BlockRelocability {
+		@Override
+		public boolean isRelocatable(BoundingBox relocatingArea) {
+			return relocatingArea.minX() <= this.requiredArea.minX()
+				&& relocatingArea.minY() <= this.requiredArea.minY()
+				&& relocatingArea.minZ() <= this.requiredArea.minZ()
+				&& relocatingArea.maxX() >= this.requiredArea.maxX()
+				&& relocatingArea.maxY() >= this.requiredArea.maxY()
+				&& relocatingArea.maxZ() >= this.requiredArea.maxZ();
+		}
+
+		@Override
+		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+			return BlockPos.betweenClosedStream(this.requiredArea)
+				.allMatch(relocatingPositions::contains);
+		}
+	}
+	/// BlockRelocability indicating a block may be moved if and only if some set of other block positions is being
+	/// moved with it.
+	///
+	/// Large multiblocks with a "core" block may reduce the number of necessary checks by having the non-core blocks
+	/// only require themselves and the core, and having the core block require all non-core positions.
+	///
+	/// @param requiredPositions Set of block positions which must be moved with this block to allow moving it.
+	public static record AmorphousMultiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
+		@Override
+		public boolean isRelocatable(BoundingBox relocatingArea) {
+			for (BlockPos pos : requiredPositions) {
+				if (!relocatingArea.isInside(pos)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
+			for (BlockPos pos : requiredPositions) {
+				if (!relocatingPositions.contains(pos)) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+}

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -14,16 +14,13 @@ import net.neoforged.neoforge.common.extensions.IBlockStateExtension;
 /// and including any blockentity data.
 ///
 /// Relocator mechanics may query {@link IBlockStateExtension#getRelocability} for each block in some area being moved.
-public sealed interface BlockRelocability permits BlockRelocability.Never, BlockRelocability.Always, BlockRelocability.Multiblock {
+public sealed interface BlockRelocability permits BlockRelocability.No, BlockRelocability.Yes, BlockRelocability.Multiblock {
     /// {@return true if the block is relocatable from a given Set of block positions, false otherwise}
     /// @param relocatingPositions Set of positions blocks are being relocated from
     public abstract boolean isRelocatable(Set<BlockPos> relocatingPositions);
 
-    /// BlockRelocability indicating some block may never be relocated.
-    /// "Never" only indicates that this BlockRelocability instance produced by some context
-    /// will always return false for isRelocatable; it does not imply that the relevant block
-    /// will always produce a Never instance in any context.
-    public static enum Never implements BlockRelocability {
+    /// BlockRelocability indicating some block is currently refusing to be moved
+    public static enum No implements BlockRelocability {
         /** Singleton instance **/
         INSTANCE;
 
@@ -33,11 +30,8 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
         }
     }
 
-    /// BlockRelocability indicating some block is movable from any position.
-    /// "Always" only indicates that this BlockRelocability instance produced by some context
-    /// will always return true for isRelocatable; it does not imply that the relevant block
-    /// will always produce an Always instance in any context.
-    public static enum Always implements BlockRelocability {
+    /// BlockRelocability indicating some block is currently agreeing to be moved
+    public static enum Yes implements BlockRelocability {
         /** Singleton instance **/
         INSTANCE;
 
@@ -54,7 +48,14 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
     /// only require themselves and the core, and having the core block require all non-core positions.
     ///
     /// @param requiredPositions Set of block positions which must be moved with this block to allow moving it.
+    /// This Set must include the block's own position.
     public static record Multiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
+        public Multiblock(Set<BlockPos> requiredPositions) {
+            if (requiredPositions.isEmpty())
+                throw new IllegalArgumentException("requiredPositions cannot be empty");
+            this.requiredPositions = requiredPositions;
+        }
+
         @Override
         public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
             return relocatingPositions.containsAll(requiredPositions);

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -57,12 +57,7 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
     public static record Multiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
         @Override
         public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
-            for (BlockPos pos : requiredPositions) {
-                if (!relocatingPositions.contains(pos)) {
-                    return false;
-                }
-            }
-            return true;
+            return relocatingPositions.containsAll(requiredPositions);
         }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -19,6 +19,7 @@ import java.util.Set;
 public sealed interface BlockRelocability permits BlockRelocability.Never, BlockRelocability.Always, BlockRelocability.Multiblock {
 
 	/// {@return true if the block is relocatable from a given Set of block positions, false otherwise}
+	/// @param relocatingPositions Set of positions blocks are being relocated from
 	public abstract boolean isRelocatable(Set<BlockPos> relocatingPositions);
 
 	/// BlockRelocability indicating some block may never be relocated.
@@ -26,7 +27,7 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
 	/// will always return false for isRelocatable; it does not imply that the relevant block
 	/// will always produce a Never instance in any context.
 	public static enum Never implements BlockRelocability {
-		/// singleton instance
+		/// Singleton instance.
 		INSTANCE;
 
 		@Override
@@ -40,7 +41,7 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
 	/// will always return true for isRelocatable; it does not imply that the relevant block
 	/// will always produce an Always instance in any context.
 	public static enum Always implements BlockRelocability {
-		/// singleton instance
+		/// Singleton instance.
 		INSTANCE;
 
 		@Override

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -1,8 +1,12 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.common.util;
 
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.neoforged.neoforge.common.extensions.IBlockStateExtension;
 
 import java.util.Set;

--- a/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/BlockRelocability.java
@@ -12,11 +12,7 @@ import java.util.Set;
 /// and including any blockentity data.
 ///
 /// Relocator mechanics may query {@link IBlockStateExtension#getRelocability} for each block in some area being moved.
-public sealed interface BlockRelocability permits BlockRelocability.Never, BlockRelocability.Always, BlockRelocability.CuboidMultiblock, BlockRelocability.AmorphousMultiblock {
-
-	/// {@return true if the block is relocatable from a given BoundingBox, false otherwise}
-	/// @param relocatingArea BoundingBox of the block positions being relocated
-	public abstract boolean isRelocatable(BoundingBox relocatingArea);
+public sealed interface BlockRelocability permits BlockRelocability.Never, BlockRelocability.Always, BlockRelocability.Multiblock {
 
 	/// {@return true if the block is relocatable from a given Set of block positions, false otherwise}
 	public abstract boolean isRelocatable(Set<BlockPos> relocatingPositions);
@@ -28,11 +24,6 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
 	public static enum Never implements BlockRelocability {
 		/// singleton instance
 		INSTANCE;
-
-		@Override
-		public boolean isRelocatable(BoundingBox relocatingArea) {
-			return false;
-		}
 
 		@Override
 		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
@@ -49,35 +40,8 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
 		INSTANCE;
 
 		@Override
-		public boolean isRelocatable(BoundingBox relocatingArea) {
-			return true;
-		}
-
-		@Override
 		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
 			return true;
-		}
-	}
-
-	/// BlockRelocability indicating some block is movable if and only if a given region of blocks is being moved with it.
-	/// This may be provided by blocks such as beds, doors, 3x3 furnaces, etc.
-	///
-	/// @param requiredArea BoundingBox of block positions which must be moved with this block to allow moving it.
-	public static record CuboidMultiblock(BoundingBox requiredArea) implements BlockRelocability {
-		@Override
-		public boolean isRelocatable(BoundingBox relocatingArea) {
-			return relocatingArea.minX() <= this.requiredArea.minX()
-				&& relocatingArea.minY() <= this.requiredArea.minY()
-				&& relocatingArea.minZ() <= this.requiredArea.minZ()
-				&& relocatingArea.maxX() >= this.requiredArea.maxX()
-				&& relocatingArea.maxY() >= this.requiredArea.maxY()
-				&& relocatingArea.maxZ() >= this.requiredArea.maxZ();
-		}
-
-		@Override
-		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
-			return BlockPos.betweenClosedStream(this.requiredArea)
-				.allMatch(relocatingPositions::contains);
 		}
 	}
 	/// BlockRelocability indicating a block may be moved if and only if some set of other block positions is being
@@ -87,17 +51,7 @@ public sealed interface BlockRelocability permits BlockRelocability.Never, Block
 	/// only require themselves and the core, and having the core block require all non-core positions.
 	///
 	/// @param requiredPositions Set of block positions which must be moved with this block to allow moving it.
-	public static record AmorphousMultiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
-		@Override
-		public boolean isRelocatable(BoundingBox relocatingArea) {
-			for (BlockPos pos : requiredPositions) {
-				if (!relocatingArea.isInside(pos)) {
-					return false;
-				}
-			}
-			return true;
-		}
-
+	public static record Multiblock(Set<BlockPos> requiredPositions) implements BlockRelocability {
 		@Override
 		public boolean isRelocatable(Set<BlockPos> relocatingPositions) {
 			for (BlockPos pos : requiredPositions) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -290,10 +290,10 @@ public class BlockTests {
                 level.setBlock(lowerPos, lowerState, 0);
                 level.setBlock(abovePos, upperState, 0);
                 // validate individual halves are not relocatable but both halves are
-                helper.assertFalse(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), lowerState + " incorrectly relocatable without upper half");
-                helper.assertFalse(upperState.isRelocatable(level, abovePos, Set.of(abovePos)::contains), upperState + " incorrectly relocatable without lower half");
-                helper.assertTrue(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)::contains), lowerState + " incorrectly non-relocatable with whole multiblock");
-                helper.assertTrue(upperState.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)::contains), upperState + " incorrectly non-relocatable with whole multiblock");
+                helper.assertFalse(lowerState.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), lowerState + " incorrectly relocatable without upper half");
+                helper.assertFalse(upperState.getRelocability(level, abovePos).isRelocatable(Set.of(abovePos)), upperState + " incorrectly relocatable without lower half");
+                helper.assertTrue(lowerState.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, abovePos)), lowerState + " incorrectly non-relocatable with whole multiblock");
+                helper.assertTrue(upperState.getRelocability(level, abovePos).isRelocatable(Set.of(lowerPos, abovePos)), upperState + " incorrectly non-relocatable with whole multiblock");
                 // clean up blocks or rose bush nukes itself from shape updates
                 level.setBlock(lowerPos, Blocks.AIR.defaultBlockState(), 0);
                 level.setBlock(abovePos, Blocks.AIR.defaultBlockState(), 0);
@@ -308,26 +308,26 @@ public class BlockTests {
             level.setBlock(floorCenter.relative(directionToHead), Blocks.DIRT.defaultBlockState(), 0);
             level.setBlock(lowerPos, bedFoot, 0);
             level.setBlock(headPos, bedHead, 0);
-            helper.assertFalse(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Bed foot " + bedFoot + " incorrectly relocatable without head");
-            helper.assertFalse(bedHead.isRelocatable(level, headPos, Set.of(headPos)::contains), "Bed head " + bedHead + " incorrectly relocatable without foot");
-            helper.assertTrue(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos, headPos)::contains), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
-            helper.assertTrue(bedHead.isRelocatable(level, headPos, Set.of(lowerPos, headPos)::contains), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
+            helper.assertFalse(bedFoot.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Bed foot " + bedFoot + " incorrectly relocatable without head");
+            helper.assertFalse(bedHead.getRelocability(level, headPos).isRelocatable(Set.of(headPos)), "Bed head " + bedHead + " incorrectly relocatable without foot");
+            helper.assertTrue(bedFoot.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, headPos)), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
+            helper.assertTrue(bedHead.getRelocability(level, headPos).isRelocatable(Set.of(lowerPos, headPos)), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
 
             // finally, check pistons
             // unextended pistons are always relocatable
             // extended pistons are relocatable if and only if both halves are being relocated
             BlockState unextendedPiston = Blocks.PISTON.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.UP);
             level.setBlock(lowerPos, unextendedPiston, 0);
-            helper.assertTrue(unextendedPiston.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
+            helper.assertTrue(unextendedPiston.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
             level.setBlock(headPos, Blocks.REDSTONE_BLOCK.defaultBlockState(), Block.UPDATE_ALL);
             helper.startSequence()
                     .thenExecuteAfter(3, () -> {
                         BlockState pistonBase = level.getBlockState(lowerPos);
                         BlockState pistonHead = level.getBlockState(abovePos);
-                        helper.assertFalse(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Piston base " + pistonBase + " incorrectly relocatable without head");
-                        helper.assertFalse(pistonHead.isRelocatable(level, abovePos, Set.of(abovePos)::contains), "Piston head " + pistonHead + " incorrectly relocatable without base");
-                        helper.assertTrue(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)::contains), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
-                        helper.assertTrue(pistonHead.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)::contains), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
+                        helper.assertFalse(pistonBase.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Piston base " + pistonBase + " incorrectly relocatable without head");
+                        helper.assertFalse(pistonHead.getRelocability(level, abovePos).isRelocatable(Set.of(abovePos)), "Piston head " + pistonHead + " incorrectly relocatable without base");
+                        helper.assertTrue(pistonBase.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, abovePos)), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
+                        helper.assertTrue(pistonHead.getRelocability(level, abovePos).isRelocatable(Set.of(lowerPos, abovePos)), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
                     })
                     .thenSucceed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.debug.block;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import net.minecraft.client.data.models.BlockModelGenerators;
 import net.minecraft.client.data.models.ItemModelGenerators;
@@ -40,10 +41,12 @@ import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.ScheduledTickAccess;
+import net.minecraft.world.level.block.BedBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BubbleColumnBlock;
 import net.minecraft.world.level.block.FenceGateBlock;
+import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.LevelData;
@@ -263,6 +266,65 @@ public class BlockTests {
                 }
             }
             test.pass();
+        });
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests if double blocks correctly implement the isRelocatable block extension")
+    static void areDoubleBlocksRelocatable(final DynamicTest test, final RegistrationHelper reg) {
+        test.onGameTest(helper -> {
+            ServerLevel level = helper.getLevel();
+            BlockPos origin = BlockPos.ZERO;
+            BlockPos lowerPos = origin.above();
+            BlockPos abovePos = lowerPos.above();
+            // set some dirt so we can place a plant on it
+            helper.setBlock(origin, Blocks.DIRT.defaultBlockState());
+            // test vertical double blocks
+            for (Block doubleBlock : new Block[] { Blocks.OAK_DOOR, Blocks.ROSE_BUSH }) {
+                BlockState lowerState = doubleBlock.defaultBlockState();
+                helper.setBlock(lowerPos, lowerState);
+                // setPlacedBy places the other half
+                lowerState.getBlock().setPlacedBy(level, helper.absolutePos(lowerPos), lowerState, null, new ItemStack(doubleBlock));
+                BlockState upperState = helper.getBlockState(abovePos);
+                // validate individual halves are not relocatable but both halves are
+                helper.assertFalse(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos)), lowerState + " incorrectly relocatable without upper half");
+                helper.assertFalse(upperState.isRelocatable(level, abovePos, Set.of(abovePos)), upperState + " incorrectly relocatable without lower half");
+                helper.assertTrue(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)), lowerState + " incorrectly non-relocatable with whole multiblock");
+                helper.assertTrue(upperState.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)), upperState + " incorrectly non-relocatable with whole multiblock");
+            }
+
+            // test beds
+            BlockState bedFoot = Blocks.WHITE_BED.defaultBlockState();
+            Direction directionToHead = BedBlock.getConnectedDirection(bedFoot);
+            BlockPos headPos = lowerPos.relative(directionToHead);
+            // do beds need support? can't remember, just place dirt under where the head will be too
+            helper.setBlock(origin.relative(directionToHead), Blocks.DIRT.defaultBlockState());
+            helper.setBlock(lowerPos, bedFoot);
+            bedFoot.getBlock().setPlacedBy(level, helper.absolutePos(lowerPos), bedFoot, null, new ItemStack(bedFoot.getBlock()));
+            BlockState bedHead = helper.getBlockState(headPos);
+            helper.assertFalse(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos)), "Bed foot " + bedFoot + " incorrectly relocatable without head");
+            helper.assertFalse(bedHead.isRelocatable(level, headPos, Set.of(headPos)), "Bed head " + bedHead + " incorrectly relocatable without foot");
+            helper.assertTrue(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos, headPos)), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
+            helper.assertTrue(bedHead.isRelocatable(level, headPos, Set.of(lowerPos, headPos)), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
+
+            // finally, check pistons
+            // unextended pistons are always relocatable
+            // extended pistons are relocatable if and only if both halves are being relocated
+            BlockState unextendedPiston = Blocks.PISTON.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.UP);
+            helper.setBlock(lowerPos, unextendedPiston);
+            helper.assertTrue(unextendedPiston.isRelocatable(level, lowerPos, Set.of(lowerPos)), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
+            helper.setBlock(headPos, Blocks.REDSTONE_BLOCK);
+            helper.startSequence()
+                    .thenExecuteAfter(3, () -> {
+                        BlockState pistonBase = helper.getBlockState(lowerPos);
+                        BlockState pistonHead = helper.getBlockState(abovePos);
+                        helper.assertFalse(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos)), "Piston base " + pistonBase + " incorrectly relocatable without head");
+                        helper.assertFalse(pistonHead.isRelocatable(level, abovePos, Set.of(abovePos)), "Piston head " + pistonHead + " incorrectly relocatable without base");
+                        helper.assertTrue(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
+                        helper.assertTrue(pistonHead.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
+                    })
+                    .thenSucceed();
         });
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -288,10 +288,10 @@ public class BlockTests {
                 lowerState.getBlock().setPlacedBy(level, helper.absolutePos(lowerPos), lowerState, null, new ItemStack(doubleBlock));
                 BlockState upperState = helper.getBlockState(abovePos);
                 // validate individual halves are not relocatable but both halves are
-                helper.assertFalse(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos)), lowerState + " incorrectly relocatable without upper half");
-                helper.assertFalse(upperState.isRelocatable(level, abovePos, Set.of(abovePos)), upperState + " incorrectly relocatable without lower half");
-                helper.assertTrue(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)), lowerState + " incorrectly non-relocatable with whole multiblock");
-                helper.assertTrue(upperState.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)), upperState + " incorrectly non-relocatable with whole multiblock");
+                helper.assertFalse(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), lowerState + " incorrectly relocatable without upper half");
+                helper.assertFalse(upperState.isRelocatable(level, abovePos, Set.of(abovePos)::contains), upperState + " incorrectly relocatable without lower half");
+                helper.assertTrue(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)::contains), lowerState + " incorrectly non-relocatable with whole multiblock");
+                helper.assertTrue(upperState.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)::contains), upperState + " incorrectly non-relocatable with whole multiblock");
             }
 
             // test beds
@@ -303,26 +303,26 @@ public class BlockTests {
             helper.setBlock(lowerPos, bedFoot);
             bedFoot.getBlock().setPlacedBy(level, helper.absolutePos(lowerPos), bedFoot, null, new ItemStack(bedFoot.getBlock()));
             BlockState bedHead = helper.getBlockState(headPos);
-            helper.assertFalse(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos)), "Bed foot " + bedFoot + " incorrectly relocatable without head");
-            helper.assertFalse(bedHead.isRelocatable(level, headPos, Set.of(headPos)), "Bed head " + bedHead + " incorrectly relocatable without foot");
-            helper.assertTrue(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos, headPos)), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
-            helper.assertTrue(bedHead.isRelocatable(level, headPos, Set.of(lowerPos, headPos)), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
+            helper.assertFalse(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Bed foot " + bedFoot + " incorrectly relocatable without head");
+            helper.assertFalse(bedHead.isRelocatable(level, headPos, Set.of(headPos)::contains), "Bed head " + bedHead + " incorrectly relocatable without foot");
+            helper.assertTrue(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos, headPos)::contains), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
+            helper.assertTrue(bedHead.isRelocatable(level, headPos, Set.of(lowerPos, headPos)::contains), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
 
             // finally, check pistons
             // unextended pistons are always relocatable
             // extended pistons are relocatable if and only if both halves are being relocated
             BlockState unextendedPiston = Blocks.PISTON.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.UP);
             helper.setBlock(lowerPos, unextendedPiston);
-            helper.assertTrue(unextendedPiston.isRelocatable(level, lowerPos, Set.of(lowerPos)), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
+            helper.assertTrue(unextendedPiston.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
             helper.setBlock(headPos, Blocks.REDSTONE_BLOCK);
             helper.startSequence()
                     .thenExecuteAfter(3, () -> {
                         BlockState pistonBase = helper.getBlockState(lowerPos);
                         BlockState pistonHead = helper.getBlockState(abovePos);
-                        helper.assertFalse(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos)), "Piston base " + pistonBase + " incorrectly relocatable without head");
-                        helper.assertFalse(pistonHead.isRelocatable(level, abovePos, Set.of(abovePos)), "Piston head " + pistonHead + " incorrectly relocatable without base");
-                        helper.assertTrue(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
-                        helper.assertTrue(pistonHead.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
+                        helper.assertFalse(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Piston base " + pistonBase + " incorrectly relocatable without head");
+                        helper.assertFalse(pistonHead.isRelocatable(level, abovePos, Set.of(abovePos)::contains), "Piston head " + pistonHead + " incorrectly relocatable without base");
+                        helper.assertTrue(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)::contains), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
+                        helper.assertTrue(pistonHead.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)::contains), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
                     })
                     .thenSucceed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -64,6 +64,7 @@ import net.neoforged.testframework.Test;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
 import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.gametest.GameTest;
 import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 import net.neoforged.testframework.registration.RegistrationHelper;
@@ -275,61 +276,59 @@ public class BlockTests {
     @GameTest
     @EmptyTemplate
     @TestHolder(description = "Tests if double blocks correctly implement the isRelocatable block extension")
-    static void areDoubleBlocksRelocatable(final DynamicTest test, final RegistrationHelper reg) {
-        test.onGameTest(helper -> {
-            ServerLevel level = helper.getLevel();
-            BlockPos floorCenter = helper.absolutePos(new BlockPos(1, 0, 1)); // we're in a 3x3x3 cube by default
-            BlockPos lowerPos = floorCenter.above();
-            BlockPos abovePos = lowerPos.above();
-            // set some dirt so we can place a plant on it
-            level.setBlock(floorCenter, Blocks.DIRT.defaultBlockState(), 0);
-            // test vertical double blocks
-            for (Block doubleBlock : new Block[] { Blocks.OAK_DOOR, Blocks.ROSE_BUSH }) {
-                BlockState lowerState = doubleBlock.defaultBlockState();
-                BlockState upperState = lowerState.setValue(BlockStateProperties.DOUBLE_BLOCK_HALF, DoubleBlockHalf.UPPER);
-                level.setBlock(lowerPos, lowerState, 0);
-                level.setBlock(abovePos, upperState, 0);
-                // validate individual halves are not relocatable but both halves are
-                helper.assertFalse(lowerState.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), lowerState + " incorrectly relocatable without upper half");
-                helper.assertFalse(upperState.getRelocability(level, abovePos).isRelocatable(Set.of(abovePos)), upperState + " incorrectly relocatable without lower half");
-                helper.assertTrue(lowerState.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, abovePos)), lowerState + " incorrectly non-relocatable with whole multiblock");
-                helper.assertTrue(upperState.getRelocability(level, abovePos).isRelocatable(Set.of(lowerPos, abovePos)), upperState + " incorrectly non-relocatable with whole multiblock");
-                // clean up blocks or rose bush nukes itself from shape updates
-                level.setBlock(lowerPos, Blocks.AIR.defaultBlockState(), 0);
-                level.setBlock(abovePos, Blocks.AIR.defaultBlockState(), 0);
-            }
+    static void areDoubleBlocksRelocatable(ExtendedGameTestHelper helper) {
+        ServerLevel level = helper.getLevel();
+        BlockPos floorCenter = helper.absolutePos(new BlockPos(1, 0, 1)); // we're in a 3x3x3 cube by default
+        BlockPos lowerPos = floorCenter.above();
+        BlockPos abovePos = lowerPos.above();
+        // set some dirt so we can place a plant on it
+        level.setBlock(floorCenter, Blocks.DIRT.defaultBlockState(), 0);
+        // test vertical double blocks
+        for (Block doubleBlock : new Block[] { Blocks.OAK_DOOR, Blocks.ROSE_BUSH }) {
+            BlockState lowerState = doubleBlock.defaultBlockState();
+            BlockState upperState = lowerState.setValue(BlockStateProperties.DOUBLE_BLOCK_HALF, DoubleBlockHalf.UPPER);
+            level.setBlock(lowerPos, lowerState, 0);
+            level.setBlock(abovePos, upperState, 0);
+            // validate individual halves are not relocatable but both halves are
+            helper.assertFalse(lowerState.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), lowerState + " incorrectly relocatable without upper half");
+            helper.assertFalse(upperState.getRelocability(level, abovePos).isRelocatable(Set.of(abovePos)), upperState + " incorrectly relocatable without lower half");
+            helper.assertTrue(lowerState.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, abovePos)), lowerState + " incorrectly non-relocatable with whole multiblock");
+            helper.assertTrue(upperState.getRelocability(level, abovePos).isRelocatable(Set.of(lowerPos, abovePos)), upperState + " incorrectly non-relocatable with whole multiblock");
+            // clean up blocks or rose bush nukes itself from shape updates
+            level.setBlock(lowerPos, Blocks.AIR.defaultBlockState(), 0);
+            level.setBlock(abovePos, Blocks.AIR.defaultBlockState(), 0);
+        }
 
-            // test beds
-            BlockState bedFoot = Blocks.WHITE_BED.defaultBlockState();
-            BlockState bedHead = bedFoot.setValue(BedBlock.PART, BedPart.HEAD);
-            Direction directionToHead = BedBlock.getConnectedDirection(bedFoot);
-            BlockPos headPos = lowerPos.relative(directionToHead);
-            // do beds need support? can't remember, just place dirt under where the head will be too
-            level.setBlock(floorCenter.relative(directionToHead), Blocks.DIRT.defaultBlockState(), 0);
-            level.setBlock(lowerPos, bedFoot, 0);
-            level.setBlock(headPos, bedHead, 0);
-            helper.assertFalse(bedFoot.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Bed foot " + bedFoot + " incorrectly relocatable without head");
-            helper.assertFalse(bedHead.getRelocability(level, headPos).isRelocatable(Set.of(headPos)), "Bed head " + bedHead + " incorrectly relocatable without foot");
-            helper.assertTrue(bedFoot.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, headPos)), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
-            helper.assertTrue(bedHead.getRelocability(level, headPos).isRelocatable(Set.of(lowerPos, headPos)), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
+        // test beds
+        BlockState bedFoot = Blocks.WHITE_BED.defaultBlockState();
+        BlockState bedHead = bedFoot.setValue(BedBlock.PART, BedPart.HEAD);
+        Direction directionToHead = BedBlock.getConnectedDirection(bedFoot);
+        BlockPos headPos = lowerPos.relative(directionToHead);
+        // do beds need support? can't remember, just place dirt under where the head will be too
+        level.setBlock(floorCenter.relative(directionToHead), Blocks.DIRT.defaultBlockState(), 0);
+        level.setBlock(lowerPos, bedFoot, 0);
+        level.setBlock(headPos, bedHead, 0);
+        helper.assertFalse(bedFoot.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Bed foot " + bedFoot + " incorrectly relocatable without head");
+        helper.assertFalse(bedHead.getRelocability(level, headPos).isRelocatable(Set.of(headPos)), "Bed head " + bedHead + " incorrectly relocatable without foot");
+        helper.assertTrue(bedFoot.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, headPos)), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
+        helper.assertTrue(bedHead.getRelocability(level, headPos).isRelocatable(Set.of(lowerPos, headPos)), "Bed head " + bedHead + " incorrectly non-relocatable with whole bed");
 
-            // finally, check pistons
-            // unextended pistons are always relocatable
-            // extended pistons are relocatable if and only if both halves are being relocated
-            BlockState unextendedPiston = Blocks.PISTON.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.UP);
-            level.setBlock(lowerPos, unextendedPiston, 0);
-            helper.assertTrue(unextendedPiston.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
-            level.setBlock(headPos, Blocks.REDSTONE_BLOCK.defaultBlockState(), Block.UPDATE_ALL);
-            helper.startSequence()
-                    .thenExecuteAfter(3, () -> {
-                        BlockState pistonBase = level.getBlockState(lowerPos);
-                        BlockState pistonHead = level.getBlockState(abovePos);
-                        helper.assertFalse(pistonBase.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Piston base " + pistonBase + " incorrectly relocatable without head");
-                        helper.assertFalse(pistonHead.getRelocability(level, abovePos).isRelocatable(Set.of(abovePos)), "Piston head " + pistonHead + " incorrectly relocatable without base");
-                        helper.assertTrue(pistonBase.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, abovePos)), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
-                        helper.assertTrue(pistonHead.getRelocability(level, abovePos).isRelocatable(Set.of(lowerPos, abovePos)), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
-                    })
-                    .thenSucceed();
-        });
+        // finally, check pistons
+        // unextended pistons are always relocatable
+        // extended pistons are relocatable if and only if both halves are being relocated
+        BlockState unextendedPiston = Blocks.PISTON.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.UP);
+        level.setBlock(lowerPos, unextendedPiston, 0);
+        helper.assertTrue(unextendedPiston.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
+        level.setBlock(headPos, Blocks.REDSTONE_BLOCK.defaultBlockState(), Block.UPDATE_ALL);
+        helper.startSequence()
+                .thenExecuteAfter(3, () -> {
+                    BlockState pistonBase = level.getBlockState(lowerPos);
+                    BlockState pistonHead = level.getBlockState(abovePos);
+                    helper.assertFalse(pistonBase.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos)), "Piston base " + pistonBase + " incorrectly relocatable without head");
+                    helper.assertFalse(pistonHead.getRelocability(level, abovePos).isRelocatable(Set.of(abovePos)), "Piston head " + pistonHead + " incorrectly relocatable without base");
+                    helper.assertTrue(pistonBase.getRelocability(level, lowerPos).isRelocatable(Set.of(lowerPos, abovePos)), "Piston base " + pistonBase + " incorrectly non-relocatable with head");
+                    helper.assertTrue(pistonHead.getRelocability(level, abovePos).isRelocatable(Set.of(lowerPos, abovePos)), "Piston head " + pistonHead + " incorrectly non-relocatable with base");
+                })
+                .thenSucceed();
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/block/BlockTests.java
@@ -49,6 +49,9 @@ import net.minecraft.world.level.block.FenceGateBlock;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BedPart;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.storage.LevelData;
 import net.minecraft.world.phys.BlockHitResult;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
@@ -275,34 +278,36 @@ public class BlockTests {
     static void areDoubleBlocksRelocatable(final DynamicTest test, final RegistrationHelper reg) {
         test.onGameTest(helper -> {
             ServerLevel level = helper.getLevel();
-            BlockPos origin = BlockPos.ZERO;
-            BlockPos lowerPos = origin.above();
+            BlockPos floorCenter = helper.absolutePos(new BlockPos(1, 0, 1)); // we're in a 3x3x3 cube by default
+            BlockPos lowerPos = floorCenter.above();
             BlockPos abovePos = lowerPos.above();
             // set some dirt so we can place a plant on it
-            helper.setBlock(origin, Blocks.DIRT.defaultBlockState());
+            level.setBlock(floorCenter, Blocks.DIRT.defaultBlockState(), 0);
             // test vertical double blocks
             for (Block doubleBlock : new Block[] { Blocks.OAK_DOOR, Blocks.ROSE_BUSH }) {
                 BlockState lowerState = doubleBlock.defaultBlockState();
-                helper.setBlock(lowerPos, lowerState);
-                // setPlacedBy places the other half
-                lowerState.getBlock().setPlacedBy(level, helper.absolutePos(lowerPos), lowerState, null, new ItemStack(doubleBlock));
-                BlockState upperState = helper.getBlockState(abovePos);
+                BlockState upperState = lowerState.setValue(BlockStateProperties.DOUBLE_BLOCK_HALF, DoubleBlockHalf.UPPER);
+                level.setBlock(lowerPos, lowerState, 0);
+                level.setBlock(abovePos, upperState, 0);
                 // validate individual halves are not relocatable but both halves are
                 helper.assertFalse(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), lowerState + " incorrectly relocatable without upper half");
                 helper.assertFalse(upperState.isRelocatable(level, abovePos, Set.of(abovePos)::contains), upperState + " incorrectly relocatable without lower half");
                 helper.assertTrue(lowerState.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)::contains), lowerState + " incorrectly non-relocatable with whole multiblock");
                 helper.assertTrue(upperState.isRelocatable(level, abovePos, Set.of(lowerPos, abovePos)::contains), upperState + " incorrectly non-relocatable with whole multiblock");
+                // clean up blocks or rose bush nukes itself from shape updates
+                level.setBlock(lowerPos, Blocks.AIR.defaultBlockState(), 0);
+                level.setBlock(abovePos, Blocks.AIR.defaultBlockState(), 0);
             }
 
             // test beds
             BlockState bedFoot = Blocks.WHITE_BED.defaultBlockState();
+            BlockState bedHead = bedFoot.setValue(BedBlock.PART, BedPart.HEAD);
             Direction directionToHead = BedBlock.getConnectedDirection(bedFoot);
             BlockPos headPos = lowerPos.relative(directionToHead);
             // do beds need support? can't remember, just place dirt under where the head will be too
-            helper.setBlock(origin.relative(directionToHead), Blocks.DIRT.defaultBlockState());
-            helper.setBlock(lowerPos, bedFoot);
-            bedFoot.getBlock().setPlacedBy(level, helper.absolutePos(lowerPos), bedFoot, null, new ItemStack(bedFoot.getBlock()));
-            BlockState bedHead = helper.getBlockState(headPos);
+            level.setBlock(floorCenter.relative(directionToHead), Blocks.DIRT.defaultBlockState(), 0);
+            level.setBlock(lowerPos, bedFoot, 0);
+            level.setBlock(headPos, bedHead, 0);
             helper.assertFalse(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Bed foot " + bedFoot + " incorrectly relocatable without head");
             helper.assertFalse(bedHead.isRelocatable(level, headPos, Set.of(headPos)::contains), "Bed head " + bedHead + " incorrectly relocatable without foot");
             helper.assertTrue(bedFoot.isRelocatable(level, lowerPos, Set.of(lowerPos, headPos)::contains), "Bed foot " + bedFoot + " incorrectly non-relocatable with whole bed");
@@ -312,13 +317,13 @@ public class BlockTests {
             // unextended pistons are always relocatable
             // extended pistons are relocatable if and only if both halves are being relocated
             BlockState unextendedPiston = Blocks.PISTON.defaultBlockState().setValue(PistonBaseBlock.FACING, Direction.UP);
-            helper.setBlock(lowerPos, unextendedPiston);
+            level.setBlock(lowerPos, unextendedPiston, 0);
             helper.assertTrue(unextendedPiston.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Unextended piston " + unextendedPiston + " incorrectly non-relocatable");
-            helper.setBlock(headPos, Blocks.REDSTONE_BLOCK);
+            level.setBlock(headPos, Blocks.REDSTONE_BLOCK.defaultBlockState(), Block.UPDATE_ALL);
             helper.startSequence()
                     .thenExecuteAfter(3, () -> {
-                        BlockState pistonBase = helper.getBlockState(lowerPos);
-                        BlockState pistonHead = helper.getBlockState(abovePos);
+                        BlockState pistonBase = level.getBlockState(lowerPos);
+                        BlockState pistonHead = level.getBlockState(abovePos);
                         helper.assertFalse(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos)::contains), "Piston base " + pistonBase + " incorrectly relocatable without head");
                         helper.assertFalse(pistonHead.isRelocatable(level, abovePos, Set.of(abovePos)::contains), "Piston head " + pistonHead + " incorrectly relocatable without base");
                         helper.assertTrue(pistonBase.isRelocatable(level, lowerPos, Set.of(lowerPos, abovePos)::contains), "Piston base " + pistonBase + " incorrectly non-relocatable with head");


### PR DESCRIPTION
The purpose of this is for multiblocks which can be relocated if and only if the whole multiblock is being relocated, to be able declare this behavior.

For example, half a door block shouldn't be relocated, but a whole door is perfectly fine to relocate.

This PR adds an overridable method IBlockExtension#getRelocability for declaring this behavior (and corresponding IBlockStateExtension API), and also patches doors, beds, double plants, and extended pistons to support it.

A mod which intends to relocate some region of blocks (meaning, to cut/copy a region of blocks and paste them somewhere else, including translation, rotation, and/or mirror) would call IBlockStateExtension#getRelocability on each blockstate in the area they are relocating blocks from, testing the returned BlockRelocability object for the region of blocks the relocator is attempting to move.

The default behavior of the extension is to just check the block tag `c:relocation_not_supported`, and blocks which are not relocatable under any circumstances may continue to add themselves to that tag instead of overriding this method.

Additionally, a relocation system which wants to know how big a multiblock is so they can expand the area being relocated to cover the multiblock, may switch over the BlockRelocability, which is a sealed interface; the Multiblock subclass declares a set of positions indicating the extent of the multiblock.