### PR TITLE
[26.1] Retain datapack reload listeners in ReloadableServerResources

### DIFF
--- a/patches/net/minecraft/server/ReloadableServerResources.java.patch
+++ b/patches/net/minecraft/server/ReloadableServerResources.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/ReloadableServerResources.java
 +++ b/net/minecraft/server/ReloadableServerResources.java
-@@ -30,6 +_,10 @@
+@@ -30,6 +_,11 @@
      private final ServerFunctionLibrary functionLibrary;
      private final List<Registry.PendingTags<?>> postponedTags;
      private final List<DataComponentInitializers.PendingComponents<?>> newComponents;
@@ -8,6 +8,7 @@
 +    private final net.minecraft.core.RegistryAccess registryAccess;
 +    private final HolderLookup.Provider loadingContext;
 +    private final net.neoforged.neoforge.common.conditions.ConditionContext context;
++    private final java.util.Map<net.neoforged.neoforge.resource.ListenerKey<?>, PreparableReloadListener> retainedListeners = new java.util.IdentityHashMap<>();
  
      private ReloadableServerResources(
          LayeredRegistryAccess<RegistryLayer> fullLayers,
@@ -22,10 +23,20 @@
      }
  
      public ServerFunctionLibrary getFunctionLibrary() {
-@@ -73,6 +_,22 @@
+@@ -73,6 +_,32 @@
          return List.of(this.recipes, this.functionLibrary, this.advancements);
      }
  
++    /// {@return the reload listener registered with the provided key}
++    @SuppressWarnings("unchecked")
++    public <T extends PreparableReloadListener> T getListener(net.neoforged.neoforge.resource.ListenerKey<T> key) {
++        PreparableReloadListener listener = this.retainedListeners.get(key);
++        if (listener == null) {
++            throw new IllegalArgumentException("No listener registered for key " + key);
++        }
++        return (T) listener;
++    }
++
 +    /**
 +     * Exposes the current condition context for usage in other reload listeners.<br>
 +     * This is not useful outside the reloading stage.
@@ -51,7 +62,7 @@
                              );
 +
 +                            // Neo: Fire the AddServerReloadListenersEvent and use the resulting listeners instead of the vanilla listener list.
-+                            List<PreparableReloadListener> listeners = net.neoforged.neoforge.event.EventHooks.onResourceReload(result, fullRegistries.layers().compositeAccess());
++                            List<PreparableReloadListener> listeners = net.neoforged.neoforge.event.EventHooks.onResourceReload(result, fullRegistries.layers().compositeAccess(), result.retainedListeners);
 +
 +                            // Neo: Inject the ConditionContext and RegistryLookup to any resource listener that requests it.
 +                            for (PreparableReloadListener rl : listeners) {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -223,7 +223,9 @@ import net.neoforged.neoforge.internal.NeoForgeProxy;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.payload.RecipeContentPayload;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
 import net.neoforged.neoforge.resource.ResourcePackLoader;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import net.neoforged.neoforge.server.permission.PermissionAPI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1121,7 +1123,10 @@ public class CommonHooks {
      */
     public static ObjectArrayList<ItemStack> modifyLoot(Identifier lootTableId, ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
         context.setQueriedLootTableId(lootTableId); // In case the ID was set via copy constructor, this will be ignored: intended
-        LootModifierManager man = NeoForgeEventHandler.getLootModifierManager();
+        LootModifierManager man = Objects.requireNonNull(ServerLifecycleHooks.getCurrentServer())
+                .getServerResources()
+                .managers()
+                .getListener(NeoForgeReloadListeners.LOOT_MODIFIERS_KEY);
         for (IGlobalLootModifier mod : man.getSortedModifiers()) {
             try {
                 generatedLoot = mod.apply(generatedLoot, context);

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -48,13 +48,9 @@ import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
 import net.neoforged.neoforge.server.command.ConfigCommand;
 import net.neoforged.neoforge.server.command.NeoForgeCommand;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.VisibleForTesting;
 
 @ApiStatus.Internal
 public class NeoForgeEventHandler {
-    private static LootModifierManager LOOT_MODIFIER_MANAGER;
-    private static DataMapLoader DATA_MAP_LOADER;
-
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onEntityJoinWorld(EntityJoinLevelEvent event) {
         Entity entity = event.getEntity();
@@ -106,7 +102,9 @@ public class NeoForgeEventHandler {
 
     @SubscribeEvent
     public void tagsUpdated(TagsUpdatedEvent.ServerDataLoad event) {
-        DATA_MAP_LOADER.apply(event.getRegistries());
+        event.getServerResources()
+                .getListener(NeoForgeReloadListeners.DATA_MAPS_KEY)
+                .apply(event.getRegistries());
     }
 
     @SubscribeEvent
@@ -153,17 +151,11 @@ public class NeoForgeEventHandler {
 
     @SubscribeEvent
     public void onResourceReload(AddServerReloadListenersEvent event) {
-        event.addListener(NeoForgeReloadListeners.LOOT_MODIFIERS, LOOT_MODIFIER_MANAGER = new LootModifierManager());
         event.addListener(NeoForgeReloadListeners.RECIPE_PRIORITIES, new RecipePriorityManager(event.getServerResources().getRecipeManager()));
-        event.addListener(NeoForgeReloadListeners.DATA_MAPS, DATA_MAP_LOADER = new DataMapLoader());
         event.addListener(NeoForgeReloadListeners.CREATIVE_TABS, CreativeModeTabRegistry.getReloadListener());
-    }
 
-    @VisibleForTesting
-    public static LootModifierManager getLootModifierManager() {
-        if (LOOT_MODIFIER_MANAGER == null)
-            throw new IllegalStateException("Can not retrieve LootModifierManager until resources have loaded once.");
-        return LOOT_MODIFIER_MANAGER;
+        event.addRetainedListener(NeoForgeReloadListeners.LOOT_MODIFIERS_KEY, new LootModifierManager());
+        event.addRetainedListener(NeoForgeReloadListeners.DATA_MAPS_KEY, new DataMapLoader());
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/src/main/java/net/neoforged/neoforge/event/AddServerReloadListenersEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/AddServerReloadListenersEvent.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.event;
 
+import java.util.Map;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
@@ -13,6 +14,7 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.resource.ContextAwareReloadListener;
+import net.neoforged.neoforge.resource.ListenerKey;
 import net.neoforged.neoforge.resource.VanillaServerListeners;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -25,12 +27,31 @@ import org.jetbrains.annotations.ApiStatus;
 public class AddServerReloadListenersEvent extends SortedReloadListenerEvent {
     private final ReloadableServerResources serverResources;
     private final RegistryAccess registryAccess;
+    private final Map<ListenerKey<?>, PreparableReloadListener> retainedListeners;
 
     @ApiStatus.Internal
-    public AddServerReloadListenersEvent(ReloadableServerResources serverResources, RegistryAccess registryAccess) {
+    public AddServerReloadListenersEvent(
+            ReloadableServerResources serverResources,
+            RegistryAccess registryAccess,
+            Map<ListenerKey<?>, PreparableReloadListener> retainedListeners) {
         super(serverResources.listeners(), AddServerReloadListenersEvent::lookupName);
         this.serverResources = serverResources;
         this.registryAccess = registryAccess;
+        this.retainedListeners = retainedListeners;
+    }
+
+    /// Adds a new [`reload listener`][PreparableReloadListener] to the resource manager and retains it in the [ReloadableServerResources]
+    /// for later access through [ReloadableServerResources#getListener(ListenerKey)()].
+    ///
+    /// Unless explicitly specified, this listener will run after all vanilla listeners, in the order it was registered.
+    ///
+    /// @param key      The resource location that identifies the reload listener for dependency sorting and lookup.
+    /// @param listener The listener to add.
+    ///
+    /// @throws IllegalArgumentException if another listener with that key was already registered.
+    public <T extends PreparableReloadListener> void addRetainedListener(ListenerKey<T> key, T listener) {
+        this.addListener(key.getListenerId(), listener);
+        this.retainedListeners.put(key, listener);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -184,6 +185,7 @@ import net.neoforged.neoforge.event.tick.LevelTickEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.resource.ListenerKey;
 import net.neoforged.neoforge.resource.ReloadListenerSort;
 import org.jetbrains.annotations.ApiStatus;
 import org.jspecify.annotations.Nullable;
@@ -819,8 +821,11 @@ public class EventHooks {
      * 
      * @throws IllegalArgumentException if {@link ReloadListenerSort#sort(SortedReloadListenerEvent)} detects a cycle.
      */
-    public static List<PreparableReloadListener> onResourceReload(ReloadableServerResources serverResources, RegistryAccess registryAccess) {
-        AddServerReloadListenersEvent event = new AddServerReloadListenersEvent(serverResources, registryAccess);
+    public static List<PreparableReloadListener> onResourceReload(
+            ReloadableServerResources serverResources,
+            RegistryAccess registryAccess,
+            Map<ListenerKey<?>, PreparableReloadListener> retainedListeners) {
+        AddServerReloadListenersEvent event = new AddServerReloadListenersEvent(serverResources, registryAccess, retainedListeners);
         NeoForge.EVENT_BUS.post(event);
         return ReloadListenerSort.sort(event);
     }

--- a/src/main/java/net/neoforged/neoforge/resource/ListenerKey.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ListenerKey.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.resource;
+
+import com.google.common.collect.MapMaker;
+import java.util.concurrent.ConcurrentMap;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.ReloadableServerResources;
+import net.minecraft.server.packs.resources.PreparableReloadListener;
+
+/// Identifies a [PreparableReloadListener] retained by the [ReloadableServerResources]
+public final class ListenerKey<T extends PreparableReloadListener> {
+    private static final ConcurrentMap<Identifier, ListenerKey<?>> VALUES = new MapMaker().weakValues().makeMap();
+
+    private final Identifier listenerId;
+
+    @SuppressWarnings("unchecked")
+    public static <T extends PreparableReloadListener> ListenerKey<T> create(Identifier listenerId) {
+        return (ListenerKey<T>) VALUES.computeIfAbsent(listenerId, ListenerKey::new);
+    }
+
+    private ListenerKey(Identifier listenerId) {
+        this.listenerId = listenerId;
+    }
+
+    public Identifier getListenerId() {
+        return this.listenerId;
+    }
+
+    @Override
+    public String toString() {
+        return this.listenerId.toString();
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/resource/NeoForgeReloadListeners.java
+++ b/src/main/java/net/neoforged/neoforge/resource/NeoForgeReloadListeners.java
@@ -7,6 +7,8 @@ package net.neoforged.neoforge.resource;
 
 import net.minecraft.resources.Identifier;
 import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.common.loot.LootModifierManager;
+import net.neoforged.neoforge.registries.DataMapLoader;
 
 /**
  * Keys for Neo-added resource listeners, for use in dependency ordering in the relevant events.
@@ -18,10 +20,12 @@ public class NeoForgeReloadListeners {
 
     // Server Listeners
     public static final Identifier LOOT_MODIFIERS = key("loot_modifiers");
+    public static final ListenerKey<LootModifierManager> LOOT_MODIFIERS_KEY = ListenerKey.create(LOOT_MODIFIERS);
 
     public static final Identifier RECIPE_PRIORITIES = key("recipe_priorities");
 
     public static final Identifier DATA_MAPS = key("data_maps");
+    public static final ListenerKey<DataMapLoader> DATA_MAPS_KEY = ListenerKey.create(DATA_MAPS);
 
     public static final Identifier CREATIVE_TABS = key("creative_tabs");
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/loot/GlobalLootModifiersTest.java
@@ -54,7 +54,6 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemBlockStatePrope
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.minecraft.world.level.storage.loot.predicates.MatchTool;
 import net.minecraft.world.phys.Vec3;
-import net.neoforged.neoforge.common.NeoForgeEventHandler;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.conditions.NeoForgeConditions;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
@@ -66,6 +65,7 @@ import net.neoforged.neoforge.common.loot.LootTableIdCondition;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.TestFramework;
 import net.neoforged.testframework.annotation.ForEachTest;
@@ -332,7 +332,11 @@ public class GlobalLootModifiersTest {
         });
 
         test.onGameTest(helper -> {
-            LootModifierManager lootModManager = NeoForgeEventHandler.getLootModifierManager();
+            LootModifierManager lootModManager = helper.getLevel()
+                    .getServer()
+                    .getServerResources()
+                    .managers()
+                    .getListener(NeoForgeReloadListeners.LOOT_MODIFIERS_KEY);
             if (lootModManager.getModifier(Identifier.fromNamespaceAndPath(HELPER.modId(), "wheat_harvest_disabled")) != null) {
                 helper.fail("GLM disabled by condition was loaded");
             }


### PR DESCRIPTION
This PR allows datapack reload listeners to request being retained on the `ReloadableServerResources` for later access through the added `ReloadableServerResources#getListener()` method.

I deliberately chose to make this opt-in because a lot of reload listeners are irrelevant after the reload completes, either because they are only used as a notification or because the data they loaded was immediately applied to something else that is already retained (applies to Neo's recipe priority and creative tab order loaders).
A dedicated key type (`ListenerKey`) is used instead of a raw `Identifier` to ensure type safety between registration and lookup (ignoring the ability of mod A to create their own key for mod B's listener) and hide the cast to the specific listener implementation.
The implementation is limited to datapack reload listeners because resourcepack reload listeners are only registered once and can almost always be stored in static final fields.

~~This PR is blocked by #3171.~~

Closes #3078