### PR TITLE
Fix lastHurt tracking post-reduction damage

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -209,7 +209,7 @@
              if (damage < 0.0F) {
                  damage = 0.0F;
              }
-@@ -1181,24 +_,38 @@
+@@ -1181,20 +_,29 @@
              if (Float.isNaN(damage) || Float.isInfinite(damage)) {
                  damage = Float.MAX_VALUE;
              }
@@ -228,29 +228,20 @@
 +                this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.INVULNERABILITY, this.lastHurt);
                  this.actuallyHurt(level, source, damage - this.lastHurt);
 -                this.lastHurt = damage;
-+                // Vanilla updates lastHurt to the local var `damage`, but we throw an event in actuallyHurt that might mess with the damage.
-+                // Also, since we're in the "damage while invuln is active" block, we need to make sure we don't reduce the lastHurt amount.
-+                this.lastHurt = java.lang.Math.max(this.lastHurt, this.damageContainers.peek().getInflictedDamage());
++                // lastHurt, in both blocks, needs to always be set to the value of `damage` since it is pre-reduction. Using a post reduction value invalidates iframes.
++                // Since we're in the "damage while invuln is active" block, we need to make sure we don't reduce the lastHurt amount.
++                this.lastHurt = java.lang.Math.max(this.lastHurt, damage);
 +                this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
                  tookFullDamage = false;
              } else {
 -                this.lastHurt = damage;
 -                this.invulnerableTime = 20;
                  this.actuallyHurt(level, source, damage);
-+                this.lastHurt = this.damageContainers.peek().getInflictedDamage();
++                this.lastHurt = damage;
 +                this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
                  this.hurtDuration = 10;
                  this.hurtTime = this.hurtDuration;
              }
- 
-+            // Neo: Note that we don't update the local tookFullDamage.
-+            //      Its name doesn't really mean that, and it is instead used to track if we're inside the invuln block above.
-+            //      Also, we need to update the `damage` local with the post-Pre-event value.
-+            damage = this.damageContainers.peek().getInflictedDamage();
-+
-             this.resolveMobResponsibleForDamage(source);
-             this.resolvePlayerResponsibleForDamage(source);
-             if (tookFullDamage) {
 @@ -1267,6 +_,10 @@
                  CriteriaTriggers.PLAYER_HURT_ENTITY.trigger(sourcePlayer, this, source, damage, damage, blocked);
              }


### PR DESCRIPTION
After #3101, `LivingEntity#lastHurt` was tracking `DamageContainer#getInflictedDamage`, which is a post-reduction damage value. The way that `lastHurt` is actually used, however, requires tracking pre-reduction values, otherwise having damage reduction can incur i-frame ignoring attack cycles.

The side effect of this, however, is that if `LivingDamageEvent.Pre` elects to _increase_ the damage taken, it will not be reflected in `lastHurt`. I suppose users should prefer `LivingIncomingDamageEvent` for that, however.

Closes #3201