### PR TITLE
[26.1] Work around item atlas sprites being invisible behind translucent block atlas sprites in DynamicFluidContainerModel

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/UnbakedElementsHelper.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/UnbakedElementsHelper.java
@@ -49,15 +49,23 @@ public final class UnbakedElementsHelper {
      * The {@link Direction#NORTH} and {@link Direction#SOUTH} faces take up only the pixels the mask texture uses.
      */
     public static QuadCollection bakeItemMaskQuads(ModelBaker baker, int layerIndex, Material.Baked maskMaterial, Material.Baked outputMaterial, ModelState modelState, ExtraFaceData faceData, UnaryOperator<BakedQuad.MaterialInfo> materialModifier) {
-        QuadCollection.Builder builder = new QuadCollection.Builder();
         ModelBaker.Interner interner = baker.interner();
-        BakedQuad.MaterialInfo maskMaterialInfo = interner.materialInfo(BakedQuad.MaterialInfo.of(maskMaterial, maskMaterial.sprite().transparency(), layerIndex, true, 0, true));
         BakedQuad.MaterialInfo outMaterialInfo = interner.materialInfo(materialModifier.apply(BakedQuad.MaterialInfo.of(outputMaterial, outputMaterial.sprite().transparency(), layerIndex, true, faceData.lightEmission(), faceData.ambientOcclusion())));
+        return bakeItemMaskQuads(baker, maskMaterial, outMaterialInfo, modelState, faceData);
+    }
+
+    /// Bakes quads in the shape of the specified mask texture with the specified output texture applied to them.
+    ///
+    /// The [Direction#NORTH] and [Direction#SOUTH] faces take up only the pixels the mask texture uses.
+    public static QuadCollection bakeItemMaskQuads(ModelBaker baker, Material.Baked maskMaterial, BakedQuad.MaterialInfo outMaterialInfo, ModelState modelState, ExtraFaceData faceData) {
+        ModelBaker.Interner interner = baker.interner();
+        QuadCollection.Builder builder = new QuadCollection.Builder();
+        BakedQuad.MaterialInfo maskMaterialInfo = interner.materialInfo(BakedQuad.MaterialInfo.of(maskMaterial, maskMaterial.sprite().transparency(), -1, true, 0, true));
 
         // TODO 26.1: why are the side faces included at all?
         ItemModelGenerator.bakeSideFaces(builder, interner, modelState, maskMaterialInfo);
 
-        SpriteContents spriteContents = maskMaterial.sprite().contents();
+        SpriteContents spriteContents = maskMaterialInfo.sprite().contents();
         int width = spriteContents.width();
         int height = spriteContents.height();
         BitSet bits = new BitSet(width * height);

--- a/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/item/DynamicFluidContainerModel.java
@@ -15,13 +15,13 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.UnaryOperator;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.block.FluidModel;
 import net.minecraft.client.renderer.block.dispatch.BlockModelRotation;
 import net.minecraft.client.renderer.block.dispatch.ModelState;
+import net.minecraft.client.renderer.chunk.ChunkSectionLayer;
 import net.minecraft.client.renderer.item.CompositeModel;
 import net.minecraft.client.renderer.item.CuboidItemModelWrapper;
 import net.minecraft.client.renderer.item.ItemModel;
@@ -131,9 +131,12 @@ public class DynamicFluidContainerModel implements ItemModel {
             Material.Baked templateSprite = materials.get(fluidMaskLocation, DEBUG_NAME);
             // Fluid layer
             ModelState transformedState = new ComposedModelState(state, FLUID_TRANSFORM);
+            boolean opaque = unbakedModel.forceOpaqueFluid;
             boolean emissive = unbakedModel.applyFluidLuminosity && fluid.getFluidType().getLightLevel() > 0;
-            UnaryOperator<BakedQuad.MaterialInfo> materialModifier = emissive ? DynamicFluidContainerModel::setMaxEmissivity : UnaryOperator.identity();
-            QuadCollection quads = UnbakedElementsHelper.bakeItemMaskQuads(baker, 0, templateSprite, fluidSprite, transformedState, ExtraFaceData.DEFAULT, materialModifier); // Use template as mask
+            ModelBaker.Interner interner = baker.interner();
+            BakedQuad.MaterialInfo fluidInfo = interner.materialInfo(new BakedQuad.MaterialInfo(
+                    fluidSprite.sprite(), ChunkSectionLayer.SOLID, computeFluidItemRenderType(fluidSprite, opaque, emissive), 0, !emissive, emissive ? Level.MAX_BRIGHTNESS : 0, !emissive));
+            QuadCollection quads = UnbakedElementsHelper.bakeItemMaskQuads(baker, templateSprite, fluidInfo, transformedState, ExtraFaceData.DEFAULT); // Use template as mask
 
             subModels.add(new CuboidItemModelWrapper(List.of(FluidContentsTint.INSTANCE), quads, renderProperties, transformation));
         }
@@ -149,27 +152,22 @@ public class DynamicFluidContainerModel implements ItemModel {
         return new CompositeModel(subModels);
     }
 
-    private static BakedQuad.MaterialInfo setMaxEmissivity(BakedQuad.MaterialInfo materialInfo) {
-        RenderType itemRenderType;
-        if (materialInfo.itemRenderType() == Sheets.cutoutBlockItemSheet()) {
-            itemRenderType = RENDER_TYPE_CUTOUT_UNLIT_BLOCK;
-        } else if (materialInfo.itemRenderType() == Sheets.cutoutItemSheet()) {
-            itemRenderType = RENDER_TYPE_CUTOUT_UNLIT_ITEM;
-        } else if (materialInfo.itemRenderType() == Sheets.translucentBlockItemSheet()) {
-            itemRenderType = RENDER_TYPE_TRANSLUCENT_UNLIT_BLOCK;
-        } else if (materialInfo.itemRenderType() == Sheets.translucentItemSheet()) {
-            itemRenderType = RENDER_TYPE_TRANSLUCENT_UNLIT_ITEM;
+    // Force all fluids into cutout to avoid blending issues with block atlas sprites being rendered in front of item atlas sprites (unless the model opts out of it)
+    private static RenderType computeFluidItemRenderType(Material.Baked material, boolean forceOpaque, boolean emissive) {
+        boolean translucent = !forceOpaque && (material.forceTranslucent() || material.sprite().transparency().hasTranslucent());
+        if (material.sprite().atlasLocation().equals(TextureAtlas.LOCATION_BLOCKS)) {
+            if (translucent) {
+                return emissive ? RENDER_TYPE_TRANSLUCENT_UNLIT_BLOCK : Sheets.translucentBlockItemSheet();
+            } else {
+                return emissive ? RENDER_TYPE_CUTOUT_UNLIT_BLOCK : Sheets.cutoutBlockItemSheet();
+            }
         } else {
-            itemRenderType = materialInfo.itemRenderType();
+            if (translucent) {
+                return emissive ? RENDER_TYPE_TRANSLUCENT_UNLIT_ITEM : Sheets.translucentItemSheet();
+            } else {
+                return emissive ? RENDER_TYPE_CUTOUT_UNLIT_ITEM : Sheets.cutoutItemSheet();
+            }
         }
-        return new BakedQuad.MaterialInfo(
-                materialInfo.sprite(),
-                materialInfo.layer(),
-                itemRenderType,
-                materialInfo.tintIndex(),
-                materialInfo.shade(),
-                Level.MAX_BRIGHTNESS,
-                materialInfo.ambientOcclusion());
     }
 
     @Override
@@ -202,7 +200,9 @@ public class DynamicFluidContainerModel implements ItemModel {
                 });
     }
 
-    public record Unbaked(Textures textures, Fluid fluid, boolean flipGas, boolean coverIsMask, boolean applyFluidLuminosity) implements ItemModel.Unbaked {
+    /// @param forceOpaqueFluid Whether the fluid should always be rendered opaque regardless of its actual translucency. Disabling this may cause issues with translucent fluids
+    ///                         on top of a base texture stitched to the item atlas
+    public record Unbaked(Textures textures, Fluid fluid, boolean flipGas, boolean coverIsMask, boolean applyFluidLuminosity, boolean forceOpaqueFluid) implements ItemModel.Unbaked {
         public static final MapCodec<Unbaked> MAP_CODEC = RecordCodecBuilder.mapCodec(
                 instance -> instance
                         .group(
@@ -210,8 +210,13 @@ public class DynamicFluidContainerModel implements ItemModel {
                                 BuiltInRegistries.FLUID.byNameCodec().fieldOf("fluid").forGetter(Unbaked::fluid),
                                 Codec.BOOL.optionalFieldOf("flip_gas", false).forGetter(Unbaked::flipGas),
                                 Codec.BOOL.optionalFieldOf("cover_is_mask", true).forGetter(Unbaked::coverIsMask),
-                                Codec.BOOL.optionalFieldOf("apply_fluid_luminosity", true).forGetter(Unbaked::applyFluidLuminosity))
+                                Codec.BOOL.optionalFieldOf("apply_fluid_luminosity", true).forGetter(Unbaked::applyFluidLuminosity),
+                                Codec.BOOL.optionalFieldOf("force_opaque_fluid", true).forGetter(Unbaked::forceOpaqueFluid))
                         .apply(instance, Unbaked::new));
+
+        public Unbaked(Textures textures, Fluid fluid, boolean flipGas, boolean coverIsMask, boolean applyFluidLuminosity) {
+            this(textures, fluid, flipGas, coverIsMask, applyFluidLuminosity, true);
+        }
 
         @Override
         public MapCodec<? extends ItemModel.Unbaked> type() {


### PR DESCRIPTION
This PR implements a workaround for translucent fluids in the `DynamicFluidContainerModel` causing the container item's base texture to be invisible behind the fluid if said base texture is on the item atlas. This is done by forcing all fluids to render opaque unless the model opts out.

Fixes #3058