### PR TITLE
Fix AnyHolderSet being unusuable in datagen

### DIFF
--- a/patches/net/minecraft/core/RegistrySetBuilder.java.patch
+++ b/patches/net/minecraft/core/RegistrySetBuilder.java.patch
@@ -58,8 +58,8 @@
                  }
 +
 +                @Override
-+                public <S> Optional<HolderLookup.RegistryLookup<S>> registryLookup(ResourceKey<? extends Registry<? extends S>> registry) {
-+                    return Optional.ofNullable((HolderLookup.RegistryLookup<S>) BuildState.this.registries.get(registry.identifier()));
++                public <S> Optional<HolderLookup<S>> holderLookup(ResourceKey<? extends Registry<? extends S>> registry) {
++                    return Optional.ofNullable((HolderLookup<S>) BuildState.this.registries.get(registry.identifier()));
 +                }
              };
          }

--- a/patches/net/minecraft/data/worldgen/BootstrapContext.java.patch
+++ b/patches/net/minecraft/data/worldgen/BootstrapContext.java.patch
@@ -5,5 +5,5 @@
  
      <S> HolderGetter<S> lookup(ResourceKey<? extends Registry<? extends S>> key);
 +
-+    default <S> java.util.Optional<net.minecraft.core.HolderLookup.RegistryLookup<S>> registryLookup(ResourceKey<? extends Registry<? extends S>> registry) { return java.util.Optional.empty(); }
++    default <S> java.util.Optional<net.minecraft.core.HolderLookup<S>> holderLookup(ResourceKey<? extends Registry<? extends S>> registry) { return java.util.Optional.empty(); }
  }

--- a/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
+++ b/src/main/java/net/neoforged/neoforge/registries/holdersets/AnyHolderSet.java
@@ -36,7 +36,12 @@ import net.neoforged.neoforge.common.NeoForgeMod;
  * }
  * </pre>
  */
-public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) implements ICustomHolderSet<T> {
+public record AnyHolderSet<T>(ResourceKey<? extends Registry<T>> registryKey, HolderLookup<T> registryLookup) implements ICustomHolderSet<T> {
+    @SuppressWarnings("unchecked")
+    public AnyHolderSet(HolderLookup.RegistryLookup<T> registryLookup) {
+        this((ResourceKey<? extends Registry<T>>) registryLookup.key(), registryLookup);
+    }
+
     @Override
     public HolderSetType type() {
         return NeoForgeMod.ANY_HOLDER_SET.value();
@@ -72,7 +77,7 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
         List<Holder<T>> holders = this.stream().toList();
         Holder<T> holder = i >= holders.size() ? null : holders.get(i);
         if (holder == null)
-            throw new NoSuchElementException("No element " + i + " in registry " + this.registryLookup.key());
+            throw new NoSuchElementException("No element " + i + " in registry " + this.registryKey);
 
         return holder;
     }
@@ -100,14 +105,14 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
 
     @Override
     public String toString() {
-        return "AnySet(" + this.registryLookup.key() + ")";
+        return "AnySet(" + this.registryKey + ")";
     }
 
     public static class Type implements HolderSetType {
         @Override
         public <T> MapCodec<? extends ICustomHolderSet<T>> makeCodec(ResourceKey<? extends Registry<T>> registryKey, Codec<Holder<T>> holderCodec, boolean forceList) {
             return RegistryOps.retrieveRegistryLookup(registryKey)
-                    .xmap(AnyHolderSet::new, AnyHolderSet::registryLookup);
+                    .xmap(lookup -> new AnyHolderSet<>(registryKey, lookup), set -> null); // Normally null would get us into trouble with codecs, but the ops resolver we're xmapping back to discards this result.
         }
 
         @Override
@@ -115,12 +120,12 @@ public record AnyHolderSet<T>(HolderLookup.RegistryLookup<T> registryLookup) imp
             return new StreamCodec<RegistryFriendlyByteBuf, AnyHolderSet<T>>() {
                 @Override
                 public AnyHolderSet<T> decode(RegistryFriendlyByteBuf buf) {
-                    return new AnyHolderSet<>(buf.registryAccess().lookupOrThrow(registryKey));
+                    return new AnyHolderSet<>(registryKey, buf.registryAccess().lookupOrThrow(registryKey));
                 }
 
                 @Override
                 public void encode(RegistryFriendlyByteBuf buf, AnyHolderSet<T> holderSet) {
-                    final var registryKeyIn = holderSet.registryLookup.key();
+                    final var registryKeyIn = holderSet.registryKey;
                     if (!registryKey.equals(registryKeyIn)) {
                         throw new IllegalStateException("Can not encode " + holderSet
                                 + ", expected registry: "

--- a/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
@@ -244,7 +244,7 @@ public class GlobalLootModifiersTest {
     static void smeltingModifierTest(final DynamicTest test) {
         var registrySetBuilder = new RegistrySetBuilder()
                 .add(Registries.ENCHANTMENT, boot -> boot
-                        .register(SMELT, new Enchantment.Builder(Enchantment.definition(boot.registryLookup(Registries.ITEM).orElseThrow().getOrThrow(ItemTags.MINING_ENCHANTABLE), 10, 1, Enchantment.dynamicCost(1, 10), Enchantment.dynamicCost(5, 10), 1, EquipmentSlotGroup.HAND))
+                        .register(SMELT, new Enchantment.Builder(Enchantment.definition(boot.holderLookup(Registries.ITEM).orElseThrow().getOrThrow(ItemTags.MINING_ENCHANTABLE), 10, 1, Enchantment.dynamicCost(1, 10), Enchantment.dynamicCost(5, 10), 1, EquipmentSlotGroup.HAND))
                                 .build(SMELT.identifier())));
 
         var subpack = HELPER.registerSubpack("smelt_glms");


### PR DESCRIPTION
This fixes an issue with AnyHolderSet being unusable for data registries in datagen. The current implementation (prior to this change) only works for built-in registries.

The reason that happens is that we don't have a `RegistryLookup` for data registries, only a `HolderLookup` (the `UniversalLookup` in the datagen context). Built-in registries always report back their "real" `RegistryLookup`, and we only test generating an `AnyHolderSet` for a builtin registry.

Code that generates an `AnyHolderSet` for a data registry is being introduced in #3134, so I've elected not to add a new superfluous test as part of this PR.

___
This change was originally part of https://github.com/neoforged/NeoForge/pull/3134