### PR TITLE
[26.2] Add support for precise appending of data components and other tooltip entries to item tooltips

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -195,16 +195,35 @@
              return lines;
          }
      }
-@@ -883,7 +_,8 @@
-         this.addToTooltip(DataComponents.PROFILE, context, display, builder, tooltipFlag);
-         this.addToTooltip(DataComponents.LORE, context, display, builder, tooltipFlag);
-         this.addToTooltip(DataComponents.SULFUR_CUBE_CONTENT, context, display, builder, tooltipFlag);
--        this.addAttributeTooltips(builder, display, player);
-+        // Neo: Replace attribute tooltips with custom handling
-+        net.neoforged.neoforge.common.util.AttributeUtil.addAttributeTooltips(this, builder, display, net.neoforged.neoforge.common.util.AttributeTooltipContext.of(player, context, display, tooltipFlag));
-         this.addUnitComponentToTooltip(DataComponents.INTANGIBLE_PROJECTILE, INTANGIBLE_TOOLTIP, display, builder);
-         this.addUnitComponentToTooltip(DataComponents.UNBREAKABLE, UNBREAKABLE_TOOLTIP, display, builder);
-         this.addToTooltip(DataComponents.OMINOUS_BOTTLE_AMPLIFIER, context, display, builder, tooltipFlag);
+@@ -861,7 +_,16 @@
+     public void addDetailsToTooltip(
+         Item.TooltipContext context, TooltipDisplay display, @Nullable Player player, TooltipFlag tooltipFlag, Consumer<Component> builder
+     ) {
++        net.neoforged.neoforge.common.tooltip.ItemTooltipHandler.addDetailsToTooltipHead(this, context, display, player, tooltipFlag, builder);
+         this.getItem().appendHoverText(this, context, display, builder, tooltipFlag);
++        net.neoforged.neoforge.common.tooltip.ItemTooltipHandler.addDetailsToTooltipMiddle(this, context, display, player, tooltipFlag, builder);
++        this.addDetailsToTooltipTail(context, display, player, tooltipFlag, builder);
++        net.neoforged.neoforge.common.tooltip.ItemTooltipHandler.addDetailsToTooltipTail(this, context, display, player, tooltipFlag, builder);
++    }
++
++    private void addDetailsToTooltipComponents(
++            Item.TooltipContext context, TooltipDisplay display, @Nullable Player player, TooltipFlag tooltipFlag, Consumer<Component> builder
++    ) {
+         this.addToTooltip(DataComponents.TROPICAL_FISH_PATTERN, context, display, builder, tooltipFlag);
+         this.addToTooltip(DataComponents.INSTRUMENT, context, display, builder, tooltipFlag);
+         this.addToTooltip(DataComponents.MAP_ID, context, display, builder, tooltipFlag);
+@@ -913,7 +_,11 @@
+             if (this.isDamaged() && display.shows(DataComponents.DAMAGE)) {
+                 builder.accept(Component.translatable("item.durability", this.getMaxDamage() - this.getDamageValue(), this.getMaxDamage()));
+             }
++        }
++    }
+ 
++    private void addDetailsToTooltipTail(Item.TooltipContext context, TooltipDisplay display, @Nullable Player player, TooltipFlag tooltipFlag, Consumer<Component> builder) {
++        if (tooltipFlag.isAdvanced()) {
+             builder.accept(Component.literal(BuiltInRegistries.ITEM.getKey(this.getItem()).toString()).withStyle(ChatFormatting.DARK_GRAY));
+             int count = this.components.size();
+             if (count > 0) {
 @@ -936,7 +_,10 @@
              builder.accept(component);
          }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -11,6 +11,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.graph.Graph;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
@@ -22,6 +23,8 @@ import com.mojang.serialization.Lifecycle;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.MapLike;
 import com.mojang.serialization.RecordBuilder;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -169,6 +172,8 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.i18n.MavenVersionTranslator;
+import net.neoforged.fml.loading.toposort.CyclePresentException;
+import net.neoforged.fml.loading.toposort.TopologicalSort;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.config.NeoForgeServerConfig;
 import net.neoforged.neoforge.common.damagesource.DamageContainer;
@@ -1840,5 +1845,42 @@ public class CommonHooks {
     @ApiStatus.Internal
     public static boolean onCustomClickAction(@Nullable ServerPlayer player, GameProfile profile, Identifier id, Optional<Tag> payload) {
         return NeoForge.EVENT_BUS.post(new CustomClickActionEvent(player, profile, id, payload.orElse(null))).isCanceled();
+    }
+
+    /// Toposort the given graph, throwing a descriptive exception if the graph contains cycles.
+    ///
+    /// @param graph           The graph to sort
+    /// @param values          The values of the graph in insertion order for secondary ordering
+    /// @param typeDescription A descriptive name of the type being sorted
+    /// @param valuePrinter    A function converting the sorted values to a human-readable representation
+    /// @return the sorted list of values
+    public static <T> List<T> sortGraphChecked(Graph<T> graph, Collection<T> values, String typeDescription, Function<T, ?> valuePrinter) {
+        // Build the index mapping in a way that can be used as a comparator to preserve insertion order.
+        Object2IntMap<T> insertionOrder = new Object2IntOpenHashMap<>();
+        int idx = 0;
+        for (T value : values) {
+            insertionOrder.put(value, idx++);
+        }
+
+        // Do the sort.
+        try {
+            return TopologicalSort.topologicalSort(graph, Comparator.comparingInt(insertionOrder::getInt));
+        } catch (CyclePresentException ex) {
+            // Build a real error message and re-throw.
+            StringBuilder sb = new StringBuilder();
+            sb.append("Cycles were detected during ").append(typeDescription).append(" sorting:\n");
+
+            Set<Set<T>> cycles = ex.getCycles();
+            idx = 0;
+            for (Set<T> cycle : cycles) {
+                sb.append(idx++).append(": ");
+                for (T key : cycle) {
+                    sb.append(valuePrinter.apply(key)).append("->");
+                }
+                sb.append(valuePrinter.apply(cycle.iterator().next())).append('\n');
+            }
+
+            throw new IllegalArgumentException(sb.toString());
+        }
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
@@ -27,10 +27,12 @@ import net.neoforged.fml.ModLoader;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.event.RegisterTooltipAppendersEvent;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class ItemTooltipHandler {
+    private static final List<DataComponentType<?>> VANILLA_APPENDER_ORDER = new ArrayList<>();
     private static final List<TooltipAppender> HEAD_APPENDERS = new ArrayList<>();
     private static final List<TooltipAppender> MIDDLE_APPENDERS = new ArrayList<>();
     private static final List<TooltipAppender> TAIL_APPENDERS = new ArrayList<>();
@@ -76,6 +78,7 @@ public final class ItemTooltipHandler {
         SequencedMap<DataComponentType<?>, TooltipAppender> componentAppenders = new LinkedHashMap<>();
         MutableGraph<DataComponentType<?>> componentGraph = GraphBuilder.directed().nodeOrder(ElementOrder.insertion()).build();
         SequencedMap<DataComponentType<?>, TooltipAppender> vanillaAppenders = VanillaDataComponentTooltips.collectVanillaAppenders();
+        VANILLA_APPENDER_ORDER.addAll(vanillaAppenders.sequencedKeySet());
         buildInitialComponentGraph(componentAppenders, componentGraph, vanillaAppenders);
         ModLoader.postEvent(new RegisterTooltipAppendersEvent(
                 appenders,
@@ -114,6 +117,11 @@ public final class ItemTooltipHandler {
         for (DataComponentType<?> type : sorted) {
             MIDDLE_APPENDERS.add(appenders.get(type));
         }
+    }
+
+    @VisibleForTesting
+    public static List<DataComponentType<?>> getVanillaAppenderOrder() {
+        return VANILLA_APPENDER_ORDER;
     }
 
     private ItemTooltipHandler() {}

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
@@ -8,17 +8,14 @@ package net.neoforged.neoforge.common.tooltip;
 import com.google.common.graph.ElementOrder;
 import com.google.common.graph.GraphBuilder;
 import com.google.common.graph.MutableGraph;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedMap;
-import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
@@ -27,8 +24,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
 import net.neoforged.fml.ModLoader;
-import net.neoforged.fml.loading.toposort.CyclePresentException;
-import net.neoforged.fml.loading.toposort.TopologicalSort;
+import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.event.RegisterTooltipAppendersEvent;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
@@ -114,35 +110,7 @@ public final class ItemTooltipHandler {
     }
 
     private static void addDataComponentAppenders(SequencedMap<DataComponentType<?>, TooltipAppender> appenders, MutableGraph<DataComponentType<?>> graph) {
-        // Build the index mapping in a way that can be used as a comparator to preserve insertion order.
-        Object2IntMap<DataComponentType<?>> insertionOrder = new Object2IntOpenHashMap<>();
-        int idx = 0;
-        for (DataComponentType<?> listener : appenders.keySet()) {
-            insertionOrder.put(listener, idx++);
-        }
-
-        // Do the sort.
-        List<DataComponentType<?>> sorted;
-        try {
-            sorted = TopologicalSort.topologicalSort(graph, Comparator.comparingInt(insertionOrder::getInt));
-        } catch (CyclePresentException ex) {
-            // Build a real error message and re-throw.
-            StringBuilder sb = new StringBuilder();
-            sb.append("Cycles were detected during component tooltip appender sorting:\n");
-
-            Set<Set<DataComponentType<?>>> cycles = ex.getCycles();
-            idx = 0;
-            for (Set<DataComponentType<?>> cycle : cycles) {
-                sb.append(idx++).append(": ");
-                for (DataComponentType<?> key : cycle) {
-                    sb.append(key).append("->");
-                }
-                sb.append(cycle.iterator().next()).append('\n');
-            }
-
-            throw new IllegalArgumentException(sb.toString());
-        }
-
+        List<DataComponentType<?>> sorted = CommonHooks.sortGraphChecked(graph, appenders.keySet(), "component tooltip appenders", Function.identity());
         for (DataComponentType<?> type : sorted) {
             MIDDLE_APPENDERS.add(appenders.get(type));
         }

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.tooltip;
+
+import com.google.common.graph.ElementOrder;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+import java.util.Set;
+import java.util.function.Consumer;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.fml.loading.toposort.CyclePresentException;
+import net.neoforged.fml.loading.toposort.TopologicalSort;
+import net.neoforged.neoforge.event.RegisterTooltipAppendersEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+@ApiStatus.Internal
+@SuppressWarnings("UnstableApiUsage")
+public final class ItemTooltipHandler {
+    private static final List<TooltipAppender> HEAD_APPENDERS = new ArrayList<>();
+    private static final List<TooltipAppender> MIDDLE_APPENDERS = new ArrayList<>();
+    private static final List<TooltipAppender> TAIL_APPENDERS = new ArrayList<>();
+
+    public static void addDetailsToTooltipHead(
+            ItemStack stack,
+            Item.TooltipContext context,
+            TooltipDisplay display,
+            @Nullable Player player,
+            TooltipFlag tooltipFlag,
+            Consumer<Component> builder) {
+        for (TooltipAppender appender : HEAD_APPENDERS) {
+            appender.append(stack, context, display, player, tooltipFlag, builder);
+        }
+    }
+
+    public static void addDetailsToTooltipMiddle(
+            ItemStack stack,
+            Item.TooltipContext context,
+            TooltipDisplay display,
+            @Nullable Player player,
+            TooltipFlag tooltipFlag,
+            Consumer<Component> builder) {
+        for (TooltipAppender appender : MIDDLE_APPENDERS) {
+            appender.append(stack, context, display, player, tooltipFlag, builder);
+        }
+    }
+
+    public static void addDetailsToTooltipTail(
+            ItemStack stack,
+            Item.TooltipContext context,
+            TooltipDisplay display,
+            @Nullable Player player,
+            TooltipFlag tooltipFlag,
+            Consumer<Component> builder) {
+        for (TooltipAppender appender : TAIL_APPENDERS) {
+            appender.append(stack, context, display, player, tooltipFlag, builder);
+        }
+    }
+
+    public static void init() {
+        Map<TooltipLocation, List<TooltipAppender>> appenders = new EnumMap<>(TooltipLocation.class);
+        SequencedMap<DataComponentType<?>, TooltipAppender> componentAppenders = new LinkedHashMap<>();
+        MutableGraph<DataComponentType<?>> componentGraph = GraphBuilder.directed().nodeOrder(ElementOrder.insertion()).build();
+        SequencedMap<DataComponentType<?>, TooltipAppender> vanillaAppenders = VanillaDataComponentTooltips.collectVanillaAppenders();
+        buildInitialComponentGraph(componentAppenders, componentGraph, vanillaAppenders);
+        ModLoader.postEvent(new RegisterTooltipAppendersEvent(
+                appenders,
+                componentAppenders,
+                componentGraph,
+                vanillaAppenders.firstEntry().getKey(),
+                vanillaAppenders.lastEntry().getKey()));
+
+        HEAD_APPENDERS.addAll(appenders.getOrDefault(TooltipLocation.HEAD, List.of()));
+
+        MIDDLE_APPENDERS.addAll(appenders.getOrDefault(TooltipLocation.POST_CUSTOM, List.of()));
+        addDataComponentAppenders(componentAppenders, componentGraph);
+        MIDDLE_APPENDERS.addAll(appenders.getOrDefault(TooltipLocation.PRE_ITEM_INFO, List.of()));
+
+        TAIL_APPENDERS.addAll(appenders.getOrDefault(TooltipLocation.TAIL, List.of()));
+    }
+
+    private static void buildInitialComponentGraph(
+            Map<DataComponentType<?>, TooltipAppender> appenders,
+            MutableGraph<DataComponentType<?>> graph,
+            Map<DataComponentType<?>, TooltipAppender> vanillaAppenders) {
+        vanillaAppenders.forEach((type, appender) -> {
+            appenders.put(type, appender);
+            graph.addNode(type);
+        });
+        List<DataComponentType<?>> types = List.copyOf(vanillaAppenders.keySet());
+        for (int i = 1; i < types.size(); i++) {
+            DataComponentType<?> prevType = types.get(i - 1);
+            DataComponentType<?> type = types.get(i);
+            graph.putEdge(prevType, type);
+        }
+    }
+
+    private static void addDataComponentAppenders(SequencedMap<DataComponentType<?>, TooltipAppender> appenders, MutableGraph<DataComponentType<?>> graph) {
+        // Build the index mapping in a way that can be used as a comparator to preserve insertion order.
+        Object2IntMap<DataComponentType<?>> insertionOrder = new Object2IntOpenHashMap<>();
+        int idx = 0;
+        for (DataComponentType<?> listener : appenders.keySet()) {
+            insertionOrder.put(listener, idx++);
+        }
+
+        // Do the sort.
+        List<DataComponentType<?>> sorted;
+        try {
+            sorted = TopologicalSort.topologicalSort(graph, Comparator.comparingInt(insertionOrder::getInt));
+        } catch (CyclePresentException ex) {
+            // Build a real error message and re-throw.
+            StringBuilder sb = new StringBuilder();
+            sb.append("Cycles were detected during component tooltip appender sorting:\n");
+
+            Set<Set<DataComponentType<?>>> cycles = ex.getCycles();
+            idx = 0;
+            for (Set<DataComponentType<?>> cycle : cycles) {
+                sb.append(idx++).append(": ");
+                for (DataComponentType<?> key : cycle) {
+                    sb.append(key).append("->");
+                }
+                sb.append(cycle.iterator().next()).append('\n');
+            }
+
+            throw new IllegalArgumentException(sb.toString());
+        }
+
+        for (DataComponentType<?> type : sorted) {
+            MIDDLE_APPENDERS.add(appenders.get(type));
+        }
+    }
+
+    private ItemTooltipHandler() {}
+}

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
 
 @ApiStatus.Internal
-@SuppressWarnings("UnstableApiUsage")
 public final class ItemTooltipHandler {
     private static final List<TooltipAppender> HEAD_APPENDERS = new ArrayList<>();
     private static final List<TooltipAppender> MIDDLE_APPENDERS = new ArrayList<>();

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/ItemTooltipHandler.java
@@ -98,9 +98,9 @@ public final class ItemTooltipHandler {
     }
 
     private static void buildInitialComponentGraph(
-            Map<DataComponentType<?>, TooltipAppender> appenders,
+            SequencedMap<DataComponentType<?>, TooltipAppender> appenders,
             MutableGraph<DataComponentType<?>> graph,
-            Map<DataComponentType<?>, TooltipAppender> vanillaAppenders) {
+            SequencedMap<DataComponentType<?>, TooltipAppender> vanillaAppenders) {
         vanillaAppenders.forEach((type, appender) -> {
             appenders.put(type, appender);
             graph.addNode(type);

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/TooltipAppender.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/TooltipAppender.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.tooltip;
+
+import java.util.function.Consumer;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.minecraft.world.item.component.TooltipProvider;
+import org.jspecify.annotations.Nullable;
+
+public interface TooltipAppender {
+    void append(ItemStack stack, Item.TooltipContext context, TooltipDisplay display, @Nullable Player player, TooltipFlag tooltipFlag, Consumer<Component> builder);
+
+    static <T extends TooltipProvider> TooltipAppender createComponentAppender(DataComponentType<T> type) {
+        return (stack, context, display, _, flag, builder) -> stack.addToTooltip(type, context, display, builder, flag);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/TooltipLocation.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/TooltipLocation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.tooltip;
+
+import java.util.function.Consumer;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+
+@SuppressWarnings("deprecation")
+public enum TooltipLocation {
+    /// Append tooltip lines before [Item#appendHoverText(ItemStack, Item.TooltipContext, TooltipDisplay, Consumer, TooltipFlag)]
+    HEAD,
+    /// Append tooltip lines between [Item#appendHoverText(ItemStack, Item.TooltipContext, TooltipDisplay, Consumer, TooltipFlag)]
+    /// and [data component][DataComponentType] tooltips
+    POST_CUSTOM,
+    /// Append tooltip lines between [data component][DataComponentType] tooltips and additional item info
+    /// (item ID, data component count, disabled status, OP warning)
+    PRE_ITEM_INFO,
+    /// Append tooltip lines after additional item info (item ID, data component count, disabled status, OP warning)
+    TAIL
+}

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/TooltipLocation.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/TooltipLocation.java
@@ -14,14 +14,18 @@ import net.minecraft.world.item.component.TooltipDisplay;
 
 @SuppressWarnings("deprecation")
 public enum TooltipLocation {
-    /// Append tooltip lines before [Item#appendHoverText(ItemStack, Item.TooltipContext, TooltipDisplay, Consumer, TooltipFlag)]
+    /** Append tooltip lines before {@link Item#appendHoverText(ItemStack, Item.TooltipContext, TooltipDisplay, Consumer, TooltipFlag)} */
     HEAD,
-    /// Append tooltip lines between [Item#appendHoverText(ItemStack, Item.TooltipContext, TooltipDisplay, Consumer, TooltipFlag)]
-    /// and [data component][DataComponentType] tooltips
+    /**
+     * Append tooltip lines between {@link Item#appendHoverText(ItemStack, Item.TooltipContext, TooltipDisplay, Consumer, TooltipFlag)}
+     * and {@linkplain DataComponentType data component} tooltips
+     */
     POST_CUSTOM,
-    /// Append tooltip lines between [data component][DataComponentType] tooltips and additional item info
-    /// (item ID, data component count, disabled status, OP warning)
+    /**
+     * Append tooltip lines between {@linkplain DataComponentType data component} tooltips and additional item info
+     * (item ID, data component count, disabled status, OP warning)
+     */
     PRE_ITEM_INFO,
-    /// Append tooltip lines after additional item info (item ID, data component count, disabled status, OP warning)
+    /** Append tooltip lines after additional item info (item ID, data component count, disabled status, OP warning) */
     TAIL
 }

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/VanillaDataComponentTooltips.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/VanillaDataComponentTooltips.java
@@ -49,6 +49,8 @@ final class VanillaDataComponentTooltips {
         putDefaultEntry(appenders, DataComponents.DYED_COLOR);
         putDefaultEntry(appenders, DataComponents.PROFILE);
         putDefaultEntry(appenders, DataComponents.LORE);
+        putDefaultEntry(appenders, DataComponents.SULFUR_CUBE_CONTENT);
+        // Neo: Replace attribute tooltips with custom handling
         appenders.put(DataComponents.ATTRIBUTE_MODIFIERS, (stack, context, display, player, flag, builder) -> AttributeUtil.addAttributeTooltips(stack, builder, display, AttributeTooltipContext.of(player, context, display, flag)));
         putUnitEntry(appenders, DataComponents.INTANGIBLE_PROJECTILE, ItemStack.INTANGIBLE_TOOLTIP);
         putUnitEntry(appenders, DataComponents.UNBREAKABLE, ItemStack.UNBREAKABLE_TOOLTIP);

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/VanillaDataComponentTooltips.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/VanillaDataComponentTooltips.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.tooltip;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.SequencedMap;
+import java.util.Set;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Unit;
+import net.minecraft.world.item.AdventureModePredicate;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.TooltipProvider;
+import net.minecraft.world.item.component.TypedEntityData;
+import net.minecraft.world.level.Spawner;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.neoforged.neoforge.common.util.AttributeTooltipContext;
+import net.neoforged.neoforge.common.util.AttributeUtil;
+
+final class VanillaDataComponentTooltips {
+    private VanillaDataComponentTooltips() {}
+
+    static SequencedMap<DataComponentType<?>, TooltipAppender> collectVanillaAppenders() {
+        SequencedMap<DataComponentType<?>, TooltipAppender> appenders = new LinkedHashMap<>();
+        putDefaultEntry(appenders, DataComponents.TROPICAL_FISH_PATTERN);
+        putDefaultEntry(appenders, DataComponents.INSTRUMENT);
+        putDefaultEntry(appenders, DataComponents.MAP_ID);
+        putDefaultEntry(appenders, DataComponents.BEES);
+        putDefaultEntry(appenders, DataComponents.CONTAINER_LOOT);
+        putDefaultEntry(appenders, DataComponents.CONTAINER);
+        putDefaultEntry(appenders, DataComponents.BANNER_PATTERNS);
+        putDefaultEntry(appenders, DataComponents.POT_DECORATIONS);
+        putDefaultEntry(appenders, DataComponents.WRITTEN_BOOK_CONTENT);
+        putDefaultEntry(appenders, DataComponents.CHARGED_PROJECTILES);
+        putDefaultEntry(appenders, DataComponents.FIREWORKS);
+        putDefaultEntry(appenders, DataComponents.FIREWORK_EXPLOSION);
+        putDefaultEntry(appenders, DataComponents.POTION_CONTENTS);
+        putDefaultEntry(appenders, DataComponents.JUKEBOX_PLAYABLE);
+        putDefaultEntry(appenders, DataComponents.TRIM);
+        putDefaultEntry(appenders, DataComponents.STORED_ENCHANTMENTS);
+        putDefaultEntry(appenders, DataComponents.ENCHANTMENTS);
+        putDefaultEntry(appenders, DataComponents.DYED_COLOR);
+        putDefaultEntry(appenders, DataComponents.PROFILE);
+        putDefaultEntry(appenders, DataComponents.LORE);
+        appenders.put(DataComponents.ATTRIBUTE_MODIFIERS, (stack, context, display, player, flag, builder) -> AttributeUtil.addAttributeTooltips(stack, builder, display, AttributeTooltipContext.of(player, context, display, flag)));
+        putUnitEntry(appenders, DataComponents.INTANGIBLE_PROJECTILE, ItemStack.INTANGIBLE_TOOLTIP);
+        putUnitEntry(appenders, DataComponents.UNBREAKABLE, ItemStack.UNBREAKABLE_TOOLTIP);
+        putDefaultEntry(appenders, DataComponents.OMINOUS_BOTTLE_AMPLIFIER);
+        putDefaultEntry(appenders, DataComponents.SUSPICIOUS_STEW_EFFECTS);
+        putDefaultEntry(appenders, DataComponents.BLOCK_STATE);
+        putDefaultEntry(appenders, DataComponents.ENTITY_DATA);
+        appenders.put(DataComponents.BLOCK_ENTITY_DATA, (stack, _, display, _, _, builder) -> {
+            if ((stack.is(Items.SPAWNER) || stack.is(Items.TRIAL_SPAWNER)) && display.shows(DataComponents.BLOCK_ENTITY_DATA)) {
+                TypedEntityData<BlockEntityType<?>> blockEntityData = stack.get(DataComponents.BLOCK_ENTITY_DATA);
+                Spawner.appendHoverText(blockEntityData, builder, "SpawnData");
+            }
+        });
+        appenders.put(DataComponents.CAN_BREAK, (stack, _, display, _, _, builder) -> {
+            AdventureModePredicate predicate = stack.get(DataComponents.CAN_BREAK);
+            if (predicate != null && display.shows(DataComponents.CAN_BREAK)) {
+                builder.accept(CommonComponents.EMPTY);
+                builder.accept(AdventureModePredicate.CAN_BREAK_HEADER);
+                predicate.addToTooltip(builder);
+            }
+        });
+        appenders.put(DataComponents.CAN_PLACE_ON, (stack, _, display, _, _, builder) -> {
+            AdventureModePredicate predicate = stack.get(DataComponents.CAN_PLACE_ON);
+            if (predicate != null && display.shows(DataComponents.CAN_PLACE_ON)) {
+                builder.accept(CommonComponents.EMPTY);
+                builder.accept(AdventureModePredicate.CAN_PLACE_HEADER);
+                predicate.addToTooltip(builder);
+            }
+        });
+        appenders.put(DataComponents.DAMAGE, (stack, _, display, _, flag, builder) -> {
+            if (flag.isAdvanced()) {
+                if (stack.isDamaged() && display.shows(DataComponents.DAMAGE)) {
+                    builder.accept(Component.translatable("item.durability", stack.getMaxDamage() - stack.getDamageValue(), stack.getMaxDamage()));
+                }
+            }
+        });
+        validate(appenders.keySet());
+        return appenders;
+    }
+
+    private static <T extends TooltipProvider> void putDefaultEntry(Map<DataComponentType<?>, TooltipAppender> appenders, DataComponentType<T> type) {
+        appenders.put(type, TooltipAppender.createComponentAppender(type));
+    }
+
+    private static void putUnitEntry(Map<DataComponentType<?>, TooltipAppender> appenders, DataComponentType<Unit> type, Component component) {
+        appenders.put(type, (stack, _, display, _, _, builder) -> {
+            if (stack.has(type) && display.shows(type)) {
+                builder.accept(component);
+            }
+        });
+    }
+
+    private static void validate(Set<DataComponentType<?>> registeredTypesSet) {
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/VanillaDataComponentTooltips.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/VanillaDataComponentTooltips.java
@@ -8,7 +8,6 @@ package net.neoforged.neoforge.common.tooltip;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.SequencedMap;
-import java.util.Set;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.CommonComponents;
@@ -87,7 +86,6 @@ final class VanillaDataComponentTooltips {
                 }
             }
         });
-        validate(appenders.keySet());
         return appenders;
     }
 
@@ -101,8 +99,5 @@ final class VanillaDataComponentTooltips {
                 builder.accept(component);
             }
         });
-    }
-
-    private static void validate(Set<DataComponentType<?>> registeredTypesSet) {
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/tooltip/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/common/tooltip/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@NullMarked
+package net.neoforged.neoforge.common.tooltip;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
@@ -9,6 +9,7 @@ import com.google.common.graph.MutableGraph;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentType;
 import net.neoforged.bus.api.Event;
 import net.neoforged.fml.event.IModBusEvent;
@@ -37,24 +38,40 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
         this.lastVanillaType = lastVanillaType;
     }
 
-    /// Register a [TooltipAppender] at the provided [TooltipLocation]
+    /// Register a [TooltipAppender] at the provided [TooltipLocation].
     ///
     /// @param location The location to apply the appender to
     /// @param appender The appender to register
     public void registerAppender(TooltipLocation location, TooltipAppender appender) {
-        this.appenders.computeIfAbsent(location, $ -> new ArrayList<>()).add(appender);
+        this.appenders.computeIfAbsent(location, _ -> new ArrayList<>()).add(appender);
     }
 
-    /// Register a [TooltipAppender] for the provided [DataComponentType] before all other data component tooltip appenders
+    /// Register a [TooltipAppender] for the provided [DataComponentType] before all vanilla data component tooltip appenders.
+    ///
+    /// @param type     The type to register the appender for
+    /// @param appender The appender to register
+    public void registerComponentAppenderBeforeAll(Supplier<DataComponentType<?>> type, TooltipAppender appender) {
+        this.registerComponentAppenderBeforeAll(type.get(), appender);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] before all vanilla data component tooltip appenders.
     ///
     /// @param type     The type to register the appender for
     /// @param appender The appender to register
     public void registerComponentAppenderBeforeAll(DataComponentType<?> type, TooltipAppender appender) {
-        this.registerComponentAppender(type, appender);
-        this.componentGraph.putEdge(type, this.firstVanillaType);
+        this.registerComponentAppenderBefore(type, this.firstVanillaType, appender);
     }
 
-    /// Register a [TooltipAppender] for the provided [DataComponentType] before the other provided data component type
+    /// Register a [TooltipAppender] for the provided [DataComponentType] before the other provided data component type.
+    ///
+    /// @param type      The type to register the appender for
+    /// @param otherType The type before which the provided appender should be applied
+    /// @param appender  The appender to register
+    public void registerComponentAppenderBefore(Supplier<DataComponentType<?>> type, DataComponentType<?> otherType, TooltipAppender appender) {
+        this.registerComponentAppenderBefore(type.get(), otherType, appender);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] before the other provided data component type.
     ///
     /// @param type      The type to register the appender for
     /// @param otherType The type before which the provided appender should be applied
@@ -64,7 +81,16 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
         this.componentGraph.putEdge(type, otherType);
     }
 
-    /// Register a [TooltipAppender] for the provided [DataComponentType] after the other provided data component type
+    /// Register a [TooltipAppender] for the provided [DataComponentType] after the other provided data component type.
+    ///
+    /// @param type      The type to register the appender for
+    /// @param otherType The type after which the provided appender should be applied
+    /// @param appender  The appender to register
+    public void registerComponentAppenderAfter(Supplier<DataComponentType<?>> type, DataComponentType<?> otherType, TooltipAppender appender) {
+        this.registerComponentAppenderAfter(type.get(), otherType, appender);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] after the other provided data component type.
     ///
     /// @param type      The type to register the appender for
     /// @param otherType The type after which the provided appender should be applied
@@ -74,13 +100,20 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
         this.componentGraph.putEdge(otherType, type);
     }
 
-    /// Register a [TooltipAppender] for the provided [DataComponentType] after all other data component tooltip appenders
+    /// Register a [TooltipAppender] for the provided [DataComponentType] after all vanilla data component tooltip appenders.
+    ///
+    /// @param type     The type to register the appender for
+    /// @param appender The appender to register
+    public void registerComponentAppenderAfterAll(Supplier<DataComponentType<?>> type, TooltipAppender appender) {
+        this.registerComponentAppenderAfterAll(type.get(), appender);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] after all vanilla data component tooltip appenders.
     ///
     /// @param type     The type to register the appender for
     /// @param appender The appender to register
     public void registerComponentAppenderAfterAll(DataComponentType<?> type, TooltipAppender appender) {
-        this.registerComponentAppender(type, appender);
-        this.componentGraph.putEdge(this.lastVanillaType, type);
+        this.registerComponentAppenderAfter(type, this.lastVanillaType, appender);
     }
 
     private void registerComponentAppender(DataComponentType<?> type, TooltipAppender appender) {

--- a/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event;
+
+import com.google.common.graph.MutableGraph;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.component.DataComponentType;
+import net.neoforged.bus.api.Event;
+import net.neoforged.fml.event.IModBusEvent;
+import net.neoforged.neoforge.common.tooltip.TooltipAppender;
+import net.neoforged.neoforge.common.tooltip.TooltipLocation;
+import org.jetbrains.annotations.ApiStatus;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class RegisterTooltipAppendersEvent extends Event implements IModBusEvent {
+    private final Map<TooltipLocation, List<TooltipAppender>> appenders;
+    private final Map<DataComponentType<?>, TooltipAppender> componentAppenders;
+    private final MutableGraph<DataComponentType<?>> componentGraph;
+    private final DataComponentType<?> firstVanillaType;
+    private final DataComponentType<?> lastVanillaType;
+
+    @ApiStatus.Internal
+    public RegisterTooltipAppendersEvent(
+            Map<TooltipLocation, List<TooltipAppender>> appenders,
+            Map<DataComponentType<?>, TooltipAppender> componentAppenders,
+            MutableGraph<DataComponentType<?>> componentGraph,
+            DataComponentType<?> firstVanillaType,
+            DataComponentType<?> lastVanillaType) {
+        this.appenders = appenders;
+        this.componentAppenders = componentAppenders;
+        this.componentGraph = componentGraph;
+        this.firstVanillaType = firstVanillaType;
+        this.lastVanillaType = lastVanillaType;
+    }
+
+    /// Register a [TooltipAppender] at the provided [TooltipLocation]
+    ///
+    /// @param location The location to apply the appender to
+    /// @param appender The appender to register
+    public void registerAppender(TooltipLocation location, TooltipAppender appender) {
+        this.appenders.computeIfAbsent(location, $ -> new ArrayList<>()).add(appender);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] before all other data component tooltip appenders
+    ///
+    /// @param type     The type to register the appender for
+    /// @param appender The appender to register
+    public void registerComponentAppenderBeforeAll(DataComponentType<?> type, TooltipAppender appender) {
+        this.registerComponentAppender(type, appender);
+        this.componentGraph.putEdge(type, this.firstVanillaType);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] before the other provided data component type
+    ///
+    /// @param type      The type to register the appender for
+    /// @param otherType The type before which the provided appender should be applied
+    /// @param appender  The appender to register
+    public void registerComponentAppenderBefore(DataComponentType<?> type, DataComponentType<?> otherType, TooltipAppender appender) {
+        this.registerComponentAppender(type, appender);
+        this.componentGraph.putEdge(type, otherType);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] after the other provided data component type
+    ///
+    /// @param type      The type to register the appender for
+    /// @param otherType The type after which the provided appender should be applied
+    /// @param appender  The appender to register
+    public void registerComponentAppenderAfter(DataComponentType<?> type, DataComponentType<?> otherType, TooltipAppender appender) {
+        this.registerComponentAppender(type, appender);
+        this.componentGraph.putEdge(otherType, type);
+    }
+
+    /// Register a [TooltipAppender] for the provided [DataComponentType] after all other data component tooltip appenders
+    ///
+    /// @param type     The type to register the appender for
+    /// @param appender The appender to register
+    public void registerComponentAppenderAfterAll(DataComponentType<?> type, TooltipAppender appender) {
+        this.registerComponentAppender(type, appender);
+        this.componentGraph.putEdge(this.lastVanillaType, type);
+    }
+
+    private void registerComponentAppender(DataComponentType<?> type, TooltipAppender appender) {
+        if (this.componentAppenders.putIfAbsent(type, appender) != null) {
+            throw new IllegalStateException("Duplicate appender registration for type: " + type);
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
@@ -16,7 +16,6 @@ import net.neoforged.neoforge.common.tooltip.TooltipAppender;
 import net.neoforged.neoforge.common.tooltip.TooltipLocation;
 import org.jetbrains.annotations.ApiStatus;
 
-@SuppressWarnings("UnstableApiUsage")
 public final class RegisterTooltipAppendersEvent extends Event implements IModBusEvent {
     private final Map<TooltipLocation, List<TooltipAppender>> appenders;
     private final Map<DataComponentType<?>, TooltipAppender> componentAppenders;

--- a/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/RegisterTooltipAppendersEvent.java
@@ -50,7 +50,7 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
     ///
     /// @param type     The type to register the appender for
     /// @param appender The appender to register
-    public void registerComponentAppenderBeforeAll(Supplier<DataComponentType<?>> type, TooltipAppender appender) {
+    public void registerComponentAppenderBeforeAll(Supplier<? extends DataComponentType<?>> type, TooltipAppender appender) {
         this.registerComponentAppenderBeforeAll(type.get(), appender);
     }
 
@@ -67,7 +67,7 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
     /// @param type      The type to register the appender for
     /// @param otherType The type before which the provided appender should be applied
     /// @param appender  The appender to register
-    public void registerComponentAppenderBefore(Supplier<DataComponentType<?>> type, DataComponentType<?> otherType, TooltipAppender appender) {
+    public void registerComponentAppenderBefore(Supplier<? extends DataComponentType<?>> type, DataComponentType<?> otherType, TooltipAppender appender) {
         this.registerComponentAppenderBefore(type.get(), otherType, appender);
     }
 
@@ -86,7 +86,7 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
     /// @param type      The type to register the appender for
     /// @param otherType The type after which the provided appender should be applied
     /// @param appender  The appender to register
-    public void registerComponentAppenderAfter(Supplier<DataComponentType<?>> type, DataComponentType<?> otherType, TooltipAppender appender) {
+    public void registerComponentAppenderAfter(Supplier<? extends DataComponentType<?>> type, DataComponentType<?> otherType, TooltipAppender appender) {
         this.registerComponentAppenderAfter(type.get(), otherType, appender);
     }
 
@@ -104,7 +104,7 @@ public final class RegisterTooltipAppendersEvent extends Event implements IModBu
     ///
     /// @param type     The type to register the appender for
     /// @param appender The appender to register
-    public void registerComponentAppenderAfterAll(Supplier<DataComponentType<?>> type, TooltipAppender appender) {
+    public void registerComponentAppenderAfterAll(Supplier<? extends DataComponentType<?>> type, TooltipAppender appender) {
         this.registerComponentAppenderAfterAll(type.get(), appender);
     }
 

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -28,6 +28,7 @@ import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.loading.progress.StartupNotificationManager;
 import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.common.CreativeModeTabRegistry;
+import net.neoforged.neoforge.common.tooltip.ItemTooltipHandler;
 import net.neoforged.neoforge.event.BlockEntityTypeAddBlocksEvent;
 import org.jetbrains.annotations.ApiStatus;
 import org.slf4j.Logger;
@@ -103,6 +104,7 @@ public class GameData {
             ModLoader.postEvent(new BlockEntityTypeAddBlocksEvent());
             CreativeModeTabRegistry.sortTabs();
             GameRuleCategory.registerModdedCategories();
+            ItemTooltipHandler.init();
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/resource/ReloadListenerSort.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ReloadListenerSort.java
@@ -9,19 +9,11 @@ import com.google.common.graph.Graph;
 import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
 import com.google.common.graph.Traverser;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
-import net.neoforged.fml.loading.toposort.CyclePresentException;
-import net.neoforged.fml.loading.toposort.TopologicalSort;
+import net.neoforged.neoforge.common.CommonHooks;
 import net.neoforged.neoforge.event.SortedReloadListenerEvent;
 import net.neoforged.neoforge.event.SortedReloadListenerEvent.NameLookup;
 import org.jetbrains.annotations.ApiStatus;
@@ -60,46 +52,7 @@ public class ReloadListenerSort {
             }
         }
 
-        // Then build the index mapping in a way that can be used as a comparator to preserve insertion order.
-        Object2IntMap<PreparableReloadListener> insertionOrder = new Object2IntOpenHashMap<>();
-        int idx = 0;
-        for (PreparableReloadListener listener : registry.values()) {
-            insertionOrder.put(listener, idx++);
-        }
-
-        // Then do the sort.
-        try {
-            List<PreparableReloadListener> sorted = TopologicalSort.topologicalSort(graph, Comparator.comparingInt(insertionOrder::getInt));
-            return Collections.unmodifiableList(sorted);
-        } catch (CyclePresentException ex) {
-            // If a cycle is found, we have to transform the information in the exception back into the registered keys.
-            Set<Set<PreparableReloadListener>> cycles = ex.getCycles();
-            Set<Set<Identifier>> keyedCycles = cycles.stream().map(set -> {
-                return set.stream().map(lookup::apply).collect(Collectors.toCollection(LinkedHashSet::new));
-            }).collect(Collectors.toSet());
-
-            // Finally, build a real error message and re-throw.
-            StringBuilder sb = new StringBuilder();
-            sb.append("Cycles were detected during reload listener sorting:").append('\n');
-
-            idx = 0;
-            for (Set<Identifier> cycle : keyedCycles) {
-                StringBuilder msg = new StringBuilder();
-
-                msg.append(idx++).append(": ");
-
-                for (Identifier key : cycle) {
-                    msg.append(key).append("->");
-                }
-
-                msg.append(cycle.iterator().next());
-
-                sb.append(msg);
-                sb.append('\n');
-            }
-
-            throw new IllegalArgumentException(sb.toString());
-        }
+        return CommonHooks.sortGraphChecked(graph, registry.values(), "reload listener", lookup);
     }
 
     /**

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -200,6 +200,8 @@ public net.minecraft.world.item.CreativeModeTab$Output
 public net.minecraft.world.item.CreativeModeTab$TabVisibility
 public net.minecraft.world.item.BucketItem content
 public net.minecraft.world.item.Item getPlayerPOVHitResult(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/ClipContext$Fluid;)Lnet/minecraft/world/phys/BlockHitResult; # getPlayerPOVHitResult
+public net.minecraft.world.item.ItemStack INTANGIBLE_TOOLTIP
+public net.minecraft.world.item.ItemStack UNBREAKABLE_TOOLTIP
 public net.minecraft.world.item.ItemStackLinkedSet TYPE_AND_TAG # TYPE_AND_TAG
 public net.minecraft.world.item.context.BlockPlaceContext <init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V # constructor
 public net.minecraft.world.item.context.UseOnContext <init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V # constructor

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentTooltipOrderTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentTooltipOrderTest.java
@@ -42,12 +42,19 @@ public class ComponentTooltipOrderTest {
 
         Assertions.assertEquals(registeredOrder.size(), vanillaOrder.size(), () -> {
             String vanillaTypeList = vanillaOrder.stream()
+                    .filter(component -> !registeredOrder.contains(component))
                     .map(DataComponentType::toString)
                     .collect(Collectors.joining(", "));
             String registeredTypeList = registeredOrder.stream()
+                    .filter(component -> !vanillaOrder.contains(component))
                     .map(DataComponentType::toString)
                     .collect(Collectors.joining(", "));
-            return String.format(Locale.ROOT, "Tooltip data component lists don't match\nVanilla: %s\nRegistered: %s", vanillaTypeList, registeredTypeList);
+            if (!vanillaTypeList.isEmpty() && !registeredTypeList.isEmpty()) {
+                return String.format(Locale.ROOT, "Tooltip data component lists don't match\nMissing Vanilla: %s\nExtra Registered: %s", vanillaTypeList, registeredTypeList);
+            } else if (vanillaTypeList.isEmpty()) {
+                return String.format(Locale.ROOT, "Registered tooltip data components have the following extra entries: %s", registeredTypeList);
+            }
+            return String.format(Locale.ROOT, "Registered tooltip data components are missing the following vanilla entries: %s", vanillaTypeList);
         });
         assertOrder(vanillaOrder, registeredOrder);
     }

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentTooltipOrderTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/ComponentTooltipOrderTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.neoforged.neoforge.common.tooltip.ItemTooltipHandler;
+import net.neoforged.testframework.junit.EphemeralTestServerProvider;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+@ExtendWith(EphemeralTestServerProvider.class)
+public class ComponentTooltipOrderTest {
+    @Test
+    void testComponentTooltipOrder() {
+        List<DataComponentType<?>> registeredOrder = ItemTooltipHandler.getVanillaAppenderOrder();
+        List<DataComponentType<?>> vanillaOrder = collectVanillaOrder();
+
+        Assertions.assertEquals(registeredOrder.size(), vanillaOrder.size(), () -> {
+            String vanillaTypeList = vanillaOrder.stream()
+                    .map(DataComponentType::toString)
+                    .collect(Collectors.joining(", "));
+            String registeredTypeList = registeredOrder.stream()
+                    .map(DataComponentType::toString)
+                    .collect(Collectors.joining(", "));
+            return String.format(Locale.ROOT, "Tooltip data component lists don't match\nVanilla: %s\nRegistered: %s", vanillaTypeList, registeredTypeList);
+        });
+        assertOrder(vanillaOrder, registeredOrder);
+    }
+
+    private static void assertOrder(List<DataComponentType<?>> vanillaTypes, List<DataComponentType<?>> registeredTypes) {
+        for (int i = 0; i < vanillaTypes.size(); i++) {
+            DataComponentType<?> type = vanillaTypes.get(i);
+            int finalI = i;
+            Assertions.assertEquals(i, registeredTypes.indexOf(type), () -> String.format(
+                    Locale.ROOT,
+                    "Expected '%s' at index %d, got '%s'",
+                    type,
+                    finalI,
+                    registeredTypes.get(finalI)));
+        }
+    }
+
+    // Inspired by component scraping implementation in https://github.com/FabricMC/fabric-api/pull/4587.
+    private static List<DataComponentType<?>> collectVanillaOrder() {
+        try (InputStream classBytes = ItemStack.class.getResourceAsStream("/" + ItemStack.class.getName().replace('.', '/') + ".class")) {
+            if (classBytes == null) {
+                throw new IllegalStateException("Cannot access ItemStack.class bytes");
+            }
+
+            ItemStackClassVisitor visitor = new ItemStackClassVisitor();
+            new ClassReader(classBytes).accept(visitor, 0);
+            return visitor.vanillaTypes;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class ItemStackClassVisitor extends ClassVisitor {
+        private static final String TOOLTIP_METHOD_NAME = "addDetailsToTooltipComponents";
+        private static final String TOOLTIP_METHOD_DESC = Type.getMethodDescriptor(
+                Type.VOID_TYPE,
+                Type.getType(Item.TooltipContext.class),
+                Type.getType(TooltipDisplay.class),
+                Type.getType(Player.class),
+                Type.getType(TooltipFlag.class),
+                Type.getType(Consumer.class));
+
+        private final List<DataComponentType<?>> vanillaTypes = new ArrayList<>();
+        private boolean methodFound = false;
+
+        ItemStackClassVisitor() {
+            super(Opcodes.ASM9);
+        }
+
+        @Override
+        @Nullable
+        public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+            if (name.equals(TOOLTIP_METHOD_NAME) && descriptor.equals(TOOLTIP_METHOD_DESC)) {
+                methodFound = true;
+                return new TooltipMethodVisitor(vanillaTypes);
+            }
+            return null;
+        }
+
+        @Override
+        public void visitEnd() {
+            if (!methodFound) {
+                throw new IllegalStateException("No addDetailsToTooltipComponents() method in ItemStack");
+            }
+            if (vanillaTypes.isEmpty()) {
+                throw new IllegalStateException("Found no component types in addDetailsToTooltipComponents() method");
+            }
+        }
+    }
+
+    private static final class TooltipMethodVisitor extends MethodVisitor {
+        private static final String ATTRIB_MOD_METHOD_NAME = "addAttributeTooltips";
+        private static final String ATTRIB_MOD_METHOD_DESC = Type.getMethodDescriptor(
+                Type.VOID_TYPE,
+                Type.getType(Consumer.class),
+                Type.getType(TooltipDisplay.class),
+                Type.getType(Player.class));
+        private static final String TYPE_FIELD_OWNER = Type.getInternalName(DataComponents.class);
+        private static final String TYPE_FIELD_DESC = Type.getDescriptor(DataComponentType.class);
+
+        private final Set<String> encounteredComponents = new HashSet<>();
+        private final List<DataComponentType<?>> vanillaTypes;
+
+        TooltipMethodVisitor(List<DataComponentType<?>> vanillaTypes) {
+            super(Opcodes.ASM9);
+            this.vanillaTypes = vanillaTypes;
+        }
+
+        @Override
+        public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+            if (opcode == Opcodes.GETSTATIC && owner.equals(TYPE_FIELD_OWNER) && descriptor.equals(TYPE_FIELD_DESC)) {
+                if (!encounteredComponents.add(name)) {
+                    return;
+                }
+
+                try {
+                    vanillaTypes.add((DataComponentType<?>) DataComponents.class.getField(name).get(null));
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            // Attribute modifier tooltips are handled by a separate method
+            if (name.equals(ATTRIB_MOD_METHOD_NAME) && descriptor.equals(ATTRIB_MOD_METHOD_DESC)) {
+                vanillaTypes.add(DataComponents.ATTRIBUTE_MODIFIERS);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR enhances vanilla's hard-coded data component tooltip solution to allow mods to append their data components as well as other tooltip entries independent of data components instead of being limited to the following options:
- Right below the item name via `Item#appendHoverText()`
- Head or tail via `ItemTooltipEvent`
- Bad heuristics for injecting between existing lines in `ItemTooltipEvent`

The API surface is loosely inspired by Fabric's data component tooltip appender API (https://github.com/FabricMC/fabric-api/pull/4587) and expanded upon to also allow appending arbitrary tooltip entries.
The proposed API does not replace `ItemTooltipEvent` for the purpose of modifying/replacing/removing parts of the tooltip, though the registration event could be expanded to allow replacing an existing appender with the obvious caveat of only one mod being able to win for a given component type.

I'm opening this as a draft because I still need to implement the validation that ensures all vanilla entries are included in the correct order. I am considering asking Fabric whether I can re-use their ASM-based approach.
I am aware that the `TooltipLocation` enum is blowing up the formatter, this is caused by a bug in Eclipse JDT: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5032.

Supersedes #3074
Fixes #1039