### PR TITLE
[1.20.6] Fix FireworkExplosion.Shape codec decoding non-small-ball shapes as SMALL_BALL

### DIFF
--- a/patches/net/minecraft/world/item/component/FireworkExplosion.java.patch
+++ b/patches/net/minecraft/world/item/component/FireworkExplosion.java.patch
@@ -20,17 +20,18 @@
          private final int id;
          private final String name;
  
-@@ -137,6 +_,17 @@
+@@ -137,6 +_,18 @@
  
          public static FireworkExplosion.Shape byId(int p_330838_) {
              return BY_ID.apply(p_330838_);
 +        }
 +
++        @org.jetbrains.annotations.Nullable
 +        public static FireworkExplosion.Shape getShape(String name) {
 +            for (Shape ret : values())
-+                if (ret.name().equals(name))
++                if (ret.getSerializedName().equals(name))
 +                    return ret;
-+            return SMALL_BALL;
++            return null;
 +        }
 +
 +        public static Shape create(String registryName, int id, String shapeName) {

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/FireworkExplosionShapeCodecTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/FireworkExplosionShapeCodecTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.mojang.serialization.JsonOps;
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.world.item.component.FireworkExplosion;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Regression test for the {@link FireworkExplosion.Shape} extensible-enum codec.
+ * <p>
+ * NeoForge replaces the vanilla {@code StringRepresentable.fromValues(...)} codec with
+ * {@code IExtensibleEnum.createCodecForExtensibleEnum(Shape::values, Shape::getShape)}, which
+ * encodes with {@code getSerializedName()} ({@code "large_ball"}) but used to decode by comparing
+ * the JVM constant name {@code name()} ({@code "LARGE_BALL"}) and defaulting to {@code SMALL_BALL}
+ * on no-match. That made every non-{@code SMALL_BALL} shape silently revert to {@code SMALL_BALL}
+ * on any disk save/load of the {@code minecraft:fireworks}/{@code minecraft:firework_explosion}
+ * data components.
+ */
+public class FireworkExplosionShapeCodecTest {
+    /**
+     * The in-game symptom: the data component codec ({@link FireworkExplosion#CODEC}) must preserve
+     * every shape through an encode/decode round-trip.
+     */
+    @ParameterizedTest
+    @EnumSource(FireworkExplosion.Shape.class)
+    void fireworkExplosionRoundTripsShape(FireworkExplosion.Shape shape) {
+        var explosion = new FireworkExplosion(shape, IntList.of(), IntList.of(), false, false);
+
+        JsonElement json = FireworkExplosion.CODEC.encodeStart(JsonOps.INSTANCE, explosion).getOrThrow();
+        FireworkExplosion decoded = FireworkExplosion.CODEC.parse(JsonOps.INSTANCE, json).getOrThrow();
+
+        Assertions.assertThat(decoded.shape())
+                .withFailMessage("Shape %s did not survive a FireworkExplosion.CODEC round-trip (got %s)", shape, decoded.shape())
+                .isEqualTo(shape);
+    }
+
+    /**
+     * The shape codec itself must round-trip the serialized name (e.g. {@code "large_ball"}) back to
+     * the matching constant rather than defaulting.
+     */
+    @ParameterizedTest
+    @EnumSource(FireworkExplosion.Shape.class)
+    void shapeCodecRoundTrips(FireworkExplosion.Shape shape) {
+        JsonElement json = FireworkExplosion.Shape.CODEC.encodeStart(JsonOps.INSTANCE, shape).getOrThrow();
+        Assertions.assertThat(json).isEqualTo(new JsonPrimitive(shape.getSerializedName()));
+
+        FireworkExplosion.Shape decoded = FireworkExplosion.Shape.CODEC.parse(JsonOps.INSTANCE, json).getOrThrow();
+        Assertions.assertThat(decoded).isEqualTo(shape);
+    }
+
+    /**
+     * An unrecognized name must now surface a codec error instead of silently defaulting to
+     * {@code SMALL_BALL}, proving the {@code getShape}-returns-{@code null} path is wired up.
+     */
+    @Test
+    void unknownShapeNameErrors() {
+        var result = FireworkExplosion.Shape.CODEC.parse(JsonOps.INSTANCE, new JsonPrimitive("not_a_shape"));
+
+        Assertions.assertThat(result.result()).isEmpty();
+        Assertions.assertThat(result.error()).isPresent();
+    }
+}


### PR DESCRIPTION
The data codec for FireworkExplosion.Shape silently loses the shape on decode: any firework rocket or firework star whose explosion shape is not SMALL_BALL reverts to SMALL_BALL whenever its ItemStack is written to disk and read back -- chests, ender chests, player inventories, dropped items surviving a chunk/world reload, and so on. The round-trip reports no codec error, so the loss is silent. Only the NBT/JSON data path is affected (the minecraft:fireworks and minecraft:firework_explosion data components); the network path is fine because the stream codec serializes the ordinal.

Shape is converted into an IExtensibleEnum, which replaces the vanilla StringRepresentable.fromValues(...) codec with
IExtensibleEnum.createCodecForExtensibleEnum(Shape::values, Shape::getShape). That codec encodes a value as its serialized name -- Either.left(value.getSerializedName()), e.g. "large_ball" -- but the injected getShape(String) lookup compared its argument against the JVM constant name Enum.name() ("LARGE_BALL") rather than the serialized name. It therefore never matched and fell through to its no-match path, which returned SMALL_BALL instead of null. Because the codec emits its "Unknown enum value name" error only when the lookup returns null, returning a default both produced the wrong value and suppressed the error.

The result: encode wrote "large_ball"; decode called getShape("large_ball"), matched nothing, and yielded SMALL_BALL.

Make getShape match getSerializedName() and return null on no-match. This restores the vanilla round-trip semantics and re-enables the codec's error branch for genuinely unknown names.

Add a JUnit regression test covering a full FireworkExplosion.CODEC round-trip for every shape, a direct Shape.CODEC round-trip, and the unknown-name error path.

This affects only the 1.20.x line. From 1.21.1 onward Shape uses the FML enumextension mechanism, which leaves the vanilla codec in place and is not subject to this failure.