### PR TITLE
Exclude main LWJGL dependency from FML-loader

### DIFF
--- a/projects/neoforge/build.gradle
+++ b/projects/neoforge/build.gradle
@@ -118,6 +118,10 @@ dependencies {
     libraries ("net.neoforged.fancymodloader:loader:${project.fancy_mod_loader_version}") {
         exclude group: 'org.slf4j'
         exclude group: 'net.fabricmc'
+        // MC currently (as of 26.2-pre-1) uses the Unsafe-using artifact of LWJGL.
+        // To avoid overriding that artifact, exclude it from here and rely on minecraft-dependencies to provide it.
+        // We must specifically exclude the main LWJGL module, since FML depends on lwjgl-tinyfd.
+        exclude group: 'org.lwjgl', module: 'lwjgl'
     }
     libraries ("net.neoforged.fancymodloader:earlydisplay:${project.fancy_mod_loader_version}") {
         exclude group: 'org.lwjgl'


### PR DESCRIPTION
This PR fixes an issue where NeoForge forces the use of the main variant of LWJGL rather than the Unsafe-using variant that Minecraft provides, by excluding LWJGL from the dependency tree used by the installer.

FancyModLoader declares a dependency on LWJGL. This dependency happens to override the LWJGL dependency used by Minecraft, which as of 26.2-pre-1 is the Unsafe-using variant due to performance implications with the (FFM API-using) main variant.

Because of how our tooling operates (which I do not sufficiently understand at the moment to explain exactly how), the installer's profile receives the declared LWJGL dependency from FancyModLoader, which is eventually put into the launcher profile.

The solution taken in this PR is to exclude that declared LWJGL dependency from FancyModLoader and rely on the provided MC dependency instead (from `net.neoforged:minecraft-dependencies`). This way, the installer profile no longer contains the LWJGL dependency, and thus neither will the launcher profile.

In the future, Mojang may switch back from the Unsafe-using variant to the main variant once the performance implications are resolved. This solution should gracefully handle that case, since we no longer care about which variant of LWJGL is in use. (FancyModLoader would likely still need to be updated though, to match the LWJGL version for the LWJGL-tinyfd artifact it uses.)