### PR TITLE
Fix missing nullcheck for LevelEvent.Unload in Minecraft#clearClientLevel

### DIFF
--- a/patches/net/minecraft/client/Minecraft.java.patch
+++ b/patches/net/minecraft/client/Minecraft.java.patch
@@ -356,7 +356,7 @@
          this.clientLevelTeardownInProgress = true;
  
          try {
-+            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.LevelEvent.Unload(this.level));
++            if (this.level != null) net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.level.LevelEvent.Unload(this.level));
              this.updateScreenAndTick(p_294558_);
              this.gui.onDisconnected();
              this.level = null;


### PR DESCRIPTION
#3151 introduced the firing of LevelEvent.Unload in Minecraft#clearClientLevel, and was backported to 1.21.1 in #3168 

However, the backport did not include the nullcheck which was present in the original PR and can cause NullPointerExceptions.