### PR TITLE
Expose IWithData#getData helper to TypedInstance implementations

### DIFF
--- a/patches/net/minecraft/world/entity/ai/behavior/WorkAtComposter.java.patch
+++ b/patches/net/minecraft/world/entity/ai/behavior/WorkAtComposter.java.patch
@@ -14,7 +14,7 @@
              ItemStack itemStack = inventory.getItem(i);
 -            int itemIndex = COMPOSTABLE_ITEMS.indexOf(itemStack.getItem());
 -            if (itemIndex != -1) {
-+            var compostable = itemStack.typeHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.COMPOSTABLES);
++            var compostable = itemStack.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.COMPOSTABLES);
 +            if (compostable != null && compostable.canVillagerCompost()) {
                  int stackSize = itemStack.getCount();
 -                int totalItemCount = itemsSeenSoFar[itemIndex] + stackSize;

--- a/patches/net/minecraft/world/entity/ai/sensing/VillagerHostilesSensor.java.patch
+++ b/patches/net/minecraft/world/entity/ai/sensing/VillagerHostilesSensor.java.patch
@@ -14,7 +14,7 @@
  
      private boolean isClose(LivingEntity body, LivingEntity mob) {
 -        float distThreshold = ACCEPTABLE_DISTANCE_FROM_HOSTILES.get(mob.getType());
-+        var acceptableDistanceFromHostile = mob.getType().builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.ACCEPTABLE_VILLAGER_DISTANCES);
++        var acceptableDistanceFromHostile = mob.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.ACCEPTABLE_VILLAGER_DISTANCES);
 +        float distThreshold = acceptableDistanceFromHostile != null ? acceptableDistanceFromHostile.distance() : ACCEPTABLE_DISTANCE_FROM_HOSTILES.get(mob.getType());
          return mob.distanceToSqr(body) <= distThreshold * distThreshold;
      }
@@ -24,7 +24,7 @@
  
      private boolean isHostile(LivingEntity entity) {
 -        return ACCEPTABLE_DISTANCE_FROM_HOSTILES.containsKey(entity.getType());
-+        var acceptableDistanceFromHostile = entity.getType().builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.ACCEPTABLE_VILLAGER_DISTANCES);
++        var acceptableDistanceFromHostile = entity.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.ACCEPTABLE_VILLAGER_DISTANCES);
 +        return acceptableDistanceFromHostile != null || ACCEPTABLE_DISTANCE_FROM_HOSTILES.containsKey(entity.getType());
      }
  }

--- a/patches/net/minecraft/world/entity/animal/parrot/Parrot.java.patch
+++ b/patches/net/minecraft/world/entity/animal/parrot/Parrot.java.patch
@@ -5,7 +5,7 @@
      private static final Predicate<Mob> NOT_PARROT_PREDICATE = new Predicate<Mob>() {
          public boolean test(@Nullable Mob input) {
 -            return input != null && Parrot.MOB_SOUND_MAP.containsKey(input.getType());
-+            return input != null && (Parrot.MOB_SOUND_MAP.containsKey(input.getType()) || input.getType().builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.PARROT_IMITATIONS) != null);
++            return input != null && (Parrot.MOB_SOUND_MAP.containsKey(input.getType()) || input.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.PARROT_IMITATIONS) != null);
          }
      };
 +    /** @deprecated Neo: use the {@link net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps#PARROT_IMITATIONS data map} instead */

--- a/patches/net/minecraft/world/item/AxeItem.java.patch
+++ b/patches/net/minecraft/world/item/AxeItem.java.patch
@@ -48,14 +48,14 @@
  
 +    @org.jspecify.annotations.Nullable
 +    public static BlockState getAxeStrippingState(BlockState originalState) {
-+        var strippable = originalState.getBlock().builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.STRIPPABLES);
++        var strippable = originalState.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.STRIPPABLES);
 +        if (strippable != null) return strippable.strippedBlock().withPropertiesOf(originalState);
 +        Block block = STRIPPABLES.get(originalState.getBlock());
 +        return block != null ? block.defaultBlockState().setValue(RotatedPillarBlock.AXIS, originalState.getValue(RotatedPillarBlock.AXIS)) : null;
 +    }
 +
      private Optional<BlockState> getStripped(BlockState state) {
-+        var strippable = state.getBlock().builtInRegistryHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.STRIPPABLES);
++        var strippable = state.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.STRIPPABLES);
 +        if (strippable != null) {
 +            return Optional.of(strippable.strippedBlock().withPropertiesOf(state));
 +        }

--- a/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/ComposterBlock.java.patch
@@ -68,7 +68,7 @@
 +    }
 +
 +    public static float getValue(ItemStack item) {
-+        var value = item.typeHolder().getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.COMPOSTABLES);
++        var value = item.getData(net.neoforged.neoforge.registries.datamaps.builtin.NeoForgeDataMaps.COMPOSTABLES);
 +        if (value != null) return value.chance();
 +        return -1f;
      }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/TypedInstanceExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/TypedInstanceExtension.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.extensions;
+
+import net.minecraft.core.TypedInstance;
+import net.neoforged.neoforge.registries.datamaps.DataMapType;
+import net.neoforged.neoforge.registries.datamaps.IWithData;
+import org.jspecify.annotations.Nullable;
+
+public interface TypedInstanceExtension<T> extends IWithData<T> {
+    private TypedInstance<T> self() {
+        return (TypedInstance<T>) this;
+    }
+
+    @Nullable
+    @Override
+    default <D> D getData(DataMapType<T, D> type) {
+        return self().typeHolder().getData(type);
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/extensions/TypedInstanceExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/TypedInstanceExtension.java
@@ -11,13 +11,13 @@ import net.neoforged.neoforge.registries.datamaps.IWithData;
 import org.jspecify.annotations.Nullable;
 
 public interface TypedInstanceExtension<T> extends IWithData<T> {
-    private TypedInstance<T> self() {
-        return (TypedInstance<T>) this;
-    }
-
     @Nullable
     @Override
     default <D> D getData(DataMapType<T, D> type) {
         return self().typeHolder().getData(type);
+    }
+
+    private TypedInstance<T> self() {
+        return (TypedInstance<T>) this;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/registries/datamaps/IWithData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/datamaps/IWithData.java
@@ -7,18 +7,14 @@ package net.neoforged.neoforge.registries.datamaps;
 
 import org.jspecify.annotations.Nullable;
 
-/**
- * Represents a registry object (usually a {@link net.minecraft.core.Holder}) that has data maps.
- *
- * @param <R> the type of the object
- */
+/// Represents a registry object (usually a [net.minecraft.core.Holder]) or an instance thereof that has data maps.
+///
+/// @param <R> the type of the object
 public interface IWithData<R> {
-    /**
-     * {@return the data of the given type that is attached to this object, or {@code null} if one isn't}
-     *
-     * @param type the data type
-     * @param <T>  the type of the data
-     */
+    /// {@return the data of the given type that is attached to this object, or `null` if one isn't}
+    ///
+    /// @param type the data type
+    /// @param <T>  the type of the data
     @Nullable
     default <T> T getData(DataMapType<R, T> type) {
         return null;

--- a/src/main/resources/META-INF/injected-interfaces.json
+++ b/src/main/resources/META-INF/injected-interfaces.json
@@ -83,6 +83,9 @@
   "net/minecraft/core/Registry": [
     "net/neoforged/neoforge/registries/IRegistryExtension<T>"
   ],
+  "net/minecraft/core/TypedInstance": [
+    "net/neoforged/neoforge/common/extensions/TypedInstanceExtension<T>"
+  ],
   "net/minecraft/core/Registry$PendingTags": [
     "net/neoforged/neoforge/common/extensions/PendingTagsExtension<T>"
   ],

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -245,8 +245,7 @@ public class DataMapTests {
         // This is to make sure that sync work
         test.eventListeners().forge().addListener((final UseItemOnBlockEvent event) -> {
             if (event.getLevel().isClientSide() && event.getHand() == InteractionHand.MAIN_HAND) {
-                event.getPlayer().sendOverlayMessage(Component.literal("Attachment value: " + event.getItemStack().typeHolder()
-                        .getData(someData)));
+                event.getPlayer().sendOverlayMessage(Component.literal("Attachment value: " + event.getItemStack().getData(someData)));
             }
         });
 


### PR DESCRIPTION
I was initially going to make a PR implementing `IWithData`  onto `RegisteredResource`, when I realized it made more sense to just implement it directly onto `TypedInstance`. I also went ahead and cleaned up the existing patches to call the added helper so that they are more readable, rather than having them have to get the type holder manually and then calling getData on that.