### PR TITLE
Fix misapplied patch in LootPool

### DIFF
--- a/patches/net/minecraft/world/level/storage/loot/LootPool.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/LootPool.java.patch
@@ -5,7 +5,7 @@
                  LootItemFunctions.ROOT_CODEC.listOf().optionalFieldOf("functions", List.of()).forGetter(p -> p.functions),
                  NumberProviders.CODEC.fieldOf("rolls").forGetter(p -> p.rolls),
 -                NumberProviders.CODEC.optionalFieldOf("bonus_rolls", ConstantValue.exactly(0.0F)).forGetter(p -> p.bonusRolls)
-+                NumberProviders.CODEC.fieldOf("bonus_rolls").orElse(ConstantValue.exactly(0.0F)).forGetter(p -> p.bonusRolls),
++                NumberProviders.CODEC.optionalFieldOf("bonus_rolls", ConstantValue.exactly(0.0F)).forGetter(p -> p.bonusRolls),
 +                Codec.STRING.optionalFieldOf("name").forGetter(pool -> java.util.Optional.ofNullable(pool.name).filter(name -> !name.startsWith("custom#")))
              )
              .apply(i, LootPool::new)

--- a/src/generated/resources/data/minecraft/loot_table/blocks/acacia_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/acacia_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/azalea_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/azalea_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/birch_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/birch_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/bush.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/bush.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:any_of",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/cherry_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/cherry_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/cobweb.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/cobweb.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/dark_oak_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/dark_oak_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",
@@ -127,7 +125,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/dead_bush.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/dead_bush.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/fern.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/fern.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/flowering_azalea_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/flowering_azalea_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/glow_lichen.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/glow_lichen.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/hanging_roots.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/hanging_roots.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "ability": "shears_dig",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/jungle_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/jungle_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -63,7 +62,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/large_fern.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/large_fern.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "block": "minecraft:large_fern",
@@ -63,7 +62,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "block": "minecraft:large_fern",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/mangrove_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/mangrove_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/nether_sprouts.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/nether_sprouts.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "ability": "shears_dig",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/oak_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/oak_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",
@@ -127,7 +125,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/pale_hanging_moss.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/pale_hanging_moss.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:any_of",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/pale_oak_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/pale_oak_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/seagrass.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/seagrass.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "ability": "shears_dig",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/short_dry_grass.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/short_dry_grass.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:any_of",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/short_grass.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/short_grass.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/small_dripleaf.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/small_dripleaf.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "ability": "shears_dig",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/spruce_leaves.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/spruce_leaves.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -62,7 +61,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:inverted",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/tall_dry_grass.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/tall_dry_grass.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "condition": "minecraft:any_of",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/tall_grass.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/tall_grass.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "block": "minecraft:tall_grass",
@@ -63,7 +62,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "block": "minecraft:tall_grass",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/tall_seagrass.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/tall_seagrass.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "ability": "shears_dig",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/twisting_vines.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/twisting_vines.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/twisting_vines_plant.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/twisting_vines_plant.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/vine.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/vine.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "conditions": [
         {
           "ability": "shears_dig",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/weeping_vines.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/weeping_vines.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/src/generated/resources/data/minecraft/loot_table/blocks/weeping_vines_plant.json
+++ b/src/generated/resources/data/minecraft/loot_table/blocks/weeping_vines_plant.json
@@ -2,7 +2,6 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:alternatives",

--- a/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_1.json
+++ b/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_1.json
@@ -1,7 +1,6 @@
 {
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -12,7 +11,6 @@
       "rolls": 1.0
     },
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_2.json
+++ b/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_2.json
@@ -1,7 +1,6 @@
 {
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_3.json
+++ b/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_3.json
@@ -1,7 +1,6 @@
 {
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",

--- a/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_4.json
+++ b/tests/src/generated/resources/data/neoforge/loot_table/test_loot_table_4.json
@@ -1,7 +1,6 @@
 {
   "pools": [
     {
-      "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",


### PR DESCRIPTION
In 26.2 `LootPool`'s `bonus_rolls` was changed to use `optionalFieldOf`. However, the patch conflict was not resolved correctly, meaning this change was reverted by NF's patches.

What I'd give for Java to allow trailing commas in argument lists :sob:.