### PR TITLE
Unfinalize StackCopySlot#remove to allow extenders to increment crafting counts similar to vanilla result slots

### DIFF
--- a/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
@@ -72,7 +72,7 @@ public abstract class StackCopySlot extends Slot {
     }
 
     @Override
-    public final ItemStack remove(int amount) {
+    public ItemStack remove(int amount) {
         ItemStack stack = getStackCopy().copy();
         ItemStack ret = stack.split(amount);
         set(stack);


### PR DESCRIPTION
There are a variety of cases where Vanilla overrides `Slot#remove(int)` rather than just implementing it as part of the container's `removeItem` call using nearly identical logic between them:
- `FurnaceResultSlot`
- `MerchantResultSlot
- `ResultSlot`

All of them follow this general logic:
```java
if (this.hasItem()) {
    this.removeCount = this.removeCount + Math.min(amount, this.getItem().getCount());
}
return super.remove(amount);
```

But mods trying to implement a result slot with say a resource handler instead of a container are currently unable to override the method to gain extra information about when it is called. In some cases vanilla goes as far as to return a stack that is of greater size than the passed in amount such as for the `MerchantResultSlot`'s `MerchantContainer#removeItem` implementation, as it isn't a real slot that can just have part of the output removed.

This PR allows mods to once again override the `remove` method, similar to how they used to be able to when extending `SlotItemHandler`.