### PR TITLE
Backport to 1.21.1: Add a ModelProvider method for flower pots with plants

### DIFF
--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ModelProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ModelProvider.java
@@ -371,6 +371,10 @@ public abstract class ModelProvider<T extends ModelBuilder<T>> implements DataPr
         return singleTexture(name, BLOCK_FOLDER + "/leaves", "all", texture);
     }
 
+    public T flowerPotCross(String name, ResourceLocation plant) {
+        return singleTexture(name, BLOCK_FOLDER + "/flower_pot_cross", "plant", plant);
+    }
+
     /**
      * {@return a model builder that's not directly saved to disk. Meant for use in custom model loaders.}
      */


### PR DESCRIPTION
This PR backports #1592, which adds a `ModelProvider` method for `flower_pot_cross`-derived block models, to 1.21.1.

It is a verbatim cherry-pick of commit 9f4b630 to the 1.21.1 branch.