### PR TITLE
Use ItemStack sensitive `getCraftingRemainder` in vanilla code

### DIFF
--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -135,3 +135,12 @@
          return (SlotDisplay)this.values
              .unwrap()
              .map(SlotDisplay.TagSlotDisplay::new, l -> new SlotDisplay.Composite(l.stream().map(Ingredient::displayForSingleItem).toList()));
+@@ -99,7 +_,7 @@
+ 
+     public static SlotDisplay displayForSingleItem(Holder<Item> item) {
+         SlotDisplay inputDisplay = new SlotDisplay.ItemSlotDisplay(item);
+-        ItemStackTemplate remainderStack = item.value().getCraftingRemainder();
++        ItemStackTemplate remainderStack = new ItemStack(item).getCraftingRemainder();
+         if (remainderStack != null) {
+             SlotDisplay remainderDisplay = new SlotDisplay.ItemStackSlotDisplay(remainderStack);
+             return new SlotDisplay.WithRemainder(inputDisplay, remainderDisplay);

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -135,12 +135,3 @@
          return (SlotDisplay)this.values
              .unwrap()
              .map(SlotDisplay.TagSlotDisplay::new, l -> new SlotDisplay.Composite(l.stream().map(Ingredient::displayForSingleItem).toList()));
-@@ -99,7 +_,7 @@
- 
-     public static SlotDisplay displayForSingleItem(Holder<Item> item) {
-         SlotDisplay inputDisplay = new SlotDisplay.ItemSlotDisplay(item);
--        ItemStackTemplate remainderStack = item.value().getCraftingRemainder();
-+        ItemStackTemplate remainderStack = new ItemStackTemplate(item).getCraftingRemainder();
-         if (remainderStack != null) {
-             SlotDisplay remainderDisplay = new SlotDisplay.ItemStackSlotDisplay(remainderStack);
-             return new SlotDisplay.WithRemainder(inputDisplay, remainderDisplay);

--- a/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
+++ b/patches/net/minecraft/world/item/crafting/Ingredient.java.patch
@@ -140,7 +140,7 @@
      public static SlotDisplay displayForSingleItem(Holder<Item> item) {
          SlotDisplay inputDisplay = new SlotDisplay.ItemSlotDisplay(item);
 -        ItemStackTemplate remainderStack = item.value().getCraftingRemainder();
-+        ItemStackTemplate remainderStack = new ItemStack(item).getCraftingRemainder();
++        ItemStackTemplate remainderStack = new ItemStackTemplate(item).getCraftingRemainder();
          if (remainderStack != null) {
              SlotDisplay remainderDisplay = new SlotDisplay.ItemStackSlotDisplay(remainderStack);
              return new SlotDisplay.WithRemainder(inputDisplay, remainderDisplay);

--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -61,6 +61,15 @@
          ContainerHelper.saveAllItems(output, this.items);
          output.store("RecipesUsed", RECIPES_USED_CODEC, this.recipesUsed);
      }
+@@ -214,7 +_,7 @@
+         Item fuelItem = fuel.getItem();
+         fuel.shrink(1);
+         if (fuel.isEmpty()) {
+-            ItemStackTemplate remainder = fuelItem.getCraftingRemainder();
++            ItemStackTemplate remainder = fuel.getCraftingRemainder();
+             items.set(1, remainder != null ? remainder.create() : ItemStack.EMPTY);
+         }
+     }
 @@ -248,7 +_,7 @@
      }
  

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -8,14 +8,17 @@
          ItemStack ingredient = items.get(3);
          PotionBrewing potionBrewing = level.potionBrewing();
  
-@@ -181,6 +_,7 @@
+@@ -181,8 +_,9 @@
              items.set(dest, potionBrewing.mix(ingredient, items.get(dest)));
          }
  
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
          ingredient.shrink(1);
-         ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
+-        ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
++        ItemStackTemplate remainder = ingredient.getCraftingRemainder();
          if (remainder != null) {
+             if (ingredient.isEmpty()) {
+                 ingredient = remainder.create();
 @@ -218,13 +_,13 @@
  
      @Override

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IItemStackExtension.java
@@ -25,7 +25,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.AdventureModePredicate;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -49,16 +48,6 @@ public interface IItemStackExtension extends ItemInstanceExtension {
     // Helpers for accessing Item data
     private ItemStack self() {
         return (ItemStack) this;
-    }
-
-    /**
-     * ItemStack sensitive version of {@link Item#getCraftingRemainder()}.
-     * Returns a full ItemStack instance of the result.
-     *
-     * @return The resulting ItemStack
-     */
-    default @Nullable ItemStackTemplate getCraftingRemainder() {
-        return self().getItem().getCraftingRemainder(self());
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ItemInstanceExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ItemInstanceExtension.java
@@ -7,14 +7,17 @@ package net.neoforged.neoforge.common.extensions;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemInstance;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemStackTemplate;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.event.EventHooks;
+import org.jspecify.annotations.Nullable;
 
 public interface ItemInstanceExtension {
     private ItemInstance self() {
@@ -53,5 +56,15 @@ public interface ItemInstanceExtension {
     default int getEnchantmentLevel(Holder<Enchantment> enchantment) {
         int level = self().typeHolder().value().getEnchantmentLevel(self(), enchantment);
         return EventHooks.getEnchantmentLevelSpecific(level, self(), enchantment);
+    }
+
+    /**
+     * ItemInstance sensitive version of {@link Item#getCraftingRemainder()}.
+     * Returns a full ItemStackTemplate instance of the result.
+     *
+     * @return The resulting ItemStackTemplate
+     */
+    default @Nullable ItemStackTemplate getCraftingRemainder() {
+        return self().typeHolder().value().getCraftingRemainder(self());
     }
 }


### PR DESCRIPTION
NeoForge allows mods to override getCraftingRemainder per ItemStack instance (rather than just per Item). Vanilla code was calling the Item-level method directly, bypassing any stack-sensitive overrides registered by mods.
