### PR TITLE
Fix attribution of damage from mobs and players

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -205,7 +205,7 @@
          if (damage < 0.0F) {
              damage = 0.0F;
          }
-@@ -1214,26 +_,34 @@
+@@ -1214,20 +_,30 @@
          if (Float.isNaN(damage) || Float.isInfinite(damage)) {
              damage = Float.MAX_VALUE;
          }
@@ -239,12 +239,6 @@
              this.hurtDuration = 10;
              this.hurtTime = this.hurtDuration;
          }
- 
--        this.resolveMobResponsibleForDamage(source);
--        this.resolvePlayerResponsibleForDamage(source);
-         if (tookFullDamage) {
-             BlocksAttacks blocksAttacks = itemInUse.get(DataComponents.BLOCKS_ATTACKS);
-             if (blocked && blocksAttacks != null) {
 @@ -1286,6 +_,10 @@
              CriteriaTriggers.PLAYER_HURT_ENTITY.trigger(sourcePlayer, this, source, originalDamage, damage, blocked);
          }


### PR DESCRIPTION
This PR fixes #3232, fixes #3239, and fixes #3242 by re-adding the calls to `LivingEntity#resolveMobResponsibleForDamage` and `LivingEntity#resolvePlayerResponsibleForDamage` that were accidentally patched out, causing attribution of damage from mobs and players to fail.

Tested through:
1. Killing a vindicator with a looting 255 sword (`/give @s netherite_sword[minecraft:enchantments={sharpness:255,smite:255,bane_of_arthropods:255,looting:255}]`) and observing both item and experience drops from killing it.
2. Placing a snow golem and husk in proximity, waiting for the snow golem to throw a snowball at the husk, and observing the husk go attack the snow golem.