### PR TITLE
Allow holdersets to skip validation in Ingredients if they are not immediately resolvable

### DIFF
--- a/patches/net/minecraft/core/HolderSet.java.patch
+++ b/patches/net/minecraft/core/HolderSet.java.patch
@@ -10,15 +10,20 @@
          }
  
          public TagKey<T> key() {
-@@ -215,6 +_,11 @@
+@@ -215,6 +_,16 @@
          @Override
          public boolean canSerializeIn(HolderOwner<T> context) {
              return this.owner.canSerializeIn(context);
 +        }
 +        // FORGE: Keep a list of invalidation callbacks so they can be run when tags rebind
 +        private List<Runnable> invalidationCallbacks = new java.util.ArrayList<>();
++        @Override
 +        public void addInvalidationListener(Runnable runnable) {
 +            invalidationCallbacks.add(runnable);
++        }
++        @Override
++        public boolean isImmediatelyResolvable() {
++            return false;
          }
      }
  }

--- a/patches/net/minecraft/util/ExtraCodecs.java.patch
+++ b/patches/net/minecraft/util/ExtraCodecs.java.patch
@@ -1,14 +1,23 @@
 --- a/net/minecraft/util/ExtraCodecs.java
 +++ b/net/minecraft/util/ExtraCodecs.java
-@@ -701,6 +_,11 @@
+@@ -480,7 +_,7 @@
+ 
+     public static <T> Codec<HolderSet<T>> nonEmptyHolderSet(Codec<HolderSet<T>> listCodec) {
+         return listCodec.validate(
+-            list -> list.unwrap().right().filter(List::isEmpty).isPresent() ? DataResult.error(() -> "List must have contents") : DataResult.success(list)
++            list -> list.isImmediatelyResolvable() && list.unwrap().right().filter(List::isEmpty).isPresent() ? DataResult.error(() -> "List must have contents") : DataResult.success(list)
+         );
+     }
+ 
+@@ -700,6 +_,11 @@
+ 
          public Set<V> values() {
              return Collections.unmodifiableSet(this.idToValue.values());
-         }
++        }
 +
 +        /// Neo: retrieve a value by ID from this [LateBoundIdMapper]
 +        public @Nullable V getValue(I id) {
 +            return this.idToValue.get(id);
-+        }
+         }
      }
  
-     public record StrictUnboundedMapCodec<K, V>(Codec<K> keyCodec, Codec<V> elementCodec) implements BaseMapCodec<K, V>, Codec<Map<K, V>> {

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/crafting/Ingredient.java
 +++ b/net/minecraft/world/item/crafting/Ingredient.java
-@@ -23,16 +_,18 @@
+@@ -23,18 +_,22 @@
  import net.minecraft.world.level.ItemLike;
  
  public final class Ingredient implements Predicate<ItemStack>, StackedContents.IngredientInfo<Holder<Item>> {
@@ -24,7 +24,11 @@
 +    private java.util.@org.jspecify.annotations.Nullable List<Holder<Item>> customIngredientValues;
  
      private Ingredient(HolderSet<Item> values) {
++        //Neo: Skip validating holderset contents for custom holdersets if they are not immediately resolvable
++        if (!(values instanceof net.neoforged.neoforge.registries.holdersets.ICustomHolderSet custom) || custom.isImmediatelyResolvable())
          values.unwrap().ifRight(directValues -> {
+             if (directValues.isEmpty()) {
+                 throw new UnsupportedOperationException("Ingredients can't be empty");
 @@ -45,30 +_,95 @@
          this.values = values;
      }

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/item/crafting/Ingredient.java
 +++ b/net/minecraft/world/item/crafting/Ingredient.java
-@@ -23,18 +_,22 @@
+@@ -23,18 +_,21 @@
  import net.minecraft.world.level.ItemLike;
  
  public final class Ingredient implements Predicate<ItemStack>, StackedContents.IngredientInfo<Holder<Item>> {
@@ -24,8 +24,7 @@
 +    private java.util.@org.jspecify.annotations.Nullable List<Holder<Item>> customIngredientValues;
  
      private Ingredient(HolderSet<Item> values) {
-+        //Neo: Skip validating holderset contents for custom holdersets if they are not immediately resolvable
-+        if (!(values instanceof net.neoforged.neoforge.registries.holdersets.ICustomHolderSet custom) || custom.isImmediatelyResolvable())
++        if (values.isImmediatelyResolvable())//Neo: Skip validating holderset contents for holdersets if they are not immediately resolvable
          values.unwrap().ifRight(directValues -> {
              if (directValues.isEmpty()) {
                  throw new UnsupportedOperationException("Ingredients can't be empty");

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderSetExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderSetExtension.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.HolderSet.ListBacked;
 
 public interface IHolderSetExtension<T> {
@@ -41,6 +42,12 @@ public interface IHolderSetExtension<T> {
                                         value -> SerializationType.OBJECT)
                                 : SerializationType.LIST)
                 : SerializationType.UNKNOWN; // unsupported holderset impl, could be anything
+    }
+
+
+    ///Determines whether this holderset can be immediately resolved to the contents it contains or if it must wait for tags to be loaded.
+    default boolean isImmediatelyResolvable() {
+        return !(this instanceof HolderSet.Named);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderSetExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderSetExtension.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.common.extensions;
 
-import net.minecraft.core.HolderSet;
 import net.minecraft.core.HolderSet.ListBacked;
 
 public interface IHolderSetExtension<T> {
@@ -46,7 +45,7 @@ public interface IHolderSetExtension<T> {
 
     ///Determines whether this holderset can be immediately resolved to the contents it contains or if it must wait for tags to be loaded.
     default boolean isImmediatelyResolvable() {
-        return !(this instanceof HolderSet.Named);
+        return true;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IHolderSetExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IHolderSetExtension.java
@@ -44,7 +44,6 @@ public interface IHolderSetExtension<T> {
                 : SerializationType.UNKNOWN; // unsupported holderset impl, could be anything
     }
 
-
     ///Determines whether this holderset can be immediately resolved to the contents it contains or if it must wait for tags to be loaded.
     default boolean isImmediatelyResolvable() {
         return !(this instanceof HolderSet.Named);

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/SimpleFluidIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/SimpleFluidIngredient.java
@@ -43,13 +43,15 @@ public class SimpleFluidIngredient extends FluidIngredient {
     private final HolderSet<Fluid> values;
 
     public SimpleFluidIngredient(HolderSet<Fluid> values) {
-        values.unwrap().ifRight(list -> {
-            if (list.isEmpty()) {
-                throw new UnsupportedOperationException("Fluid ingredients can't be empty!");
-            } else if (list.contains(Fluids.EMPTY.builtInRegistryHolder())) {
-                throw new UnsupportedOperationException("Fluid ingredients can't contain the empty fluid");
-            }
-        });
+        if (values.isImmediatelyResolvable()) {
+            values.unwrap().ifRight(list -> {
+                if (list.isEmpty()) {
+                    throw new UnsupportedOperationException("Fluid ingredients can't be empty!");
+                } else if (list.contains(Fluids.EMPTY.builtInRegistryHolder())) {
+                    throw new UnsupportedOperationException("Fluid ingredients can't contain the empty fluid");
+                }
+            });
+        }
         this.values = values;
     }
 

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/CompositeHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/CompositeHolderSet.java
@@ -43,12 +43,7 @@ public abstract class CompositeHolderSet<T> implements ICustomHolderSet<T> {
 
     @Override
     public boolean isImmediatelyResolvable() {
-        for (HolderSet<T> component : getComponents()) {
-            if (component instanceof ICustomHolderSet<T> custom && !custom.isImmediatelyResolvable()) {
-                return false;
-            }
-        }
-        return true;
+        return getComponents().stream().allMatch(HolderSet::isImmediatelyResolvable);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/CompositeHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/CompositeHolderSet.java
@@ -41,6 +41,16 @@ public abstract class CompositeHolderSet<T> implements ICustomHolderSet<T> {
         }
     }
 
+    @Override
+    public boolean isImmediatelyResolvable() {
+        for (HolderSet<T> component : getComponents()) {
+            if (component instanceof ICustomHolderSet<T> custom && !custom.isImmediatelyResolvable()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * {@return immutable Set of Holders given this composite holderset's component holdersets}
      */

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/ICustomHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/ICustomHolderSet.java
@@ -20,9 +20,4 @@ public interface ICustomHolderSet<T> extends HolderSet<T> {
     default SerializationType serializationType() {
         return SerializationType.OBJECT;
     }
-
-    ///Determines whether this custom holderset can be immediately resolved to the contents it contains or if it must wait for tags to be loaded.
-    default boolean isImmediatelyResolvable() {
-        return true;
-    }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/ICustomHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/ICustomHolderSet.java
@@ -20,4 +20,9 @@ public interface ICustomHolderSet<T> extends HolderSet<T> {
     default SerializationType serializationType() {
         return SerializationType.OBJECT;
     }
+
+    ///Determines whether this custom holderset can be immediately resolved to the contents it contains or if it must wait for tags to be loaded.
+    default boolean isImmediatelyResolvable() {
+        return true;
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
@@ -70,6 +70,11 @@ public class NotHolderSet<T> implements ICustomHolderSet<T> {
     }
 
     @Override
+    public boolean isImmediatelyResolvable() {
+        return !(value instanceof ICustomHolderSet<T> custom) || custom.isImmediatelyResolvable();
+    }
+
+    @Override
     public void addInvalidationListener(Runnable runnable) {
         this.owners.add(runnable);
     }

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/NotHolderSet.java
@@ -71,7 +71,7 @@ public class NotHolderSet<T> implements ICustomHolderSet<T> {
 
     @Override
     public boolean isImmediatelyResolvable() {
-        return !(value instanceof ICustomHolderSet<T> custom) || custom.isImmediatelyResolvable();
+        return value.isImmediatelyResolvable();
     }
 
     @Override


### PR DESCRIPTION
This PR fixes usage of custom holdersets that reference tag's from crashing during data gen when used within an Ingredient. If the HolderSet for an Ingredient is not a tag, then they iterate the contents to validate that there are contents and they do not contain air. This PR makes that check be skipped for custom holdersets that return false from the new `ICustomHolderSet#isImmediatelyResolvable` method.


As discussed on [discord](https://discord.com/channels/313125603924639766/1154167065519861831/1499447973258727655)