### PR TITLE
Move useful methods from StructureTemplateBuilder to TemplateBuilderHelper

### DIFF
--- a/testframework/src/main/java/net/neoforged/testframework/gametest/StructureTemplateBuilder.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/StructureTemplateBuilder.java
@@ -20,7 +20,6 @@ import java.util.function.UnaryOperator;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
@@ -48,29 +47,6 @@ public class StructureTemplateBuilder implements TemplateBuilderHelper<Structure
 
     public static StructureTemplate empty(int length, int height, int width) {
         return withSize(length, height, width).build();
-    }
-
-    public StructureTemplateBuilder fill(int x, int y, int z, int toX, int toY, int toZ, Block block) {
-        return fill(x, y, z, toX, toY, toZ, block.defaultBlockState());
-    }
-
-    public StructureTemplateBuilder fill(int x, int y, int z, int toX, int toY, int toZ, BlockState state) {
-        return fill(x, y, z, toX, toY, toZ, state, null);
-    }
-
-    public StructureTemplateBuilder fill(int x, int y, int z, int toX, int toY, int toZ, BlockState state, @Nullable CompoundTag nbt) {
-        for (int x1 = x; x1 <= toX; x1++) {
-            for (int y1 = y; y1 <= toY; y1++) {
-                for (int z1 = z; z1 <= toZ; z1++) {
-                    set(x1, y1, z1, state, nbt);
-                }
-            }
-        }
-        return this;
-    }
-
-    public StructureTemplateBuilder set(int x, int y, int z, BlockState state) {
-        return set(x, y, z, state, null);
     }
 
     @Override

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/TemplateBuilderHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/TemplateBuilderHelper.java
@@ -6,6 +6,7 @@
 package net.neoforged.testframework.gametest;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LeverBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -15,6 +16,29 @@ import org.jspecify.annotations.Nullable;
 @SuppressWarnings("unchecked")
 public interface TemplateBuilderHelper<T extends TemplateBuilderHelper<T>> {
     T set(int x, int y, int z, BlockState state, @Nullable CompoundTag nbt);
+
+    default T fill(int x, int y, int z, int toX, int toY, int toZ, Block block) {
+        return fill(x, y, z, toX, toY, toZ, block.defaultBlockState());
+    }
+
+    default T fill(int x, int y, int z, int toX, int toY, int toZ, BlockState state) {
+        return fill(x, y, z, toX, toY, toZ, state, null);
+    }
+
+    default T fill(int x, int y, int z, int toX, int toY, int toZ, BlockState state, @Nullable CompoundTag nbt) {
+        for (int x1 = x; x1 <= toX; x1++) {
+            for (int y1 = y; y1 <= toY; y1++) {
+                for (int z1 = z; z1 <= toZ; z1++) {
+                    set(x1, y1, z1, state, nbt);
+                }
+            }
+        }
+        return (T) this;
+    }
+
+    default T set(int x, int y, int z, BlockState state) {
+        return set(x, y, z, state, null);
+    }
 
     default T placeFloorLever(int x, int y, int z, boolean powered) {
         set(x, y, z, Blocks.LEVER.defaultBlockState().setValue(LeverBlock.FACE, AttachFace.FLOOR).setValue(LeverBlock.POWERED, powered), null);


### PR DESCRIPTION
Moves methods from StructureTemplateBuilder into TemplateBuilderHelper so mod authors can extend TemplateBuilderHelper to create their own template builder.
