### PR TITLE
Expose Game Profiles of Command Sources for Permission Checks

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -11,7 +11,16 @@
              ServerPlayer.this.connection.send(new ClientboundContainerSetDataPacket(container.containerId, id, value));
          }
  
-@@ -379,6 +_,8 @@
+@@ -375,10 +_,17 @@
+         public void sendSystemMessage(Component message) {
+             ServerPlayer.this.sendSystemMessage(message);
+         }
++
++        @Override
++        public Optional<GameProfile> getGameProfile() {
++            return Optional.of(ServerPlayer.this.getGameProfile());
++        }
+     };
      private Set<DebugSubscription<?>> requestedDebugSubscriptions = Set.of();
      private int containerCounter;
      public boolean wonGame;

--- a/src/client/java/net/neoforged/neoforge/client/ClientCommandHandler.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientCommandHandler.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.client;
 
+import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.ParseResults;
 import com.mojang.brigadier.StringReader;
@@ -15,6 +16,7 @@ import com.mojang.brigadier.tree.CommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Optional;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
@@ -130,6 +132,11 @@ public class ClientCommandHandler {
             @Override
             public void sendSystemMessage(Component message) {
                 Minecraft.getInstance().gui.getChat().addClientSystemMessage(message);
+            }
+
+            @Override
+            public Optional<GameProfile> getGameProfile() {
+                return Optional.of(player.getGameProfile());
             }
         };
         return new ClientCommandSourceStack(commandSource, player.position(), player.getRotationVector(), player.permissions(),

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceExtension.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import com.mojang.authlib.GameProfile;
+import java.util.Optional;
+import net.minecraft.commands.CommandSource;
+
+/**
+ * Additional methods for {@link CommandSource} so that command source stacks can retrieve the {@link GameProfile}s.
+ */
+public interface ICommandSourceExtension {
+    /**
+     * @return the game profile of this command source if available
+     */
+    default Optional<GameProfile> getGameProfile() {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceExtension.java
@@ -9,13 +9,9 @@ import com.mojang.authlib.GameProfile;
 import java.util.Optional;
 import net.minecraft.commands.CommandSource;
 
-/**
- * Additional methods for {@link CommandSource} so that command source stacks can retrieve the {@link GameProfile}s.
- */
+/// Additional methods for [CommandSource].
 public interface ICommandSourceExtension {
-    /**
-     * @return the game profile of this command source if available
-     */
+    /// {@return the game profile of this command source, if available}
     default Optional<GameProfile> getGameProfile() {
         return Optional.empty();
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension.java
@@ -44,9 +44,7 @@ public interface ICommandSourceStackExtension {
         return self().getLevel();
     }
 
-    /**
-     * @return the game profile of the command source if available
-     */
+    /// {@return the game profile of the command source, if available}
     default Optional<GameProfile> getSourceProfile() {
         return self().source.getGameProfile();
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension.java
@@ -5,6 +5,8 @@
 
 package net.neoforged.neoforge.common.extensions;
 
+import com.mojang.authlib.GameProfile;
+import java.util.Optional;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.resources.Identifier;
@@ -40,5 +42,12 @@ public interface ICommandSourceStackExtension {
      */
     default Level getUnsidedLevel() {
         return self().getLevel();
+    }
+
+    /**
+     * @return the game profile of the command source if available
+     */
+    default Optional<GameProfile> getSourceProfile() {
+        return self().source.getGameProfile();
     }
 }

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -65,6 +65,9 @@
   "net/minecraft/client/resources/model/geometry/UnbakedGeometry": [
     "net/neoforged/neoforge/client/extensions/UnbakedGeometryExtension"
   ],
+  "net/minecraft/commands/CommandSource": [
+    "net/neoforged/neoforge/common/extensions/ICommandSourceExtension"
+  ],
   "net/minecraft/commands/CommandSourceStack": [
     "net/neoforged/neoforge/common/extensions/ICommandSourceStackExtension"
   ],


### PR DESCRIPTION
This pull request attempts to solve a command permission issue. Before 26.1, modders are able to determine whether a command had additionally required permissions by checking whether the `CommandSource` was a `ServerPlayer`. However, starting with 26.1, Vanilla Minecraft no longer provides any way to retrieve player information from a `CommandSource`.

Instead, some modder have worked around this by using `CommandSourceStack#getEntity` (for example, [LuckPerms](https://github.com/LuckPerms/LuckPerms/blob/master/common/minecraft/src/main/java/me/lucko/luckperms/common/minecraft/command/BrigadierInjector.java#L143)) which introduces a privilege escalation issue with the execute command: when player Alice runs `execute as Bob run command`, the `command` will only check Bob's permissions rather than Alice's. This can be a disaster if Bob has more permissions than Alice.

This pull request introduces `CommandSourceStack#getSourceProfile`, allowing modders to check the permissions of the **actual** player via `Commands.literal("...").requires(stack -> stack.getSourceProfile().filter(...).isPresent()).executes(...)` or similar patterns.