### PR TITLE
Update IClientItemExtensions#getArmPose with proper enum extension docs

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -28,7 +28,6 @@ import net.minecraft.world.item.component.DyedItemColor;
 import net.minecraft.world.item.equipment.Equippable;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.client.ClientHooks;
-import net.neoforged.neoforge.client.IArmPoseTransformer;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -60,16 +59,14 @@ public interface IClientItemExtensions {
         return null;
     }
 
-    /**
-     * This method returns an ArmPose that can be defined using an enum extension defined using a json file referenced in your neoforge.mods.toml.
-     * This allows for creating custom item use animations.
-     *
-     * @param entityLiving The entity holding the item
-     * @param hand         The hand the ArmPose will be applied to
-     * @param itemStack    The stack being held
-     * @return A custom ArmPose that can be used to define movement of the arm
-     * @see <a href="https://docs.neoforged.net/docs/advanced/extensibleenums/">Enum Extensions Documentation</a>
-     */
+    /// This method returns an [ArmPose][net.minecraft.client.model.HumanoidModel.ArmPose] that will be used when arms holding this item are rendered.
+    /// Vanilla ones can be used to mimic vanilla behaviour, or custom ones can be defined using enum extensions.
+    ///
+    /// @param entityLiving The entity holding the item
+    /// @param hand         The hand the ArmPose will be applied to
+    /// @param itemStack    The stack being held
+    /// @return A custom ArmPose that can be used to define movement of the arm
+    /// @see <a href="https://docs.neoforged.net/docs/advanced/extensibleenums/">Enum Extensions Documentation</a>
     default HumanoidModel.@Nullable ArmPose getArmPose(LivingEntity entityLiving, InteractionHand hand, ItemStack itemStack) {
         return null;
     }

--- a/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/common/IClientItemExtensions.java
@@ -61,13 +61,14 @@ public interface IClientItemExtensions {
     }
 
     /**
-     * This method returns an ArmPose that can be defined using the {@link net.minecraft.client.model.HumanoidModel.ArmPose#create(String, boolean, IArmPoseTransformer)} method.
+     * This method returns an ArmPose that can be defined using an enum extension defined using a json file referenced in your neoforge.mods.toml.
      * This allows for creating custom item use animations.
      *
      * @param entityLiving The entity holding the item
      * @param hand         The hand the ArmPose will be applied to
      * @param itemStack    The stack being held
      * @return A custom ArmPose that can be used to define movement of the arm
+     * @see <a href="https://docs.neoforged.net/docs/advanced/extensibleenums/">Enum Extensions Documentation</a>
      */
     default HumanoidModel.@Nullable ArmPose getArmPose(LivingEntity entityLiving, InteractionHand hand, ItemStack itemStack) {
         return null;


### PR DESCRIPTION
It still referenced the old enum extension method.
Includes just a link to the docs, but may be worth including an inline example of the enum extension json + java code required (was just doing a quick and dirty fix in the web editor though).


This bad doc still exists on 1.21.1 too, so would be nice if the change can get cherry picked back.