### PR TITLE
[26.2] Add conditional model loader

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -52,6 +52,7 @@ import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 import net.neoforged.neoforge.client.internal.SelfTestClient;
 import net.neoforged.neoforge.client.model.CompositeUnbakedModel;
+import net.neoforged.neoforge.client.model.ConditionalModelLoader;
 import net.neoforged.neoforge.client.model.EmptyModel;
 import net.neoforged.neoforge.client.model.block.CompositeBlockModel;
 import net.neoforged.neoforge.client.model.item.DynamicFluidContainerModel;
@@ -193,6 +194,7 @@ public class ClientNeoForgeMod {
         event.register(neoForgeId("empty"), EmptyModel.LOADER);
         event.register(neoForgeId("obj"), ObjLoader.INSTANCE);
         event.register(neoForgeId("composite"), CompositeUnbakedModel.Loader.INSTANCE);
+        event.register(ConditionalModelLoader.ID, ConditionalModelLoader.INSTANCE);
     }
 
     @SubscribeEvent

--- a/src/client/java/net/neoforged/neoforge/client/model/ConditionalModelLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/ConditionalModelLoader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.mojang.serialization.JsonOps;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.client.resources.model.cuboid.CuboidModel;
+import net.minecraft.client.resources.model.cuboid.MissingCuboidModel;
+import net.minecraft.resources.FileToIdConverter;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.util.GsonHelper;
+import net.neoforged.neoforge.client.model.generators.loaders.ConditionalModelBuilder;
+import net.neoforged.neoforge.common.NeoForgeMod;
+import net.neoforged.neoforge.common.conditions.ConditionalOps;
+import net.neoforged.neoforge.common.conditions.ICondition;
+
+/// Loads the model it is specified in only when all specified [loading conditions][ICondition] are
+/// satisfied, otherwise loads the specified fallback model.
+///
+/// This is primarily intended for models which reference textures from other mods which may not be present.
+///
+/// @see ConditionalModelBuilder
+public final class ConditionalModelLoader implements UnbakedModelLoader<UnbakedModel> {
+    public static final Identifier ID = Identifier.fromNamespaceAndPath(NeoForgeMod.MOD_ID, "conditional");
+    public static final ConditionalModelLoader INSTANCE = new ConditionalModelLoader();
+    private static final FileToIdConverter MODEL_LISTER = FileToIdConverter.json("models");
+
+    private ConditionalModelLoader() {}
+
+    @Override
+    public UnbakedModel read(JsonObject json, JsonDeserializationContext ctx) throws JsonParseException {
+        JsonArray conditionArray = GsonHelper.getAsJsonArray(json, ConditionalOps.DEFAULT_CONDITIONS_KEY);
+        List<ICondition> conditions = ICondition.LIST_CODEC.decode(JsonOps.INSTANCE, conditionArray).getOrThrow(
+                err -> new JsonParseException("Failed to parse conditions: " + err)).getFirst();
+
+        if (conditions.stream().allMatch(cond -> cond.test(ICondition.IContext.EMPTY))) {
+            json.remove("loader");
+            return ctx.deserialize(json, CuboidModel.class);
+        }
+
+        Identifier fallback = Identifier.parse(GsonHelper.getAsString(json, "fallback"));
+        // Missing model must be special-cased as it's a "synthetic" model and cannot be loaded from a file
+        if (fallback.equals(MissingCuboidModel.LOCATION)) {
+            return MissingCuboidModel.missingModel();
+        }
+        fallback = MODEL_LISTER.idToFile(fallback);
+        try {
+            Resource resource = Minecraft.getInstance().getResourceManager().getResourceOrThrow(fallback);
+            try (Reader reader = resource.openAsReader()) {
+                return UnbakedModelParser.parse(reader);
+            }
+        } catch (IOException e) {
+            throw new JsonParseException("Failed to parse fallback model", e);
+        }
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.generators.loaders;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.JsonOps;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.resources.Identifier;
+import net.neoforged.neoforge.client.model.ConditionalModelLoader;
+import net.neoforged.neoforge.client.model.generators.template.CustomLoaderBuilder;
+import net.neoforged.neoforge.common.conditions.ConditionalOps;
+import net.neoforged.neoforge.common.conditions.ICondition;
+import org.jspecify.annotations.Nullable;
+
+/// @see ConditionalModelLoader
+public final class ConditionalModelBuilder extends CustomLoaderBuilder {
+    private final List<ICondition> conditions = new ArrayList<>();
+    @Nullable
+    private Identifier fallback;
+
+    public ConditionalModelBuilder() {
+        super(ConditionalModelLoader.ID, true);
+    }
+
+    /// Add a loading condition which must be satisfied for this model to be loaded.
+    ///
+    /// @param condition The condition to add
+    public ConditionalModelBuilder addCondition(ICondition condition) {
+        Preconditions.checkNotNull(condition, "Condition must not be null");
+        conditions.add(condition);
+        return this;
+    }
+
+    /// Specify the model to fall back to when any condition fails.
+    ///
+    /// @param fallback The fallback model
+    public ConditionalModelBuilder setFallback(Identifier fallback) {
+        Preconditions.checkNotNull(fallback, "Fallback must not be null");
+        this.fallback = fallback;
+        return this;
+    }
+
+    @Override
+    protected CustomLoaderBuilder copyInternal() {
+        ConditionalModelBuilder builder = new ConditionalModelBuilder();
+        builder.conditions.addAll(conditions);
+        builder.fallback = fallback;
+        return builder;
+    }
+
+    @Override
+    public JsonObject toJson(JsonObject json) {
+        Preconditions.checkNotNull(fallback, "No fallback model set");
+        Preconditions.checkState(!conditions.isEmpty(), "No conditions specified");
+
+        json = super.toJson(json);
+        json.add(ConditionalOps.DEFAULT_CONDITIONS_KEY, ICondition.LIST_CODEC.encodeStart(JsonOps.INSTANCE, conditions).getOrThrow());
+        json.addProperty("fallback", fallback.toString());
+        return json;
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
@@ -10,18 +10,17 @@ import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.client.resources.model.cuboid.MissingCuboidModel;
 import net.minecraft.resources.Identifier;
 import net.neoforged.neoforge.client.model.ConditionalModelLoader;
 import net.neoforged.neoforge.client.model.generators.template.CustomLoaderBuilder;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.conditions.ICondition;
-import org.jspecify.annotations.Nullable;
 
 /// @see ConditionalModelLoader
 public final class ConditionalModelBuilder extends CustomLoaderBuilder {
     private final List<ICondition> conditions = new ArrayList<>();
-    @Nullable
-    private Identifier fallback;
+    private Identifier fallback = MissingCuboidModel.LOCATION;
 
     public ConditionalModelBuilder() {
         super(ConditionalModelLoader.ID, true);
@@ -55,7 +54,6 @@ public final class ConditionalModelBuilder extends CustomLoaderBuilder {
 
     @Override
     public JsonObject toJson(JsonObject json) {
-        Preconditions.checkNotNull(fallback, "No fallback model set");
         Preconditions.checkState(!conditions.isEmpty(), "No conditions specified");
 
         json = super.toJson(json);


### PR DESCRIPTION
This PR adds the conditional model loader which allows guarding a model behind loading conditions. This is primarily intended for models referencing textures from other mods which may not be present in order to reduce the amount of "missing texture" log spam at resource (re)load.
If needed, the loader can be extended to also support loading a model from a nested JSON object. This would allow guarding a model which uses yet another, potentially missing loader. Allowing the "primary" model to be a reference to another file however cannot be added as it would defeat the whole purpose of this loader.