### PR TITLE
[26.1] Fix potential desync in `BrewingStandBlockEntity.doBrew`

### DIFF
--- a/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/BrewingStandBlockEntity.java.patch
@@ -8,11 +8,13 @@
          ItemStack ingredient = items.get(3);
          PotionBrewing potionBrewing = level.potionBrewing();
  
-@@ -181,8 +_,10 @@
+@@ -181,8 +_,12 @@
              items.set(dest, potionBrewing.mix(ingredient, items.get(dest)));
          }
  
 +        net.neoforged.neoforge.event.EventHooks.onPotionBrewed(items);
++        // Neo: Refresh local field to match any potential changes applied via brew event
++        ingredient = items.get(INGREDIENT_SLOT);
 +        // Neo: Query the crafting remainder prior to stack mutation (shrink) in order to grab the correct value
 +        ItemStackTemplate remainder = ingredient.getCraftingRemainder();
          ingredient.shrink(1);


### PR DESCRIPTION
This PR fixes a potential desync and oversight in `BrewingStandBlockEntity.doBrew`, where the `PotionBrewEvent.Post` event allows users to modify the ingredient slot via the `setItem` method.

While the event does modify the backing `NonNullList` the `doBrew` method relies on a local `ingredient` field which is not correctly updated after the event has fired leading to this desync.

This is fixed by simply refreshing the local fields value after the event to pull in any potential mutations that might have occurred.

~~Note: Initially opening as draft as this PR may need updating after #3179 has been merged to ensure the crafting remainder line is correctly below the patched in field refresher line~~