### PR TITLE
Fix invisible channel name text on ModMismatchDisconnectedScreen

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/ModMismatchDisconnectedScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ModMismatchDisconnectedScreen.java
@@ -33,6 +33,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.ARGB;
 import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.util.Util;
 import net.neoforged.fml.ModList;
@@ -249,9 +250,9 @@ public class ModMismatchDisconnectedScreen extends Screen {
                 int color = styleColor != null ? styleColor.getValue() : 0xFFFFFFFF;
                 //Only indent the given name if a version string is present. This makes it easier to distinguish table section headers and mod entries
                 int nameLeft = left + border + (reasons == null ? 0 : nameIndent);
-                guiGraphics.text(font, name, nameLeft, relativeY + i * ROW_HEIGHT, color, false);
+                guiGraphics.text(font, name, nameLeft, relativeY + i * ROW_HEIGHT, ARGB.opaque(color), false);
                 if (reasons != null) {
-                    guiGraphics.text(font, reasons, left + border + nameIndent + nameWidth, relativeY + i * ROW_HEIGHT, color, false);
+                    guiGraphics.text(font, reasons, left + border + nameIndent + nameWidth, relativeY + i * ROW_HEIGHT, ARGB.opaque(color), false);
                 }
 
                 i++;


### PR DESCRIPTION
This PR fixes issue #3195. The invisible channel name and reason text on `ModMismatchDisconnectedScreen` was caused by 0 alpha color applied by ChatFormatting. `GuiGraphicsExtractor.text` will skip the actual submission if the alpha of the provided text color is 0. An `ARGB.opaque(int color)` should be applied to the color in the submission of both channel name text and reason text in order to make them visible.

## Before:
<img width="856" height="512" alt="mismatch_before" src="https://github.com/user-attachments/assets/2b050fd8-f839-444f-aea2-bde311c8bb63" />

## After:
<img width="856" height="512" alt="mismatch_after" src="https://github.com/user-attachments/assets/f7843c96-0de9-4e81-8886-552edfb2a217" />
