### PR TITLE
Add flip frame event for managing per-frame GPU resources and rotating custom dynamic uniforms.

### DIFF
--- a/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
+++ b/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
@@ -8,6 +8,14 @@
  
      public static SamplerCache getSamplerCache() {
          return samplerCache;
+@@ -121,6 +_,7 @@
+ 
+         dynamicUniforms.reset();
+         Minecraft.getInstance().levelRenderer.endFrame();
++        net.neoforged.neoforge.client.ClientHooks.fireFlipFrame();
+     }
+ 
+     public static void setShaderFog(GpuBufferSlice fog) {
 @@ -379,4 +_,38 @@
      @OnlyIn(Dist.CLIENT)
      record GpuAsyncTask(Runnable callback, GpuFence fence) {

--- a/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
+++ b/patches/com/mojang/blaze3d/systems/RenderSystem.java.patch
@@ -12,7 +12,7 @@
  
          dynamicUniforms.reset();
          Minecraft.getInstance().levelRenderer.endFrame();
-+        net.neoforged.neoforge.client.ClientHooks.fireFlipFrame();
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.FlipFrameEvent());
      }
  
      public static void setShaderFog(GpuBufferSlice fog) {

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -159,6 +159,7 @@ import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
 import net.neoforged.neoforge.client.event.ConfigureMainRenderTargetEvent;
 import net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.FlipFrameEvent;
 import net.neoforged.neoforge.client.event.FrameGraphSetupEvent;
 import net.neoforged.neoforge.client.event.GatherEffectScreenTooltipsEvent;
 import net.neoforged.neoforge.client.event.InitializeClientRegistriesEvent;
@@ -914,6 +915,10 @@ public class ClientHooks {
 
     public static void fireWindowResize(Window window) {
         NeoForge.EVENT_BUS.post(new WindowResizeEvent(window));
+    }
+
+    public static void fireFlipFrame() {
+        NeoForge.EVENT_BUS.post(new FlipFrameEvent());
     }
 
     /**

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -159,7 +159,6 @@ import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
 import net.neoforged.neoforge.client.event.ConfigureMainRenderTargetEvent;
 import net.neoforged.neoforge.client.event.CustomizeGuiOverlayEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
-import net.neoforged.neoforge.client.event.FlipFrameEvent;
 import net.neoforged.neoforge.client.event.FrameGraphSetupEvent;
 import net.neoforged.neoforge.client.event.GatherEffectScreenTooltipsEvent;
 import net.neoforged.neoforge.client.event.InitializeClientRegistriesEvent;
@@ -915,10 +914,6 @@ public class ClientHooks {
 
     public static void fireWindowResize(Window window) {
         NeoForge.EVENT_BUS.post(new WindowResizeEvent(window));
-    }
-
-    public static void fireFlipFrame() {
-        NeoForge.EVENT_BUS.post(new FlipFrameEvent());
     }
 
     /**

--- a/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
@@ -5,13 +5,15 @@
 
 package net.neoforged.neoforge.client.event;
 
+import com.mojang.blaze3d.TracyFrameCapture;
+import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.renderer.DynamicUniformStorage;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 
-/// Fired when the frame [`flipped`][com.mojang.blaze3d.systems.RenderSystem#flipFrame(com.mojang.blaze3d.TracyFrameCapture)].
+/// Fired when the frame [`flipped`][RenderSystem#flipFrame(TracyFrameCapture)].
 ///
 /// This event can be used to manage per-frame GPU resources, or rotate custom [`dynamic uniforms`][DynamicUniformStorage].
 ///

--- a/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
@@ -11,6 +11,8 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 
+/// Fired when the frame [`flipped`][com.mojang.blaze3d.systems.RenderSystem#flipFrame(com.mojang.blaze3d.TracyFrameCapture)].
+///
 /// This event can be used to manage per-frame GPU resources, or rotate custom [`dynamic uniforms`][DynamicUniformStorage].
 ///
 /// This event is not [cancellable][ICancellableEvent]

--- a/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import net.minecraft.client.renderer.DynamicUniformStorage;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+
+/**
+ * This event can be used to reset per-frame GPU resources, or rotate custom {@link DynamicUniformStorage dynamic uniforms}.
+ *
+ * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
+ *
+ * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main NeoForge event bus}, only on the
+ * {@linkplain LogicalSide#CLIENT logical client}.</p>
+ */
+public class FlipFrameEvent extends Event {
+
+}

--- a/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
@@ -13,7 +13,7 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 
-/// Fired when the frame [`flipped`][RenderSystem#flipFrame(TracyFrameCapture)].
+/// Fired when the frame is [`flipped`][RenderSystem#flipFrame(TracyFrameCapture)].
 ///
 /// This event can be used to manage per-frame GPU resources, or rotate custom [`dynamic uniforms`][DynamicUniformStorage].
 ///

--- a/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
@@ -12,7 +12,7 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 
 /**
- * This event can be used to reset per-frame GPU resources, or rotate custom {@link DynamicUniformStorage dynamic uniforms}.
+ * This event can be used to manage per-frame GPU resources, or rotate custom {@link DynamicUniformStorage dynamic uniforms}.
  *
  * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
  *

--- a/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/FlipFrameEvent.java
@@ -11,14 +11,12 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 
-/**
- * This event can be used to manage per-frame GPU resources, or rotate custom {@link DynamicUniformStorage dynamic uniforms}.
- *
- * <p>This event is not {@linkplain ICancellableEvent cancellable}</p>
- *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main NeoForge event bus}, only on the
- * {@linkplain LogicalSide#CLIENT logical client}.</p>
- */
+/// This event can be used to manage per-frame GPU resources, or rotate custom [`dynamic uniforms`][DynamicUniformStorage].
+///
+/// This event is not [cancellable][ICancellableEvent]
+///
+/// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS], only on the
+/// [logical client][LogicalSide#CLIENT].
 public class FlipFrameEvent extends Event {
 
 }


### PR DESCRIPTION
## Proposal

Dynamic uniforms need to be rotated (`DynamicUniformStorage#endFrame()`) every time the frame is presented. Currently there is no event for that and modders have to use Mixin to inject `RenderSystem#flipFrame()` or `LevelRenderer#endFrame()`. Therefore a new event `FlipFrameEvent` should be added for modders to easily manage their per-frame GPU resources and custom dynamic uniforms.

## Difference from `RenderFrameEvent.Post`:

The FlipFrameEvent is fired in the `RenderSystem#flipFrame()` which the vanilla Minecraft uses to rotate its dynamic uniforms. It is safer and more consistent for resource management compared to `RenderFrameEvent.Post` which fires immediately after `GameRenderer#render(...)`.