### PR TITLE
[26.1] Split TagsUpdatedEvent and extend provided context

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -41,7 +41,7 @@
                      )
                  )
              );
-+        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.TagsUpdatedEvent(registries, true, this.connection.isMemoryConnection()));
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.TagsUpdatedEvent.ClientPacketReceived(registries, this.connection.isMemoryConnection()));
 +        // Packets can only be sent after the outbound protocol is set up again
 +        if (!this.initializedConnection && this.connectionType.isOther()) {
 +            // Neo: Fallback detection for servers with a delayed brand payload (BungeeCord)

--- a/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientPacketListener.java.patch
@@ -117,7 +117,7 @@
          this.fuelValues = FuelValues.vanillaBurnTimes(this.registryAccess, this.enabledFeatures);
 -        List<ItemStack> searchItems = List.copyOf(CreativeModeTabs.searchTab().getDisplayItems());
 -        this.searchTrees.updateCreativeTags(searchItems);
-+        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.TagsUpdatedEvent(this.registryAccess, true, this.connection.isMemoryConnection()));
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.TagsUpdatedEvent.ClientPacketReceived(this.registryAccess, this.connection.isMemoryConnection()));
 +        CreativeModeTabs.allTabs().stream().filter(net.minecraft.world.item.CreativeModeTab::hasSearchBar).forEach(tab -> {
 +            List<ItemStack> stacks = List.copyOf(tab.getDisplayItems());
 +            this.searchTrees.updateCreativeTags(stacks, net.neoforged.neoforge.client.CreativeModeTabSearchRegistry.getTagSearchKey(tab));

--- a/patches/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/net/minecraft/server/ReloadableServerResources.java.patch
@@ -1,22 +1,30 @@
 --- a/net/minecraft/server/ReloadableServerResources.java
 +++ b/net/minecraft/server/ReloadableServerResources.java
-@@ -47,6 +_,9 @@
+@@ -30,6 +_,9 @@
+     private final ServerFunctionLibrary functionLibrary;
+     private final List<Registry.PendingTags<?>> postponedTags;
+     private final List<DataComponentInitializers.PendingComponents<?>> newComponents;
++    private final net.minecraft.core.RegistryAccess registryAccess;
++    private final HolderLookup.Provider loadingContext;
++    private final net.neoforged.neoforge.common.conditions.ConditionContext context;
+ 
+     private ReloadableServerResources(
+         LayeredRegistryAccess<RegistryLayer> fullLayers,
+@@ -47,6 +_,10 @@
          this.commands = new Commands(commandSelection, CommandBuildContext.simple(loadingContext, enabledFeatures));
          this.advancements = new ServerAdvancementManager(loadingContext);
          this.functionLibrary = new ServerFunctionLibrary(functionCompilationPermissions, this.commands.getDispatcher());
 +        // Neo: Store registries and create context object
-+        this.registryLookup = loadingContext;
-+        this.context = new net.neoforged.neoforge.common.conditions.ConditionContext(this.postponedTags, fullLayers.compositeAccess(), enabledFeatures);
++        this.registryAccess = fullLayers.compositeAccess();
++        this.loadingContext = loadingContext;
++        this.context = new net.neoforged.neoforge.common.conditions.ConditionContext(this.postponedTags, registryAccess, enabledFeatures);
      }
  
      public ServerFunctionLibrary getFunctionLibrary() {
-@@ -73,6 +_,25 @@
+@@ -73,6 +_,22 @@
          return List.of(this.recipes, this.functionLibrary, this.advancements);
      }
  
-+    private final HolderLookup.Provider registryLookup;
-+    private final net.neoforged.neoforge.common.conditions.ConditionContext context;
-+
 +    /**
 +     * Exposes the current condition context for usage in other reload listeners.<br>
 +     * This is not useful outside the reloading stage.
@@ -30,7 +38,7 @@
 +      * {@return the lookup provider access for the currently active reload}
 +      */
 +    public HolderLookup.Provider getRegistryLookup() {
-+        return this.registryLookup;
++        return this.loadingContext;
 +    }
 +
      public static CompletableFuture<ReloadableServerResources> loadResources(
@@ -47,7 +55,7 @@
 +                            // Neo: Inject the ConditionContext and RegistryLookup to any resource listener that requests it.
 +                            for (PreparableReloadListener rl : listeners) {
 +                                if (rl instanceof net.neoforged.neoforge.resource.ContextAwareReloadListener carl) {
-+                                    carl.injectContext(result.context, result.registryLookup);
++                                    carl.injectContext(result.context, result.loadingContext);
 +                                }
 +                            }
 +
@@ -77,7 +85,7 @@
  
      public void updateComponentsAndStaticRegistryTags() {
          this.postponedTags.forEach(Registry.PendingTags::apply);
-+        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.TagsUpdatedEvent(registryLookup, false, false));
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.TagsUpdatedEvent.ServerDataLoad(this, this.registryAccess));
          this.newComponents.forEach(DataComponentInitializers.PendingComponents::apply);
 +        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.DefaultDataComponentsBoundEvent(false, false));
      }

--- a/patches/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/net/minecraft/server/ReloadableServerResources.java.patch
@@ -1,9 +1,10 @@
 --- a/net/minecraft/server/ReloadableServerResources.java
 +++ b/net/minecraft/server/ReloadableServerResources.java
-@@ -30,6 +_,9 @@
+@@ -30,6 +_,10 @@
      private final ServerFunctionLibrary functionLibrary;
      private final List<Registry.PendingTags<?>> postponedTags;
      private final List<DataComponentInitializers.PendingComponents<?>> newComponents;
++    // Neo: Store registries and condition context object
 +    private final net.minecraft.core.RegistryAccess registryAccess;
 +    private final HolderLookup.Provider loadingContext;
 +    private final net.neoforged.neoforge.common.conditions.ConditionContext context;

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -105,10 +105,8 @@ public class NeoForgeEventHandler {
     }
 
     @SubscribeEvent
-    public void tagsUpdated(TagsUpdatedEvent event) {
-        if (event.getUpdateCause() == TagsUpdatedEvent.UpdateCause.SERVER_DATA_LOAD) {
-            DATA_MAP_LOADER.apply();
-        }
+    public void tagsUpdated(TagsUpdatedEvent.ServerDataLoad event) {
+        DATA_MAP_LOADER.apply(event.getRegistries());
     }
 
     @SubscribeEvent
@@ -157,7 +155,7 @@ public class NeoForgeEventHandler {
     public void onResourceReload(AddServerReloadListenersEvent event) {
         event.addListener(NeoForgeReloadListeners.LOOT_MODIFIERS, LOOT_MODIFIER_MANAGER = new LootModifierManager());
         event.addListener(NeoForgeReloadListeners.RECIPE_PRIORITIES, new RecipePriorityManager(event.getServerResources().getRecipeManager()));
-        event.addListener(NeoForgeReloadListeners.DATA_MAPS, DATA_MAP_LOADER = new DataMapLoader(event.getRegistryAccess()));
+        event.addListener(NeoForgeReloadListeners.DATA_MAPS, DATA_MAP_LOADER = new DataMapLoader());
         event.addListener(NeoForgeReloadListeners.CREATIVE_TABS, CreativeModeTabRegistry.getReloadListener());
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
+++ b/src/main/java/net/neoforged/neoforge/common/conditions/ICondition.java
@@ -122,6 +122,9 @@ public interface ICondition {
         /// must be used instead.
         ///
         /// @return The [RegistryAccess] context for the currently active reload.
+        ///
+        /// @deprecated Use [ContextAwareReloadListener#getRegistryLookup()] instead
+        @Deprecated(forRemoval = true, since = "26.1.2")
         default RegistryAccess registryAccess() {
             return RegistryAccess.EMPTY;
         }

--- a/src/main/java/net/neoforged/neoforge/event/AddServerReloadListenersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/AddServerReloadListenersEvent.java
@@ -57,6 +57,9 @@ public class AddServerReloadListenersEvent extends SortedReloadListenerEvent {
     /// must be used instead.
     ///
     /// @return The [RegistryAccess] context for the currently active reload.
+    ///
+    /// @deprecated Use [ContextAwareReloadListener#getRegistryLookup()] instead
+    @Deprecated(forRemoval = true, since = "26.1.2")
     public RegistryAccess getRegistryAccess() {
         return registryAccess;
     }

--- a/src/main/java/net/neoforged/neoforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/TagsUpdatedEvent.java
@@ -14,15 +14,13 @@ import org.jetbrains.annotations.ApiStatus;
 /// Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
 ///
 /// Listeners intending to use this event to update static data guarded by [#shouldUpdateStaticData()] should listen to
-/// the root event. Listeners interested the side-specific notification or the side-specific context should listen to
+/// the root event. Listeners interested in the side-specific notification or the side-specific context should listen to
 /// the [TagsUpdatedEvent.ServerDataLoad] and [TagsUpdatedEvent.ClientPacketReceived] subclasses instead.
 public sealed class TagsUpdatedEvent extends Event {
     private final RegistryAccess registries;
-    private final UpdateCause updateCause;
 
-    protected TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket) {
+    protected TagsUpdatedEvent(RegistryAccess registries) {
         this.registries = registries;
-        this.updateCause = fromClientPacket ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
     }
 
     /// {@return the registries that have had their tags rebound}
@@ -43,7 +41,7 @@ public sealed class TagsUpdatedEvent extends Event {
     /// @deprecated Subscribe to subclasses instead
     @Deprecated(forRemoval = true, since = "26.1.2")
     public UpdateCause getUpdateCause() {
-        return updateCause;
+        return UpdateCause.SERVER_DATA_LOAD;
     }
 
     /// Whether static data (which in single player is shared between server and client thread) should be updated as a
@@ -58,7 +56,7 @@ public sealed class TagsUpdatedEvent extends Event {
 
         @ApiStatus.Internal
         public ServerDataLoad(ReloadableServerResources serverResources, RegistryAccess registries) {
-            super(registries, false);
+            super(registries);
             this.serverResources = serverResources;
         }
 
@@ -74,8 +72,14 @@ public sealed class TagsUpdatedEvent extends Event {
 
         @ApiStatus.Internal
         public ClientPacketReceived(RegistryAccess registries, boolean isIntegratedServerConnection) {
-            super(registries, true);
+            super(registries);
             this.integratedServer = isIntegratedServerConnection;
+        }
+
+        @Override
+        @Deprecated(forRemoval = true, since = "26.1.2")
+        public UpdateCause getUpdateCause() {
+            return UpdateCause.CLIENT_PACKET_RECEIVED;
         }
 
         @Override

--- a/src/main/java/net/neoforged/neoforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/TagsUpdatedEvent.java
@@ -9,19 +9,20 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.server.ReloadableServerResources;
 import net.neoforged.bus.api.Event;
+import org.jetbrains.annotations.ApiStatus;
 
-/**
- * Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
- */
+/// Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
+///
+/// Listeners intending to use this event to update static data guarded by [#shouldUpdateStaticData()] should listen to
+/// the root event. Listeners interested the side-specific notification or the side-specific context should listen to
+/// the [TagsUpdatedEvent.ServerDataLoad] and [TagsUpdatedEvent.ClientPacketReceived] subclasses instead.
 public sealed class TagsUpdatedEvent extends Event {
     private final RegistryAccess registries;
     private final UpdateCause updateCause;
-    private final boolean integratedServer;
 
-    protected TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket, boolean isIntegratedServerConnection) {
+    protected TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket) {
         this.registries = registries;
         this.updateCause = fromClientPacket ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
-        this.integratedServer = isIntegratedServerConnection;
     }
 
     /// {@return the registries that have had their tags rebound}
@@ -32,32 +33,32 @@ public sealed class TagsUpdatedEvent extends Event {
     /// @return The dynamic registries that have had their tags rebound.
     ///
     /// @deprecated Use [#getRegistries()] instead
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "26.1.2")
     public HolderLookup.Provider getLookupProvider() {
         return registries;
     }
 
-    /**
-     * @return the cause for this tag update
-     */
+    /// {@return the cause for this tag update}
+    ///
+    /// @deprecated Subscribe to subclasses instead
+    @Deprecated(forRemoval = true, since = "26.1.2")
     public UpdateCause getUpdateCause() {
         return updateCause;
     }
 
-    /**
-     * Whether static data (which in single player is shared between server and client thread) should be updated as a
-     * result of this event. Effectively this means that in single player only the server-side updates this data.
-     */
+    /// Whether static data (which in single player is shared between server and client thread) should be updated as a
+    /// result of this event. Effectively this means that in single player only the server-side updates this data.
     public boolean shouldUpdateStaticData() {
-        return updateCause == UpdateCause.SERVER_DATA_LOAD || !integratedServer;
+        return true;
     }
 
     /// Fired when tags are updated following a server datapack (re)load
     public static final class ServerDataLoad extends TagsUpdatedEvent {
         private final ReloadableServerResources serverResources;
 
+        @ApiStatus.Internal
         public ServerDataLoad(ReloadableServerResources serverResources, RegistryAccess registries) {
-            super(registries, false, false);
+            super(registries, false);
             this.serverResources = serverResources;
         }
 
@@ -69,14 +70,22 @@ public sealed class TagsUpdatedEvent extends Event {
 
     /// Fired when tags are updated by the client receiving tag data from the server
     public static final class ClientPacketReceived extends TagsUpdatedEvent {
+        private final boolean integratedServer;
+
+        @ApiStatus.Internal
         public ClientPacketReceived(RegistryAccess registries, boolean isIntegratedServerConnection) {
-            super(registries, true, isIntegratedServerConnection);
+            super(registries, true);
+            this.integratedServer = isIntegratedServerConnection;
+        }
+
+        @Override
+        public boolean shouldUpdateStaticData() {
+            return !integratedServer;
         }
     }
 
-    /**
-     * Represents the cause for a tag update.
-     */
+    /// Represents the cause for a tag update.
+    @Deprecated(forRemoval = true, since = "26.1.2")
     public enum UpdateCause {
         /**
          * The tag update is caused by the server loading datapack data. Note that in single player this still happens

--- a/src/main/java/net/neoforged/neoforge/event/TagsUpdatedEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/TagsUpdatedEvent.java
@@ -6,27 +6,35 @@
 package net.neoforged.neoforge.event;
 
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.ReloadableServerResources;
 import net.neoforged.bus.api.Event;
 
 /**
  * Fired when tags are updated on either server or client. This event can be used to refresh data that depends on tags.
  */
-public class TagsUpdatedEvent extends Event {
-    private final HolderLookup.Provider lookupProvider;
+public sealed class TagsUpdatedEvent extends Event {
+    private final RegistryAccess registries;
     private final UpdateCause updateCause;
     private final boolean integratedServer;
 
-    public TagsUpdatedEvent(HolderLookup.Provider lookupProvider, boolean fromClientPacket, boolean isIntegratedServerConnection) {
-        this.lookupProvider = lookupProvider;
+    protected TagsUpdatedEvent(RegistryAccess registries, boolean fromClientPacket, boolean isIntegratedServerConnection) {
+        this.registries = registries;
         this.updateCause = fromClientPacket ? UpdateCause.CLIENT_PACKET_RECEIVED : UpdateCause.SERVER_DATA_LOAD;
         this.integratedServer = isIntegratedServerConnection;
     }
 
-    /**
-     * @return The dynamic registries that have had their tags rebound.
-     */
+    /// {@return the registries that have had their tags rebound}
+    public RegistryAccess getRegistries() {
+        return registries;
+    }
+
+    /// @return The dynamic registries that have had their tags rebound.
+    ///
+    /// @deprecated Use [#getRegistries()] instead
+    @Deprecated
     public HolderLookup.Provider getLookupProvider() {
-        return lookupProvider;
+        return registries;
     }
 
     /**
@@ -42,6 +50,28 @@ public class TagsUpdatedEvent extends Event {
      */
     public boolean shouldUpdateStaticData() {
         return updateCause == UpdateCause.SERVER_DATA_LOAD || !integratedServer;
+    }
+
+    /// Fired when tags are updated following a server datapack (re)load
+    public static final class ServerDataLoad extends TagsUpdatedEvent {
+        private final ReloadableServerResources serverResources;
+
+        public ServerDataLoad(ReloadableServerResources serverResources, RegistryAccess registries) {
+            super(registries, false, false);
+            this.serverResources = serverResources;
+        }
+
+        /// {@return the server resources which triggered this tag update}
+        public ReloadableServerResources getServerResources() {
+            return serverResources;
+        }
+    }
+
+    /// Fired when tags are updated by the client receiving tag data from the server
+    public static final class ClientPacketReceived extends TagsUpdatedEvent {
+        public ClientPacketReceived(RegistryAccess registries, boolean isIntegratedServerConnection) {
+            super(registries, true, isIntegratedServerConnection);
+        }
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
@@ -44,11 +44,6 @@ public class DataMapLoader extends ContextAwareReloadListener {
     private static final Logger LOGGER = LogUtils.getLogger();
     public static final String PATH = "data_maps";
     private Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> results;
-    private final RegistryAccess registryAccess;
-
-    public DataMapLoader(RegistryAccess registryAccess) {
-        this.registryAccess = registryAccess;
-    }
 
     @Override
     public CompletableFuture<Void> reload(SharedState sharedState, Executor backgroundExecutor, PreparationBarrier preparationBarrier, Executor gameExecutor) {
@@ -57,14 +52,14 @@ public class DataMapLoader extends ContextAwareReloadListener {
                 .thenAcceptAsync(values -> this.results = values, gameExecutor);
     }
 
-    public void apply() {
-        results.forEach((key, result) -> this.apply((BaseMappedRegistry) registryAccess.lookupOrThrow(key), result));
+    public void apply(RegistryAccess registryAccess) {
+        results.forEach((key, result) -> this.apply(registryAccess, (BaseMappedRegistry) registryAccess.lookupOrThrow(key), result));
 
         // Clear the intermediary maps and objects
         results = null;
     }
 
-    private <T> void apply(BaseMappedRegistry<T> registry, LoadResult<T> result) {
+    private <T> void apply(RegistryAccess registryAccess, BaseMappedRegistry<T> registry, LoadResult<T> result) {
         registry.dataMaps.clear();
         result.results().forEach((key, entries) -> registry.dataMaps.put(
                 key, this.buildDataMap(registry, key, (List) entries)));


### PR DESCRIPTION
This PR splits `TagsUpdatedEvent` into two sub-events, `TagsUpdatedEvent.ServerDataLoad` and `TagsUpdatedEvent.ClientPacketReceived`, to allow providing side-specific context (for now just the `ReloadableServerResources`). `TagsUpdatedEvent` is kept non-abstract to still allow listening to it "unfiltered".

The event now exposes the full `RegistryAccess` instead of just a `HolderLookup.Provider` (inconsequential on the client because those two callsites already passed in a `RegistryAccess`) and the aforementioned `ReloadableServerResources`.
This change gives the `DataMapLoader` access to a full `RegistryAccess` without having to capture it during listener registration, allowing the removal of the "broken" `AddServerReloadListenersEvent#getRegistryAccess()` and `ICondition.IContext#registryAccess()` methods (~~deprecated for now, waiting for some WAIFU info before removing them entirely~~ keeping them as deprecated, there's no practical reason to make this a BC). The addition of `ReloadableServerResources` will become relevant in a subsequent PR.

Fixes #1259