### PR TITLE
 Add ServerTickEvent.Empty for empty server ticks when the server is paused

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -98,7 +98,13 @@
                  this.onServerExit();
              }
          }
-@@ -987,11 +_,13 @@
+@@ -982,16 +_,19 @@
+                 }
+ 
+                 this.tickConnection();
++                net.neoforged.neoforge.event.EventHooks.fireServerTickEmpty(haveTime, this);
+                 return;
+             }
          }
  
          this.tickCount++;

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1027,6 +1027,17 @@ public class EventHooks {
         NeoForge.EVENT_BUS.post(new ServerTickEvent.Post(haveTime, server));
     }
 
+    /**
+     * Fires {@link ServerTickEvent.Empty} for an empty tick while the server is paused after being empty for some time.
+     * Called when {@link MinecraftServer#tickServer(BooleanSupplier)} returns early from the empty tick path.
+     * 
+     * @param haveTime The time supplier, indicating if there is remaining time to do work in the current tick.
+     * @param server   The current server
+     */
+    public static void fireServerTickEmpty(BooleanSupplier haveTime, MinecraftServer server) {
+        NeoForge.EVENT_BUS.post(new ServerTickEvent.Empty(haveTime, server));
+    }
+
     private static final WeightedList<MobSpawnSettings.SpawnerData> NO_SPAWNS = WeightedList.of();
 
     public static WeightedList<MobSpawnSettings.SpawnerData> getPotentialSpawns(LevelAccessor level, MobCategory category, BlockPos pos, WeightedList<MobSpawnSettings.SpawnerData> oldList) {

--- a/src/main/java/net/neoforged/neoforge/event/tick/ServerTickEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/tick/ServerTickEvent.java
@@ -10,10 +10,11 @@ import net.minecraft.server.MinecraftServer;
 import net.neoforged.bus.api.Event;
 
 /**
- * Base class of the two server tick events.
+ * Base class of the three server tick events.
  * 
  * @see ServerTickEvent.Pre
  * @see ServerTickEvent.Post
+ * @see ServerTickEvent.Empty
  */
 public abstract class ServerTickEvent extends Event {
     private final BooleanSupplier hasTime;
@@ -58,6 +59,18 @@ public abstract class ServerTickEvent extends Event {
      */
     public static class Post extends ServerTickEvent {
         public Post(BooleanSupplier haveTime, MinecraftServer server) {
+            super(haveTime, server);
+        }
+    }
+
+    /**
+     * {@link ServerTickEvent.Empty} is fired once per skipped server tick after the server has been empty for some time
+     * and pauses; during this pause, skipped ticks are handled by this event.
+     * <p>
+     * This event only fires on the logical server.
+     */
+    public static class Empty extends ServerTickEvent {
+        public Empty(BooleanSupplier haveTime, MinecraftServer server) {
             super(haveTime, server);
         }
     }


### PR DESCRIPTION
Starting in Minecraft 26.1, the server pauses after it has been empty for some time. Once that happens, the normal server tick flow no longer runs, so the existing server tick events are not fired during that paused period.

Some mods still need to preserve tick-driven behavior when the server is paused with no players online. This PR adds `ServerTickEvent.Empty` without changing the behavior of the existing pre and post server tick events.