### PR TITLE
[26.2] Add API for custom feature renderers

### DIFF
--- a/patches/net/minecraft/client/renderer/SubmitNodeCollection.java.patch
+++ b/patches/net/minecraft/client/renderer/SubmitNodeCollection.java.patch
@@ -9,13 +9,10 @@
              this.translucentBlocksAndItems.submit(submit);
          } else {
              this.solid.submit(submit);
-@@ -249,6 +_,27 @@
-                         )
-                     );
-             }
-+        }
-+    }
-+
+@@ -252,6 +_,27 @@
+         }
+     }
+ 
 +    @Override
 +    public void submitMultiLayerBlockModel(
 +            PoseStack poseStack,
@@ -34,6 +31,23 @@
 +            this.translucentBlocksAndItems.submit(submit);
 +        } else {
 +            this.solid.submit(submit);
++        }
++    }
++
+     private static @Nullable RenderType getOutlineRenderType(RenderType renderType) {
+         if (renderType.isOutline()) {
+             return renderType;
+@@ -350,6 +_,13 @@
+         } else {
+             this.gizmos.submit(submit);
          }
++    }
++
++    @Override
++    public <T extends net.minecraft.client.renderer.feature.submit.SubmitNode, S extends T> void submitSpecial(
++        net.neoforged.neoforge.client.submit.RenderPhaseKey<T> phaseKey, S submitNode
++    ) {
++        phaseKey.resolve(this).submit(submitNode);
      }
  
+     public List<FeatureRenderPhase<?>> allPhases() {

--- a/patches/net/minecraft/client/renderer/feature/FeatureRenderDispatcher.java.patch
+++ b/patches/net/minecraft/client/renderer/feature/FeatureRenderDispatcher.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/client/renderer/feature/FeatureRenderDispatcher.java
 +++ b/net/minecraft/client/renderer/feature/FeatureRenderDispatcher.java
-@@ -55,6 +_,8 @@
+@@ -55,6 +_,7 @@
          this.featureRenderers.put(QuadParticleFeatureRenderer.TYPE, new QuadParticleFeatureRenderer());
          this.featureRenderers.put(ShapeOutlineFeatureRenderer.TYPE, new ShapeOutlineFeatureRenderer());
          this.featureRenderers.put(GizmoFeatureRenderer.TYPE, new GizmoFeatureRenderer());
-+        this.featureRenderers.put(net.neoforged.neoforge.client.submit.ExtendedBlockModelFeatureRenderer.TYPE, new net.neoforged.neoforge.client.submit.ExtendedBlockModelFeatureRenderer());
-+        // TODO 26.2: add registration event
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.client.event.RegisterFeatureRenderersEvent(this.featureRenderers));
      }
  
      public FeatureRenderDispatcher.PreparedFrame prepareFrame(SubmitNodeStorage submitNodeStorage) {

--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -42,6 +42,7 @@ import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.RegisterBlockStateModels;
 import net.neoforged.neoforge.client.event.RegisterClientCommandsEvent;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
+import net.neoforged.neoforge.client.event.RegisterFeatureRenderersEvent;
 import net.neoforged.neoforge.client.event.RegisterFluidModelsEvent;
 import net.neoforged.neoforge.client.event.RegisterItemModelsEvent;
 import net.neoforged.neoforge.client.event.RegisterSpriteSourcesEvent;
@@ -57,6 +58,7 @@ import net.neoforged.neoforge.client.model.item.DynamicFluidContainerModel;
 import net.neoforged.neoforge.client.model.item.TrimmedArmorModel;
 import net.neoforged.neoforge.client.model.obj.ObjLoader;
 import net.neoforged.neoforge.client.resources.VanillaClientListeners;
+import net.neoforged.neoforge.client.submit.ExtendedBlockModelFeatureRenderer;
 import net.neoforged.neoforge.client.textures.DirectoryPalettedPermutations;
 import net.neoforged.neoforge.client.textures.NamespacedDirectoryLister;
 import net.neoforged.neoforge.common.ModConfigSpec;
@@ -149,6 +151,10 @@ public class ClientNeoForgeMod {
                     Minecraft.getInstance().getModelManager().getItemModel(modelId);
                 }
             }
+        });
+
+        NeoForge.EVENT_BUS.addListener(RegisterFeatureRenderersEvent.class, event -> {
+            event.register(ExtendedBlockModelFeatureRenderer.TYPE, new ExtendedBlockModelFeatureRenderer());
         });
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/event/RegisterFeatureRenderersEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RegisterFeatureRenderersEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.event;
+
+import net.minecraft.client.renderer.feature.FeatureRenderDispatcher;
+import net.minecraft.client.renderer.feature.FeatureRenderer;
+import net.minecraft.client.renderer.feature.FeatureRendererMap;
+import net.minecraft.client.renderer.feature.FeatureRendererType;
+import net.minecraft.client.renderer.feature.submit.SubmitNode;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.ICancellableEvent;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+
+/// Fired when a [FeatureRenderDispatcher] collects all [FeatureRenderer]s for mods to register renderers
+/// for custom [SubmitNode]s.
+///
+/// This event is not [cancelable][ICancellableEvent].
+///
+/// This event fires on the [game event bus][NeoForge#EVENT_BUS] only on the [logical client][LogicalSide#CLIENT].
+public final class RegisterFeatureRenderersEvent extends Event {
+    private final FeatureRendererMap featureRenderers;
+
+    @ApiStatus.Internal
+    public RegisterFeatureRenderersEvent(FeatureRendererMap featureRenderers) {
+        this.featureRenderers = featureRenderers;
+    }
+
+    /// Register the provided [FeatureRenderer] for [SubmitNode]s referencing the given [FeatureRendererType].
+    ///
+    /// @param type     The type referenced by the [SubmitNode]s
+    /// @param renderer The feature renderer to use for rendering the [SubmitNode]s
+    public <S extends SubmitNode> void register(FeatureRendererType<S> type, FeatureRenderer<S> renderer) {
+        if (this.featureRenderers.get(type) != null) {
+            throw new IllegalStateException("Duplicate renderer registration for " + type);
+        }
+        this.featureRenderers.put(type, renderer);
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/extensions/OrderedSubmitNodeCollectorExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/OrderedSubmitNodeCollectorExtension.java
@@ -10,6 +10,9 @@ import java.util.List;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.feature.phase.FeatureRenderPhase;
+import net.minecraft.client.renderer.feature.submit.SubmitNode;
+import net.neoforged.neoforge.client.submit.RenderPhaseKey;
 
 public interface OrderedSubmitNodeCollectorExtension {
     /// Submit the provided [BlockStateModelPart]s with full support for per-quad render types.
@@ -30,4 +33,10 @@ public interface OrderedSubmitNodeCollectorExtension {
             int lightCoords,
             int overlayCoords,
             int outlineColor) {}
+
+    /// Submit the provided [SubmitNode] to the [FeatureRenderPhase] identified by the provided [RenderPhaseKey].
+    ///
+    /// @param phaseKey   The render phase to submit to
+    /// @param submitNode The submit node to submit
+    default <T extends SubmitNode, S extends T> void submitSpecial(RenderPhaseKey<T> phaseKey, S submitNode) {}
 }

--- a/src/client/java/net/neoforged/neoforge/client/extensions/SubmitNodeStorageExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/SubmitNodeStorageExtension.java
@@ -10,6 +10,8 @@ import java.util.List;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.feature.submit.SubmitNode;
+import net.neoforged.neoforge.client.submit.RenderPhaseKey;
 
 public interface SubmitNodeStorageExtension extends SubmitNodeCollector {
     private SubmitNodeStorage self() {
@@ -28,12 +30,8 @@ public interface SubmitNodeStorageExtension extends SubmitNodeCollector {
         self().order(0).submitMultiLayerBlockModel(poseStack, modelParts, translucent, tintLayers, lightCoords, overlayCoords, outlineColor);
     }
 
-    record MultiLayerBlockModelSubmit(
-            PoseStack.Pose pose,
-            List<BlockStateModelPart> modelParts,
-            boolean translucent,
-            int[] tintLayers,
-            int lightCoords,
-            int overlayCoords,
-            int outlineColor) {}
+    @Override
+    default <T extends SubmitNode, S extends T> void submitSpecial(RenderPhaseKey<T> phaseKey, S submitNode) {
+        self().order(0).submitSpecial(phaseKey, submitNode);
+    }
 }

--- a/src/client/java/net/neoforged/neoforge/client/submit/RenderPhaseKey.java
+++ b/src/client/java/net/neoforged/neoforge/client/submit/RenderPhaseKey.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.submit;
+
+import java.util.function.Function;
+import net.minecraft.client.renderer.SubmitNodeCollection;
+import net.minecraft.client.renderer.feature.phase.FeatureRenderPhase;
+import net.minecraft.client.renderer.feature.submit.SubmitNode;
+import net.neoforged.neoforge.client.extensions.OrderedSubmitNodeCollectorExtension;
+
+/// Identifies a specific [FeatureRenderPhase] in a typesafe way and can resolve it from a [SubmitNodeCollection].
+///
+/// @see OrderedSubmitNodeCollectorExtension#submitSpecial(RenderPhaseKey, SubmitNode)
+public final class RenderPhaseKey<T extends SubmitNode> {
+    private final Function<SubmitNodeCollection, FeatureRenderPhase<T>> phaseGetter;
+
+    public RenderPhaseKey(Function<SubmitNodeCollection, FeatureRenderPhase<T>> phaseGetter) {
+        this.phaseGetter = phaseGetter;
+    }
+
+    public FeatureRenderPhase<T> resolve(SubmitNodeCollection collection) {
+        return this.phaseGetter.apply(collection);
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/submit/RenderPhaseKeys.java
+++ b/src/client/java/net/neoforged/neoforge/client/submit/RenderPhaseKeys.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.submit;
+
+import net.minecraft.client.renderer.feature.phase.FeatureRenderPhase;
+import net.minecraft.client.renderer.feature.submit.SubmitNode;
+import net.minecraft.client.renderer.feature.submit.TranslucentSubmit;
+import net.neoforged.neoforge.client.extensions.OrderedSubmitNodeCollectorExtension;
+
+/// Holds the [RenderPhaseKey]s for all vanilla [FeatureRenderPhase]s.
+///
+/// @see OrderedSubmitNodeCollectorExtension#submitSpecial(RenderPhaseKey, SubmitNode)
+public final class RenderPhaseKeys {
+    public static final RenderPhaseKey<SubmitNode> SOLID = new RenderPhaseKey<>(collection -> collection.solid);
+    public static final RenderPhaseKey<SubmitNode> SHADOWS = new RenderPhaseKey<>(collection -> collection.shadows);
+    public static final RenderPhaseKey<SubmitNode> NAME_TAGS = new RenderPhaseKey<>(collection -> collection.nameTags);
+    public static final RenderPhaseKey<TranslucentSubmit> SEE_THROUGH_NAME_TAGS = new RenderPhaseKey<>(collection -> collection.seeThroughNameTags);
+    public static final RenderPhaseKey<SubmitNode> TEXTS = new RenderPhaseKey<>(collection -> collection.texts);
+    public static final RenderPhaseKey<SubmitNode> SHAPE_OUTLINES = new RenderPhaseKey<>(collection -> collection.shapeOutlines);
+    public static final RenderPhaseKey<TranslucentSubmit> TRANSLUCENT_BLOCKS_AND_ITEMS = new RenderPhaseKey<>(collection -> collection.translucentBlocksAndItems);
+    public static final RenderPhaseKey<TranslucentSubmit> TRANSLUCENT_MODELS = new RenderPhaseKey<>(collection -> collection.translucentModels);
+    public static final RenderPhaseKey<SubmitNode> TRANSLUCENT_CUSTOM_GEOMETRY = new RenderPhaseKey<>(collection -> collection.translucentCustomGeometry);
+    public static final RenderPhaseKey<SubmitNode> GIZMOS = new RenderPhaseKey<>(collection -> collection.gizmos);
+    public static final RenderPhaseKey<SubmitNode> BREAKING_OVERLAY = new RenderPhaseKey<>(collection -> collection.breakingOverlay);
+    public static final RenderPhaseKey<SubmitNode> WATER_MASK = new RenderPhaseKey<>(collection -> collection.waterMask);
+    public static final RenderPhaseKey<SubmitNode> AFTER_TERRAIN = new RenderPhaseKey<>(collection -> collection.afterTerrain);
+    public static final RenderPhaseKey<SubmitNode> ALWAYS_ON_TOP = new RenderPhaseKey<>(collection -> collection.alwaysOnTop);
+    public static final RenderPhaseKey<SubmitNode> OUTLINE = new RenderPhaseKey<>(collection -> collection.outline);
+
+    private RenderPhaseKeys() {}
+}


### PR DESCRIPTION
This PR adds APIs for registering custom `FeatureRenderer`s and submitting `SubmitNode`s for these custom renderers.