### PR TITLE
Chainable Post Shader Effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,16 @@ build
 **/runs/
 
 **/out/
+
+# MixinMCP auto-injected rules
+.cursor/rules/minecraft-mod-project.mdc
+.cursor/skills/mixin-writing/SKILL.md
+.cursor/skills/mixin-writing/references/at-reference.md
+.cursor/skills/mixin-writing/references/expressions-language.md
+.cursor/skills/mixinmcp-tools/SKILL.md
+.cursor/skills/mixinmcp-tools/references/toolchains.md
+.claude/skills/mixin-writing/SKILL.md
+.claude/skills/mixin-writing/references/at-reference.md
+.claude/skills/mixin-writing/references/expressions-language.md
+.claude/skills/mixinmcp-tools/SKILL.md
+.claude/skills/mixinmcp-tools/references/toolchains.md

--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/GameRenderer.java
 +++ b/net/minecraft/client/renderer/GameRenderer.java
-@@ -301,19 +_,46 @@
+@@ -301,19 +_,45 @@
  
      public void checkEntityPostEffect(@Nullable Entity p_109107_) {
          if (this.postEffect != null) {
@@ -8,7 +8,7 @@
 +            this.togglePostChainEffect(null, net.neoforged.neoforge.client.PostChainGroup.ENTITY_SHADERS);
          }
  
-         this.postEffect = null;
+-        this.postEffect = null;
          if (p_109107_ instanceof Creeper) {
 -            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"));
 +            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"), net.neoforged.neoforge.client.PostChainGroup.ENTITY_SHADERS);

--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -1,34 +1,26 @@
 --- a/net/minecraft/client/renderer/GameRenderer.java
 +++ b/net/minecraft/client/renderer/GameRenderer.java
-@@ -77,6 +_,7 @@
- import net.minecraft.world.phys.Vec3;
- import net.neoforged.api.distmarker.Dist;
- import net.neoforged.api.distmarker.OnlyIn;
-+import net.neoforged.neoforge.client.PostChainGroup;
- import org.joml.Matrix4f;
- import org.joml.Matrix4fStack;
- import org.joml.Quaternionf;
 @@ -301,19 +_,46 @@
  
      public void checkEntityPostEffect(@Nullable Entity p_109107_) {
          if (this.postEffect != null) {
 -            this.postEffect.close();
-+            this.togglePostChainEffect(null, PostChainGroup.ENTITY_SHADERS);
++            this.togglePostChainEffect(null, net.neoforged.neoforge.client.PostChainGroup.ENTITY_SHADERS);
          }
  
          this.postEffect = null;
          if (p_109107_ instanceof Creeper) {
 -            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"));
-+            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"), PostChainGroup.ENTITY_SHADERS);
++            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"), net.neoforged.neoforge.client.PostChainGroup.ENTITY_SHADERS);
          } else if (p_109107_ instanceof Spider) {
 -            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/spider.json"));
-+            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/spider.json"), PostChainGroup.ENTITY_SHADERS);
++            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/spider.json"), net.neoforged.neoforge.client.PostChainGroup.ENTITY_SHADERS);
          } else if (p_109107_ instanceof EnderMan) {
 -            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/invert.json"));
 -        }
 -    }
 -
-+            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/invert.json"), PostChainGroup.ENTITY_SHADERS);
++            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/invert.json"), net.neoforged.neoforge.client.PostChainGroup.ENTITY_SHADERS);
 +        } else {
 +            net.neoforged.neoforge.client.ClientHooks.loadEntityShader(p_109107_, this);
 +        }
@@ -42,7 +34,7 @@
 +     * @param postEffect post-effect. Null to remove it
 +     * @param group      effect group. Used for priority and mutual exclusivity.
 +     */
-+    public void togglePostChainEffect(@Nullable ResourceLocation postEffect, PostChainGroup group) {
++    public void togglePostChainEffect(@Nullable ResourceLocation postEffect, net.neoforged.neoforge.client.PostChainGroup group) {
 +        try {
 +            this.postEffect = PostChain.refreshComposite(this.postEffect, postEffect, group);
 +            this.effectActive = this.postEffect != null;

--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -1,14 +1,67 @@
 --- a/net/minecraft/client/renderer/GameRenderer.java
 +++ b/net/minecraft/client/renderer/GameRenderer.java
-@@ -311,6 +_,8 @@
-             this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/spider.json"));
+@@ -77,6 +_,7 @@
+ import net.minecraft.world.phys.Vec3;
+ import net.neoforged.api.distmarker.Dist;
+ import net.neoforged.api.distmarker.OnlyIn;
++import net.neoforged.neoforge.client.PostChainGroup;
+ import org.joml.Matrix4f;
+ import org.joml.Matrix4fStack;
+ import org.joml.Quaternionf;
+@@ -301,19 +_,46 @@
+ 
+     public void checkEntityPostEffect(@Nullable Entity p_109107_) {
+         if (this.postEffect != null) {
+-            this.postEffect.close();
++            this.togglePostChainEffect(null, PostChainGroup.ENTITY_SHADERS);
+         }
+ 
+         this.postEffect = null;
+         if (p_109107_ instanceof Creeper) {
+-            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"));
++            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/creeper.json"), PostChainGroup.ENTITY_SHADERS);
+         } else if (p_109107_ instanceof Spider) {
+-            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/spider.json"));
++            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/spider.json"), PostChainGroup.ENTITY_SHADERS);
          } else if (p_109107_ instanceof EnderMan) {
-             this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/invert.json"));
+-            this.loadEffect(ResourceLocation.withDefaultNamespace("shaders/post/invert.json"));
+-        }
+-    }
+-
++            this.togglePostChainEffect(ResourceLocation.withDefaultNamespace("shaders/post/invert.json"), PostChainGroup.ENTITY_SHADERS);
 +        } else {
 +            net.neoforged.neoforge.client.ClientHooks.loadEntityShader(p_109107_, this);
-         }
-     }
- 
++        }
++    }
++
++
++    /**
++     * Use instead of loadEffect.
++     * This allows adding a post-effect in a non-destructive manner, allowing multiple mods to work together.
++     *
++     * @param postEffect post-effect. Null to remove it
++     * @param group      effect group. Used for priority and mutual exclusivity.
++     */
++    public void togglePostChainEffect(@Nullable ResourceLocation postEffect, PostChainGroup group) {
++        try {
++            this.postEffect = PostChain.refreshComposite(this.postEffect, postEffect, group);
++            this.effectActive = this.postEffect != null;
++        } catch (IOException ioexception) {
++            LOGGER.warn("Failed to load shader: {}", postEffect, ioexception);
++            this.effectActive = false;
++        } catch (JsonSyntaxException jsonsyntaxexception) {
++            LOGGER.warn("Failed to parse shader: {}", postEffect, jsonsyntaxexception);
++            this.effectActive = false;
++        }
++    }
++
++    /**
++     * Use togglePostChainEffect
++     */
++    @Deprecated
+     public void loadEffect(ResourceLocation p_109129_) {
+         if (this.postEffect != null) {
+             this.postEffect.close();
 @@ -714,6 +_,7 @@
                  )
              );

--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/renderer/GameRenderer.java
 +++ b/net/minecraft/client/renderer/GameRenderer.java
-@@ -301,19 +_,45 @@
+@@ -301,19 +_,46 @@
  
      public void checkEntityPostEffect(@Nullable Entity p_109107_) {
          if (this.postEffect != null) {
@@ -36,7 +36,8 @@
 +     */
 +    public void togglePostChainEffect(@Nullable ResourceLocation postEffect, net.neoforged.neoforge.client.PostChainGroup group) {
 +        try {
-+            this.postEffect = PostChain.refreshComposite(this.postEffect, postEffect, group);
++            var target = this.postEffect != null ? this.postEffect.screenTarget : Minecraft.getInstance().getMainRenderTarget();
++            this.postEffect = PostChain.refreshComposite(this.postEffect, postEffect, group, target);
 +            this.effectActive = this.postEffect != null;
 +        } catch (IOException ioexception) {
 +            LOGGER.warn("Failed to load shader: {}", postEffect, ioexception);

--- a/patches/net/minecraft/client/renderer/PostChain.java.patch
+++ b/patches/net/minecraft/client/renderer/PostChain.java.patch
@@ -1,5 +1,59 @@
 --- a/net/minecraft/client/renderer/PostChain.java
 +++ b/net/minecraft/client/renderer/PostChain.java
+@@ -12,6 +_,7 @@
+ import com.mojang.blaze3d.systems.RenderSystem;
+ import java.io.IOException;
+ import java.io.Reader;
++import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ import javax.annotation.Nullable;
+@@ -21,26 +_,29 @@
+ import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.server.ChainedJsonException;
+ import net.minecraft.server.packs.resources.Resource;
++import net.minecraft.server.packs.resources.ResourceManager;
+ import net.minecraft.server.packs.resources.ResourceProvider;
+ import net.minecraft.util.GsonHelper;
+ import net.neoforged.api.distmarker.Dist;
+ import net.neoforged.api.distmarker.OnlyIn;
++import net.neoforged.neoforge.client.PostChainGroup;
++import org.jetbrains.annotations.ApiStatus;
+ import org.joml.Matrix4f;
+ 
+ @OnlyIn(Dist.CLIENT)
+ public class PostChain implements AutoCloseable {
+     private static final String MAIN_RENDER_TARGET = "minecraft:main";
+-    private final RenderTarget screenTarget;
++    protected final RenderTarget screenTarget;
+     private final ResourceProvider resourceProvider;
+     private final String name;
+-    private final List<PostPass> passes = Lists.newArrayList();
+-    private final Map<String, RenderTarget> customRenderTargets = Maps.newHashMap();
+-    private final List<RenderTarget> fullSizedTargets = Lists.newArrayList();
+-    private Matrix4f shaderOrthoMatrix;
++    protected final List<PostPass> passes = Lists.newArrayList();
++    protected final Map<String, RenderTarget> customRenderTargets = Maps.newHashMap();
++    protected final List<RenderTarget> fullSizedTargets = Lists.newArrayList();
++    protected Matrix4f shaderOrthoMatrix;
+     private int screenWidth;
+     private int screenHeight;
+-    private float time;
+-    private float lastStamp;
++    protected float time;
++    protected float lastStamp;
+ 
+     public PostChain(TextureManager p_110018_, ResourceProvider p_330592_, RenderTarget p_110020_, ResourceLocation p_110021_) throws IOException, JsonSyntaxException {
+         this.resourceProvider = p_330592_;
+@@ -54,7 +_,7 @@
+         this.load(p_110018_, p_110021_);
+     }
+ 
+-    private void load(TextureManager p_110034_, ResourceLocation p_110035_) throws IOException, JsonSyntaxException {
++    protected void load(TextureManager p_110034_, ResourceLocation p_110035_) throws IOException, JsonSyntaxException {
+         Resource resource = this.resourceProvider.getResourceOrThrow(p_110035_);
+ 
+         try {
 @@ -156,7 +_,8 @@
                                  throw new ChainedJsonException("Render target '" + s4 + "' can't be used as depth buffer");
                              }
@@ -18,3 +72,128 @@
          this.customRenderTargets.put(p_110039_, rendertarget);
          if (p_110040_ == this.screenWidth && p_110041_ == this.screenHeight) {
              this.fullSizedTargets.add(rendertarget);
+@@ -346,6 +_,124 @@
+             return null;
+         } else {
+             return p_110050_.equals("minecraft:main") ? this.screenTarget : this.customRenderTargets.get(p_110050_);
++        }
++    }
++
++    @ApiStatus.Internal
++    public static @Nullable PostChain refreshComposite(@Nullable PostChain currentChain, @Nullable ResourceLocation newPost, PostChainGroup group) throws IOException {
++        PostChain newChain;
++        if (currentChain == null) {
++            if (newPost == null) return null;
++            newChain = ComposedPostChain.create(newPost, group);
++        } else if (currentChain instanceof ComposedPostChain cpc) {
++            newChain = cpc.with(newPost, group);
++        } else {
++            newChain = ComposedPostChain.wrap(currentChain, PostChainGroup.DEFAULT);
++        }
++        return newChain;
++    }
++
++    private static final class ComposedPostChain extends PostChain {
++
++        private final Map<PostChainGroup, PostChain> chainsPerGroup = new HashMap<>();
++
++        //prevent it from loading normally
++        @Override
++        protected void load(TextureManager textureManager, ResourceLocation resourceLocation) throws IOException, JsonSyntaxException {
++        }
++
++        private ComposedPostChain(TextureManager textureManager, ResourceProvider resourceProvider,
++                                  RenderTarget screenTarget, ResourceLocation resourceLocation) throws IOException, JsonSyntaxException {
++            super(textureManager, resourceProvider, screenTarget, resourceLocation);
++        }
++
++        private static ComposedPostChain wrap(PostChain vanillaChain, PostChainGroup group) throws IOException {
++            Minecraft mc = Minecraft.getInstance();
++            TextureManager tm = mc.getTextureManager();
++            ResourceManager rm = mc.getResourceManager();
++            var cc = new ComposedPostChain(tm, rm, vanillaChain.screenTarget, ResourceLocation.parse(vanillaChain.getName()));
++            cc.addSubChain(vanillaChain, group);
++            return cc;
++        }
++
++        private static ComposedPostChain create(ResourceLocation postEffect, PostChainGroup group) throws IOException {
++            Minecraft mc = Minecraft.getInstance();
++            TextureManager tm = mc.getTextureManager();
++            ResourceManager rm = mc.getResourceManager();
++            PostChain vanillaChain = new PostChain(tm, rm, mc.getMainRenderTarget(), postEffect);
++            vanillaChain.resize(mc.getWindow().getWidth(), mc.getWindow().getHeight());
++            return wrap(vanillaChain, group);
++        }
++
++        private @Nullable ComposedPostChain with(@Nullable ResourceLocation newEffect, PostChainGroup group) throws IOException {
++            Minecraft mc = Minecraft.getInstance();
++            TextureManager tm = mc.getTextureManager();
++            ResourceManager rm = mc.getResourceManager();
++
++            //check if it's already good
++            if (newEffect != null) {
++                PostChain existing = this.chainsPerGroup.get(group);
++                if (existing != null && existing.getName().equals(newEffect.toString())) {
++                    return this;
++                }
++            }
++            // copy existing groups
++            Map<PostChainGroup, PostChain> newGroups = new HashMap<>(this.chainsPerGroup);
++            if (newEffect == null) {
++                PostChain removed = newGroups.remove(group);
++                if (removed != null) removed.close();
++                if (newGroups.isEmpty()) {
++                    // if no groups left, return null to indicate no post-chain needed
++                    return null;
++                }
++            } else {
++                PostChain newChain = new PostChain(tm, rm, this.screenTarget, newEffect);
++                newChain.resize(mc.getWindow().getWidth(), mc.getWindow().getHeight());
++                newGroups.put(group, newChain);
++            }
++
++            // sort groups by priority
++            List<Map.Entry<PostChainGroup, PostChain>> ordered =
++                    newGroups.entrySet().stream()
++                            .sorted((a, b) -> Integer.compare(a.getKey().priority(), b.getKey().priority()))
++                            .toList();
++
++            ResourceLocation newName = ordered.size() == 1 ?
++                    ResourceLocation.parse(ordered.getFirst().getValue().getName()) :
++                    ResourceLocation.withDefaultNamespace("composed/" +
++                            ordered.stream()
++                            .map(e -> e.getValue().getName()
++                                      .replace(":", "_"))
++                            .reduce((a, b) -> a + "_" + b).orElse("empty"));
++
++            // create new composed chain (empty base)
++            ComposedPostChain result = new ComposedPostChain(
++                    tm, rm,
++                    this.screenTarget,
++                    newName // reuse same name
++            );
++            // rebuild passes + targets in order
++            for (var entry : ordered) {
++                PostChain pc = entry.getValue();
++                result.addSubChain(pc, entry.getKey());
++            }
++
++            return result;
++
++        }
++
++        private void addSubChain(PostChain chain, PostChainGroup group) {
++            this.chainsPerGroup.put(group, chain);
++
++            this.passes.addAll(chain.passes);
++            this.customRenderTargets.putAll(chain.customRenderTargets);
++            this.fullSizedTargets.addAll(chain.fullSizedTargets);
++
++            for (PostPass postPass : this.passes) {
++                postPass.setOrthoMatrix(this.shaderOrthoMatrix);
++            }
++            this.time = chain.time;
++            this.lastStamp = chain.lastStamp;
+         }
+     }
+ }

--- a/patches/net/minecraft/client/renderer/PostChain.java.patch
+++ b/patches/net/minecraft/client/renderer/PostChain.java.patch
@@ -1,47 +1,27 @@
 --- a/net/minecraft/client/renderer/PostChain.java
 +++ b/net/minecraft/client/renderer/PostChain.java
-@@ -12,6 +_,7 @@
- import com.mojang.blaze3d.systems.RenderSystem;
- import java.io.IOException;
- import java.io.Reader;
-+import java.util.HashMap;
- import java.util.List;
- import java.util.Map;
- import javax.annotation.Nullable;
-@@ -21,26 +_,29 @@
- import net.minecraft.resources.ResourceLocation;
- import net.minecraft.server.ChainedJsonException;
- import net.minecraft.server.packs.resources.Resource;
-+import net.minecraft.server.packs.resources.ResourceManager;
- import net.minecraft.server.packs.resources.ResourceProvider;
- import net.minecraft.util.GsonHelper;
- import net.neoforged.api.distmarker.Dist;
- import net.neoforged.api.distmarker.OnlyIn;
-+import net.neoforged.neoforge.client.PostChainGroup;
-+import org.jetbrains.annotations.ApiStatus;
- import org.joml.Matrix4f;
- 
+@@ -30,17 +_,17 @@
  @OnlyIn(Dist.CLIENT)
  public class PostChain implements AutoCloseable {
      private static final String MAIN_RENDER_TARGET = "minecraft:main";
--    private final RenderTarget screenTarget;
-+    protected final RenderTarget screenTarget;
+-    protected final RenderTarget screenTarget;
++    private final RenderTarget screenTarget;
      private final ResourceProvider resourceProvider;
      private final String name;
--    private final List<PostPass> passes = Lists.newArrayList();
--    private final Map<String, RenderTarget> customRenderTargets = Maps.newHashMap();
--    private final List<RenderTarget> fullSizedTargets = Lists.newArrayList();
--    private Matrix4f shaderOrthoMatrix;
-+    protected final List<PostPass> passes = Lists.newArrayList();
-+    protected final Map<String, RenderTarget> customRenderTargets = Maps.newHashMap();
-+    protected final List<RenderTarget> fullSizedTargets = Lists.newArrayList();
-+    protected Matrix4f shaderOrthoMatrix;
+-    protected final List<PostPass> passes = Lists.newArrayList();
+-    protected final Map<String, RenderTarget> customRenderTargets = Maps.newHashMap();
+-    protected final List<RenderTarget> fullSizedTargets = Lists.newArrayList();
+-    protected Matrix4f shaderOrthoMatrix;
++    private final List<PostPass> passes = Lists.newArrayList();
++    private final Map<String, RenderTarget> customRenderTargets = Maps.newHashMap();
++    private final List<RenderTarget> fullSizedTargets = Lists.newArrayList();
++    private Matrix4f shaderOrthoMatrix;
      private int screenWidth;
      private int screenHeight;
--    private float time;
--    private float lastStamp;
-+    protected float time;
-+    protected float lastStamp;
+-    protected float time;
+-    protected float lastStamp;
++    private float time;
++    private float lastStamp;
  
      public PostChain(TextureManager p_110018_, ResourceProvider p_330592_, RenderTarget p_110020_, ResourceLocation p_110021_) throws IOException, JsonSyntaxException {
          this.resourceProvider = p_330592_;
@@ -49,8 +29,8 @@
          this.load(p_110018_, p_110021_);
      }
  
--    private void load(TextureManager p_110034_, ResourceLocation p_110035_) throws IOException, JsonSyntaxException {
-+    protected void load(TextureManager p_110034_, ResourceLocation p_110035_) throws IOException, JsonSyntaxException {
+-    protected void load(TextureManager p_110034_, ResourceLocation p_110035_) throws IOException, JsonSyntaxException {
++    private void load(TextureManager p_110034_, ResourceLocation p_110035_) throws IOException, JsonSyntaxException {
          Resource resource = this.resourceProvider.getResourceOrThrow(p_110035_);
  
          try {
@@ -72,15 +52,14 @@
          this.customRenderTargets.put(p_110039_, rendertarget);
          if (p_110040_ == this.screenWidth && p_110041_ == this.screenHeight) {
              this.fullSizedTargets.add(rendertarget);
-@@ -346,6 +_,134 @@
+@@ -346,6 +_,132 @@
              return null;
          } else {
              return p_110050_.equals("minecraft:main") ? this.screenTarget : this.customRenderTargets.get(p_110050_);
 +        }
 +    }
 +
-+    @ApiStatus.Internal
-+    public static @Nullable PostChain refreshComposite(@Nullable PostChain currentChain, @Nullable ResourceLocation newPost, PostChainGroup group) throws IOException {
++    public static @Nullable PostChain refreshComposite(@Nullable PostChain currentChain, @Nullable ResourceLocation newPost, net.neoforged.neoforge.client.PostChainGroup group) throws IOException {
 +        PostChain newChain;
 +        if (currentChain == null) {
 +            if (newPost == null) return null;
@@ -88,14 +67,14 @@
 +        } else if (currentChain instanceof ComposedPostChain cpc) {
 +            newChain = cpc.with(newPost, group);
 +        } else {
-+            newChain = ComposedPostChain.wrap(currentChain, PostChainGroup.DEFAULT);
++            newChain = ComposedPostChain.wrap(currentChain, net.neoforged.neoforge.client.PostChainGroup.DEFAULT);
 +        }
 +        return newChain;
 +    }
 +
 +    private static final class ComposedPostChain extends PostChain {
 +
-+        private final Map<PostChainGroup, PostChain> chainsPerGroup = new HashMap<>();
++        private final Map<net.neoforged.neoforge.client.PostChainGroup, PostChain> chainsPerGroup = Maps.newHashMap();
 +
 +        //prevent it from loading normally
 +        private ComposedPostChain(TextureManager textureManager, ResourceProvider resourceProvider,
@@ -114,31 +93,31 @@
 +        }
 +
 +        @Override
-+        protected void load(TextureManager textureManager, ResourceLocation resourceLocation) throws IOException, JsonSyntaxException {
++        protected void load(TextureManager textureManager, ResourceLocation resourceLocation) throws JsonSyntaxException {
 +        }
 +
-+        private static ComposedPostChain wrap(PostChain vanillaChain, PostChainGroup group) throws IOException {
++        private static ComposedPostChain wrap(PostChain vanillaChain, net.neoforged.neoforge.client.PostChainGroup group) throws IOException {
 +            Minecraft mc = Minecraft.getInstance();
-+            TextureManager tm = mc.getTextureManager();
-+            ResourceManager rm = mc.getResourceManager();
++            var tm = mc.getTextureManager();
++            var rm = mc.getResourceManager();
 +            var cc = new ComposedPostChain(tm, rm, vanillaChain.screenTarget, ResourceLocation.parse(vanillaChain.getName()));
 +            cc.addSubChain(vanillaChain, group);
 +            return cc;
 +        }
 +
-+        private static ComposedPostChain create(ResourceLocation postEffect, PostChainGroup group) throws IOException {
++        private static ComposedPostChain create(ResourceLocation postEffect, net.neoforged.neoforge.client.PostChainGroup group) throws IOException {
 +            Minecraft mc = Minecraft.getInstance();
-+            TextureManager tm = mc.getTextureManager();
-+            ResourceManager rm = mc.getResourceManager();
++            var tm = mc.getTextureManager();
++            var rm = mc.getResourceManager();
 +            PostChain vanillaChain = new PostChain(tm, rm, mc.getMainRenderTarget(), postEffect);
 +            vanillaChain.resize(mc.getWindow().getWidth(), mc.getWindow().getHeight());
 +            return wrap(vanillaChain, group);
 +        }
 +
-+        private @Nullable ComposedPostChain with(@Nullable ResourceLocation newEffect, PostChainGroup group) throws IOException {
++        private @Nullable ComposedPostChain with(@Nullable ResourceLocation newEffect, net.neoforged.neoforge.client.PostChainGroup group) throws IOException {
 +            Minecraft mc = Minecraft.getInstance();
-+            TextureManager tm = mc.getTextureManager();
-+            ResourceManager rm = mc.getResourceManager();
++            var tm = mc.getTextureManager();
++            var rm = mc.getResourceManager();
 +
 +            //check if it's already good
 +            if (newEffect != null) {
@@ -148,7 +127,7 @@
 +                }
 +            }
 +            // copy existing groups
-+            Map<PostChainGroup, PostChain> newGroups = new HashMap<>(this.chainsPerGroup);
++            Map<net.neoforged.neoforge.client.PostChainGroup, PostChain> newGroups = Maps.newHashMap(this.chainsPerGroup);
 +            if (newEffect == null) {
 +                PostChain removed = newGroups.remove(group);
 +                if (removed != null) removed.close();
@@ -163,10 +142,9 @@
 +            }
 +
 +            // sort groups by priority
-+            List<Map.Entry<PostChainGroup, PostChain>> ordered =
-+                    newGroups.entrySet().stream()
-+                            .sorted((a, b) -> Integer.compare(a.getKey().priority(), b.getKey().priority()))
-+                            .toList();
++            var ordered = newGroups.entrySet().stream()
++                    .sorted(java.util.Comparator.comparingInt(a -> a.getKey().priority()))
++                    .toList();
 +
 +            ResourceLocation newName = ordered.size() == 1 ?
 +                    ResourceLocation.parse(ordered.getFirst().getValue().getName()) :
@@ -192,7 +170,7 @@
 +
 +        }
 +
-+        private void addSubChain(PostChain chain, PostChainGroup group) {
++        private void addSubChain(PostChain chain, net.neoforged.neoforge.client.PostChainGroup group) {
 +            this.chainsPerGroup.put(group, chain);
 +
 +            this.passes.addAll(chain.passes);

--- a/patches/net/minecraft/client/renderer/PostChain.java.patch
+++ b/patches/net/minecraft/client/renderer/PostChain.java.patch
@@ -52,18 +52,18 @@
          this.customRenderTargets.put(p_110039_, rendertarget);
          if (p_110040_ == this.screenWidth && p_110041_ == this.screenHeight) {
              this.fullSizedTargets.add(rendertarget);
-@@ -346,6 +_,132 @@
+@@ -346,6 +_,130 @@
              return null;
          } else {
              return p_110050_.equals("minecraft:main") ? this.screenTarget : this.customRenderTargets.get(p_110050_);
 +        }
 +    }
 +
-+    public static @Nullable PostChain refreshComposite(@Nullable PostChain currentChain, @Nullable ResourceLocation newPost, net.neoforged.neoforge.client.PostChainGroup group) throws IOException {
++    public static @Nullable PostChain refreshComposite(@Nullable PostChain currentChain, @Nullable ResourceLocation newPost, net.neoforged.neoforge.client.PostChainGroup group, RenderTarget mainTarget) throws IOException {
 +        PostChain newChain;
 +        if (currentChain == null) {
 +            if (newPost == null) return null;
-+            newChain = ComposedPostChain.create(newPost, group);
++            newChain = ComposedPostChain.create(newPost, group, mainTarget);
 +        } else if (currentChain instanceof ComposedPostChain cpc) {
 +            newChain = cpc.with(newPost, group);
 +        } else {
@@ -105,12 +105,12 @@
 +            return cc;
 +        }
 +
-+        private static ComposedPostChain create(ResourceLocation postEffect, net.neoforged.neoforge.client.PostChainGroup group) throws IOException {
++        private static ComposedPostChain create(ResourceLocation postEffect, net.neoforged.neoforge.client.PostChainGroup group, RenderTarget mainTarget) throws IOException {
 +            Minecraft mc = Minecraft.getInstance();
 +            var tm = mc.getTextureManager();
 +            var rm = mc.getResourceManager();
-+            PostChain vanillaChain = new PostChain(tm, rm, mc.getMainRenderTarget(), postEffect);
-+            vanillaChain.resize(mc.getWindow().getWidth(), mc.getWindow().getHeight());
++            PostChain vanillaChain = new PostChain(tm, rm, mainTarget, postEffect);
++            vanillaChain.resize(mainTarget.width, mainTarget.height);
 +            return wrap(vanillaChain, group);
 +        }
 +
@@ -137,7 +137,7 @@
 +                }
 +            } else {
 +                PostChain newChain = new PostChain(tm, rm, this.screenTarget, newEffect);
-+                newChain.resize(mc.getWindow().getWidth(), mc.getWindow().getHeight());
++                newChain.resize(this.screenTarget.width, this.screenTarget.height);
 +                newGroups.put(group, newChain);
 +            }
 +
@@ -165,6 +165,7 @@
 +                PostChain pc = entry.getValue();
 +                result.addSubChain(pc, entry.getKey());
 +            }
++            this.resize(this.screenTarget.width, this.screenTarget.height);
 +
 +            return result;
 +
@@ -177,9 +178,6 @@
 +            this.customRenderTargets.putAll(chain.customRenderTargets);
 +            this.fullSizedTargets.addAll(chain.fullSizedTargets);
 +
-+            for (PostPass postPass : this.passes) {
-+                postPass.setOrthoMatrix(this.shaderOrthoMatrix);
-+            }
 +            this.time = chain.time;
 +            this.lastStamp = chain.lastStamp;
          }

--- a/patches/net/minecraft/client/renderer/PostChain.java.patch
+++ b/patches/net/minecraft/client/renderer/PostChain.java.patch
@@ -72,7 +72,7 @@
          this.customRenderTargets.put(p_110039_, rendertarget);
          if (p_110040_ == this.screenWidth && p_110041_ == this.screenHeight) {
              this.fullSizedTargets.add(rendertarget);
-@@ -346,6 +_,124 @@
+@@ -346,6 +_,134 @@
              return null;
          } else {
              return p_110050_.equals("minecraft:main") ? this.screenTarget : this.customRenderTargets.get(p_110050_);
@@ -98,13 +98,23 @@
 +        private final Map<PostChainGroup, PostChain> chainsPerGroup = new HashMap<>();
 +
 +        //prevent it from loading normally
-+        @Override
-+        protected void load(TextureManager textureManager, ResourceLocation resourceLocation) throws IOException, JsonSyntaxException {
-+        }
-+
 +        private ComposedPostChain(TextureManager textureManager, ResourceProvider resourceProvider,
 +                                  RenderTarget screenTarget, ResourceLocation resourceLocation) throws IOException, JsonSyntaxException {
 +            super(textureManager, resourceProvider, screenTarget, resourceLocation);
++        }
++
++        @Override
++        public void close() {
++            super.close();
++            for (PostChain postChain : chainsPerGroup.values()){
++                try {
++                    postChain.close();
++                } catch (Exception ignored){}
++            }
++        }
++
++        @Override
++        protected void load(TextureManager textureManager, ResourceLocation resourceLocation) throws IOException, JsonSyntaxException {
 +        }
 +
 +        private static ComposedPostChain wrap(PostChain vanillaChain, PostChainGroup group) throws IOException {

--- a/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -535,7 +535,7 @@ public class ClientHooks {
         if (entity != null) {
             ResourceLocation shader = EntitySpectatorShaderManager.get(entity.getType());
             if (shader != null) {
-                entityRenderer.loadEffect(shader);
+                entityRenderer.togglePostChainEffect(shader, PostChainGroup.ENTITY_SHADERS);
             }
         }
     }

--- a/src/main/java/net/neoforged/neoforge/client/PostChainGroup.java
+++ b/src/main/java/net/neoforged/neoforge/client/PostChainGroup.java
@@ -1,0 +1,18 @@
+package net.neoforged.neoforge.client;
+
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * A group identifies a set of post-shader which is mutually exclusive.
+ * The priority field controls in which order the various groups are applied
+ */
+public record PostChainGroup(ResourceLocation resourceLocation, int priority) {
+    /**
+     * Default post-effect group. Unused
+     */
+    public static final PostChainGroup DEFAULT = new PostChainGroup(ResourceLocation.withDefaultNamespace("default"), 0);
+    /**
+     * Group used by spectator entity effects
+     */
+    public static final PostChainGroup ENTITY_SHADERS = new PostChainGroup(ResourceLocation.withDefaultNamespace("entity_shaders"), 1);
+}

--- a/src/main/java/net/neoforged/neoforge/client/PostChainGroup.java
+++ b/src/main/java/net/neoforged/neoforge/client/PostChainGroup.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.client;
 
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/net/neoforged/neoforge/client/PostChainGroup.java
+++ b/src/main/java/net/neoforged/neoforge/client/PostChainGroup.java
@@ -9,9 +9,9 @@ import net.minecraft.resources.ResourceLocation;
 
 /**
  * A group identifies a set of post-shader which is mutually exclusive.
- * The priority field controls in which order the various groups are applied
+ * The priority field controls in which order the various groups are applied, starting from low priority to high priority
  */
-public record PostChainGroup(ResourceLocation resourceLocation, int priority) {
+public record PostChainGroup(ResourceLocation resourceLocation, float priority) {
     /**
      * Default post-effect group. Unused
      */

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -542,3 +542,13 @@ public net.minecraft.client.resources.SplashManager SPLASHES_LOCATION
 
 # Default scoping texture
 public net.minecraft.client.gui.Gui SPYGLASS_SCOPE_LOCATION
+
+# Made protected for CompositePostChain
+protected net.minecraft.client.renderer.PostChain screenTarget
+protected net.minecraft.client.renderer.PostChain lastStamp
+protected net.minecraft.client.renderer.PostChain time
+protected net.minecraft.client.renderer.PostChain customRenderTargets
+protected net.minecraft.client.renderer.PostChain passes
+protected net.minecraft.client.renderer.PostChain fullSizedTargets
+protected net.minecraft.client.renderer.PostChain shaderOrthoMatrix
+protected net.minecraft.client.renderer.PostChain load(Lnet/minecraft/client/renderer/texture/TextureManager;Lnet/minecraft/resources/ResourceLocation;)V


### PR DESCRIPTION
Hi.

These changes offer a standardized way to add Post Shader Effects in an ordered and non destrictive way between mods.

**Use case example:**

- Mod A wants to apply the creeper vision shader when the player is in a dimension
- Mod B wants to apply their blur shader when the player is wearing a particular helmet

Currently, in the case of both conditions being true, mod A would have overwritten the effect of mod B when instead it would be more correct to have both applied.

**Exmple usage:**

```java
        GameRenderer gameRenderer = Minecraft.getInstance().gameRenderer;
        var creeperShader = ResourceLocation.withDefaultNamespace("shaders/post/creeper.json");
        var spiderShader = ResourceLocation.withDefaultNamespace("shaders/post/spider.json");
        PostChainGroup creeperGroup = new PostChainGroup(
                ResourceLocation.parse("ceeeper"), 1
        );
        PostChainGroup spiderGroup = new PostChainGroup(
                ResourceLocation.parse("spider"), 1
        );
        boolean crouch = player.isCrouching();
        boolean jumping = player.input.jumping;
        gameRenderer.togglePostChainEffect(crouch ? creeperShader : null, creeperGroup);
        gameRenderer.togglePostChainEffect(jumping ? spiderShader : null, spiderGroup);
```
Here showing how 2 shaders effects could be applied on two independent condiitons.


Using PostChainGroup one is able to create mutually exclusive shader groups as well as assigning priority to their effects.
Only one shader effect per group can be applied a the time.


**Note**

Please let me know of any mistakes here, this is my first PR here.
