### PR TITLE
Fix CustomClickActionEvent missing player context in configuration phase

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -288,12 +288,16 @@
      public RegistryAccess.Frozen registryAccess() {
          return this.registries.compositeAccess();
      }
-@@ -2080,6 +_,13 @@
+@@ -2080,6 +_,17 @@
          return true;
      }
  
 +    public void handleCustomClickAction(Identifier id, Optional<Tag> payload, ServerPlayer player) {
-+        if (!net.neoforged.neoforge.common.CommonHooks.onCustomClickAction(player, id, payload))
++        handleCustomClickAction(id, payload, player, player.getGameProfile());
++    }
++
++    public void handleCustomClickAction(Identifier id, Optional<Tag> payload, @Nullable ServerPlayer player, GameProfile profile) {
++        if (!net.neoforged.neoforge.common.CommonHooks.onCustomClickAction(player, profile, id, payload))
 +            handleCustomClickAction(id, payload);
 +    }
 +

--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -288,14 +288,10 @@
      public RegistryAccess.Frozen registryAccess() {
          return this.registries.compositeAccess();
      }
-@@ -2080,6 +_,17 @@
+@@ -2080,6 +_,13 @@
          return true;
      }
  
-+    public void handleCustomClickAction(Identifier id, Optional<Tag> payload, ServerPlayer player) {
-+        handleCustomClickAction(id, payload, player, player.getGameProfile());
-+    }
-+
 +    public void handleCustomClickAction(Identifier id, Optional<Tag> payload, @Nullable ServerPlayer player, GameProfile profile) {
 +        if (!net.neoforged.neoforge.common.CommonHooks.onCustomClickAction(player, profile, id, payload))
 +            handleCustomClickAction(id, payload);

--- a/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -56,7 +56,7 @@
      public void handleCustomClickAction(ServerboundCustomClickActionPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.server.packetProcessor());
 -        this.server.handleCustomClickAction(packet.id(), packet.payload());
-+        this.server.handleCustomClickAction(packet.id(), packet.payload(), this instanceof ServerGamePacketListenerImpl gamePacketListener ? gamePacketListener.getPlayer() : null);
++        this.server.handleCustomClickAction(packet.id(), packet.payload(), this instanceof ServerGamePacketListenerImpl gamePacketListener ? gamePacketListener.getPlayer() : null, this.playerProfile());
      }
  
      @Override

--- a/patches/net/minecraft/world/level/block/entity/SignBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/SignBlockEntity.java.patch
@@ -5,7 +5,7 @@
                      break;
                  case ClickEvent.Custom custom:
 -                    level.getServer().handleCustomClickAction(custom.id(), custom.payload());
-+                    level.getServer().handleCustomClickAction(custom.id(), custom.payload(), (net.minecraft.server.level.ServerPlayer) player);
++                    level.getServer().handleCustomClickAction(custom.id(), custom.payload(), (net.minecraft.server.level.ServerPlayer) player, player.getGameProfile());
                      hasAnyClickCommand = true;
                      break;
                  case null:

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -10,6 +10,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.datafixers.util.Pair;
@@ -1833,7 +1834,7 @@ public class CommonHooks {
     }
 
     @ApiStatus.Internal
-    public static boolean onCustomClickAction(@Nullable ServerPlayer player, Identifier id, Optional<Tag> payload) {
-        return NeoForge.EVENT_BUS.post(new CustomClickActionEvent(player, id, payload.orElse(null))).isCanceled();
+    public static boolean onCustomClickAction(@Nullable ServerPlayer player, GameProfile profile, Identifier id, Optional<Tag> payload) {
+        return NeoForge.EVENT_BUS.post(new CustomClickActionEvent(player, profile, id, payload.orElse(null))).isCanceled();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/CustomClickActionEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/CustomClickActionEvent.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.event.entity.player;
 
+import com.mojang.authlib.GameProfile;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.resources.Identifier;
@@ -19,27 +20,36 @@ import org.jspecify.annotations.Nullable;
 /// 
 /// If an event handler receives this and performs its own custom action, that event handler **must cancel** this event.
 /// 
+/// During the configuration phase, the player is not yet in the world, so [#getProfile()] must be used to obtain sender context.
+/// 
 /// This event is fired only on the logical server.
 /// 
 /// This event is [cancelable][ICancellableEvent]. If canceled, vanilla's processing of the custom click payload is skipped.
 public class CustomClickActionEvent extends Event implements ICancellableEvent {
     @Nullable
     private final ServerPlayer player;
+    private final GameProfile profile;
     private final Identifier identifier;
     @Nullable
     private final Tag payload;
 
     @ApiStatus.Internal
-    public CustomClickActionEvent(@Nullable ServerPlayer player, Identifier identifier, @Nullable Tag payload) {
+    public CustomClickActionEvent(@Nullable ServerPlayer player, GameProfile profile, Identifier identifier, @Nullable Tag payload) {
         this.player = player;
+        this.profile = profile;
         this.identifier = identifier;
         this.payload = payload;
     }
 
-    /// {@return the player who clicked this custom click event or null if the custom click event is received during configuration}
+    /// {@return the player who clicked this custom click event, or `null` if it was received during configuration}
     @Nullable
     public ServerPlayer getPlayer() {
         return player;
+    }
+
+    /// {@return the profile of the player that sent this custom click action}
+    public GameProfile getProfile() {
+        return profile;
     }
 
     /// {@return the custom click event's identifier}


### PR DESCRIPTION
I was looking over recent additions and saw https://github.com/neoforged/NeoForge/pull/3167 merged yesterday.

Unfortunately, it is unusable for dialogs presented in the configuration phase. As it is, without forgoing event, it would be more involved than it should be to identify players through click identifier or payload in a tamperproof manner (as those are both user input). The naïve approach would be trivially exploitable. So, I've added `GameProfile` to correctly identify the originator of the click action from the packet listener.

I chose this manner as the closest equivalent of shared configuration and play API surfaces are `IPayloadContext` and `PlayerNegotiationEvent`. In the former, it presents `ICommonPacketListener`, expecting users to cast to the server or client common listener accordingly. From there, the server listener has a public `GameProfile getOwner()`, which is however, Mojang-annotated `@VisibleForDebug`, not giving much confidence. In the latter, there is no `ServerPlayer` factor but it is a precedent for an event offering a `GameProfile` to consumers. I chose to offer nullable player and nonnull game profile for ease of use.

Note: the `handleCustomClickAction(Identifier,Optional<Tag>,ServerPlayer)` overload from the original PR no longer has a nullable player, which was erroneously not annotated nullable anyway. Instead, a new overload is added to support a profile with an absent player. 