### PR TITLE
Expose a helper to clear StackCopySlot's cachedReturnStack

### DIFF
--- a/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/world/inventory/StackCopySlot.java
@@ -76,7 +76,13 @@ public abstract class StackCopySlot extends Slot {
         ItemStack stack = getStackCopy().copy();
         ItemStack ret = stack.split(amount);
         set(stack);
-        cachedReturnedStack = null;
+        clearCachedReturnStack();
         return ret;
+    }
+
+    /// Clears the current cached return stack to prevent a [#setChanged] call from potentially overriding the contents of this slot.
+    /// This is useful when the slot's backing inventory may have been modified directly.
+    protected void clearCachedReturnStack() {
+        cachedReturnedStack = null;
     }
 }


### PR DESCRIPTION
Makes it possible to clear the cached return stack for a `StackCopySlot` in cases where the caller might know the cache is out of date (such as if they performed an operation that directly modified the backing handler). My specific use case is clearing the cache after updating a result slot via `Slot#onTake`