### PR TITLE
[26.1] Allow a null return from ItemAcccess#update to indicate container item should be consumed

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -163,8 +163,8 @@ public class FluidHandlerItemStack implements IFluidHandlerItem {
     /**
      * Destroys the container item when it's emptied.
      *
-     * @deprecated Deprecated with no direct equivalent, however {@link ItemAccessFluidHandler} can serve as inspiration.
-     *             Please open an issue on GitHub if you have a use for an equivalent of this class.
+     * @deprecated Use {@link ItemAccessFluidHandler} instead, with an override of {@link ItemAccessFluidHandler#update}
+     *             to return {@code null} if the fluid amount is 0.
      */
     @Deprecated(since = "1.21.9", forRemoval = true)
     public static class Consumable extends FluidHandlerItemStack {

--- a/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/ItemAccessResourceHandler.java
@@ -10,6 +10,7 @@ import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.resource.Resource;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Base implementation of a {@link ResourceHandler} backed by an {@link ItemAccess}.
@@ -55,11 +56,12 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
      * @param newResource    the new resource, <strong>never empty</strong>: empty is indicated by a 0 amount
      * @param newAmount      the new amount
      * @return {@code accessResource} updated with the new resource and amount,
-     *         or {@link ItemResource#EMPTY} if the new resource or amount cannot be stored
+     *         or {@link ItemResource#EMPTY} if the new resource or amount cannot be stored,
+     *         or {@code null} if the container items should be consumed instead of replaced
      * @implNote This function <strong>should not</strong> mutate the {@linkplain #itemAccess item access},
      *           that will be done by the calling code based on the results of this function.
      */
-    // TODO: we could allow returning null when the resource/amount should be deleted, to allow for "consumable" implementations with minimal effort
+    @Nullable
     protected abstract ItemResource update(ItemResource accessResource, int index, T newResource, int newAmount);
 
     /**
@@ -137,7 +139,9 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
             if (insertedPerItem > 0) {
                 ItemResource filledResource = update(accessResource, index, resource, insertedPerItem + currentAmountPerItem);
 
-                if (!filledResource.isEmpty()) {
+                if (filledResource == null) {
+                    return insertedPerItem * itemAccess.extract(itemAccess.getResource(), accessAmount, transaction);
+                } else if (!filledResource.isEmpty()) {
                     return insertedPerItem * itemAccess.exchange(filledResource, accessAmount, transaction);
                 }
             }
@@ -166,7 +170,9 @@ public abstract class ItemAccessResourceHandler<T extends Resource> implements R
             if (extractedPerItem > 0) {
                 ItemResource emptiedResource = update(accessResource, index, resource, currentAmountPerItem - extractedPerItem);
 
-                if (!emptiedResource.isEmpty()) {
+                if (emptiedResource == null) {
+                    return extractedPerItem * itemAccess.extract(itemAccess.getResource(), accessAmount, transaction);
+                } else if (!emptiedResource.isEmpty()) {
                     return extractedPerItem * itemAccess.exchange(emptiedResource, accessAmount, transaction);
                 }
             }

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/ItemAccessFluidHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/ItemAccessFluidHandler.java
@@ -12,6 +12,7 @@ import net.neoforged.neoforge.transfer.ItemAccessResourceHandler;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.item.ItemResource;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Base implementation of a simple fluid {@link ResourceHandler} backed by an {@link ItemAccess}.
@@ -51,6 +52,7 @@ public class ItemAccessFluidHandler extends ItemAccessResourceHandler<FluidResou
     }
 
     @Override
+    @Nullable
     protected ItemResource update(ItemResource accessResource, int index, FluidResource newResource, int newAmount) {
         return accessResource.with(component, SimpleFluidContent.copyOf(newResource.toStack(newAmount)));
     }

--- a/src/main/java/net/neoforged/neoforge/transfer/item/ItemAccessItemHandler.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/item/ItemAccessItemHandler.java
@@ -16,6 +16,7 @@ import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 import net.neoforged.neoforge.transfer.ItemAccessResourceHandler;
 import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.access.ItemAccess;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Base implementation of an item {@link ResourceHandler} backed by an {@link ItemAccess}.
@@ -75,6 +76,7 @@ public class ItemAccessItemHandler extends ItemAccessResourceHandler<ItemResourc
     }
 
     @Override
+    @Nullable
     protected ItemResource update(ItemResource accessResource, int index, ItemResource newResource, int newAmount) {
         var contents = getContents(accessResource);
         // Ensure we don't truncate any data by taking the max of the number of slots we need to fit, and our desired size

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ConsumableItemAccessTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ConsumableItemAccessTest.java
@@ -1,0 +1,74 @@
+package net.neoforged.neoforge.unittest.transfer;
+
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.SimpleFluidContent;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.transfer.access.ItemAccess;
+import net.neoforged.neoforge.transfer.fluid.FluidResource;
+import net.neoforged.neoforge.transfer.fluid.ItemAccessFluidHandler;
+import net.neoforged.neoforge.transfer.item.ItemResource;
+import net.neoforged.neoforge.transfer.transaction.Transaction;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConsumableItemAccessTest {
+    @Test
+    void testConsumableFluidAccessItem() {
+        FluidResource water = FluidResource.of(Fluids.WATER);
+        ItemStack containerItem = new ItemStack(Items.DIAMOND);
+        containerItem.set(TestMod.STORED_FLUID, SimpleFluidContent.copyOf(new FluidStack(Fluids.WATER, 1000)));
+
+        ConsumableFluidHandler handler = new ConsumableFluidHandler(ItemAccess.forStack(containerItem));
+
+        try (Transaction transaction = Transaction.openRoot()) {
+            handler.insert(water, 100, transaction);
+            transaction.commit();
+        }
+        assertFalse(containerItem.isEmpty(), "fluid container item should not be empty");
+
+        try (Transaction transaction = Transaction.openRoot()) {
+            handler.extract(water, 1100, transaction);
+            transaction.commit();
+        }
+        assertTrue(containerItem.isEmpty(), "fluid container item should be empty");
+    }
+
+    private static class ConsumableFluidHandler extends ItemAccessFluidHandler {
+        public ConsumableFluidHandler(ItemAccess itemAccess) {
+            super(itemAccess, TestMod.STORED_FLUID.get(), 1000);
+        }
+
+        @Override
+        protected @Nullable ItemResource update(ItemResource accessResource, int index, FluidResource newResource, int newAmount) {
+            return newResource.isEmpty() || newAmount == 0 ? null : super.update(accessResource, index, newResource, newAmount);
+        }
+    }
+
+    @Mod(TestMod.MOD_ID)
+    public static class TestMod {
+        public static final String MOD_ID = "consumable_item_access_test";
+        private static final DeferredRegister.DataComponents COMPONENTS
+                = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, MOD_ID);
+        public static final Supplier<DataComponentType<SimpleFluidContent>> STORED_FLUID
+                = COMPONENTS.registerComponentType("stored_fluid", builder -> builder
+                .persistent(SimpleFluidContent.CODEC)
+                .networkSynchronized(SimpleFluidContent.STREAM_CODEC)
+        );
+
+        public TestMod(IEventBus modBus) {
+            COMPONENTS.register(modBus);
+        }
+    }
+}

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ConsumableItemAccessTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ConsumableItemAccessTest.java
@@ -5,6 +5,10 @@
 
 package net.neoforged.neoforge.unittest.transfer;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.ItemStack;
@@ -22,11 +26,6 @@ import net.neoforged.neoforge.transfer.item.ItemResource;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-
-import java.util.function.Supplier;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumableItemAccessTest {
     @Test
@@ -64,13 +63,10 @@ public class ConsumableItemAccessTest {
     @Mod(TestMod.MOD_ID)
     public static class TestMod {
         public static final String MOD_ID = "consumable_item_access_test";
-        private static final DeferredRegister.DataComponents COMPONENTS
-                = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, MOD_ID);
-        public static final Supplier<DataComponentType<SimpleFluidContent>> STORED_FLUID
-                = COMPONENTS.registerComponentType("stored_fluid", builder -> builder
+        private static final DeferredRegister.DataComponents COMPONENTS = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, MOD_ID);
+        public static final Supplier<DataComponentType<SimpleFluidContent>> STORED_FLUID = COMPONENTS.registerComponentType("stored_fluid", builder -> builder
                 .persistent(SimpleFluidContent.CODEC)
-                .networkSynchronized(SimpleFluidContent.STREAM_CODEC)
-        );
+                .networkSynchronized(SimpleFluidContent.STREAM_CODEC));
 
         public TestMod(IEventBus modBus) {
             COMPONENTS.register(modBus);

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ConsumableItemAccessTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/transfer/ConsumableItemAccessTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.neoforge.unittest.transfer;
 
 import net.minecraft.core.component.DataComponentType;

--- a/tests/src/junit/resources/META-INF/neoforge.mods.toml
+++ b/tests/src/junit/resources/META-INF/neoforge.mods.toml
@@ -16,3 +16,5 @@ modId="startup_config_test"
 [[mods]]
 modId="custom_feature_flags_test"
 featureFlags="feature_flags.json"
+[[mods]]
+modId="consumable_item_access_test"


### PR DESCRIPTION
This change modifies `ItemAccess#update` to make the method return value nullable. A null return value indicates that the container item should be consumed rather than exchanged with another item (or indeed the same item with new data components).

Typical usage would be to extend e.g. `ItemAccessFluidHandler` like this:

```java
    private static class ConsumableFluidHandler extends ItemAccessFluidHandler {
        public ConsumableFluidHandler(ItemAccess itemAccess) {
            super(itemAccess, TestMod.STORED_FLUID.get(), 1000);
        }

        @Override
        protected @Nullable ItemResource update(ItemResource accessResource, int index, FluidResource newResource, int newAmount) {
            return newResource.isEmpty() || newAmount == 0 ? null : super.update(accessResource, index, newResource, newAmount);
        }
    }
```

Unit test provided. This has also been tested with an external mod (FTB Stuff & Things, which provides a consumable fluid capsule item which disappears when emptied).