### PR TITLE
[26.2] Allow block bounce restitution to be state specific

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -37,6 +37,24 @@
          }
  
          this.checkBelowWorld();
+@@ -818,7 +_,7 @@
+         if (this.verticalCollision) {
+             if (this.verticalCollisionBelow) {
+                 restitution = !(-currentMovement.y < this.getEffectiveGravity()) && !this.isSuppressingBounce() && !effectState.is(BlockTags.SUPPRESSES_BOUNCE)
+-                    ? Math.max(restitution, this.getBlockBounciness(effectState.getBlock()))
++                    ? Math.max(restitution, this.getBlockBounciness(effectState)) // NeoForge: Allow bounciness to be state specific
+                     : 0.0;
+             }
+ 
+@@ -845,6 +_,8 @@
+         this.setDeltaMovement(movementAfterBounce);
+     }
+ 
++    /// @deprecated NeoForge: Use [IEntityExtension#getBlockBounciness(BlockState)]
++    @Deprecated
+     private double getBlockBounciness(Block onBlock) {
+         float blockBounciness = onBlock.getBounceRestitution();
+         if (!(this instanceof LivingEntity)) {
 @@ -1062,9 +_,7 @@
              }
  

--- a/patches/net/minecraft/world/level/block/Block.java.patch
+++ b/patches/net/minecraft/world/level/block/Block.java.patch
@@ -107,6 +107,15 @@
      public float getExplosionResistance() {
          return this.explosionResistance;
      }
+@@ -464,6 +_,8 @@
+         entity.causeFallDamage(fallDistance, 1.0F, entity.damageSources().fall());
+     }
+ 
++    /// @deprecated NeoForge: Use [net.neoforged.neoforge.common.extensions.IBlockStateExtension#getBounceRestitution()]
++    @Deprecated
+     public float getBounceRestitution() {
+         return this.bounceRestitution;
+     }
 @@ -497,6 +_,7 @@
      public void handlePrecipitation(BlockState state, Level level, BlockPos pos, Biome.Precipitation precipitation) {
      }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockExtension.java
@@ -1077,4 +1077,9 @@ public interface IBlockExtension {
     default boolean shouldHideAdjacentFluidFace(BlockState state, Direction selfFace, FluidState adjacentFluid) {
         return state.getFluidState().getType().isSame(adjacentFluid.getType());
     }
+
+    /// Returns this blocks bounce restitution for the given state. Normally between 0 and 1
+    default float getBounceRestitution(BlockState blockState) {
+        return self().getBounceRestitution();
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IBlockStateExtension.java
@@ -811,4 +811,9 @@ public interface IBlockStateExtension {
     default boolean shouldHideAdjacentFluidFace(Direction selfFace, FluidState adjacentFluid) {
         return self().getBlock().shouldHideAdjacentFluidFace(self(), selfFace, adjacentFluid);
     }
+
+    /// Returns this block states bounce restitution. Normally between 0 and 1
+    default float getBounceRestitution() {
+        return self().getBlock().getBounceRestitution(self());
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IEntityExtension.java
@@ -14,6 +14,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -356,5 +357,18 @@ public interface IEntityExtension {
      */
     default void copyAttachmentsFrom(Entity other, boolean isDeath) {
         AttachmentInternals.copyEntityAttachments(other, self(), isDeath);
+    }
+
+    /// Returns the block bounciness for the given block state. Normally between 0 and 1
+    /// @see IBlockStateExtension#getBounceRestitution()
+    default double getBlockBounciness(BlockState blockState) {
+        // must be kept inine with Entity.getBlockBounciness(Block)
+        var blockBounciness = blockState.getBounceRestitution();
+
+        if (!(this instanceof LivingEntity)) {
+            blockBounciness *= .8F;
+        }
+
+        return blockBounciness;
     }
 }


### PR DESCRIPTION
This PR allows modders to define their blocks bounce restitution (bounciness) based on the state of their block. While vanilla does add the `bounceRestitution` field for your blocks properties this is a general field that applies to all your blocks states and should be considered the default bounciness for your block, the state based overload is here to allow post changes to said bounciness.

My mods usecase, i only allow bouncing at the origin (index==0) point of my chair blocks (the seat/cushion section, not the back of the chair). which i do by determining which index in my multiblock is being queried

returning 0F for any non-zero index makes that part of my block non-bouncy, while delegating back to super (the block property) returns my desired bounciness for this block making only that part bouncy
```java
@Override
public float getBounceRestitution(BlockState blockState) {
    return MultiBlock.getIndex(blockState) == 0 ? super.getBounceRestitution(blockState) : 0F;
}
```