### PR TITLE
[26.1] Fix GLMs failing to resolve tags during loading

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -154,7 +154,7 @@ public class NeoForgeEventHandler {
 
     @SubscribeEvent
     public void onResourceReload(AddServerReloadListenersEvent event) {
-        event.addListener(NeoForgeReloadListeners.LOOT_MODIFIERS, LOOT_MODIFIER_MANAGER = new LootModifierManager(event.getRegistryAccess()));
+        event.addListener(NeoForgeReloadListeners.LOOT_MODIFIERS, LOOT_MODIFIER_MANAGER = new LootModifierManager());
         event.addListener(NeoForgeReloadListeners.RECIPE_PRIORITIES, new RecipePriorityManager(event.getServerResources().getRecipeManager()));
         event.addListener(NeoForgeReloadListeners.DATA_MAPS, DATA_MAP_LOADER = new DataMapLoader(event.getConditionContext(), event.getRegistryAccess()));
         event.addListener(NeoForgeReloadListeners.CREATIVE_TABS, CreativeModeTabRegistry.getReloadListener());

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -156,7 +156,7 @@ public class NeoForgeEventHandler {
     public void onResourceReload(AddServerReloadListenersEvent event) {
         event.addListener(NeoForgeReloadListeners.LOOT_MODIFIERS, LOOT_MODIFIER_MANAGER = new LootModifierManager());
         event.addListener(NeoForgeReloadListeners.RECIPE_PRIORITIES, new RecipePriorityManager(event.getServerResources().getRecipeManager()));
-        event.addListener(NeoForgeReloadListeners.DATA_MAPS, DATA_MAP_LOADER = new DataMapLoader(event.getConditionContext(), event.getRegistryAccess()));
+        event.addListener(NeoForgeReloadListeners.DATA_MAPS, DATA_MAP_LOADER = new DataMapLoader(event.getRegistryAccess()));
         event.addListener(NeoForgeReloadListeners.CREATIVE_TABS, CreativeModeTabRegistry.getReloadListener());
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -48,6 +48,7 @@ import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
 import net.neoforged.neoforge.server.command.ConfigCommand;
 import net.neoforged.neoforge.server.command.NeoForgeCommand;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.VisibleForTesting;
 
 @ApiStatus.Internal
 public class NeoForgeEventHandler {
@@ -160,7 +161,8 @@ public class NeoForgeEventHandler {
         event.addListener(NeoForgeReloadListeners.CREATIVE_TABS, CreativeModeTabRegistry.getReloadListener());
     }
 
-    static LootModifierManager getLootModifierManager() {
+    @VisibleForTesting
+    public static LootModifierManager getLootModifierManager() {
         if (LOOT_MODIFIER_MANAGER == null)
             throw new IllegalStateException("Can not retrieve LootModifierManager until resources have loaded once.");
         return LOOT_MODIFIER_MANAGER;

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
@@ -26,6 +26,7 @@ import net.minecraft.util.Unit;
 import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.flag.FeatureFlags;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.resource.ContextAwareReloadListener;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 public interface ICondition {
@@ -114,6 +115,13 @@ public interface ICondition {
             return List.of();
         }
 
+        /// Provides access to the loaded registries if this context is used for a datapack reload.
+        ///
+        /// @apiNote The returned [RegistryAccess] does NOT provide access to the tags loaded during the active reload.
+        /// To resolve tags the [HolderLookup.Provider] provided via [ContextAwareReloadListener#getRegistryLookup()]
+        /// must be used instead.
+        ///
+        /// @return The [RegistryAccess] context for the currently active reload.
         default RegistryAccess registryAccess() {
             return RegistryAccess.EMPTY;
         }

--- a/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
@@ -59,4 +59,9 @@ public class LootModifierManager extends SimpleJsonResourceReloadListener<IGloba
     public Identifier getId(IGlobalLootModifier modifier) {
         return this.registeredLootModifiers.inverse().get(modifier);
     }
+
+    @Nullable
+    public IGlobalLootModifier getModifier(Identifier id) {
+        return this.registeredLootModifiers.get(id);
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
+++ b/src/main/java/net/neoforged/neoforge/common/loot/LootModifierManager.java
@@ -11,36 +11,32 @@ import com.google.common.collect.ImmutableBiMap.Builder;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
-import net.neoforged.neoforge.common.conditions.WithConditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jspecify.annotations.Nullable;
 
-public class LootModifierManager extends SimpleJsonResourceReloadListener<Optional<WithConditions<IGlobalLootModifier>>> {
+public class LootModifierManager extends SimpleJsonResourceReloadListener<IGlobalLootModifier> {
     public static final Logger LOGGER = LogManager.getLogger();
     private static final String FOLDER = "loot_modifiers";
 
     private BiMap<Identifier, IGlobalLootModifier> registeredLootModifiers = ImmutableBiMap.of();
     private List<IGlobalLootModifier> sortedModifiers = List.of();
 
-    public LootModifierManager(RegistryAccess registries) {
-        super(registries, IGlobalLootModifier.CONDITIONAL_CODEC, ResourceKey.createRegistryKey(Identifier.withDefaultNamespace(FOLDER)));
+    public LootModifierManager() {
+        super(IGlobalLootModifier.DIRECT_CODEC, FileToIdConverter.registry(ResourceKey.createRegistryKey(Identifier.withDefaultNamespace(FOLDER))));
     }
 
     @Override
-    protected void apply(Map<Identifier, Optional<WithConditions<IGlobalLootModifier>>> resourceList, ResourceManager resourceManagerIn, ProfilerFiller profilerIn) {
+    protected void apply(Map<Identifier, IGlobalLootModifier> resourceList, ResourceManager resourceManagerIn, ProfilerFiller profilerIn) {
         Builder<Identifier, IGlobalLootModifier> builder = ImmutableBiMap.builder();
-        for (Map.Entry<Identifier, Optional<WithConditions<IGlobalLootModifier>>> entry : resourceList.entrySet()) {
-            if (entry.getValue().isPresent()) {
-                builder.put(entry.getKey(), entry.getValue().get().carrier());
-            }
+        for (Map.Entry<Identifier, IGlobalLootModifier> entry : resourceList.entrySet()) {
+            builder.put(entry.getKey(), entry.getValue());
         }
 
         this.registeredLootModifiers = builder.build();

--- a/src/main/java/net/neoforged/neoforge/event/AddServerReloadListenersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/AddServerReloadListenersEvent.java
@@ -5,12 +5,14 @@
 
 package net.neoforged.neoforge.event;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.ReloadableServerResources;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.conditions.ICondition;
+import net.neoforged.neoforge.resource.ContextAwareReloadListener;
 import net.neoforged.neoforge.resource.VanillaServerListeners;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -47,12 +49,14 @@ public class AddServerReloadListenersEvent extends SortedReloadListenerEvent {
         return serverResources.getConditionContext();
     }
 
-    /**
-     * Provides access to the loaded registries associated with these server resources.
-     * All built-in and dynamic registries are loaded and frozen by this point.
-     * 
-     * @return The RegistryAccess context for the currently active reload.
-     */
+    /// Provides access to the loaded registries associated with these server resources.
+    /// All built-in and dynamic registries are loaded and frozen by this point.
+    ///
+    /// @apiNote The returned [RegistryAccess] does NOT provide access to the tags loaded during the active reload.
+    /// To resolve tags the [HolderLookup.Provider] provided via [ContextAwareReloadListener#getRegistryLookup()]
+    /// must be used instead.
+    ///
+    /// @return The [RegistryAccess] context for the currently active reload.
     public RegistryAccess getRegistryAccess() {
         return registryAccess;
     }

--- a/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
@@ -9,7 +9,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mojang.datafixers.util.Either;
 import com.mojang.logging.LogUtils;
-import com.mojang.serialization.JsonOps;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -26,32 +25,28 @@ import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.profiling.Profiler;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.conditions.ConditionalOps;
-import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.registries.datamaps.AdvancedDataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapFile;
 import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueMerger;
 import net.neoforged.neoforge.registries.datamaps.DataMapsUpdatedEvent;
+import net.neoforged.neoforge.resource.ContextAwareReloadListener;
 import org.slf4j.Logger;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class DataMapLoader implements PreparableReloadListener {
+public class DataMapLoader extends ContextAwareReloadListener {
     private static final Logger LOGGER = LogUtils.getLogger();
     public static final String PATH = "data_maps";
     private Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> results;
-    private final ICondition.IContext conditionContext;
     private final RegistryAccess registryAccess;
 
-    public DataMapLoader(ICondition.IContext conditionContext, RegistryAccess registryAccess) {
-        this.conditionContext = conditionContext;
+    public DataMapLoader(RegistryAccess registryAccess) {
         this.registryAccess = registryAccess;
     }
 
@@ -140,15 +135,15 @@ public class DataMapLoader implements PreparableReloadListener {
     }
 
     private CompletableFuture<Map<ResourceKey<? extends Registry<?>>, LoadResult<?>>> load(ResourceManager manager, Executor executor, ProfilerFiller profiler) {
-        return CompletableFuture.supplyAsync(() -> load(manager, profiler, registryAccess, conditionContext), executor);
+        return CompletableFuture.supplyAsync(() -> load(manager, profiler), executor);
     }
 
-    private static Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> load(ResourceManager manager, ProfilerFiller profiler, RegistryAccess access, ICondition.IContext context) {
-        final RegistryOps<JsonElement> ops = new ConditionalOps<>(RegistryOps.create(JsonOps.INSTANCE, access), context);
+    private Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> load(ResourceManager manager, ProfilerFiller profiler) {
+        final RegistryOps<JsonElement> ops = makeConditionalOps();
 
         final Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> values = new HashMap<>();
-        access.registries().forEach(registryEntry -> {
-            final var registryKey = registryEntry.key();
+        getRegistryLookup().listRegistries().forEach(registryLookup -> {
+            final var registryKey = registryLookup.key();
             profiler.push("registry_data_maps/" + registryKey.identifier() + "/locating");
             final var fileToId = FileToIdConverter.json(PATH + "/" + getFolderLocation(registryKey.identifier()));
             for (Map.Entry<Identifier, List<Resource>> entry : fileToId.listMatchingResourceStacks(manager).entrySet()) {

--- a/tests/src/generated/resources/neotests_glm_test_wheat_seed_glms/data/neotests_glm_test/loot_modifiers/wheat_harvest_disabled.json
+++ b/tests/src/generated/resources/neotests_glm_test_wheat_seed_glms/data/neotests_glm_test/loot_modifiers/wheat_harvest_disabled.json
@@ -1,12 +1,11 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:never"
+    }
+  ],
   "type": "neotests_glm_test:wheat_harvest",
   "conditions": [
-    {
-      "condition": "minecraft:match_tool",
-      "predicate": {
-        "items": "#c:tools/shear"
-      }
-    },
     {
       "block": "minecraft:wheat",
       "condition": "minecraft:block_state_property"
@@ -18,6 +17,7 @@
     }
   ],
   "numSeeds": 1,
-  "replacement": "minecraft:wheat",
-  "seedItem": "minecraft:wheat_seeds"
+  "priority": 900,
+  "replacement": "minecraft:bamboo",
+  "seedItem": "minecraft:wheat"
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
@@ -54,6 +54,8 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePrope
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraft.world.level.storage.loot.predicates.MatchTool;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.conditions.NeoForgeConditions;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 import net.neoforged.neoforge.common.data.GlobalLootModifierProvider;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
@@ -303,12 +305,22 @@ public class GlobalLootModifiersTest {
             protected void start() {
                 this.add("wheat_harvest", new WheatSeedsConverterModifier(
                         new LootItemCondition[] {
-                                MatchTool.toolMatches(ItemPredicate.Builder.item().of(this.registries.lookupOrThrow(Registries.ITEM), Items.SHEARS)).build(),
+                                // Check shear tool tag to ensure GLMs can resolve tags during loading
+                                MatchTool.toolMatches(ItemPredicate.Builder.item().of(this.registries.lookupOrThrow(Registries.ITEM), Tags.Items.TOOLS_SHEAR)).build(),
                                 LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.WHEAT).build(),
                                 new TestEnabledLootCondition(test)
                         },
                         IGlobalLootModifier.DEFAULT_PRIORITY,
                         1, Items.WHEAT_SEEDS, Items.WHEAT));
+
+                // Ensure loading conditions work on GLMs
+                this.add("wheat_harvest_disabled", new WheatSeedsConverterModifier(
+                        new LootItemCondition[] {
+                                LootItemBlockStatePropertyCondition.hasBlockStateProperties(Blocks.WHEAT).build(),
+                                new TestEnabledLootCondition(test)
+                        },
+                        IGlobalLootModifier.DEFAULT_PRIORITY - 100,
+                        1, Items.WHEAT, Items.BAMBOO), NeoForgeConditions.never());
             }
 
             @Override

--- a/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
@@ -54,12 +54,14 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePrope
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraft.world.level.storage.loot.predicates.MatchTool;
 import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.NeoForgeEventHandler;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.conditions.NeoForgeConditions;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 import net.neoforged.neoforge.common.data.GlobalLootModifierProvider;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
 import net.neoforged.neoforge.common.loot.LootModifier;
+import net.neoforged.neoforge.common.loot.LootModifierManager;
 import net.neoforged.neoforge.common.loot.LootTableIdCondition;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -329,20 +331,27 @@ public class GlobalLootModifiersTest {
             }
         });
 
-        test.onGameTest(helper -> helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL).preventItemPickup())
-                .thenExecute(player -> player.setItemInHand(InteractionHand.MAIN_HAND, Items.SHEARS.getDefaultInstance()))
+        test.onGameTest(helper -> {
+            LootModifierManager lootModManager = NeoForgeEventHandler.getLootModifierManager();
+            if (lootModManager.getModifier(Identifier.fromNamespaceAndPath(HELPER.modId(), "wheat_harvest_disabled")) != null) {
+                helper.fail("GLM disabled by condition was loaded");
+            }
 
-                .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.FARMLAND))
-                .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.WHEAT.defaultBlockState().setValue(CropBlock.AGE, 7)))
+            helper.startSequence(() -> helper.makeTickingMockServerPlayerInCorner(GameType.SURVIVAL).preventItemPickup())
+                    .thenExecute(player -> player.setItemInHand(InteractionHand.MAIN_HAND, Items.SHEARS.getDefaultInstance()))
 
-                .thenIdle(5)
-                .thenExecute(player -> player.gameMode.destroyBlock(helper.absolutePos(new BlockPos(1, 2, 1))))
-                .thenIdle(5)
-                // At least one seed will be dropped (which will be converted to wheat), and one wheat
-                .thenExecute(player -> helper.assertItemEntityCountIsAtLeast(Items.WHEAT, new BlockPos(1, 2, 1), 1d, 2))
-                .thenExecute(player -> helper.assertItemEntityNotPresent(Items.WHEAT_SEEDS, new BlockPos(1, 2, 1), 1d))
+                    .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.FARMLAND))
+                    .thenExecute(() -> helper.setBlock(1, 2, 1, Blocks.WHEAT.defaultBlockState().setValue(CropBlock.AGE, 7)))
 
-                .thenSucceed());
+                    .thenIdle(5)
+                    .thenExecute(player -> player.gameMode.destroyBlock(helper.absolutePos(new BlockPos(1, 2, 1))))
+                    .thenIdle(5)
+                    // At least one seed will be dropped (which will be converted to wheat), and one wheat
+                    .thenExecute(player -> helper.assertItemEntityCountIsAtLeast(Items.WHEAT, new BlockPos(1, 2, 1), 1d, 2))
+                    .thenExecute(player -> helper.assertItemEntityNotPresent(Items.WHEAT_SEEDS, new BlockPos(1, 2, 1), 1d))
+
+                    .thenSucceed();
+        });
     }
 
     @GameTest


### PR DESCRIPTION
This PR fixes GLMs not being able to resolve tags during loading, for example as part of the `ItemPredicate` in a `MatchTool` condition.
This regression was introduced in #3061 by using the `RegistryAccess` from `AddServerReloadListenersEvent` to construct a `RegistryOps` instead of leaving the ops wrapping entirely to `ContextAwareReloadListener#makeConditionalOps()`. The `RegistryAccess` provided by said event being problematic is a longstanding known issue, see #1259.