### PR TITLE
Fix some inconsistencies in FluidUtil#tryPlaceFluid and allow calling FluidUtil methods from a transactional context

### DIFF
--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
@@ -53,7 +53,7 @@ public final class DispenseFluidContainer extends DefaultDispenseItemBehavior {
 
             // Grow by 1 to match the shrink in consumeWithRemainder
             stack0.grow(1);
-            return this.consumeWithRemainder(source, stack, stack1);
+            return this.consumeWithRemainder(source, stack0, stack1);
         } else {
             return super.execute(source, stack);
         }

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.neoforged.neoforge.capabilities.Capabilities;
@@ -48,7 +47,7 @@ public final class DispenseFluidContainer extends DefaultDispenseItemBehavior {
 
         // First try to pick up fluid in front of the dispenser, then try to drain a filled container and place the fluid in front of the dispenser
         if (!FluidUtil.tryPickupFluid(resourceHandler, null, source.level(), targetPos, dispenserFacing.getOpposite()).isEmpty()
-                || !FluidUtil.tryPlaceFluid(resourceHandler, null, source.level(), InteractionHand.MAIN_HAND, targetPos).isEmpty()) {
+                || !FluidUtil.tryPlaceFluid(resourceHandler, null, source.level(), targetPos).isEmpty()) {
             var stack0 = ItemUtil.getStack(containingHandler, 0);
             var stack1 = ItemUtil.getStack(containingHandler, 1);
 

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
@@ -47,7 +47,7 @@ public final class DispenseFluidContainer extends DefaultDispenseItemBehavior {
 
         // First try to pick up fluid in front of the dispenser, then try to drain a filled container and place the fluid in front of the dispenser
         if (!FluidUtil.tryPickupFluid(resourceHandler, null, source.level(), targetPos, dispenserFacing.getOpposite(), null).isEmpty()
-                || !FluidUtil.tryPlaceFluid(resourceHandler, null, source.level(), targetPos, null).isEmpty()) {
+                || !FluidUtil.tryPlaceFluid(resourceHandler, null, source.level(), targetPos, false, null).isEmpty()) {
             var stack0 = ItemUtil.getStack(containingHandler, 0);
             var stack1 = ItemUtil.getStack(containingHandler, 1);
 

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/DispenseFluidContainer.java
@@ -46,8 +46,8 @@ public final class DispenseFluidContainer extends DefaultDispenseItemBehavior {
         BlockPos targetPos = source.pos().relative(dispenserFacing);
 
         // First try to pick up fluid in front of the dispenser, then try to drain a filled container and place the fluid in front of the dispenser
-        if (!FluidUtil.tryPickupFluid(resourceHandler, null, source.level(), targetPos, dispenserFacing.getOpposite()).isEmpty()
-                || !FluidUtil.tryPlaceFluid(resourceHandler, null, source.level(), targetPos).isEmpty()) {
+        if (!FluidUtil.tryPickupFluid(resourceHandler, null, source.level(), targetPos, dispenserFacing.getOpposite(), null).isEmpty()
+                || !FluidUtil.tryPlaceFluid(resourceHandler, null, source.level(), targetPos, null).isEmpty()) {
             var stack0 = ItemUtil.getStack(containingHandler, 0);
             var stack1 = ItemUtil.getStack(containingHandler, 1);
 

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -16,7 +16,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.BucketPickup;
@@ -242,7 +241,7 @@ public final class FluidUtil {
     /**
      * Tries to extract {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource from a resource handler
      * and place it into the level as a block.
-     * Unlike {@link #tryPlaceFluid(FluidResource, Player, Level, InteractionHand, BlockPos)},
+     * Unlike {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos)},
      * this function will modify the source handler directly and return what was placed.
      *
      * <p>Makes a fluid emptying or vaporization sound when successful.
@@ -255,8 +254,30 @@ public final class FluidUtil {
      * @param hand   Hand of the player to place the fluid with
      * @param pos    The position in the level to place the fluid block
      * @return a {@link FluidStack} holding a copy of the fluid stack that was placed, or {@link FluidStack#EMPTY} if nothing was placed
+     * @deprecated Use {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos)} instead
      */
+    @Deprecated(since = "26.1.2", forRemoval = true)
     public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, InteractionHand hand, BlockPos pos) {
+        return tryPlaceFluid(source, player, level, pos);
+    }
+
+    /**
+     * Tries to extract {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource from a resource handler
+     * and place it into the level as a block.
+     * Unlike {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos)},
+     * this function will modify the source handler directly and return what was placed.
+     *
+     * <p>Makes a fluid emptying or vaporization sound when successful.
+     * Honors the amount of fluid contained by the used container.
+     * Checks if water-like fluids should vaporize like in the nether.
+     *
+     * @param source The source for the placed fluid. May be null.
+     * @param player Player who places the fluid. May be null for blocks like dispensers.
+     * @param level  Level to place the fluid in
+     * @param pos    The position in the level to place the fluid block
+     * @return a {@link FluidStack} holding a copy of the fluid stack that was placed, or {@link FluidStack#EMPTY} if nothing was placed
+     */
+    public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, BlockPos pos) {
         if (source == null) {
             return FluidStack.EMPTY;
         }
@@ -272,7 +293,7 @@ public final class FluidUtil {
                     continue;
                 }
                 // Managed to extract 1 bucket, try to place it!
-                if (tryPlaceFluid(resource, player, level, hand, pos)) {
+                if (tryPlaceFluid(resource, player, level, pos)) {
                     tx.commit();
                     return resource.toStack(FluidType.BUCKET_VOLUME);
                 }
@@ -284,7 +305,7 @@ public final class FluidUtil {
     /**
      * Tries to place {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource into the level as a block.
      * Note that e.g. extracting it from a handler on successful placement is the responsibility of the caller.
-     * See also {@link #tryPlaceFluid(ResourceHandler, Player, Level, InteractionHand, BlockPos)} to modify a source handler directly.
+     * See also {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos)} to modify a source handler directly.
      *
      * <p>Makes a fluid emptying or vaporization sound when successful.
      * Honors the amount of fluid contained by the used container.
@@ -298,20 +319,38 @@ public final class FluidUtil {
      * @param hand     Hand of the player to place the fluid with
      * @param pos      The position in the level to place the fluid block
      * @return true if the placement was successful, false otherwise
+     * @deprecated Use {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos)} instead
      */
+    @Deprecated(since = "26.1.2", forRemoval = true)
     public static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, InteractionHand hand, BlockPos pos) {
+        return tryPlaceFluid(resource, player, level, pos);
+    }
+
+    /// Tries to place [one bucket][FluidType#BUCKET_VOLUME] of a fluid resource into the level as a block.
+    /// Note that e.g. extracting it from a handler on successful placement is the responsibility of the caller.
+    /// See also [#tryPlaceFluid(ResourceHandler, Player, Level, BlockPos)] to modify a source handler directly.
+    ///
+    /// Makes a fluid emptying or vaporization sound when successful.
+    /// Honors the amount of fluid contained by the used container.
+    /// Checks if water-like fluids should vaporize like in the nether.
+    ///
+    /// Modeled after [BucketItem#emptyContents(LivingEntity, Level, BlockPos, BlockHitResult, ItemStack)].
+    ///
+    /// @param resource The fluid resource to place
+    /// @param player   Player who places the fluid. May be null for blocks like dispensers.
+    /// @param level    Level to place the fluid in
+    /// @param pos      The position in the level to place the fluid block
+    /// @return true if the placement was successful, false otherwise
+    public static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, BlockPos pos) {
         var stack = resource.toStack(FluidType.BUCKET_VOLUME);
         var fluidType = resource.getFluidType();
         if (stack.isEmpty() || !fluidType.canBePlacedInLevel(level, pos, stack)) {
             return false;
         }
 
-        var handItem = player == null ? ItemStack.EMPTY : player.getItemInHand(hand);
-        BlockPlaceContext context = new BlockPlaceContext(level, player, hand, handItem, new BlockHitResult(Vec3.atCenterOf(pos), Direction.UP, pos, false));
-
         // check that we can place the fluid at the destination
         BlockState destBlockState = level.getBlockState(pos);
-        boolean isDestReplaceable = destBlockState.canBeReplaced(context);
+        boolean isDestReplaceable = destBlockState.canBeReplaced(resource.getFluid());
         boolean canDestContainFluid = destBlockState.getBlock() instanceof LiquidBlockContainer lbc
                 && lbc.canPlaceLiquid(player, level, pos, destBlockState, resource.getFluid());
         if (!destBlockState.isAir() && !isDestReplaceable && !canDestContainFluid) {

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -34,6 +34,7 @@ import net.neoforged.neoforge.transfer.ResourceHandler;
 import net.neoforged.neoforge.transfer.ResourceHandlerUtil;
 import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.resource.ResourceStack;
+import net.neoforged.neoforge.transfer.transaction.RootCommitJournal;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
 import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 import org.jspecify.annotations.Nullable;
@@ -175,12 +176,12 @@ public final class FluidUtil {
 
         var moved = ResourceHandlerUtil.moveFirst(from, to, fr -> true, Integer.MAX_VALUE, transaction);
         if (moved != null) {
-            playSoundAndGameEvent(moved.resource(), level, pos, player, pickup);
+            playSoundAndGameEvent(moved.resource(), level, pos, player, transaction, pickup);
         }
         return moved;
     }
 
-    private static void playSoundAndGameEvent(FluidResource resource, Level level, @Nullable BlockPos blockPos, @Nullable Player player, boolean pickup) {
+    private static void playSoundAndGameEvent(FluidResource resource, Level level, @Nullable BlockPos blockPos, @Nullable Player player, @Nullable TransactionContext transaction, boolean pickup) {
         if (player == null && blockPos == null) {
             throw new IllegalArgumentException("Either player or blockPos must be provided.");
         }
@@ -188,7 +189,14 @@ public final class FluidUtil {
         // Prioritize block position, use player position as a fallback
         Vec3 position = blockPos != null ? Vec3.atCenterOf(blockPos) : new Vec3(player.getX(), player.getY() + 0.5, player.getZ());
 
-        triggerSoundAndGameEvent(resource, level, position, player, pickup);
+        if (transaction == null) {
+            //No transaction, just trigger the sound and game event immediately
+            triggerSoundAndGameEvent(resource, level, position, player, pickup);
+        } else {
+            //Trigger on root commit
+            RootCommitJournal onRootCommit = new RootCommitJournal(() -> triggerSoundAndGameEvent(resource, level, position, player, pickup));
+            onRootCommit.updateSnapshots(transaction);
+        }
     }
 
     /**
@@ -237,7 +245,7 @@ public final class FluidUtil {
     /// @param pos         The position of the fluid in the level.
     /// @param side        The side of the fluid that is being drained.
     /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
-    /// allow you to make the final decision to commit based on the results of this method.
+    /// allow you to make the final decision to commit based on the results of this method. Note: there may be in world side effects even if the passed transaction is not committed.
     /// @return a [FluidStack] holding a copy of the fluid stack that was picked up, or [FluidStack#EMPTY] if nothing was picked up
     public static FluidStack tryPickupFluid(@Nullable ResourceHandler<FluidResource> destination, @Nullable Player player, Level level, BlockPos pos, @Nullable Direction side, @Nullable TransactionContext transaction) {
         if (destination == null) {
@@ -281,8 +289,8 @@ public final class FluidUtil {
                             BuiltInRegistries.FLUID.getKey(fluid), pos, level.dimension().identifier(), BuiltInRegistries.FLUID.getKey(bucket.content));
                     return FluidStack.EMPTY;
                 }
+                playSoundAndGameEvent(resource, level, pos, player, tx, true);
                 tx.commit();
-                playSoundAndGameEvent(resource, level, pos, player, true);
                 return extracted;
             }
         } else {
@@ -332,7 +340,7 @@ public final class FluidUtil {
     /// @param level  Level to place the fluid in
     /// @param pos    The position in the level to place the fluid block
     /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
-    /// allow you to make the final decision to commit based on the results of this method.
+    /// allow you to make the final decision to commit based on the results of this method. Note: there may be in world side effects even if the passed transaction is not committed.
     /// @return a [FluidStack] holding a copy of the fluid stack that was placed, or [FluidStack#EMPTY] if nothing was placed
     public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, BlockPos pos, boolean validatePlaced, @Nullable TransactionContext transaction) {
         if (source == null) {
@@ -350,7 +358,7 @@ public final class FluidUtil {
                     continue;
                 }
                 // Managed to extract 1 bucket, try to place it!
-                if (tryPlaceFluid(resource, player, level, pos, validatePlaced)) {
+                if (tryPlaceFluid(resource, player, level, pos, validatePlaced, tx)) {
                     tx.commit();
                     return resource.toStack(FluidType.BUCKET_VOLUME);
                 }
@@ -400,6 +408,10 @@ public final class FluidUtil {
     /// @param validatePlaced `true` to respect the result returned by [LiquidBlockContainer#placeLiquid]. To directly mirror [BucketItem#emptyContents] pass `false`.
     /// @return true if the placement was successful, false otherwise
     public static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, BlockPos pos, boolean validatePlaced) {
+        return tryPlaceFluid(resource, player, level, pos, validatePlaced, null);
+    }
+
+    private static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, BlockPos pos, boolean validatePlaced, @Nullable TransactionContext transaction) {
         var stack = resource.toStack(FluidType.BUCKET_VOLUME);
         var fluidType = resource.getFluidType();
         if (stack.isEmpty() || !fluidType.canBePlacedInLevel(level, pos, stack)) {
@@ -432,7 +444,7 @@ public final class FluidUtil {
                 var state = fluidType.getBlockForFluidState(level, pos, resource.getFluid().defaultFluidState());
                 level.setBlock(pos, state, Block.UPDATE_ALL_IMMEDIATE);
             }
-            playSoundAndGameEvent(resource, level, pos, player, false);
+            playSoundAndGameEvent(resource, level, pos, player, transaction, false);
             return true;
         }
     }

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -247,52 +247,15 @@ public final class FluidUtil {
     /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
     /// allow you to make the final decision to commit based on the results of this method. Note: there may be in world side effects even if the passed transaction is not committed.
     /// @return a [FluidStack] holding a copy of the fluid stack that was picked up, or [FluidStack#EMPTY] if nothing was picked up
+    /// @see #tryPickupFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext) For picking up from a BucketPickup without falling back to a fluid handler.
     public static FluidStack tryPickupFluid(@Nullable ResourceHandler<FluidResource> destination, @Nullable Player player, Level level, BlockPos pos, @Nullable Direction side, @Nullable TransactionContext transaction) {
         if (destination == null) {
             return FluidStack.EMPTY;
         }
 
         BlockState state = level.getBlockState(pos);
-        Block block = state.getBlock();
-        if (block instanceof BucketPickup bucketPickup) {
-            // Get stored fluid
-            Fluid fluid = level.getFluidState(pos).getType();
-            if (fluid == Fluids.EMPTY) {
-                return FluidStack.EMPTY;
-            }
-            // Try to insert it into the destination
-            try (var tx = Transaction.open(transaction)) {
-                var resource = FluidResource.of(fluid);
-                int inserted = destination.insert(resource, FluidType.BUCKET_VOLUME, tx);
-                if (inserted != FluidType.BUCKET_VOLUME) {
-                    return FluidStack.EMPTY;
-                }
-                // Fluid could fit, so pickup from the level
-                if (level.getFluidState(pos).getType() != fluid) {
-                    // Inserting into destination caused type in the level to change, aborting
-                    return FluidStack.EMPTY;
-                }
-                ItemStack pickedUpStack = bucketPickup.pickupBlock(player, level, pos, level.getBlockState(pos));
-                if (!(pickedUpStack.getItem() instanceof BucketItem bucket)) {
-                    // Not a bucket, abort
-                    if (!pickedUpStack.isEmpty()) {
-                        // Be loud since we are going to void the stack
-                        LOGGER.warn("Picked up stack is not a bucket. Fluid {} at {} in {} picked up as {}.",
-                                BuiltInRegistries.FLUID.getKey(fluid), pos, level.dimension().identifier(), pickedUpStack);
-                    }
-                    return FluidStack.EMPTY;
-                }
-                FluidStack extracted = new FluidStack(bucket.content, FluidType.BUCKET_VOLUME);
-                if (!resource.matches(extracted)) {
-                    // Be loud if something went wrong
-                    LOGGER.warn("Fluid removed without successfully being picked up. Fluid {} at {} in {} matched requested type, but after performing pickup was {}.",
-                            BuiltInRegistries.FLUID.getKey(fluid), pos, level.dimension().identifier(), BuiltInRegistries.FLUID.getKey(bucket.content));
-                    return FluidStack.EMPTY;
-                }
-                playSoundAndGameEvent(resource, level, pos, player, tx, true);
-                tx.commit();
-                return extracted;
-            }
+        if (state.getBlock() instanceof BucketPickup bucketPickup) {
+            return tryPickupFluid(destination, player, level, pos, bucketPickup, transaction);
         } else {
             var fluidHandler = level.getCapability(Capabilities.Fluid.BLOCK, pos, state, null, side);
             if (fluidHandler == null) {
@@ -300,6 +263,68 @@ public final class FluidUtil {
             }
             var moved = moveWithSound(fluidHandler, destination, level, pos, player, transaction, true);
             return moved != null ? moved.resource().toStack(moved.amount()) : FluidStack.EMPTY;
+        }
+    }
+
+    /// Attempts to pick up a fluid in the level from a [BucketPickup] block (such as fluid sources and waterlogged blocks) and put it into a fluid handler
+    ///
+    /// @param destination The destination for the picked up fluid. May be null.
+    /// @param player      The player filling the container. Optional.
+    /// @param level       The level the fluid is in.
+    /// @param pos         The position of the fluid in the level.
+    /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
+    /// allow you to make the final decision to commit based on the results of this method. Note: there may be in world side effects even if the passed transaction is not committed.
+    /// @return a [FluidStack] holding a copy of the fluid stack that was picked up, or [FluidStack#EMPTY] if nothing was picked up
+    /// @see #tryPickupFluid(ResourceHandler, Player, Level, BlockPos, Direction, TransactionContext) For falling back to picking up from a fluid handler if the block is not a BucketPickup.
+    public static FluidStack tryPickupFluid(@Nullable ResourceHandler<FluidResource> destination, @Nullable Player player, Level level, BlockPos pos, @Nullable TransactionContext transaction) {
+        if (destination == null) {
+            return FluidStack.EMPTY;
+        }
+        BlockState state = level.getBlockState(pos);
+        if (state.getBlock() instanceof BucketPickup bucketPickup) {
+            return tryPickupFluid(destination, player, level, pos, bucketPickup, transaction);
+        }
+        return FluidStack.EMPTY;
+    }
+
+    private static FluidStack tryPickupFluid(ResourceHandler<FluidResource> destination, @Nullable Player player, Level level, BlockPos pos, BucketPickup bucketPickup, @Nullable TransactionContext transaction) {
+        // Get stored fluid
+        Fluid fluid = level.getFluidState(pos).getType();
+        if (fluid == Fluids.EMPTY) {
+            return FluidStack.EMPTY;
+        }
+        // Try to insert it into the destination
+        try (var tx = Transaction.open(transaction)) {
+            var resource = FluidResource.of(fluid);
+            int inserted = destination.insert(resource, FluidType.BUCKET_VOLUME, tx);
+            if (inserted != FluidType.BUCKET_VOLUME) {
+                return FluidStack.EMPTY;
+            }
+            // Fluid could fit, so pickup from the level
+            if (level.getFluidState(pos).getType() != fluid) {
+                // Inserting into destination caused type in the level to change, aborting
+                return FluidStack.EMPTY;
+            }
+            ItemStack pickedUpStack = bucketPickup.pickupBlock(player, level, pos, level.getBlockState(pos));
+            if (!(pickedUpStack.getItem() instanceof BucketItem bucket)) {
+                // Not a bucket, abort
+                if (!pickedUpStack.isEmpty()) {
+                    // Be loud since we are going to void the stack
+                    LOGGER.warn("Picked up stack is not a bucket. Fluid {} at {} in {} picked up as {}.",
+                            BuiltInRegistries.FLUID.getKey(fluid), pos, level.dimension().identifier(), pickedUpStack);
+                }
+                return FluidStack.EMPTY;
+            }
+            FluidStack extracted = new FluidStack(bucket.content, FluidType.BUCKET_VOLUME);
+            if (!resource.matches(extracted)) {
+                // Be loud if something went wrong
+                LOGGER.warn("Fluid removed without successfully being picked up. Fluid {} at {} in {} matched requested type, but after performing pickup was {}.",
+                        BuiltInRegistries.FLUID.getKey(fluid), pos, level.dimension().identifier(), BuiltInRegistries.FLUID.getKey(bucket.content));
+                return FluidStack.EMPTY;
+            }
+            playSoundAndGameEvent(resource, level, pos, player, tx, true);
+            tx.commit();
+            return extracted;
         }
     }
 

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -35,6 +35,7 @@ import net.neoforged.neoforge.transfer.ResourceHandlerUtil;
 import net.neoforged.neoforge.transfer.access.ItemAccess;
 import net.neoforged.neoforge.transfer.resource.ResourceStack;
 import net.neoforged.neoforge.transfer.transaction.Transaction;
+import net.neoforged.neoforge.transfer.transaction.TransactionContext;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -96,13 +97,32 @@ public final class FluidUtil {
      * @param pos    The position of the fluid handler block in the level.
      * @param side   The side of the block to interact with. May be null.
      * @return true if the interaction succeeded, false otherwise.
+     * @deprecated Use {@link #interactWithFluidHandler(Player, InteractionHand, Level, BlockPos, Direction, TransactionContext)} instead.
      */
+    @Deprecated(since = "26.1.2", forRemoval = true)
     public static boolean interactWithFluidHandler(Player player, InteractionHand hand, Level level, BlockPos pos, @Nullable Direction side) {
+        return interactWithFluidHandler(player, hand, level, pos, side, null);
+    }
+
+    /// Used to handle the common case of a player holding a fluid item and right-clicking on a fluid handler block.
+    /// First it tries to fill the item from the block,
+    /// if that action fails then it tries to drain the item into the block.
+    /// Automatically updates the item in the player's hand and stashes any extra items created.
+    ///
+    /// @param player The player doing the interaction between the item and fluid handler block.
+    /// @param hand   The player's hand that is holding an item that should interact with the fluid handler block.
+    /// @param level  The level that contains the fluid handler block.
+    /// @param pos    The position of the fluid handler block in the level.
+    /// @param side   The side of the block to interact with. May be null.
+    /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
+    /// allow you to make the final decision to commit based on the results of this method.
+    /// @return true if the interaction succeeded, false otherwise.
+    public static boolean interactWithFluidHandler(Player player, InteractionHand hand, Level level, BlockPos pos, @Nullable Direction side, @Nullable TransactionContext transaction) {
         Preconditions.checkNotNull(level);
         Preconditions.checkNotNull(pos);
 
         var fluidHandler = level.getCapability(Capabilities.Fluid.BLOCK, pos, side);
-        return fluidHandler != null && interactWithFluidHandler(player, hand, pos, fluidHandler);
+        return fluidHandler != null && interactWithFluidHandler(player, hand, pos, fluidHandler, transaction);
     }
 
     /**
@@ -116,25 +136,44 @@ public final class FluidUtil {
      * @param pos     The position at which to send game events and play sounds. If {@code null}, the player's position will be used.
      * @param handler The fluid handler.
      * @return true if the interaction succeeded, false otherwise.
+     * @deprecated Use {@link #interactWithFluidHandler(Player, InteractionHand, BlockPos, ResourceHandler, TransactionContext)} instead.
      */
+    @Deprecated(since = "26.1.2", forRemoval = true)
     public static boolean interactWithFluidHandler(Player player, InteractionHand hand, @Nullable BlockPos pos, ResourceHandler<FluidResource> handler) {
+        return interactWithFluidHandler(player, hand, pos, handler, null);
+    }
+
+    /// Used to handle the common case of a player holding a fluid item and right-clicking on a fluid handler.
+    /// First it tries to fill the item from the handler,
+    /// if that action fails then it tries to drain the item into the handler.
+    /// Automatically updates the item in the player's hand and stashes any extra items created.
+    ///
+    /// @param player  The player doing the interaction between the item and fluid handler.
+    /// @param hand    The player's hand that is holding an item that should interact with the fluid handler.
+    /// @param pos     The position at which to send game events and play sounds. If `null`, the player's position will be used.
+    /// @param handler The fluid handler.
+    /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
+    /// allow you to make the final decision to commit based on the results of this method.
+    /// @return true if the interaction succeeded, false otherwise.
+    public static boolean interactWithFluidHandler(Player player, InteractionHand hand, @Nullable BlockPos pos, ResourceHandler<FluidResource> handler, @Nullable TransactionContext transaction) {
         var itemAccess = ItemAccess.forPlayerInteraction(player, hand).oneByOne();
         var handHandler = itemAccess.getCapability(Capabilities.Fluid.ITEM);
         if (handHandler == null) {
             return false;
         }
 
-        return moveWithSound(handler, handHandler, player.level(), pos, player, true) != null
-                || moveWithSound(handHandler, handler, player.level(), pos, player, false) != null;
+        return moveWithSound(handler, handHandler, player.level(), pos, player, transaction, true) != null
+                || moveWithSound(handHandler, handler, player.level(), pos, player, transaction, false) != null;
     }
 
     @Nullable
-    private static ResourceStack<FluidResource> moveWithSound(ResourceHandler<FluidResource> from, ResourceHandler<FluidResource> to, Level level, @Nullable BlockPos pos, @Nullable Player player, boolean pickup) {
+    private static ResourceStack<FluidResource> moveWithSound(ResourceHandler<FluidResource> from, ResourceHandler<FluidResource> to, Level level, @Nullable BlockPos pos,
+            @Nullable Player player, @Nullable TransactionContext transaction, boolean pickup) {
         if (player == null && pos == null) {
             throw new IllegalArgumentException("Either player or pos must be provided.");
         }
 
-        var moved = ResourceHandlerUtil.moveFirst(from, to, fr -> true, Integer.MAX_VALUE, null);
+        var moved = ResourceHandlerUtil.moveFirst(from, to, fr -> true, Integer.MAX_VALUE, transaction);
         if (moved != null) {
             playSoundAndGameEvent(moved.resource(), level, pos, player, pickup);
         }
@@ -181,8 +220,26 @@ public final class FluidUtil {
      * @param pos         The position of the fluid in the level.
      * @param side        The side of the fluid that is being drained.
      * @return a {@link FluidStack} holding a copy of the fluid stack that was picked up, or {@link FluidStack#EMPTY} if nothing was picked up
+     * @deprecated Use {@link #tryPickupFluid(ResourceHandler, Player, Level, BlockPos, Direction, TransactionContext)} instead.
      */
+    @Deprecated(since = "26.1.2", forRemoval = true)
     public static FluidStack tryPickupFluid(@Nullable ResourceHandler<FluidResource> destination, @Nullable Player player, Level level, BlockPos pos, @Nullable Direction side) {
+        return tryPickupFluid(destination, player, level, pos, side, null);
+    }
+
+    /// Attempts to pick up a fluid in the level and put it into a fluid handler,
+    /// first from a [BucketPickup] block (such as fluid sources and waterlogged blocks),
+    /// or second from a [Capabilities.Fluid#BLOCK] capability instance.
+    ///
+    /// @param destination The destination for the picked up fluid. May be null.
+    /// @param player      The player filling the container. Optional.
+    /// @param level       The level the fluid is in.
+    /// @param pos         The position of the fluid in the level.
+    /// @param side        The side of the fluid that is being drained.
+    /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
+    /// allow you to make the final decision to commit based on the results of this method.
+    /// @return a [FluidStack] holding a copy of the fluid stack that was picked up, or [FluidStack#EMPTY] if nothing was picked up
+    public static FluidStack tryPickupFluid(@Nullable ResourceHandler<FluidResource> destination, @Nullable Player player, Level level, BlockPos pos, @Nullable Direction side, @Nullable TransactionContext transaction) {
         if (destination == null) {
             return FluidStack.EMPTY;
         }
@@ -196,7 +253,7 @@ public final class FluidUtil {
                 return FluidStack.EMPTY;
             }
             // Try to insert it into the destination
-            try (var tx = Transaction.openRoot()) {
+            try (var tx = Transaction.open(transaction)) {
                 var resource = FluidResource.of(fluid);
                 int inserted = destination.insert(resource, FluidType.BUCKET_VOLUME, tx);
                 if (inserted != FluidType.BUCKET_VOLUME) {
@@ -233,7 +290,7 @@ public final class FluidUtil {
             if (fluidHandler == null) {
                 return FluidStack.EMPTY;
             }
-            var moved = moveWithSound(fluidHandler, destination, level, pos, player, true);
+            var moved = moveWithSound(fluidHandler, destination, level, pos, player, transaction, true);
             return moved != null ? moved.resource().toStack(moved.amount()) : FluidStack.EMPTY;
         }
     }
@@ -254,30 +311,30 @@ public final class FluidUtil {
      * @param hand   Hand of the player to place the fluid with
      * @param pos    The position in the level to place the fluid block
      * @return a {@link FluidStack} holding a copy of the fluid stack that was placed, or {@link FluidStack#EMPTY} if nothing was placed
-     * @deprecated Use {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos)} instead
+     * @deprecated Use {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext)} instead
      */
     @Deprecated(since = "26.1.2", forRemoval = true)
     public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, InteractionHand hand, BlockPos pos) {
-        return tryPlaceFluid(source, player, level, pos);
+        return tryPlaceFluid(source, player, level, pos, null);
     }
 
-    /**
-     * Tries to extract {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource from a resource handler
-     * and place it into the level as a block.
-     * Unlike {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos)},
-     * this function will modify the source handler directly and return what was placed.
-     *
-     * <p>Makes a fluid emptying or vaporization sound when successful.
-     * Honors the amount of fluid contained by the used container.
-     * Checks if water-like fluids should vaporize like in the nether.
-     *
-     * @param source The source for the placed fluid. May be null.
-     * @param player Player who places the fluid. May be null for blocks like dispensers.
-     * @param level  Level to place the fluid in
-     * @param pos    The position in the level to place the fluid block
-     * @return a {@link FluidStack} holding a copy of the fluid stack that was placed, or {@link FluidStack#EMPTY} if nothing was placed
-     */
-    public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, BlockPos pos) {
+    /// Tries to extract [one bucket][FluidType#BUCKET_VOLUME] of a fluid resource from a resource handler
+    /// and place it into the level as a block.
+    /// Unlike [#tryPlaceFluid(FluidResource, Player, Level, BlockPos)],
+    /// this function will modify the source handler directly and return what was placed.
+    ///
+    /// Makes a fluid emptying or vaporization sound when successful.
+    /// Honors the amount of fluid contained by the used container.
+    /// Checks if water-like fluids should vaporize like in the nether.
+    ///
+    /// @param source The source for the placed fluid. May be null.
+    /// @param player Player who places the fluid. May be null for blocks like dispensers.
+    /// @param level  Level to place the fluid in
+    /// @param pos    The position in the level to place the fluid block
+    /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
+    /// allow you to make the final decision to commit based on the results of this method.
+    /// @return a [FluidStack] holding a copy of the fluid stack that was placed, or [FluidStack#EMPTY] if nothing was placed
+    public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, BlockPos pos, @Nullable TransactionContext transaction) {
         if (source == null) {
             return FluidStack.EMPTY;
         }
@@ -287,7 +344,7 @@ public final class FluidUtil {
             if (resource.isEmpty()) {
                 continue;
             }
-            try (var tx = Transaction.openRoot()) {
+            try (var tx = Transaction.open(transaction)) {
                 int amount = source.extract(index, resource, FluidType.BUCKET_VOLUME, tx);
                 if (amount != FluidType.BUCKET_VOLUME) {
                     continue;
@@ -305,7 +362,7 @@ public final class FluidUtil {
     /**
      * Tries to place {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource into the level as a block.
      * Note that e.g. extracting it from a handler on successful placement is the responsibility of the caller.
-     * See also {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos)} to modify a source handler directly.
+     * See also {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext)} to modify a source handler directly.
      *
      * <p>Makes a fluid emptying or vaporization sound when successful.
      * Honors the amount of fluid contained by the used container.
@@ -328,7 +385,7 @@ public final class FluidUtil {
 
     /// Tries to place [one bucket][FluidType#BUCKET_VOLUME] of a fluid resource into the level as a block.
     /// Note that e.g. extracting it from a handler on successful placement is the responsibility of the caller.
-    /// See also [#tryPlaceFluid(ResourceHandler, Player, Level, BlockPos)] to modify a source handler directly.
+    /// See also [#tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext)] to modify a source handler directly.
     ///
     /// Makes a fluid emptying or vaporization sound when successful.
     /// Honors the amount of fluid contained by the used container.

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -324,7 +324,9 @@ public final class FluidUtil {
         } else {
             if (canDestContainFluid) {
                 LiquidBlockContainer lbc = (LiquidBlockContainer) destBlockState.getBlock();
-                lbc.placeLiquid(level, pos, destBlockState, fluidType.getStateForPlacement(level, pos, stack));
+                if (!lbc.placeLiquid(level, pos, destBlockState, fluidType.getStateForPlacement(level, pos, stack))) {
+                    return false;
+                }
             } else {
                 // Destroy the existing state on fluid placement
                 if (!level.isClientSide() && isDestReplaceable && !destBlockState.liquid()) {

--- a/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
+++ b/src/main/java/net/neoforged/neoforge/transfer/fluid/FluidUtil.java
@@ -298,7 +298,7 @@ public final class FluidUtil {
     /**
      * Tries to extract {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource from a resource handler
      * and place it into the level as a block.
-     * Unlike {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos)},
+     * Unlike {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos, boolean)},
      * this function will modify the source handler directly and return what was placed.
      *
      * <p>Makes a fluid emptying or vaporization sound when successful.
@@ -311,16 +311,16 @@ public final class FluidUtil {
      * @param hand   Hand of the player to place the fluid with
      * @param pos    The position in the level to place the fluid block
      * @return a {@link FluidStack} holding a copy of the fluid stack that was placed, or {@link FluidStack#EMPTY} if nothing was placed
-     * @deprecated Use {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext)} instead
+     * @deprecated Use {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, boolean, TransactionContext)} instead
      */
     @Deprecated(since = "26.1.2", forRemoval = true)
     public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, InteractionHand hand, BlockPos pos) {
-        return tryPlaceFluid(source, player, level, pos, null);
+        return tryPlaceFluid(source, player, level, pos, false, null);
     }
 
     /// Tries to extract [one bucket][FluidType#BUCKET_VOLUME] of a fluid resource from a resource handler
     /// and place it into the level as a block.
-    /// Unlike [#tryPlaceFluid(FluidResource, Player, Level, BlockPos)],
+    /// Unlike [#tryPlaceFluid(FluidResource, Player, Level, BlockPos, boolean)],
     /// this function will modify the source handler directly and return what was placed.
     ///
     /// Makes a fluid emptying or vaporization sound when successful.
@@ -334,7 +334,7 @@ public final class FluidUtil {
     /// @param transaction The transaction context for the operation. Passing in `null` will open a root transaction, whereas passing in a transaction will
     /// allow you to make the final decision to commit based on the results of this method.
     /// @return a [FluidStack] holding a copy of the fluid stack that was placed, or [FluidStack#EMPTY] if nothing was placed
-    public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, BlockPos pos, @Nullable TransactionContext transaction) {
+    public static FluidStack tryPlaceFluid(@Nullable ResourceHandler<FluidResource> source, @Nullable Player player, Level level, BlockPos pos, boolean validatePlaced, @Nullable TransactionContext transaction) {
         if (source == null) {
             return FluidStack.EMPTY;
         }
@@ -350,7 +350,7 @@ public final class FluidUtil {
                     continue;
                 }
                 // Managed to extract 1 bucket, try to place it!
-                if (tryPlaceFluid(resource, player, level, pos)) {
+                if (tryPlaceFluid(resource, player, level, pos, validatePlaced)) {
                     tx.commit();
                     return resource.toStack(FluidType.BUCKET_VOLUME);
                 }
@@ -362,7 +362,7 @@ public final class FluidUtil {
     /**
      * Tries to place {@linkplain FluidType#BUCKET_VOLUME one bucket} of a fluid resource into the level as a block.
      * Note that e.g. extracting it from a handler on successful placement is the responsibility of the caller.
-     * See also {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext)} to modify a source handler directly.
+     * See also {@link #tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, boolean, TransactionContext)} to modify a source handler directly.
      *
      * <p>Makes a fluid emptying or vaporization sound when successful.
      * Honors the amount of fluid contained by the used container.
@@ -376,16 +376,16 @@ public final class FluidUtil {
      * @param hand     Hand of the player to place the fluid with
      * @param pos      The position in the level to place the fluid block
      * @return true if the placement was successful, false otherwise
-     * @deprecated Use {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos)} instead
+     * @deprecated Use {@link #tryPlaceFluid(FluidResource, Player, Level, BlockPos, boolean)} instead
      */
     @Deprecated(since = "26.1.2", forRemoval = true)
     public static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, InteractionHand hand, BlockPos pos) {
-        return tryPlaceFluid(resource, player, level, pos);
+        return tryPlaceFluid(resource, player, level, pos, false);
     }
 
     /// Tries to place [one bucket][FluidType#BUCKET_VOLUME] of a fluid resource into the level as a block.
     /// Note that e.g. extracting it from a handler on successful placement is the responsibility of the caller.
-    /// See also [#tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, TransactionContext)] to modify a source handler directly.
+    /// See also [#tryPlaceFluid(ResourceHandler, Player, Level, BlockPos, boolean, TransactionContext)] to modify a source handler directly.
     ///
     /// Makes a fluid emptying or vaporization sound when successful.
     /// Honors the amount of fluid contained by the used container.
@@ -397,8 +397,9 @@ public final class FluidUtil {
     /// @param player   Player who places the fluid. May be null for blocks like dispensers.
     /// @param level    Level to place the fluid in
     /// @param pos      The position in the level to place the fluid block
+    /// @param validatePlaced `true` to respect the result returned by [LiquidBlockContainer#placeLiquid]. To directly mirror [BucketItem#emptyContents] pass `false`.
     /// @return true if the placement was successful, false otherwise
-    public static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, BlockPos pos) {
+    public static boolean tryPlaceFluid(FluidResource resource, @Nullable Player player, Level level, BlockPos pos, boolean validatePlaced) {
         var stack = resource.toStack(FluidType.BUCKET_VOLUME);
         var fluidType = resource.getFluidType();
         if (stack.isEmpty() || !fluidType.canBePlacedInLevel(level, pos, stack)) {
@@ -420,7 +421,7 @@ public final class FluidUtil {
         } else {
             if (canDestContainFluid) {
                 LiquidBlockContainer lbc = (LiquidBlockContainer) destBlockState.getBlock();
-                if (!lbc.placeLiquid(level, pos, destBlockState, fluidType.getStateForPlacement(level, pos, stack))) {
+                if (!lbc.placeLiquid(level, pos, destBlockState, fluidType.getStateForPlacement(level, pos, stack)) && validatePlaced) {
                     return false;
                 }
             } else {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/transfer/FluidUtilTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/transfer/FluidUtilTests.java
@@ -99,7 +99,8 @@ public class FluidUtilTests {
         testWaterPlacement(
                 helper,
                 Blocks.AIR.defaultBlockState(),
-                Blocks.WATER.defaultBlockState());
+                Blocks.WATER.defaultBlockState(),
+                false);
     }
 
     @GameTest
@@ -109,10 +110,11 @@ public class FluidUtilTests {
         testWaterPlacement(
                 helper,
                 Blocks.STONE_SLAB.defaultBlockState(),
-                Blocks.STONE_SLAB.defaultBlockState().setValue(BlockStateProperties.WATERLOGGED, true));
+                Blocks.STONE_SLAB.defaultBlockState().setValue(BlockStateProperties.WATERLOGGED, true),
+                true);
     }
 
-    private static void testWaterPlacement(ExtendedGameTestHelper helper, BlockState initialState, BlockState finalState) {
+    private static void testWaterPlacement(ExtendedGameTestHelper helper, BlockState initialState, BlockState finalState, boolean shouldFailFilledValidation) {
         var waterPos = new BlockPos(1, 0, 0);
         helper.setBlock(waterPos, initialState);
 
@@ -128,6 +130,7 @@ public class FluidUtilTests {
                 player,
                 helper.getLevel(),
                 helper.absolutePos(waterPos),
+                false,
                 null);
         helper.assertValueEqual(Fluids.WATER, placementResult.getFluid(), "placed fluid");
         helper.assertValueEqual(FluidType.BUCKET_VOLUME, placementResult.getAmount(), "placed amount");
@@ -144,6 +147,7 @@ public class FluidUtilTests {
                 player,
                 helper.getLevel(),
                 helper.absolutePos(waterPos),
+                false,
                 null);
         helper.assertTrue(secondPlacementResult.isEmpty(), "second placement result is empty");
         // Block state should not have changed
@@ -156,8 +160,8 @@ public class FluidUtilTests {
                 player,
                 helper.getLevel(),
                 helper.absolutePos(waterPos),
+                false,
                 null);
-        helper.assertTrue(secondPlacementResult.isEmpty(), "third placement result is empty");
         helper.assertValueEqual(Fluids.WATER, thirdPlacementResult.getFluid(), "third placed fluid");
         helper.assertValueEqual(FluidType.BUCKET_VOLUME, thirdPlacementResult.getAmount(), "third placed amount");
         helper.assertBlockState(waterPos, finalState);
@@ -166,6 +170,25 @@ public class FluidUtilTests {
         mainHandItem = player.getMainHandItem();
         helper.assertValueEqual(Items.BUCKET, mainHandItem.getItem(), "main hand item");
         helper.assertValueEqual(1, mainHandItem.getCount(), "main hand item count");
+
+        if (shouldFailFilledValidation) {
+            // But yet another placement with a full bucket in hand should fail, since placing additional water into a water block is allowed
+            player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.WATER_BUCKET));
+            var fourthPlacementResult = FluidUtil.tryPlaceFluid(
+                    handHandler,
+                    player,
+                    helper.getLevel(),
+                    helper.absolutePos(waterPos),
+                    true,
+                    null);
+            helper.assertTrue(fourthPlacementResult.isEmpty(), "fourth placement result is empty");
+            helper.assertBlockState(waterPos, finalState);
+
+            // Bucket should not have been emptied
+            mainHandItem = player.getMainHandItem();
+            helper.assertValueEqual(Items.WATER_BUCKET, mainHandItem.getItem(), "main hand item");
+            helper.assertValueEqual(1, mainHandItem.getCount(), "main hand item count");
+        }
 
         // Block state should not have changed
         helper.assertBlockState(waterPos, finalState);

--- a/tests/src/main/java/net/neoforged/neoforge/debug/transfer/FluidUtilTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/transfer/FluidUtilTests.java
@@ -125,7 +125,6 @@ public class FluidUtilTests {
                 handHandler,
                 player,
                 helper.getLevel(),
-                InteractionHand.MAIN_HAND,
                 helper.absolutePos(waterPos));
         helper.assertValueEqual(Fluids.WATER, placementResult.getFluid(), "placed fluid");
         helper.assertValueEqual(FluidType.BUCKET_VOLUME, placementResult.getAmount(), "placed amount");
@@ -141,7 +140,6 @@ public class FluidUtilTests {
                 handHandler,
                 player,
                 helper.getLevel(),
-                InteractionHand.MAIN_HAND,
                 helper.absolutePos(waterPos));
         helper.assertTrue(secondPlacementResult.isEmpty(), "second placement result is empty");
         // Block state should not have changed
@@ -153,7 +151,6 @@ public class FluidUtilTests {
                 handHandler,
                 player,
                 helper.getLevel(),
-                InteractionHand.MAIN_HAND,
                 helper.absolutePos(waterPos));
         helper.assertTrue(secondPlacementResult.isEmpty(), "third placement result is empty");
         helper.assertValueEqual(Fluids.WATER, thirdPlacementResult.getFluid(), "third placed fluid");

--- a/tests/src/main/java/net/neoforged/neoforge/debug/transfer/FluidUtilTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/transfer/FluidUtilTests.java
@@ -62,6 +62,7 @@ public class FluidUtilTests {
                 player,
                 helper.getLevel(),
                 helper.absolutePos(waterPos),
+                null,
                 null);
         helper.assertValueEqual(Fluids.WATER, pickupResult.getFluid(), "picked up fluid");
         helper.assertValueEqual(FluidType.BUCKET_VOLUME, pickupResult.getAmount(), "picked up amount");
@@ -82,6 +83,7 @@ public class FluidUtilTests {
                 player,
                 helper.getLevel(),
                 helper.absolutePos(waterPos),
+                null,
                 null);
         helper.assertTrue(secondPickupResult.isEmpty(), "second pickup result is empty");
         // Block state should not have changed
@@ -125,7 +127,8 @@ public class FluidUtilTests {
                 handHandler,
                 player,
                 helper.getLevel(),
-                helper.absolutePos(waterPos));
+                helper.absolutePos(waterPos),
+                null);
         helper.assertValueEqual(Fluids.WATER, placementResult.getFluid(), "placed fluid");
         helper.assertValueEqual(FluidType.BUCKET_VOLUME, placementResult.getAmount(), "placed amount");
         helper.assertBlockState(waterPos, finalState);
@@ -140,7 +143,8 @@ public class FluidUtilTests {
                 handHandler,
                 player,
                 helper.getLevel(),
-                helper.absolutePos(waterPos));
+                helper.absolutePos(waterPos),
+                null);
         helper.assertTrue(secondPlacementResult.isEmpty(), "second placement result is empty");
         // Block state should not have changed
         helper.assertBlockState(waterPos, finalState);
@@ -151,7 +155,8 @@ public class FluidUtilTests {
                 handHandler,
                 player,
                 helper.getLevel(),
-                helper.absolutePos(waterPos));
+                helper.absolutePos(waterPos),
+                null);
         helper.assertTrue(secondPlacementResult.isEmpty(), "third placement result is empty");
         helper.assertValueEqual(Fluids.WATER, thirdPlacementResult.getFluid(), "third placed fluid");
         helper.assertValueEqual(FluidType.BUCKET_VOLUME, thirdPlacementResult.getAmount(), "third placed amount");

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -94,7 +94,7 @@ public class CustomFluidContainerTest {
                 blockHitResult = getPlayerPOVHitResult(level, player, ClipContext.Fluid.NONE);
                 //try to place fluid in hit block (waterlogging, fill tank, ...). When no success try the block on the hit side.
                 for (BlockPos pos : Arrays.asList(blockHitResult.getBlockPos(), blockHitResult.getBlockPos().relative(blockHitResult.getDirection()))) {
-                    success = !FluidUtil.tryPlaceFluid(handler, player, level, pos, null).isEmpty();
+                    success = !FluidUtil.tryPlaceFluid(handler, player, level, pos, false, null).isEmpty();
                     if (success) break;
                 }
             }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -94,7 +94,7 @@ public class CustomFluidContainerTest {
                 blockHitResult = getPlayerPOVHitResult(level, player, ClipContext.Fluid.NONE);
                 //try to place fluid in hit block (waterlogging, fill tank, ...). When no success try the block on the hit side.
                 for (BlockPos pos : Arrays.asList(blockHitResult.getBlockPos(), blockHitResult.getBlockPos().relative(blockHitResult.getDirection()))) {
-                    success = !FluidUtil.tryPlaceFluid(handler, player, level, hand, pos).isEmpty();
+                    success = !FluidUtil.tryPlaceFluid(handler, player, level, pos).isEmpty();
                     if (success) break;
                 }
             }

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/item/CustomFluidContainerTest.java
@@ -88,13 +88,13 @@ public class CustomFluidContainerTest {
             var handler = ItemAccess.forPlayerInteraction(player, hand).oneByOne().getCapability(Capabilities.Fluid.ITEM);
 
             var blockHitResult = getPlayerPOVHitResult(level, player, ClipContext.Fluid.SOURCE_ONLY);
-            boolean success = !FluidUtil.tryPickupFluid(handler, player, level, blockHitResult.getBlockPos(), blockHitResult.getDirection()).isEmpty();
+            boolean success = !FluidUtil.tryPickupFluid(handler, player, level, blockHitResult.getBlockPos(), blockHitResult.getDirection(), null).isEmpty();
 
             if (!success) {
                 blockHitResult = getPlayerPOVHitResult(level, player, ClipContext.Fluid.NONE);
                 //try to place fluid in hit block (waterlogging, fill tank, ...). When no success try the block on the hit side.
                 for (BlockPos pos : Arrays.asList(blockHitResult.getBlockPos(), blockHitResult.getBlockPos().relative(blockHitResult.getDirection()))) {
-                    success = !FluidUtil.tryPlaceFluid(handler, player, level, pos).isEmpty();
+                    success = !FluidUtil.tryPlaceFluid(handler, player, level, pos, null).isEmpty();
                     if (success) break;
                 }
             }


### PR DESCRIPTION
- Added overloads to FluidUtil with a nullable transaction context param and deprecated the older versions that did not have this param. I also included a note in the javadocs for cases where the passed transaction might not be fully able to be rolled back (namely for tryPlaceFluid/tryPickupFluid, the `interactWithFluidHandler` should fully support rolling back, and not post any game events or sound when done so)
- Removed need for passing a hand parameter to `FluidUtil#tryPlaceFluid` as the idea of the method is to mirror `BucketItem#emptyContents` which checks  `BlockStateBase#canBeReplaced(Fluid)` and not the `BlockPlaceContext` override.
- Added a parameter to `FluidUtil#tryPlaceFluid` to respect the result of `LiquidBlockContainer#placeLiquid`, and thus return false in cases like slabs where they don't actually place the liquid if the slab is already waterlogged. Passing `false` to this parameter mirrors how buckets behave, and the previous behavior.
- Added a variant of `FluidUtil#tryPickupFluid` that doesn't fall back to picking up from a fluid handler
- Fix DispenseFluidContainer deleting items due to passing the wrong stack to `consumeWithRemainder`