### PR TITLE
[26.2] Fix modded debug entries not being visible upon initial game load

### DIFF
--- a/patches/net/minecraft/client/gui/components/debug/DebugScreenEntries.java.patch
+++ b/patches/net/minecraft/client/gui/components/debug/DebugScreenEntries.java.patch
@@ -28,7 +28,7 @@
 +
 +    // Neo: Register modded debug entries and profile inclusions
 +    @org.jetbrains.annotations.ApiStatus.Internal
-+    public static void registerModdedDebugEntries() {
++    static void registerModdedDebugEntries() {
 +        if (MODDED_ENTRIES_REGISTERED) {
 +            throw new IllegalStateException("Already registered modded debug entries!");
 +        }

--- a/patches/net/minecraft/client/gui/components/debug/DebugScreenEntryList.java.patch
+++ b/patches/net/minecraft/client/gui/components/debug/DebugScreenEntryList.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/client/gui/components/debug/DebugScreenEntryList.java
 +++ b/net/minecraft/client/gui/components/debug/DebugScreenEntryList.java
+@@ -42,6 +_,7 @@
+ 
+     public DebugScreenEntryList(File workingDirectory, DataFixer dataFixer) {
+         this.debugProfileFile = new File(workingDirectory, "debug-profile.json");
++        DebugScreenEntries.registerModdedDebugEntries(); // Neo: Register modded debug entries
+         this.codec = DataFixTypes.DEBUG_PROFILE.wrapCodec(DebugScreenEntryList.SerializedOptions.CODEC, dataFixer, 4649);
+         this.load();
+     }
 @@ -164,7 +_,8 @@
                  }
              }

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -811,7 +811,6 @@ public class ClientHooks {
         RenderPipelines.registerCustomPipelines();
         PipelineModifiers.init();
         GameRuleEntryFactoryManager.register();
-        DebugScreenEntries.registerModdedDebugEntries();
     }
 
     // Runs during Minecraft construction, before initial resource loading and during datagen startup


### PR DESCRIPTION
Fixes modded debug screen entries not being visible upon initial game load. This is due to the registration event being fired after `DebugScreenEntries` is initialized and the initial values are loaded.

To fix this modded entry registration was moved out of `ClientHooks.initClientHooks` and into the constructor of `DebugScreenEntryList`, which is also whats used to initialize and load the debug entry values.

Fixes #3234

Confirmed this also is a issue on 26.1 and may want backporting.