### PR TITLE
Add an experimental extended slot API

### DIFF
--- a/patches/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/patches/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -58,8 +58,8 @@
                  }
 +
 +                @Override
-+                public <S> Optional<HolderLookup.RegistryLookup<S>> registryLookup(ResourceKey<? extends Registry<? extends S>> registry) {
-+                    return Optional.ofNullable((HolderLookup.RegistryLookup<S>) BuildState.this.registries.get(registry.identifier()));
++                public <S> Optional<HolderLookup<S>> holderLookup(ResourceKey<? extends Registry<? extends S>> registry) {
++                    return Optional.ofNullable((HolderLookup<S>) BuildState.this.registries.get(registry.identifier()));
 +                }
              };
          }

--- a/patches/net/minecraft/data/worldgen/BootstrapContext.java.patch
+++ b/patches/net/minecraft/data/worldgen/BootstrapContext.java.patch
@@ -5,5 +5,5 @@
  
      <S> HolderGetter<S> lookup(ResourceKey<? extends Registry<? extends S>> key);
 +
-+    default <S> java.util.Optional<net.minecraft.core.HolderLookup.RegistryLookup<S>> registryLookup(ResourceKey<? extends Registry<? extends S>> registry) { return java.util.Optional.empty(); }
++    default <S> java.util.Optional<net.minecraft.core.HolderLookup<S>> holderLookup(ResourceKey<? extends Registry<? extends S>> registry) { return java.util.Optional.empty(); }
  }

--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -69,6 +69,7 @@ import net.neoforged.neoforge.common.data.internal.NeoForgeDamageTypeTagsProvide
 import net.neoforged.neoforge.common.data.internal.NeoForgeDataMapsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeEnchantmentTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeEntityTypeTagsProvider;
+import net.neoforged.neoforge.common.data.internal.NeoForgeExtendedSlotsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeFluidTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeItemTagsProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeLanguageProvider;
@@ -173,6 +174,7 @@ public class ClientNeoForgeMod {
         event.createProvider(NeoForgeDamageTypeTagsProvider::new);
         event.createProvider(NeoForgeRegistryOrderReportProvider::new);
         event.createProvider(NeoForgeDataMapsProvider::new);
+        event.createProvider(NeoForgeExtendedSlotsProvider::new);
 
         event.createProvider(NeoForgeSpriteSourceProvider::new);
         event.createProvider(VanillaModelProvider::new);

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/body.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/body.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "body"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/chest.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/chest.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "chest"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/feet.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/feet.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "feet"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/head.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/head.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "head"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/legs.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/legs.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "legs"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/mainhand.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/mainhand.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "mainhand"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/offhand.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/offhand.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "offhand"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/saddle.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_equipment_slot/saddle.json
@@ -1,0 +1,4 @@
+{
+  "type": "neoforge:vanilla",
+  "slot": "saddle"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/any.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/any.json
@@ -1,0 +1,5 @@
+{
+  "slots": {
+    "type": "neoforge:any"
+  }
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/any_vanilla.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/any_vanilla.json
@@ -1,0 +1,12 @@
+{
+  "slots": [
+    "neoforge:mainhand",
+    "neoforge:offhand",
+    "neoforge:head",
+    "neoforge:chest",
+    "neoforge:legs",
+    "neoforge:feet",
+    "neoforge:body",
+    "neoforge:saddle"
+  ]
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/armor.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/armor.json
@@ -1,0 +1,8 @@
+{
+  "slots": [
+    "neoforge:head",
+    "neoforge:chest",
+    "neoforge:legs",
+    "neoforge:feet"
+  ]
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/body.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/body.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:body"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/chest.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/chest.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:chest"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/feet.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/feet.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:feet"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/hand.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/hand.json
@@ -1,0 +1,6 @@
+{
+  "slots": [
+    "neoforge:mainhand",
+    "neoforge:offhand"
+  ]
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/head.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/head.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:head"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/legs.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/legs.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:legs"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/mainhand.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/mainhand.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:mainhand"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/offhand.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/offhand.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:offhand"
+}

--- a/src/generated/resources/data/neoforge/neoforge/extended_slot_group/saddle.json
+++ b/src/generated/resources/data/neoforge/neoforge/extended_slot_group/saddle.json
@@ -1,0 +1,3 @@
+{
+  "slots": "neoforge:saddle"
+}

--- a/src/generated/resources/reports/registry_order.json
+++ b/src/generated/resources/reports/registry_order.json
@@ -99,6 +99,7 @@
     "neoforge:biome_modifier_serializers",
     "neoforge:condition_codecs",
     "neoforge:entity_data_serializers",
+    "neoforge:extended_equipment_slot_type",
     "neoforge:fluid_ingredient_type",
     "neoforge:fluid_type",
     "neoforge:global_loot_modifier_serializers",

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -165,6 +165,9 @@ import net.neoforged.neoforge.server.command.ModIdArgument;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
 import net.neoforged.neoforge.server.permission.nodes.PermissionNode;
 import net.neoforged.neoforge.server.permission.nodes.PermissionTypes;
+import net.neoforged.neoforge.slot.ExtendedEquipmentSlot;
+import net.neoforged.neoforge.slot.ExtendedSlotGroup;
+import net.neoforged.neoforge.slot.VanillaExtendedSlot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
@@ -191,6 +194,42 @@ public class NeoForgeMod {
     private static final DeferredRegister<HolderSetType> HOLDER_SET_TYPES = DeferredRegister.create(NeoForgeRegistries.Keys.HOLDER_SET_TYPES, MOD_ID);
     private static final DeferredRegister<AttributeType<?>> ATTRIBUTE_TYPES = DeferredRegister.create(Registries.ATTRIBUTE_TYPE, MOD_ID);
     private static final DeferredRegister<EnvironmentAttribute<?>> ENVIRONMENT_ATTRIBUTES = DeferredRegister.create(Registries.ENVIRONMENT_ATTRIBUTE, MOD_ID);
+    private static final DeferredRegister<MapCodec<? extends ExtendedEquipmentSlot>> EXTENDED_EQUIPMENT_SLOT_SERIALIZERS = DeferredRegister.create(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOT_SERIALIZERS, MOD_ID);
+
+    /**
+     * Built-in serializer for vanilla-equipment-slot-backed {@link ExtendedEquipmentSlot}s.
+     */
+    public static final Holder<MapCodec<? extends ExtendedEquipmentSlot>> VANILLA_SLOT_TYPE = EXTENDED_EQUIPMENT_SLOT_SERIALIZERS.register("vanilla", () -> VanillaExtendedSlot.CODEC);
+
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_MAINHAND = slotKey("mainhand");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_OFFHAND = slotKey("offhand");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_HEAD = slotKey("head");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_CHEST = slotKey("chest");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_LEGS = slotKey("legs");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_FEET = slotKey("feet");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_BODY = slotKey("body");
+    public static final ResourceKey<ExtendedEquipmentSlot> SLOT_SADDLE = slotKey("saddle");
+
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_ANY = groupKey("any");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_ANY_VANILLA = groupKey("any_vanilla");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_MAINHAND = groupKey("mainhand");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_OFFHAND = groupKey("offhand");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_HAND = groupKey("hand");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_HEAD = groupKey("head");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_CHEST = groupKey("chest");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_LEGS = groupKey("legs");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_FEET = groupKey("feet");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_ARMOR = groupKey("armor");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_BODY = groupKey("body");
+    public static final ResourceKey<ExtendedSlotGroup> GROUP_SADDLE = groupKey("saddle");
+
+    private static ResourceKey<ExtendedEquipmentSlot> slotKey(String name) {
+        return ResourceKey.create(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS, Identifier.fromNamespaceAndPath(MOD_ID, name));
+    }
+
+    private static ResourceKey<ExtendedSlotGroup> groupKey(String name) {
+        return ResourceKey.create(NeoForgeRegistries.Keys.EXTENDED_SLOT_GROUPS, Identifier.fromNamespaceAndPath(MOD_ID, name));
+    }
 
     @SuppressWarnings({ "unchecked", "rawtypes" }) // Uses Holder instead of DeferredHolder as the type due to weirdness between ECJ and javac.
     private static final Holder<ArgumentTypeInfo<?, ?>> ENUM_COMMAND_ARGUMENT_TYPE = COMMAND_ARGUMENT_TYPES.register("enum", () -> ArgumentTypeInfos.registerByClass(EnumArgument.class, new EnumArgument.Info()));
@@ -564,6 +603,9 @@ public class NeoForgeMod {
         modEventBus.addListener((DataPackRegistryEvent.NewRegistry event) -> {
             event.dataPackRegistry(NeoForgeRegistries.Keys.BIOME_MODIFIERS, BiomeModifier.DIRECT_CODEC);
             event.dataPackRegistry(NeoForgeRegistries.Keys.STRUCTURE_MODIFIERS, StructureModifier.DIRECT_CODEC);
+            Codec<ExtendedEquipmentSlot> slotLoadCodec = NeoForgeRegistries.EXTENDED_EQUIPMENT_SLOT_SERIALIZERS.byNameCodec().dispatch(ExtendedEquipmentSlot::codec, Function.identity());
+            event.dataPackRegistry(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS, slotLoadCodec, slotLoadCodec);
+            event.dataPackRegistry(NeoForgeRegistries.Keys.EXTENDED_SLOT_GROUPS, ExtendedSlotGroup.LOAD_CODEC, ExtendedSlotGroup.LOAD_CODEC);
         });
         modEventBus.addListener(this::preInit);
         modEventBus.addListener(this::loadComplete);
@@ -587,6 +629,7 @@ public class NeoForgeMod {
         GLOBAL_LOOT_MODIFIER_SERIALIZERS.register(modEventBus);
         ATTRIBUTE_TYPES.register(modEventBus);
         ENVIRONMENT_ATTRIBUTES.register(modEventBus);
+        EXTENDED_EQUIPMENT_SLOT_SERIALIZERS.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
         ConfigSync.registerEventListeners();
         container.registerConfig(ModConfig.Type.SERVER, NeoForgeServerConfig.SPEC);

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeExtendedSlotsProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeExtendedSlotsProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.data.internal;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistrySetBuilder;
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.registries.holdersets.AnyHolderSet;
+import net.neoforged.neoforge.slot.ExtendedEquipmentSlot;
+import net.neoforged.neoforge.slot.ExtendedSlotGroup;
+import net.neoforged.neoforge.slot.VanillaExtendedSlot;
+
+/**
+ * Data provider for {@link ExtendedEquipmentSlot} and {@link ExtendedSlotGroup}.
+ */
+public class NeoForgeExtendedSlotsProvider extends DatapackBuiltinEntriesProvider {
+    private static final RegistrySetBuilder BUILDER = new RegistrySetBuilder()
+            .add(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS, ctx -> {
+                ctx.register(NeoForgeMod.SLOT_MAINHAND, new VanillaExtendedSlot(EquipmentSlot.MAINHAND));
+                ctx.register(NeoForgeMod.SLOT_OFFHAND, new VanillaExtendedSlot(EquipmentSlot.OFFHAND));
+                ctx.register(NeoForgeMod.SLOT_HEAD, new VanillaExtendedSlot(EquipmentSlot.HEAD));
+                ctx.register(NeoForgeMod.SLOT_CHEST, new VanillaExtendedSlot(EquipmentSlot.CHEST));
+                ctx.register(NeoForgeMod.SLOT_LEGS, new VanillaExtendedSlot(EquipmentSlot.LEGS));
+                ctx.register(NeoForgeMod.SLOT_FEET, new VanillaExtendedSlot(EquipmentSlot.FEET));
+                ctx.register(NeoForgeMod.SLOT_BODY, new VanillaExtendedSlot(EquipmentSlot.BODY));
+                ctx.register(NeoForgeMod.SLOT_SADDLE, new VanillaExtendedSlot(EquipmentSlot.SADDLE));
+            })
+            .add(NeoForgeRegistries.Keys.EXTENDED_SLOT_GROUPS, ctx -> {
+                var slots = ctx.lookup(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS);
+                HolderSet<ExtendedEquipmentSlot> allVanillaSlots = HolderSet.direct(
+                        slots.getOrThrow(NeoForgeMod.SLOT_MAINHAND),
+                        slots.getOrThrow(NeoForgeMod.SLOT_OFFHAND),
+                        slots.getOrThrow(NeoForgeMod.SLOT_HEAD),
+                        slots.getOrThrow(NeoForgeMod.SLOT_CHEST),
+                        slots.getOrThrow(NeoForgeMod.SLOT_LEGS),
+                        slots.getOrThrow(NeoForgeMod.SLOT_FEET),
+                        slots.getOrThrow(NeoForgeMod.SLOT_BODY),
+                        slots.getOrThrow(NeoForgeMod.SLOT_SADDLE));
+
+                var set = new AnyHolderSet<ExtendedEquipmentSlot>(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS, ctx.holderLookup(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS).get());
+                ctx.register(NeoForgeMod.GROUP_ANY, new ExtendedSlotGroup(set));
+                ctx.register(NeoForgeMod.GROUP_ANY_VANILLA, new ExtendedSlotGroup(allVanillaSlots));
+                ctx.register(NeoForgeMod.GROUP_MAINHAND, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_MAINHAND))));
+                ctx.register(NeoForgeMod.GROUP_OFFHAND, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_OFFHAND))));
+                ctx.register(NeoForgeMod.GROUP_HAND, new ExtendedSlotGroup(HolderSet.direct(
+                        slots.getOrThrow(NeoForgeMod.SLOT_MAINHAND),
+                        slots.getOrThrow(NeoForgeMod.SLOT_OFFHAND))));
+                ctx.register(NeoForgeMod.GROUP_HEAD, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_HEAD))));
+                ctx.register(NeoForgeMod.GROUP_CHEST, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_CHEST))));
+                ctx.register(NeoForgeMod.GROUP_LEGS, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_LEGS))));
+                ctx.register(NeoForgeMod.GROUP_FEET, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_FEET))));
+                ctx.register(NeoForgeMod.GROUP_ARMOR, new ExtendedSlotGroup(HolderSet.direct(
+                        slots.getOrThrow(NeoForgeMod.SLOT_HEAD),
+                        slots.getOrThrow(NeoForgeMod.SLOT_CHEST),
+                        slots.getOrThrow(NeoForgeMod.SLOT_LEGS),
+                        slots.getOrThrow(NeoForgeMod.SLOT_FEET))));
+                ctx.register(NeoForgeMod.GROUP_BODY, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_BODY))));
+                ctx.register(NeoForgeMod.GROUP_SADDLE, new ExtendedSlotGroup(HolderSet.direct(slots.getOrThrow(NeoForgeMod.SLOT_SADDLE))));
+            });
+
+    public NeoForgeExtendedSlotsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
+        super(output, registries, BUILDER, Set.of(NeoForgeMod.MOD_ID));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistries.java
@@ -22,6 +22,8 @@ import net.neoforged.neoforge.common.world.StructureModifier;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.fluids.crafting.FluidIngredientType;
 import net.neoforged.neoforge.registries.holdersets.HolderSetType;
+import net.neoforged.neoforge.slot.ExtendedEquipmentSlot;
+import net.neoforged.neoforge.slot.ExtendedSlotGroup;
 
 /**
  * A class that exposes static references to NeoForge registries.
@@ -41,6 +43,7 @@ public class NeoForgeRegistries {
     public static final Registry<FluidIngredientType<?>> FLUID_INGREDIENT_TYPES = new RegistryBuilder<>(Keys.FLUID_INGREDIENT_TYPES).sync(true).create();
     public static final Registry<MapCodec<? extends ICondition>> CONDITION_SERIALIZERS = new RegistryBuilder<>(Keys.CONDITION_CODECS).create();
     public static final Registry<AttachmentType<?>> ATTACHMENT_TYPES = new RegistryBuilder<>(Keys.ATTACHMENT_TYPES).create();
+    public static final Registry<MapCodec<? extends ExtendedEquipmentSlot>> EXTENDED_EQUIPMENT_SLOT_SERIALIZERS = new RegistryBuilder<>(Keys.EXTENDED_EQUIPMENT_SLOT_SERIALIZERS).sync(true).create();
 
     // Reminder: If you add a registry to NeoForge itself, remember to add it to NeoForgeRegistriesSetup#registerRegistries.
 
@@ -56,10 +59,13 @@ public class NeoForgeRegistries {
         public static final ResourceKey<Registry<FluidIngredientType<?>>> FLUID_INGREDIENT_TYPES = key("fluid_ingredient_type");
         public static final ResourceKey<Registry<MapCodec<? extends ICondition>>> CONDITION_CODECS = key("condition_codecs");
         public static final ResourceKey<Registry<AttachmentType<?>>> ATTACHMENT_TYPES = key("attachment_types");
+        public static final ResourceKey<Registry<MapCodec<? extends ExtendedEquipmentSlot>>> EXTENDED_EQUIPMENT_SLOT_SERIALIZERS = key("extended_equipment_slot_type");
 
         // NeoForge Dynamic
         public static final ResourceKey<Registry<BiomeModifier>> BIOME_MODIFIERS = key("biome_modifier");
         public static final ResourceKey<Registry<StructureModifier>> STRUCTURE_MODIFIERS = key("structure_modifier");
+        public static final ResourceKey<Registry<ExtendedEquipmentSlot>> EXTENDED_EQUIPMENT_SLOTS = key("extended_equipment_slot");
+        public static final ResourceKey<Registry<ExtendedSlotGroup>> EXTENDED_SLOT_GROUPS = key("extended_slot_group");
 
         private static <T> ResourceKey<Registry<T>> key(String name) {
             return ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(NeoForgeMod.MOD_ID, name));

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -73,6 +73,7 @@ public class NeoForgeRegistriesSetup {
         event.register(NeoForgeRegistries.CONDITION_SERIALIZERS);
         event.register(NeoForgeRegistries.ATTACHMENT_TYPES);
         event.register(AttachmentSync.SYNCED_ATTACHMENT_TYPES);
+        event.register(NeoForgeRegistries.EXTENDED_EQUIPMENT_SLOT_SERIALIZERS);
     }
 
     private static void modifyRegistries(ModifyRegistriesEvent event) {

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
@@ -36,7 +36,12 @@ import net.neoforged.neoforge.common.NeoForgeMod;
  * }
  * </pre>
  */
-public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) implements ICustomHolderSet<T> {
+public record AnyHolderSet<T>(ResourceKey<? extends Registry<T>> registryKey, HolderLookup<T> registryLookup) implements ICustomHolderSet<T> {
+    @SuppressWarnings("unchecked")
+    public AnyHolderSet(HolderLookup.RegistryLookup<T> registryLookup) {
+        this((ResourceKey<? extends Registry<T>>) registryLookup.key(), registryLookup);
+    }
+
     @Override
     public HolderSetType type() {
         return NeoForgeMod.ANY_HOLDER_SET.value();
@@ -72,7 +77,7 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
         List<Holder<T>> holders = this.stream().toList();
         Holder<T> holder = i >= holders.size() ? null : holders.get(i);
         if (holder == null)
-            throw new NoSuchElementException("No element " + i + " in registry " + this.registryLookup.key());
+            throw new NoSuchElementException("No element " + i + " in registry " + this.registryKey);
 
         return holder;
     }
@@ -100,14 +105,14 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
 
     @Override
     public String toString() {
-        return "AnySet(" + this.registryLookup.key() + ")";
+        return "AnySet(" + this.registryKey + ")";
     }
 
     public static class Type implements HolderSetType {
         @Override
         public <T> MapCodec<? extends ICustomHolderSet<T>> makeCodec(ResourceKey<? extends Registry<T>> registryKey, Codec<Holder<T>> holderCodec, boolean forceList) {
             return RegistryOps.retrieveRegistryLookup(registryKey)
-                    .xmap(AnyHolderSet::new, AnyHolderSet::registryLookup);
+                    .xmap(lookup -> new AnyHolderSet<>(registryKey, lookup), set -> null); // Normally null would get us into trouble with codecs, but the ops resolver we're xmapping back to discards this result.
         }
 
         @Override
@@ -115,12 +120,12 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
             return new StreamCodec<RegistryFriendlyByteBuf, AnyHolderSet<T>>() {
                 @Override
                 public AnyHolderSet<T> decode(RegistryFriendlyByteBuf buf) {
-                    return new AnyHolderSet<>(buf.registryAccess().lookupOrThrow(registryKey));
+                    return new AnyHolderSet<>(registryKey, buf.registryAccess().lookupOrThrow(registryKey));
                 }
 
                 @Override
                 public void encode(RegistryFriendlyByteBuf buf, AnyHolderSet<T> holderSet) {
-                    final var registryKeyIn = holderSet.registryLookup.key();
+                    final var registryKeyIn = holderSet.registryKey;
                     if (!registryKey.equals(registryKeyIn)) {
                         throw new IllegalStateException("Can not encode " + holderSet
                                 + ", expected registry: "

--- a/src/main/java/net/neoforged/neoforge/slot/ExtendedEquipmentSlot.java
+++ b/src/main/java/net/neoforged/neoforge/slot/ExtendedEquipmentSlot.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.slot;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.Holder;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.RegistryFixedCodec;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Extensible replacement for {@link EquipmentSlot}. Used when we need to talk abstractly about any equipment an entity might be wearing, instead of only vanilla equipment slots.
+ *
+ * @see ExtendedSlotGroup
+ * @see ExtendedSlotCompat
+ */
+@ApiStatus.Experimental
+public interface ExtendedEquipmentSlot {
+    public static final Codec<Holder<ExtendedEquipmentSlot>> CODEC = RegistryFixedCodec.create(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS);
+    public static final StreamCodec<RegistryFriendlyByteBuf, Holder<ExtendedEquipmentSlot>> STREAM_CODEC = ByteBufCodecs.holderRegistry(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS);
+
+    /**
+     * Returns the single item stack worn in this slot on the given entity. May be empty.
+     * <p>
+     * Slots are intentionally single-stack: a slot type that conceptually holds multiple items (e.g., a list of rings)
+     * registers one {@link ExtendedEquipmentSlot} per index.
+     */
+    ItemStack getStack(LivingEntity entity);
+
+    /**
+     * Sets the item in this slot on the entity to the given stack.
+     */
+    void setStack(LivingEntity entity, ItemStack stack, boolean insideTransaction);
+
+    /**
+     * The serializer that produced this slot, used by {@link #DIRECT_CODEC} to round-trip the {@code "type"} field.
+     */
+    MapCodec<? extends ExtendedEquipmentSlot> codec();
+}

--- a/src/main/java/net/neoforged/neoforge/slot/ExtendedSlotCompat.java
+++ b/src/main/java/net/neoforged/neoforge/slot/ExtendedSlotCompat.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.slot;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Util;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.EquipmentSlotGroup;
+import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Compat layer between vanilla {@link EquipmentSlot}/{@link EquipmentSlotGroup} and our {@link ExtendedEquipmentSlot}/{@link ExtendedSlotGroup}.
+ * <p>
+ * Mappings are by registry key, so {@code toVanilla} works without any registry lookup. {@code fromVanilla} requires
+ * a {@link HolderGetter} to resolve the holder for the extended slot/group.
+ */
+@ApiStatus.Experimental
+public final class ExtendedSlotCompat {
+    private ExtendedSlotCompat() {}
+
+    private static final BiMap<EquipmentSlot, ResourceKey<ExtendedEquipmentSlot>> SLOT_KEY_MAP = Util.make(HashBiMap.create(8), m -> {
+        m.put(EquipmentSlot.MAINHAND, NeoForgeMod.SLOT_MAINHAND);
+        m.put(EquipmentSlot.OFFHAND, NeoForgeMod.SLOT_OFFHAND);
+        m.put(EquipmentSlot.HEAD, NeoForgeMod.SLOT_HEAD);
+        m.put(EquipmentSlot.CHEST, NeoForgeMod.SLOT_CHEST);
+        m.put(EquipmentSlot.LEGS, NeoForgeMod.SLOT_LEGS);
+        m.put(EquipmentSlot.FEET, NeoForgeMod.SLOT_FEET);
+        m.put(EquipmentSlot.BODY, NeoForgeMod.SLOT_BODY);
+        m.put(EquipmentSlot.SADDLE, NeoForgeMod.SLOT_SADDLE);
+    });
+
+    private static final BiMap<EquipmentSlotGroup, ResourceKey<ExtendedSlotGroup>> GROUP_KEY_MAP = Util.make(HashBiMap.create(11), m -> {
+        m.put(EquipmentSlotGroup.ANY, NeoForgeMod.GROUP_ANY_VANILLA);
+        m.put(EquipmentSlotGroup.MAINHAND, NeoForgeMod.GROUP_MAINHAND);
+        m.put(EquipmentSlotGroup.OFFHAND, NeoForgeMod.GROUP_OFFHAND);
+        m.put(EquipmentSlotGroup.HAND, NeoForgeMod.GROUP_HAND);
+        m.put(EquipmentSlotGroup.HEAD, NeoForgeMod.GROUP_HEAD);
+        m.put(EquipmentSlotGroup.CHEST, NeoForgeMod.GROUP_CHEST);
+        m.put(EquipmentSlotGroup.LEGS, NeoForgeMod.GROUP_LEGS);
+        m.put(EquipmentSlotGroup.FEET, NeoForgeMod.GROUP_FEET);
+        m.put(EquipmentSlotGroup.ARMOR, NeoForgeMod.GROUP_ARMOR);
+        m.put(EquipmentSlotGroup.BODY, NeoForgeMod.GROUP_BODY);
+        m.put(EquipmentSlotGroup.SADDLE, NeoForgeMod.GROUP_SADDLE);
+    });
+
+    /**
+     * Convert an extended slot holder back to the vanilla enum value, or null if the extended slot does not map to vanilla.
+     */
+    @Nullable
+    public static EquipmentSlot toVanillaSlot(Holder<ExtendedEquipmentSlot> slot) {
+        return slot.unwrapKey().map(SLOT_KEY_MAP.inverse()::get).orElse(null);
+    }
+
+    /**
+     * {@return the registry key of the built-in extended slot corresponding to a vanilla {@link EquipmentSlot}.}
+     */
+    public static ResourceKey<ExtendedEquipmentSlot> slotKey(EquipmentSlot slot) {
+        return SLOT_KEY_MAP.get(slot);
+    }
+
+    /**
+     * {@return the registry key of the built-in extended slot group corresponding to a vanilla {@link EquipmentSlotGroup}.}
+     */
+    public static ResourceKey<ExtendedSlotGroup> groupKey(EquipmentSlotGroup group) {
+        return GROUP_KEY_MAP.get(group);
+    }
+
+    /**
+     * Convert an extended slot-group holder back to the vanilla enum value, or null if the group does not map to vanilla.
+     * <p>
+     * As a special case, we remap {@link NeoForgeMod#GROUP_ANY} back to {@link EquipmentSlotGroup#ANY}, even though {@link #fromVanilla} will give us GROUP_ANY_VANILLA.
+     */
+    @Nullable
+    public static EquipmentSlotGroup toVanillaGroup(Holder<ExtendedSlotGroup> group) {
+        ResourceKey<ExtendedSlotGroup> key = group.unwrapKey().orElse(null);
+        if (key == null) return null;
+        if (key == NeoForgeMod.GROUP_ANY) return EquipmentSlotGroup.ANY;
+        return GROUP_KEY_MAP.inverse().get(key);
+    }
+
+    /**
+     * Resolve the extended-slot holder corresponding to a vanilla slot.
+     */
+    public static Holder<ExtendedEquipmentSlot> fromVanilla(EquipmentSlot slot, HolderGetter<ExtendedEquipmentSlot> holders) {
+        return holders.getOrThrow(slotKey(slot));
+    }
+
+    public static Holder<ExtendedEquipmentSlot> fromVanilla(EquipmentSlot slot, RegistryAccess access) {
+        return fromVanilla(slot, access.lookupOrThrow(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS));
+    }
+
+    /**
+     * Resolve the extended-slot-group holder corresponding to a vanilla group.
+     */
+    public static Holder<ExtendedSlotGroup> fromVanilla(EquipmentSlotGroup group, HolderGetter<ExtendedSlotGroup> holders) {
+        return holders.getOrThrow(groupKey(group));
+    }
+
+    public static Holder<ExtendedSlotGroup> fromVanilla(EquipmentSlotGroup group, RegistryAccess access) {
+        return fromVanilla(group, access.lookupOrThrow(NeoForgeRegistries.Keys.EXTENDED_SLOT_GROUPS));
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/slot/ExtendedSlotGroup.java
+++ b/src/main/java/net/neoforged/neoforge/slot/ExtendedSlotGroup.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.slot;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.function.Predicate;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryCodecs;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.RegistryFixedCodec;
+import net.minecraft.world.entity.EquipmentSlotGroup;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Datapack-loaded grouping of {@link ExtendedEquipmentSlot}s. Replaces vanilla
+ * {@link EquipmentSlotGroup} for cases where the slots involved cannot be expressed by the fixed enum.
+ */
+@ApiStatus.Experimental
+public record ExtendedSlotGroup(HolderSet<ExtendedEquipmentSlot> slots) implements Predicate<Holder<ExtendedEquipmentSlot>> {
+    public static final Codec<ExtendedSlotGroup> LOAD_CODEC = RecordCodecBuilder.create(inst -> inst
+            .group(RegistryCodecs.homogeneousList(NeoForgeRegistries.Keys.EXTENDED_EQUIPMENT_SLOTS).fieldOf("slots").forGetter(ExtendedSlotGroup::slots))
+            .apply(inst, ExtendedSlotGroup::new));
+
+    public static final Codec<Holder<ExtendedSlotGroup>> CODEC = RegistryFixedCodec.create(NeoForgeRegistries.Keys.EXTENDED_SLOT_GROUPS);
+    public static final StreamCodec<RegistryFriendlyByteBuf, Holder<ExtendedSlotGroup>> STREAM_CODEC = ByteBufCodecs.holderRegistry(NeoForgeRegistries.Keys.EXTENDED_SLOT_GROUPS);
+
+    @Override
+    public boolean test(Holder<ExtendedEquipmentSlot> slot) {
+        return this.slots.contains(slot);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/slot/VanillaExtendedSlot.java
+++ b/src/main/java/net/neoforged/neoforge/slot/VanillaExtendedSlot.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.slot;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Built-in {@link ExtendedEquipmentSlot} implementation that wraps a vanilla {@link EquipmentSlot}. Returns the single
+ * stack worn in the matching vanilla slot.
+ */
+public record VanillaExtendedSlot(EquipmentSlot slot) implements ExtendedEquipmentSlot {
+    public static final MapCodec<VanillaExtendedSlot> CODEC = RecordCodecBuilder.mapCodec(inst -> inst
+            .group(EquipmentSlot.CODEC.fieldOf("slot").forGetter(VanillaExtendedSlot::slot))
+            .apply(inst, VanillaExtendedSlot::new));
+
+    @Override
+    public ItemStack getStack(LivingEntity entity) {
+        return entity.getItemBySlot(this.slot);
+    }
+
+    @Override
+    public void setStack(LivingEntity entity, ItemStack stack, boolean insideTransaction) {
+        entity.setItemSlot(this.slot, stack, insideTransaction);
+    }
+
+    @Override
+    public MapCodec<VanillaExtendedSlot> codec() {
+        return CODEC;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/slot/package-info.java
+++ b/src/main/java/net/neoforged/neoforge/slot/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+@NullMarked
+package net.neoforged.neoforge.slot;
+
+import org.jspecify.annotations.NullMarked;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
@@ -244,7 +244,7 @@ public class GlobalLootModifiersTest {
     static void smeltingModifierTest(final DynamicTest test) {
         var registrySetBuilder = new RegistrySetBuilder()
                 .add(Registries.ENCHANTMENT, boot -> boot
-                        .register(SMELT, new Enchantment.Builder(Enchantment.definition(boot.registryLookup(Registries.ITEM).orElseThrow().getOrThrow(ItemTags.MINING_ENCHANTABLE), 10, 1, Enchantment.dynamicCost(1, 10), Enchantment.dynamicCost(5, 10), 1, EquipmentSlotGroup.HAND))
+                        .register(SMELT, new Enchantment.Builder(Enchantment.definition(boot.holderLookup(Registries.ITEM).orElseThrow().getOrThrow(ItemTags.MINING_ENCHANTABLE), 10, 1, Enchantment.dynamicCost(1, 10), Enchantment.dynamicCost(5, 10), 1, EquipmentSlotGroup.HAND))
                                 .build(SMELT.identifier())));
 
         var subpack = HELPER.registerSubpack("smelt_glms");


### PR DESCRIPTION
This PR adds what is, in its current form, really just a bunch of boilerplate. Specifically, it adds a way to talk abstractly about entity equipment slots (and slot groups) but does not yet _do_ anything with those fixtures. I have some staged changes locally that rewire our `ItemAttributeModifiersEvent` to use these but I wanted to get these through in at least experimental mode first.

Anyway, this adds `ExtendedEquipmentSlot` and `ExtendedSlotGroup` as abstract analogues to vanilla's `EquipmentSlot` and `EquipmentSlotGroup` (both of which are enums). 

The goal for this system is to create a unified model to talk about "equipment slots", be that vanilla equipment slots, things such as curios or accessories, or other custom equipment-slot-like features (like whatever Aether has that I recall being not quite the same thing as either curios or accessories).

In the future this means this interface will likely get a larger set of declarative properties, including things like drop-on-death, ticking, etc (maybe even as tags!); but today we need to get started on talking about them as a concept.

This PR also includes a (breaking change) bugfix for creating `AnyHolderSet` in datagen for dynamic registries, which is currently impossible.