### PR TITLE
Add missing nullability annotations to ItemeAccess#exchange, and DataComponentHolderResource#with

### DIFF
--- a/src/main/java/net/neoforged/neoforge/transfer/access/ItemAccess.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/access/ItemAccess.java
@@ -200,13 +200,13 @@ public interface ItemAccess {
      *
      * @param newResource The resource of the items after the exchange. <strong>Must be non-empty.</strong>
      * @param amount      The amount of items to exchange. <strong>Must be non-negative.</strong>
-     * @param transaction The transaction that this operation is part of.
+     * @param transaction The transaction that this operation is part of. Passing in {@code null} will open a root transaction, and commit it at the end of the method if everything was exchanged.
      * @throws IllegalArgumentException If the given resource is empty or the amount is negative. See also {@link TransferPreconditions#checkNonEmptyNonNegative} to help perform this check.
      * @throws IllegalStateException    If the current resource is empty.
      * @return The amount that was exchanged. Between {@code 0} (inclusive, nothing was exchanged) and {@code amount} (inclusive, everything was exchanged).
      */
     @ApiStatus.NonExtendable
-    default int exchange(ItemResource newResource, int amount, TransactionContext transaction) {
+    default int exchange(ItemResource newResource, int amount, @Nullable TransactionContext transaction) {
         TransferPreconditions.checkNonEmptyNonNegative(newResource, amount);
         var currentResource = getResource();
         TransferPreconditions.checkNonEmpty(currentResource);

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidResource.java
@@ -199,7 +199,7 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
     }
 
     @Override
-    public <D> FluidResource with(DataComponentType<D> type, D data) {
+    public <D> FluidResource with(DataComponentType<D> type, @Nullable D data) {
         if (isEmpty()) return FluidResource.EMPTY;
         if (Objects.equals(get(type), data)) return this;
 
@@ -210,7 +210,7 @@ public final class FluidResource implements DataComponentHolderResource<Fluid> {
 
     //This is overridden to return FluidResource to allow method chaining
     @Override
-    public <D> FluidResource with(Supplier<? extends DataComponentType<D>> type, D data) {
+    public <D> FluidResource with(Supplier<? extends DataComponentType<D>> type, @Nullable D data) {
         return with(type.get(), data);
     }
 

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemResource.java
@@ -248,7 +248,7 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
     }
 
     @Override
-    public <D> ItemResource with(DataComponentType<D> type, D data) {
+    public <D> ItemResource with(DataComponentType<D> type, @Nullable D data) {
         if (isEmpty()) return ItemResource.EMPTY;
         if (Objects.equals(get(type), data)) return this;
 
@@ -259,7 +259,7 @@ public final class ItemResource implements DataComponentHolderResource<Item> {
 
     //This is overridden to return ItemResource to allow method chaining
     @Override
-    public <D> ItemResource with(Supplier<? extends DataComponentType<D>> type, D data) {
+    public <D> ItemResource with(Supplier<? extends DataComponentType<D>> type, @Nullable D data) {
         return with(type.get(), data);
     }
 

--- a/src/main/java/net/neoforged/neoforge/transfer/resource/DataComponentHolderResource.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/resource/DataComponentHolderResource.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentHolder;
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.component.DataComponentType;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Helper interface for resources backed by a registry entry and which also hold data component values.
@@ -40,7 +41,7 @@ public interface DataComponentHolderResource<T> extends RegisteredResource<T>, D
      * @param data the data to set
      * @param <D>  the type of data component
      */
-    <D> DataComponentHolderResource<T> with(DataComponentType<D> type, D data);
+    <D> DataComponentHolderResource<T> with(DataComponentType<D> type, @Nullable D data);
 
     /**
      * {@return a resource without the data component, i.e. with the data component explicitly removed}
@@ -61,7 +62,7 @@ public interface DataComponentHolderResource<T> extends RegisteredResource<T>, D
      * @param data the data to set
      * @param <D>  the type of data component
      */
-    default <D> DataComponentHolderResource<T> with(Supplier<? extends DataComponentType<D>> type, D data) {
+    default <D> DataComponentHolderResource<T> with(Supplier<? extends DataComponentType<D>> type, @Nullable D data) {
         return with(type.get(), data);
     }
 


### PR DESCRIPTION
- Adds a missing nullable annotation to ItemAccess#exchange which is marked as NonExtendable so is not a breaking change, and it already opens a sub transaction (or in this case root transaction if passed null)
- Adds missing nullable annotations to both forms of `DataComponentHolderResource#with`. This technically could be a breaking change for custom resources if they don't accept null but as it is still during the breaking change phase I think it is worth it rather than only adding it to `FluidResource` and `ItemResource`. The reason it is needed for `ItemResource` and `FluidResource` need it is that the way to reset a resource's data components to default value is by setting them to `null`, as opposed to `without` which makes the component explicitly not present.