### PR TITLE
[26.1] Fix missing block model rendering with "random" texture

### DIFF
--- a/patches/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -152,6 +152,18 @@
      ) {
          final Multimap<String, Identifier> missingSprites = Multimaps.synchronizedMultimap(HashMultimap.create());
          final Multimap<String, String> missingReferences = Multimaps.synchronizedMultimap(HashMultimap.create());
+@@ -244,8 +_,9 @@
+             }
+ 
+             private Material.@Nullable Baked bake(Material material) {
+-                Material.Baked itemMaterial = this.bakeForAtlas(material, itemAtlas);
+-                return itemMaterial != null ? itemMaterial : this.bakeForAtlas(material, blockAtlas);
++                // Neo: fix missing block model rendering "random" texture (MC-307221)
++                Material.Baked blockMaterial = this.bakeForAtlas(material, blockAtlas);
++                return blockMaterial != null ? blockMaterial : this.bakeForAtlas(material, itemAtlas);
+             }
+ 
+             private Material.@Nullable Baked bakeForAtlas(Material material, SpriteLoader.Preparations atlas) {
 @@ -261,7 +_,7 @@
          };
          CompletableFuture<ModelBakery.BakingResult> bakedStateResults = bakery.bakeModels(materialBaker, taskExecutor);


### PR DESCRIPTION
This PR fixes the missing block model rendering with a "random" texture ([MC-307221](https://mojira.dev/MC-307221)).
This fix also solves cases where a block model references a sprite that is present on both block and item atlases, causing it to run into the same issue.

This is caused by the way the model baking process resolves `Material.Baked`s from the `Material`s specified in the model JSON. When any model is baked, both atlases are searched for the textures. This search checks the item atlas first and the block atlas second and only if the item atlas query returns null, causing textures existing on both atlases to be resolved to the item atlas. Since `minecraft:missingno` exists on all atlases, this behavior applies to it. Normally the block model baking has a subsequent check in `SimpleModelWrapper.bake()` to reject block models using item atlas sprites and fall back to the missing model. However, no such check exists in the special-cased baking of the “global” missing models in `ModelBakery.MissingModels.bake()` nor does said code attempt to force the use of the missing sprite from the block atlas. Since block models are unconditionally rendered with the block atlas, this causes the placed block to render whatever happens to be on the block atlas in the UV coordinate range occupied by the missing sprite on the item atlas.