### PR TITLE
[26.1] Query crafting remainders prior to shrinkage to fix empty remainder bug

### DIFF
--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -66,7 +66,7 @@
      private static void consumeFuel(NonNullList<ItemStack> items, ItemStack fuel) {
          Item fuelItem = fuel.getItem();
 +        // Neo: Need to query for the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
-+        ItemStackTemplate remainder = fuelItem.getCraftingRemainder(fuel);
++        ItemStackTemplate remainder = fuel.getCraftingRemainder();
          fuel.shrink(1);
          if (fuel.isEmpty()) {
 -            ItemStackTemplate remainder = fuelItem.getCraftingRemainder();

--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -61,12 +61,19 @@
          ContainerHelper.saveAllItems(output, this.items);
          output.store("RecipesUsed", RECIPES_USED_CODEC, this.recipesUsed);
      }
-@@ -214,7 +_,7 @@
+@@ -211,10 +_,14 @@
+     }
+ 
+     private static void consumeFuel(NonNullList<ItemStack> items, ItemStack fuel) {
++        // Neo: Copy fuel stack to allow stack based crafting remainder
++        // the stack is modified and potentially emptied via the shrink call
++        // but we require the original stack to obtain the correct crafting remainder
++        ItemStack originalFuel = fuel.copy();
          Item fuelItem = fuel.getItem();
          fuel.shrink(1);
          if (fuel.isEmpty()) {
 -            ItemStackTemplate remainder = fuelItem.getCraftingRemainder();
-+            ItemStackTemplate remainder = fuel.getCraftingRemainder();
++            ItemStackTemplate remainder = originalFuel.getCraftingRemainder();
              items.set(1, remainder != null ? remainder.create() : ItemStack.EMPTY);
          }
      }

--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -61,22 +61,6 @@
          ContainerHelper.saveAllItems(output, this.items);
          output.store("RecipesUsed", RECIPES_USED_CODEC, this.recipesUsed);
      }
-@@ -211,10 +_,14 @@
-     }
- 
-     private static void consumeFuel(NonNullList<ItemStack> items, ItemStack fuel) {
-+        // Neo: Copy fuel stack to allow stack based crafting remainder
-+        // the stack is modified and potentially emptied via the shrink call
-+        // but we require the original stack to obtain the correct crafting remainder
-+        ItemStack originalFuel = fuel.copy();
-         Item fuelItem = fuel.getItem();
-         fuel.shrink(1);
-         if (fuel.isEmpty()) {
--            ItemStackTemplate remainder = fuelItem.getCraftingRemainder();
-+            ItemStackTemplate remainder = originalFuel.getCraftingRemainder();
-             items.set(1, remainder != null ? remainder.create() : ItemStack.EMPTY);
-         }
-     }
 @@ -248,7 +_,7 @@
      }
  

--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -61,6 +61,18 @@
          ContainerHelper.saveAllItems(output, this.items);
          output.store("RecipesUsed", RECIPES_USED_CODEC, this.recipesUsed);
      }
+@@ -212,9 +_,10 @@
+ 
+     private static void consumeFuel(NonNullList<ItemStack> items, ItemStack fuel) {
+         Item fuelItem = fuel.getItem();
++        // Neo: Need to query for the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
++        ItemStackTemplate remainder = fuelItem.getCraftingRemainder(fuel);
+         fuel.shrink(1);
+         if (fuel.isEmpty()) {
+-            ItemStackTemplate remainder = fuelItem.getCraftingRemainder();
+             items.set(1, remainder != null ? remainder.create() : ItemStack.EMPTY);
+         }
+     }
 @@ -248,7 +_,7 @@
      }
  

--- a/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java.patch
@@ -65,7 +65,7 @@
  
      private static void consumeFuel(NonNullList<ItemStack> items, ItemStack fuel) {
          Item fuelItem = fuel.getItem();
-+        // Neo: Need to query for the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
++        // Neo: Query the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
 +        ItemStackTemplate remainder = fuel.getCraftingRemainder();
          fuel.shrink(1);
          if (fuel.isEmpty()) {

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -14,7 +14,7 @@
  
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
 +        // Neo: Need to query for the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
-+        ItemStackTemplate remainder = items.get(INGREDIENT_SLOT).getCraftingRemainder();
++        ItemStackTemplate remainder = ingredient.getCraftingRemainder();
          ingredient.shrink(1);
 -        ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
          if (remainder != null) {

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -8,14 +8,18 @@
          ItemStack ingredient = items.get(3);
          PotionBrewing potionBrewing = level.potionBrewing();
  
-@@ -181,6 +_,7 @@
+@@ -181,8 +_,10 @@
              items.set(dest, potionBrewing.mix(ingredient, items.get(dest)));
          }
  
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
++        // Neo: Need to query for the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
++        ItemStackTemplate remainder = items.get(INGREDIENT_SLOT).getCraftingRemainder();
          ingredient.shrink(1);
-         ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
+-        ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
          if (remainder != null) {
+             if (ingredient.isEmpty()) {
+                 ingredient = remainder.create();
 @@ -218,13 +_,13 @@
  
      @Override

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -13,7 +13,7 @@
          }
  
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
-+        // Neo: Need to query for the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
++        // Neo: Query the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
 +        ItemStackTemplate remainder = ingredient.getCraftingRemainder();
          ingredient.shrink(1);
 -        ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -1,14 +1,18 @@
 --- a/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
-@@ -174,6 +_,7 @@
+@@ -174,15 +_,21 @@
      }
  
      private static void doBrew(Level level, BlockPos pos, NonNullList<ItemStack> items) {
 +        if (net.neoforged.neoforge.event.EventHooks.onPotionAttemptBrew(items)) return;
          ItemStack ingredient = items.get(3);
++        // Neo: Copy ingredient stack to allow stack based crafting remainder
++        // the stack is modified and potentially emptied via the shrink call
++        // but we require the original stack to obtain the correct crafting remainder
++        ItemStack originalIngredient = ingredient.copy();
          PotionBrewing potionBrewing = level.potionBrewing();
  
-@@ -181,8 +_,9 @@
+         for (int dest = 0; dest < 3; dest++) {
              items.set(dest, potionBrewing.mix(ingredient, items.get(dest)));
          }
  

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -19,7 +19,7 @@
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
          ingredient.shrink(1);
 -        ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
-+        ItemStackTemplate remainder = ingredient.getCraftingRemainder();
++        ItemStackTemplate remainder = originalIngredient.getCraftingRemainder();
          if (remainder != null) {
              if (ingredient.isEmpty()) {
                  ingredient = remainder.create();

--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -1,28 +1,21 @@
 --- a/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
 +++ b/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java
-@@ -174,15 +_,21 @@
+@@ -174,6 +_,7 @@
      }
  
      private static void doBrew(Level level, BlockPos pos, NonNullList<ItemStack> items) {
 +        if (net.neoforged.neoforge.event.EventHooks.onPotionAttemptBrew(items)) return;
          ItemStack ingredient = items.get(3);
-+        // Neo: Copy ingredient stack to allow stack based crafting remainder
-+        // the stack is modified and potentially emptied via the shrink call
-+        // but we require the original stack to obtain the correct crafting remainder
-+        ItemStack originalIngredient = ingredient.copy();
          PotionBrewing potionBrewing = level.potionBrewing();
  
-         for (int dest = 0; dest < 3; dest++) {
+@@ -181,6 +_,7 @@
              items.set(dest, potionBrewing.mix(ingredient, items.get(dest)));
          }
  
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
          ingredient.shrink(1);
--        ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
-+        ItemStackTemplate remainder = originalIngredient.getCraftingRemainder();
+         ItemStackTemplate remainder = ingredient.getItem().getCraftingRemainder();
          if (remainder != null) {
-             if (ingredient.isEmpty()) {
-                 ingredient = remainder.create();
 @@ -218,13 +_,13 @@
  
      @Override

--- a/tests/src/main/java/net/neoforged/neoforge/debug/crafting/CraftingRemainderTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/crafting/CraftingRemainderTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.crafting;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
+import net.neoforged.testframework.DynamicTest;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.gametest.GameTest;
+
+@ForEachTest(groups = "crafting_remainder_tests")
+public interface CraftingRemainderTests {
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Ensures lava buckets turn into empty buckets when used as fuel", enabledByDefault = true)
+    static void testLavaBucketToEmptyBucket(DynamicTest test) {
+        test.onGameTest(helper -> helper.startSequence()
+                .thenExecute(() -> helper.setBlock(BlockPos.ZERO, Blocks.FURNACE))
+                .thenMap(() -> helper.getBlockEntity(BlockPos.ZERO, FurnaceBlockEntity.class))
+                .thenExecute(furnace -> {
+                    furnace.setItem(/* AbstractFurnaceBlockEntity.SLOT_INPUT */ 0, new ItemStack(Items.RAW_IRON, 64));
+                    furnace.setItem(/* AbstractFurnaceBlockEntity.SLOT_FUEL */ 1, new ItemStack(Items.LAVA_BUCKET));
+                })
+                .thenIdle(1)
+                .thenMap(furnace -> furnace.getItem(/* AbstractFurnaceBlockEntity.SLOT_FUEL */ 1))
+                .thenExecute(fuel -> {
+                    if (!fuel.is(Items.BUCKET)) {
+                        helper.fail("Exepected crafting raminder to be '" + itemName(Items.BUCKET) + "' but found '" + itemName(fuel.getItem()) + "'");
+                    }
+                })
+                .thenSucceed());
+    }
+
+    private static String itemName(Item item) {
+        return item.builtInRegistryHolder().getRegisteredName();
+    }
+}


### PR DESCRIPTION
Fixes a bug introduced by #3157 where crafting remainders were queried against shrunken stacks resulting in the wrong crafting remainder.

This is done by moving the line that queries for the crafting remainder up before the shrink occurs

While the original bug report mentioned the furnace the PR introducing the bug also looks to have introduced the bug for the brewing stand, which I have gone ahead and applied the same fix to.

Fixes #3178