### PR TITLE
[26.1] Allow BEs to react to structure rotation

### DIFF
--- a/patches/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
+++ b/patches/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java.patch
@@ -1,5 +1,23 @@
 --- a/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java
 +++ b/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java
+@@ -209,7 +_,7 @@
+                         new StructureTemplate.StructureBlockInfo(
+                             calculateRelativePosition(settings, blockInfo.pos()).offset(position),
+                             blockInfo.state.rotate(settings.getRotation()),
+-                            blockInfo.nbt
++                            net.neoforged.neoforge.common.CommonHooks.captureStructureRotation(blockInfo.nbt, rotation)
+                         )
+                     )
+                 );
+@@ -228,7 +_,7 @@
+             for (StructureTemplate.StructureBlockInfo blockInfo : settings.getRandomPalette(this.palettes, position).blocks(block)) {
+                 BlockPos blockPos = absolute ? calculateRelativePosition(settings, blockInfo.pos).offset(position) : blockInfo.pos;
+                 if (boundingBox == null || boundingBox.isInside(blockPos)) {
+-                    result.add(new StructureTemplate.StructureBlockInfo(blockPos, blockInfo.state.rotate(settings.getRotation()), blockInfo.nbt));
++                    result.add(new StructureTemplate.StructureBlockInfo(blockPos, blockInfo.state.rotate(settings.getRotation()), net.neoforged.neoforge.common.CommonHooks.captureStructureRotation(blockInfo.nbt, settings.getRotation())));
+                 }
+             }
+ 
 @@ -246,6 +_,10 @@
          return transform(pos, settings.getMirror(), settings.getRotation(), settings.getRotationPivot());
      }
@@ -20,6 +38,14 @@
  
                  try (ProblemReporter.ScopedCollector reporter = new ProblemReporter.ScopedCollector(LOGGER)) {
                      for (StructureTemplate.StructureBlockInfo blockInfo : processedBlockInfoList) {
+@@ -302,6 +_,7 @@
+                                         blockEntity.loadWithComponents(
+                                             TagValueInput.create(reporter.forChild(blockEntity.problemPath()), level.registryAccess(), blockInfo.nbt)
+                                         );
++                                        net.neoforged.neoforge.common.CommonHooks.applyStructureRotation(blockEntity, blockInfo.nbt, settings);
+                                     }
+                                 }
+ 
 @@ -387,16 +_,7 @@
                      }
  

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -145,12 +145,14 @@ import net.minecraft.world.level.biome.MobSpawnSettings;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraft.world.level.block.GameMasterBlock;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.pattern.BlockInWorld;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.storage.LevelStorageSource;
@@ -1791,5 +1793,33 @@ public class CommonHooks {
         if (clock.is(Tags.WorldClocks.IGNORES_PAUSE_COMMAND)) {
             throw ERROR_IGNORES_PAUSING.create(clock.getRegisteredName());
         }
+    }
+
+    @Nullable
+    public static CompoundTag captureStructureRotation(@Nullable CompoundTag blockEntityNbt, Rotation rotation) {
+        if (blockEntityNbt != null && rotation != Rotation.NONE) {
+            Optional<Rotation> prevRotation = blockEntityNbt.read("neoforge:structure_rotation", Rotation.CODEC);
+            if (prevRotation.isPresent()) {
+                rotation = rotation.getRotated(prevRotation.get());
+            }
+
+            blockEntityNbt = blockEntityNbt.copy();
+
+            if (rotation != Rotation.NONE) {
+                blockEntityNbt.store("neoforge:structure_rotation", Rotation.CODEC, rotation);
+            } else {
+                blockEntityNbt.remove("neoforge:structure_rotation");
+            }
+        }
+        return blockEntityNbt;
+    }
+
+    public static void applyStructureRotation(BlockEntity blockEntity, CompoundTag blockEntityNbt, StructurePlaceSettings settings) {
+        Rotation rotation = settings.getRotation();
+        Optional<Rotation> prevRotation = blockEntityNbt.read("neoforge:structure_rotation", Rotation.CODEC);
+        if (prevRotation.isPresent()) {
+            rotation = rotation.getRotated(prevRotation.get());
+        }
+        blockEntity.applyStructureRotation(settings.getMirror(), rotation);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1795,10 +1795,12 @@ public class CommonHooks {
         }
     }
 
+    private static final String STRUCTURE_ROTATION_KEY = "neoforge:structure_rotation";
+
     @Nullable
     public static CompoundTag captureStructureRotation(@Nullable CompoundTag blockEntityNbt, Rotation rotation) {
         if (blockEntityNbt != null && rotation != Rotation.NONE) {
-            Optional<Rotation> prevRotation = blockEntityNbt.read("neoforge:structure_rotation", Rotation.CODEC);
+            Optional<Rotation> prevRotation = blockEntityNbt.read(STRUCTURE_ROTATION_KEY, Rotation.CODEC);
             if (prevRotation.isPresent()) {
                 rotation = rotation.getRotated(prevRotation.get());
             }
@@ -1806,9 +1808,9 @@ public class CommonHooks {
             blockEntityNbt = blockEntityNbt.copy();
 
             if (rotation != Rotation.NONE) {
-                blockEntityNbt.store("neoforge:structure_rotation", Rotation.CODEC, rotation);
+                blockEntityNbt.store(STRUCTURE_ROTATION_KEY, Rotation.CODEC, rotation);
             } else {
-                blockEntityNbt.remove("neoforge:structure_rotation");
+                blockEntityNbt.remove(STRUCTURE_ROTATION_KEY);
             }
         }
         return blockEntityNbt;
@@ -1816,7 +1818,7 @@ public class CommonHooks {
 
     public static void applyStructureRotation(BlockEntity blockEntity, CompoundTag blockEntityNbt, StructurePlaceSettings settings) {
         Rotation rotation = settings.getRotation();
-        Optional<Rotation> prevRotation = blockEntityNbt.read("neoforge:structure_rotation", Rotation.CODEC);
+        Optional<Rotation> prevRotation = blockEntityNbt.read(STRUCTURE_ROTATION_KEY, Rotation.CODEC);
         if (prevRotation.isPresent()) {
             rotation = rotation.getRotated(prevRotation.get());
         }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockEntityExtension.java
@@ -121,6 +121,10 @@ public interface IBlockEntityExtension {
 
     /// React to the rotation and mirroring applied by a structure to the block this BE belongs to.
     ///
+    /// This method may be called in a worldgen context on a worker thread where this BE has no [Level]
+    /// set yet. Implementations of this method may only mutate the BE's internal state and access
+    /// neither the BE's level nor any other non-thread-safe data storage.
+    ///
     /// @param mirror   The mirroring applied to this BE's host block
     /// @param rotation The rotation applied to this BE's host block
     default void applyStructureRotation(Mirror mirror, Rotation rotation) {}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockEntityExtension.java
@@ -11,6 +11,8 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.storage.ValueInput;
@@ -116,4 +118,10 @@ public interface IBlockEntityExtension {
     default boolean hasCustomOutlineRendering(Player player) {
         return false;
     }
+
+    /// React to the rotation and mirroring applied by a structure to the block this BE belongs to.
+    ///
+    /// @param mirror   The mirroring applied to this BE's host block
+    /// @param rotation The rotation applied to this BE's host block
+    default void applyStructureRotation(Mirror mirror, Rotation rotation) {}
 }


### PR DESCRIPTION
This PR adds an API to allow `BlockEntity`s to react to the rotation and mirroring applied to the blocks of a structure. This allows blocks to adjust their BE's data to the applied rotation in cases where they cannot afford multiplying their blockstate count by four or more to store the rotation in the blockstate.
I would have preferred to store the captured rotation in a dedicated field of the `StructureTemplate.StructureBlockInfo` but that would require patching 14 invocations of the constructor to correctly copy over the rotation, so I store the rotation in the BE NBT tag instead.

I'm opening this as a draft because I need some eyes on it from people who have more experience with the structure system than me, in particular because I'm unsure about two things:
- Are `StructureTemplate#getJigsaws()`, `StructureTemplate#filterBlocks()` and `StructureTemplate#placeInWorld()` the only places I need to capture and handle the rotation or is there some other place that applies a rotation or places the blocks of a structure in the world?
- Is the defensive copy of the NBT data needed when I store the captured rotation in the first two methods?