### PR TITLE
Fire LevelEvent.Unload from Minecraft#clearClientLevel

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -408,6 +408,14 @@
      }
  
      public void clearDownloadedResourcePacks() {
+@@ -2254,6 +_,7 @@
+         try {
+             this.setScreenAndShow(screen);
+             this.gui.onDisconnected();
++            if (this.level != null) net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.LevelEvent.Unload(this.level));
+             this.level = null;
+             this.updateLevelInEngines(null);
+             this.player = null;
 @@ -2372,6 +_,7 @@
  
      private void pickBlockOrEntity() {

--- a/src/main/java/net/neoforged/neoforge/event/level/LevelEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/level/LevelEvent.java
@@ -7,7 +7,6 @@ package net.neoforged.neoforge.event.level;
 
 import java.util.List;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.ProgressListener;
 import net.minecraft.util.random.Weighted;
@@ -57,18 +56,11 @@ public abstract class LevelEvent extends Event {
         }
     }
 
-    /**
-     * This event is fired whenever a level unloads.
-     * This event is fired whenever a level unloads in
-     * {@link Minecraft#setLevel(ClientLevel)},
-     * {@link MinecraftServer#stopServer()},
-     * {@link Minecraft#clearLevel(Screen)}.
-     * <p>
-     * This event is not {@linkplain ICancellableEvent cancellable} and does not {@linkplain HasResult have a result}.
-     * <p>
-     * This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus}
-     * on both logical sides.
-     **/
+    /// Fired whenever a level unloads. This may be due to the server being stopped, or the client switching to another level or server.
+    ///
+    /// This event is not [cancellable][ICancellableEvent].
+    ///
+    /// This event is fired on the [game event bus][NeoForge#EVENT_BUS] on both [logical sides][LogicalSide].
     public static class Unload extends LevelEvent {
         public Unload(LevelAccessor level) {
             super(level);


### PR DESCRIPTION
This PR fixes #3150 by firing `LevelEvent.Unload` from `Minecraft#clearClientLevel`, which is the remaining site (out of three) in `Minecraft` where the level changes.

The javadocs for the event are also cleaned up to use Markdown doc comments. (This change will need to be reverted when backported to 1.21.1, since that uses Java 21 which lacks Markdown doc comments.)