### PR TITLE
Broaden spawn rule helpers to accept subclasses of the entity types

### DIFF
--- a/patches/net/minecraft/world/entity/ambient/Bat.java.patch
+++ b/patches/net/minecraft/world/entity/ambient/Bat.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/ambient/Bat.java
++++ b/net/minecraft/world/entity/ambient/Bat.java
+@@ -219,7 +_,7 @@
+         output.putByte("BatFlags", this.entityData.get(DATA_ID_FLAGS));
+     }
+ 
+-    public static boolean checkBatSpawnRules(EntityType<Bat> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkBatSpawnRules(EntityType<? extends Bat> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         if (pos.getY() >= level.getHeightmapPos(Heightmap.Types.WORLD_SURFACE, pos).getY()) {
+             return false;
+         } else if (random.nextBoolean()) {

--- a/patches/net/minecraft/world/entity/animal/armadillo/Armadillo.java.patch
+++ b/patches/net/minecraft/world/entity/animal/armadillo/Armadillo.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/armadillo/Armadillo.java
 +++ b/net/minecraft/world/entity/animal/armadillo/Armadillo.java
+@@ -236,7 +_,7 @@
+     }
+ 
+     public static boolean checkArmadilloSpawnRules(
+-        EntityType<Armadillo> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends Armadillo> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         return level.getBlockState(pos.below()).is(BlockTags.ARMADILLO_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
 @@ -314,7 +_,7 @@
      @Override
      public InteractionResult mobInteract(Player player, InteractionHand hand) {

--- a/patches/net/minecraft/world/entity/animal/camel/Camel.java.patch
+++ b/patches/net/minecraft/world/entity/animal/camel/Camel.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/camel/Camel.java
 +++ b/net/minecraft/world/entity/animal/camel/Camel.java
+@@ -141,7 +_,7 @@
+         return super.finalizeSpawn(level, difficulty, spawnReason, groupData);
+     }
+ 
+-    public static boolean checkCamelSpawnRules(EntityType<Camel> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkCamelSpawnRules(EntityType<? extends Camel> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return level.getBlockState(pos.below()).is(BlockTags.CAMELS_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
+ 
 @@ -312,6 +_,7 @@
          this.dashCooldown = 55;
          this.setDashing(true);

--- a/patches/net/minecraft/world/entity/animal/cow/MushroomCow.java.patch
+++ b/patches/net/minecraft/world/entity/animal/cow/MushroomCow.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/cow/MushroomCow.java
 +++ b/net/minecraft/world/entity/animal/cow/MushroomCow.java
+@@ -75,7 +_,7 @@
+     }
+ 
+     public static boolean checkMushroomSpawnRules(
+-        EntityType<MushroomCow> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends MushroomCow> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         return level.getBlockState(pos.below()).is(BlockTags.MOOSHROOMS_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
 @@ -179,11 +_,19 @@
      @Override
      public void shear(ServerLevel level, SoundSource soundSource, ItemStack tool) {

--- a/patches/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
+++ b/patches/net/minecraft/world/entity/animal/feline/Ocelot.java.patch
@@ -9,3 +9,12 @@
                      this.setTrusting(true);
                      this.spawnTrustingParticles(true);
                      this.level().broadcastEntityEvent(this, (byte)41);
+@@ -234,7 +_,7 @@
+         return itemStack.is(ItemTags.OCELOT_FOOD);
+     }
+ 
+-    public static boolean checkOcelotSpawnRules(EntityType<Ocelot> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkOcelotSpawnRules(EntityType<? extends Ocelot> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return random.nextInt(3) != 0;
+     }
+ 

--- a/patches/net/minecraft/world/entity/animal/fish/TropicalFish.java.patch
+++ b/patches/net/minecraft/world/entity/animal/fish/TropicalFish.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/fish/TropicalFish.java
++++ b/net/minecraft/world/entity/animal/fish/TropicalFish.java
+@@ -259,7 +_,7 @@
+     }
+ 
+     public static boolean checkTropicalFishSpawnRules(
+-        EntityType<TropicalFish> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends TropicalFish> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         return level.getFluidState(pos.below()).is(FluidTags.WATER)
+             && level.getBlockState(pos.above()).is(Blocks.WATER)

--- a/patches/net/minecraft/world/entity/animal/fox/Fox.java.patch
+++ b/patches/net/minecraft/world/entity/animal/fox/Fox.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/fox/Fox.java
 +++ b/net/minecraft/world/entity/animal/fox/Fox.java
+@@ -331,7 +_,7 @@
+         return baby;
+     }
+ 
+-    public static boolean checkFoxSpawnRules(EntityType<Fox> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkFoxSpawnRules(EntityType<? extends Fox> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return level.getBlockState(pos.below()).is(BlockTags.FOXES_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
+ 
 @@ -706,13 +_,18 @@
  
      @Override

--- a/patches/net/minecraft/world/entity/animal/parrot/Parrot.java.patch
+++ b/patches/net/minecraft/world/entity/animal/parrot/Parrot.java.patch
@@ -22,6 +22,15 @@
                      this.tame(player);
                      this.level().broadcastEntityEvent(this, (byte)7);
                  } else {
+@@ -303,7 +_,7 @@
+         return false;
+     }
+ 
+-    public static boolean checkParrotSpawnRules(EntityType<Parrot> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkParrotSpawnRules(EntityType<? extends Parrot> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return level.getBlockState(pos.below()).is(BlockTags.PARROTS_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
+ 
 @@ -328,7 +_,10 @@
  
      public static SoundEvent getAmbient(Level level, RandomSource random) {

--- a/patches/net/minecraft/world/entity/animal/polarbear/PolarBear.java.patch
+++ b/patches/net/minecraft/world/entity/animal/polarbear/PolarBear.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/polarbear/PolarBear.java
++++ b/net/minecraft/world/entity/animal/polarbear/PolarBear.java
+@@ -108,7 +_,7 @@
+     }
+ 
+     public static boolean checkPolarBearSpawnRules(
+-        EntityType<PolarBear> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends PolarBear> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         Holder<Biome> biome = level.getBiome(pos);
+         return !biome.is(BiomeTags.POLAR_BEARS_SPAWN_ON_ALTERNATE_BLOCKS)

--- a/patches/net/minecraft/world/entity/animal/rabbit/Rabbit.java.patch
+++ b/patches/net/minecraft/world/entity/animal/rabbit/Rabbit.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/animal/rabbit/Rabbit.java
 +++ b/net/minecraft/world/entity/animal/rabbit/Rabbit.java
+@@ -432,7 +_,7 @@
+         }
+     }
+ 
+-    public static boolean checkRabbitSpawnRules(EntityType<Rabbit> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkRabbitSpawnRules(EntityType<? extends Rabbit> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return level.getBlockState(pos.below()).is(BlockTags.RABBITS_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
+ 
 @@ -599,7 +_,7 @@
          @Override
          public boolean canUse() {

--- a/patches/net/minecraft/world/entity/animal/turtle/Turtle.java.patch
+++ b/patches/net/minecraft/world/entity/animal/turtle/Turtle.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/animal/turtle/Turtle.java
++++ b/net/minecraft/world/entity/animal/turtle/Turtle.java
+@@ -141,7 +_,7 @@
+         return super.finalizeSpawn(level, difficulty, spawnReason, groupData);
+     }
+ 
+-    public static boolean checkTurtleSpawnRules(EntityType<Turtle> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkTurtleSpawnRules(EntityType<? extends Turtle> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return pos.getY() < level.getSeaLevel() + 4 && TurtleEggBlock.onSand(level, pos) && isBrightEnoughToSpawn(level, pos);
+     }
+ 

--- a/patches/net/minecraft/world/entity/animal/wolf/Wolf.java.patch
+++ b/patches/net/minecraft/world/entity/animal/wolf/Wolf.java.patch
@@ -9,3 +9,12 @@
              this.tame(player);
              this.navigation.stop();
              this.setTarget(null);
+@@ -659,7 +_,7 @@
+         return new Vec3(0.0, 0.6F * this.getEyeHeight(), this.getBbWidth() * 0.4F);
+     }
+ 
+-    public static boolean checkWolfSpawnRules(EntityType<Wolf> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkWolfSpawnRules(EntityType<? extends Wolf> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return level.getBlockState(pos.below()).is(BlockTags.WOLVES_SPAWNABLE_ON) && isBrightEnoughToSpawn(level, pos);
+     }
+ 

--- a/patches/net/minecraft/world/entity/monster/Endermite.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Endermite.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/Endermite.java
++++ b/net/minecraft/world/entity/monster/Endermite.java
+@@ -129,7 +_,7 @@
+     }
+ 
+     public static boolean checkEndermiteSpawnRules(
+-        EntityType<Endermite> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends Endermite> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         if (!checkAnyLightMonsterSpawnRules(type, level, spawnReason, pos, random)) {
+             return false;

--- a/patches/net/minecraft/world/entity/monster/Ghast.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Ghast.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/Ghast.java
++++ b/net/minecraft/world/entity/monster/Ghast.java
+@@ -146,7 +_,7 @@
+         return 5.0F;
+     }
+ 
+-    public static boolean checkGhastSpawnRules(EntityType<Ghast> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkGhastSpawnRules(EntityType<? extends Ghast> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return level.getDifficulty() != Difficulty.PEACEFUL && random.nextInt(20) == 0 && checkMobSpawnRules(type, level, spawnReason, pos, random);
+     }
+ 

--- a/patches/net/minecraft/world/entity/monster/Silverfish.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Silverfish.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/monster/Silverfish.java
 +++ b/net/minecraft/world/entity/monster/Silverfish.java
+@@ -109,7 +_,7 @@
+     }
+ 
+     public static boolean checkSilverfishSpawnRules(
+-        EntityType<Silverfish> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends Silverfish> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         if (!checkAnyLightMonsterSpawnRules(type, level, spawnReason, pos, random)) {
+             return false;
 @@ -143,7 +_,7 @@
              }
  

--- a/patches/net/minecraft/world/entity/monster/Strider.java.patch
+++ b/patches/net/minecraft/world/entity/monster/Strider.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/Strider.java
++++ b/net/minecraft/world/entity/monster/Strider.java
+@@ -100,7 +_,7 @@
+     }
+ 
+     public static boolean checkStriderSpawnRules(
+-        EntityType<Strider> ignoredType, LevelAccessor level, EntitySpawnReason ignoredSpawnType, BlockPos pos, RandomSource ignoredRandom
++        EntityType<? extends Strider> ignoredType, LevelAccessor level, EntitySpawnReason ignoredSpawnType, BlockPos pos, RandomSource ignoredRandom
+     ) {
+         BlockPos.MutableBlockPos checkPos = pos.mutable();
+ 

--- a/patches/net/minecraft/world/entity/monster/cubemob/MagmaCube.java.patch
+++ b/patches/net/minecraft/world/entity/monster/cubemob/MagmaCube.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/monster/cubemob/MagmaCube.java
 +++ b/net/minecraft/world/entity/monster/cubemob/MagmaCube.java
+@@ -51,7 +_,7 @@
+     }
+ 
+     public static boolean checkMagmaCubeSpawnRules(
+-        EntityType<MagmaCube> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends MagmaCube> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         return level.getDifficulty() != Difficulty.PEACEFUL;
+     }
 @@ -96,17 +_,28 @@
          float sizeJumpBoostPower = this.getSize() * 0.1F;
          this.setDeltaMovement(movement.x, this.getJumpPower() + sizeJumpBoostPower, movement.z);

--- a/patches/net/minecraft/world/entity/monster/cubemob/Slime.java.patch
+++ b/patches/net/minecraft/world/entity/monster/cubemob/Slime.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/cubemob/Slime.java
++++ b/net/minecraft/world/entity/monster/cubemob/Slime.java
+@@ -70,7 +_,7 @@
+         return this.isTiny() ? SoundEvents.SLIME_JUMP_SMALL : SoundEvents.SLIME_JUMP;
+     }
+ 
+-    public static boolean checkSlimeSpawnRules(EntityType<Slime> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkSlimeSpawnRules(EntityType<? extends Slime> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         if (level.getDifficulty() != Difficulty.PEACEFUL) {
+             if (EntitySpawnReason.isSpawner(spawnReason)) {
+                 return checkMobSpawnRules(type, level, spawnReason, pos, random);

--- a/patches/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
+++ b/patches/net/minecraft/world/entity/monster/cubemob/SulfurCube.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/cubemob/SulfurCube.java
++++ b/net/minecraft/world/entity/monster/cubemob/SulfurCube.java
+@@ -224,7 +_,7 @@
+     }
+ 
+     public static boolean checkSulfurCubeSpawnRules(
+-        EntityType<SulfurCube> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends SulfurCube> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         return true;
+     }

--- a/patches/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
+++ b/patches/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
@@ -9,6 +9,15 @@
                  this.makeSound(SoundEvents.HOGLIN_CONVERTED_TO_ZOMBIFIED);
                  this.finishConversion();
              }
+@@ -182,7 +_,7 @@
+         }
+     }
+ 
+-    public static boolean checkHoglinSpawnRules(EntityType<Hoglin> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkHoglinSpawnRules(EntityType<? extends Hoglin> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);
+     }
+ 
 @@ -248,7 +_,10 @@
  
      private void finishConversion() {

--- a/patches/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
+++ b/patches/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/entity/monster/piglin/Piglin.java
 +++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
+@@ -165,7 +_,7 @@
+         return Monster.createMonsterAttributes().add(Attributes.MAX_HEALTH, 16.0).add(Attributes.MOVEMENT_SPEED, 0.35F).add(Attributes.ATTACK_DAMAGE, 5.0);
+     }
+ 
+-    public static boolean checkPiglinSpawnRules(EntityType<Piglin> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
++    public static boolean checkPiglinSpawnRules(EntityType<? extends Piglin> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random) {
+         return !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);
+     }
+ 
 @@ -321,7 +_,7 @@
          } else if (this.isChargingCrossbow()) {
              return PiglinArmPose.CROSSBOW_CHARGE;

--- a/patches/net/minecraft/world/entity/monster/skeleton/Stray.java.patch
+++ b/patches/net/minecraft/world/entity/monster/skeleton/Stray.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/skeleton/Stray.java
++++ b/net/minecraft/world/entity/monster/skeleton/Stray.java
+@@ -24,7 +_,7 @@
+     }
+ 
+     public static boolean checkStraySpawnRules(
+-        EntityType<Stray> type, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends Stray> type, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         BlockPos checkSkyPos = pos;
+ 

--- a/patches/net/minecraft/world/entity/monster/zombie/Drowned.java.patch
+++ b/patches/net/minecraft/world/entity/monster/zombie/Drowned.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/zombie/Drowned.java
++++ b/net/minecraft/world/entity/monster/zombie/Drowned.java
+@@ -135,7 +_,7 @@
+     }
+ 
+     public static boolean checkDrownedSpawnRules(
+-        EntityType<Drowned> type, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends Drowned> type, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         if (!level.getFluidState(pos.below()).is(FluidTags.WATER) && !EntitySpawnReason.isSpawner(spawnReason)) {
+             return false;

--- a/patches/net/minecraft/world/entity/monster/zombie/ZombifiedPiglin.java.patch
+++ b/patches/net/minecraft/world/entity/monster/zombie/ZombifiedPiglin.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/monster/zombie/ZombifiedPiglin.java
++++ b/net/minecraft/world/entity/monster/zombie/ZombifiedPiglin.java
+@@ -168,7 +_,7 @@
+     }
+ 
+     public static boolean checkZombifiedPiglinSpawnRules(
+-        EntityType<ZombifiedPiglin> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
++        EntityType<? extends ZombifiedPiglin> type, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
+         return level.getDifficulty() != Difficulty.PEACEFUL && !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);
+     }


### PR DESCRIPTION
The constructor for Stray already supports entity types of classes extending it, but the helper for checking the spawn rules does not.