### PR TITLE
Backport to 1.21.1: Create Dynamic Armor Trim System

### DIFF
--- a/src/generated/resources/assets/minecraft/atlases/armor_trims.json
+++ b/src/generated/resources/assets/minecraft/atlases/armor_trims.json
@@ -1,14 +1,10 @@
 {
   "sources": [
     {
-      "type": "minecraft:single",
-      "resource": "neoforge:white"
-    },
-    {
       "type": "neoforge:directory_paletted_permutations",
       "palette_key": "minecraft:trims/color_palettes/trim_palette",
       "palettes": "trims/color_palettes",
-      "textures": "trims/items"
+      "textures": "trims/models"
     }
   ]
 }

--- a/src/generated/resources/assets/minecraft/models/item/chainmail_boots.json
+++ b/src/generated/resources/assets/minecraft/models/item/chainmail_boots.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/chainmail_boots"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/boots_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/chainmail_chestplate.json
+++ b/src/generated/resources/assets/minecraft/models/item/chainmail_chestplate.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/chainmail_chestplate"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/chestplate_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/chainmail_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/chainmail_helmet.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/chainmail_helmet"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/chainmail_leggings.json
+++ b/src/generated/resources/assets/minecraft/models/item/chainmail_leggings.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/chainmail_leggings"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/leggings_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/diamond_boots.json
+++ b/src/generated/resources/assets/minecraft/models/item/diamond_boots.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/diamond_boots"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/boots_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/diamond_chestplate.json
+++ b/src/generated/resources/assets/minecraft/models/item/diamond_chestplate.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/diamond_chestplate"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/chestplate_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/diamond_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/diamond_helmet.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/diamond_helmet"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/diamond_leggings.json
+++ b/src/generated/resources/assets/minecraft/models/item/diamond_leggings.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/diamond_leggings"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/leggings_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/golden_boots.json
+++ b/src/generated/resources/assets/minecraft/models/item/golden_boots.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/golden_boots"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/boots_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/golden_chestplate.json
+++ b/src/generated/resources/assets/minecraft/models/item/golden_chestplate.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/golden_chestplate"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/chestplate_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/golden_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/golden_helmet.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/golden_helmet"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/golden_leggings.json
+++ b/src/generated/resources/assets/minecraft/models/item/golden_leggings.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/golden_leggings"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/leggings_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/iron_boots.json
+++ b/src/generated/resources/assets/minecraft/models/item/iron_boots.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/iron_boots"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/boots_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/iron_chestplate.json
+++ b/src/generated/resources/assets/minecraft/models/item/iron_chestplate.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/iron_chestplate"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/chestplate_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/iron_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/iron_helmet.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/iron_helmet"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/iron_leggings.json
+++ b/src/generated/resources/assets/minecraft/models/item/iron_leggings.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/iron_leggings"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/leggings_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/leather_boots.json
+++ b/src/generated/resources/assets/minecraft/models/item/leather_boots.json
@@ -1,0 +1,11 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/leather_boots",
+      "layer1": "minecraft:item/leather_boots_overlay"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/boots_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/leather_chestplate.json
+++ b/src/generated/resources/assets/minecraft/models/item/leather_chestplate.json
@@ -1,0 +1,11 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/leather_chestplate",
+      "layer1": "minecraft:item/leather_chestplate_overlay"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/chestplate_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/leather_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/leather_helmet.json
@@ -1,0 +1,11 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/leather_helmet",
+      "layer1": "minecraft:item/leather_helmet_overlay"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/leather_leggings.json
+++ b/src/generated/resources/assets/minecraft/models/item/leather_leggings.json
@@ -1,0 +1,11 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/leather_leggings",
+      "layer1": "minecraft:item/leather_leggings_overlay"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/leggings_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/netherite_boots.json
+++ b/src/generated/resources/assets/minecraft/models/item/netherite_boots.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/netherite_boots"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/boots_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/netherite_chestplate.json
+++ b/src/generated/resources/assets/minecraft/models/item/netherite_chestplate.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/netherite_chestplate"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/chestplate_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/netherite_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/netherite_helmet.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/netherite_helmet"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/netherite_leggings.json
+++ b/src/generated/resources/assets/minecraft/models/item/netherite_leggings.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/netherite_leggings"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/leggings_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/generated/resources/assets/minecraft/models/item/turtle_helmet.json
+++ b/src/generated/resources/assets/minecraft/models/item/turtle_helmet.json
@@ -1,0 +1,10 @@
+{
+  "base_model": {
+    "parent": "minecraft:item/generated",
+    "textures": {
+      "layer0": "minecraft:item/turtle_helmet"
+    }
+  },
+  "base_trim_texture": "minecraft:trims/items/helmet_trim",
+  "loader": "neoforge:trimmed_armor"
+}

--- a/src/main/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -35,6 +35,7 @@ import net.neoforged.neoforge.client.model.ElementsModel;
 import net.neoforged.neoforge.client.model.EmptyModel;
 import net.neoforged.neoforge.client.model.ItemLayerModel;
 import net.neoforged.neoforge.client.model.SeparateTransformsModel;
+import net.neoforged.neoforge.client.model.TrimmedArmorModel;
 import net.neoforged.neoforge.client.model.obj.ObjLoader;
 import net.neoforged.neoforge.client.textures.NamespacedDirectoryLister;
 import net.neoforged.neoforge.common.ModConfigSpec;
@@ -71,6 +72,7 @@ public class ClientNeoForgeMod {
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "empty"), EmptyModel.LOADER);
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "elements"), ElementsModel.Loader.INSTANCE);
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "obj"), ObjLoader.INSTANCE);
+        event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "trimmed_armor"), TrimmedArmorModel.Loader.INSTANCE);
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "fluid_container"), DynamicFluidContainerModel.Loader.INSTANCE);
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "composite"), CompositeModel.Loader.INSTANCE);
         event.register(ResourceLocation.fromNamespaceAndPath("neoforge", "item_layers"), ItemLayerModel.Loader.INSTANCE);

--- a/src/main/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -37,6 +37,7 @@ import net.neoforged.neoforge.client.model.ItemLayerModel;
 import net.neoforged.neoforge.client.model.SeparateTransformsModel;
 import net.neoforged.neoforge.client.model.TrimmedArmorModel;
 import net.neoforged.neoforge.client.model.obj.ObjLoader;
+import net.neoforged.neoforge.client.textures.DirectoryPalettedPermutations;
 import net.neoforged.neoforge.client.textures.NamespacedDirectoryLister;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import net.neoforged.neoforge.common.NeoForge;
@@ -93,6 +94,7 @@ public class ClientNeoForgeMod {
     @SubscribeEvent
     static void onRegisterSpriteSourceTypes(RegisterSpriteSourceTypesEvent event) {
         event.register(NamespacedDirectoryLister.ID, NamespacedDirectoryLister.TYPE);
+        event.register(DirectoryPalettedPermutations.ID, DirectoryPalettedPermutations.TYPE);
     }
 
     @SubscribeEvent

--- a/src/main/java/net/neoforged/neoforge/client/model/PropagatingBakedModelWrapper.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/PropagatingBakedModelWrapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.List;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+
+/// A variant of {@link BakedModelWrapper} that re-wraps any derivative {@link BakedModel}s returned by the wrapped model's methods.
+///
+/// Useful for ensuring wrapper behavior is preserved across transforms and render passes.
+public abstract class PropagatingBakedModelWrapper<T extends BakedModel> extends BakedModelWrapper<T> {
+    public PropagatingBakedModelWrapper(T originalModel) {
+        super(originalModel);
+    }
+
+    @Override
+    public BakedModel applyTransform(ItemDisplayContext cameraTransformType, PoseStack poseStack, boolean applyLeftHandTransform) {
+        return rewrap(super.applyTransform(cameraTransformType, poseStack, applyLeftHandTransform));
+    }
+
+    @Override
+    public List<BakedModel> getRenderPasses(ItemStack itemStack, boolean fabulous) {
+        return super.getRenderPasses(itemStack, fabulous).stream().map(this::rewrap).toList();
+    }
+
+    protected abstract BakedModel rewrap(BakedModel model);
+}

--- a/src/main/java/net/neoforged/neoforge/client/model/TrimmedArmorModel.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/TrimmedArmorModel.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import java.util.List;
+import java.util.function.Function;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.BlockElement;
+import net.minecraft.client.renderer.block.model.BlockModel;
+import net.minecraft.client.renderer.block.model.ItemOverrides;
+import net.minecraft.client.renderer.texture.TextureAtlas;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ModelState;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.armortrim.ArmorTrim;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.client.model.geometry.IGeometryBakingContext;
+import net.neoforged.neoforge.client.model.geometry.IGeometryLoader;
+import net.neoforged.neoforge.client.model.geometry.IUnbakedGeometry;
+import net.neoforged.neoforge.client.model.geometry.UnbakedGeometryHelper;
+import net.neoforged.neoforge.common.util.ConcatenatedListView;
+import org.jetbrains.annotations.Nullable;
+
+/// A dynamic model that applies an armor trim texture on top of an existing model when the trim component exists.
+///
+/// NOTE: If multiple mods add a trim material with the same path, only the one that gets loaded last will have its proper colors.
+///
+/// Example: if mod A and mod B register a "tin" trim material, and mod B loads after A, mod B's material will be the one used.
+///
+/// **Mod A's ingot will still work just fine as a trim material, it will just look like whatever mod B defined for theirs!**
+///
+/// All this means is that if another mod is registering the same material(s) as you and uses this system, your trim colors *may* not look exactly how you want them to.
+///
+/// This issue can be avoided by making your material path more unique. We would encourage you to prefix your material with your mod id or something along those lines.
+public class TrimmedArmorModel implements IUnbakedGeometry<TrimmedArmorModel> {
+    private static final IQuadTransformer TRIM_TRANSFORM = quad -> {
+        int[] vertices = quad.getVertices();
+        for (int quadIdx = 0; quadIdx < 4; quadIdx++) {
+            int baseIdx = IQuadTransformer.POSITION + quadIdx * IQuadTransformer.STRIDE;
+            for (int coordIdx = 0; coordIdx < 3; coordIdx++) {
+                int index = baseIdx + coordIdx;
+                float value = Float.intBitsToFloat(vertices[index]);
+                value = (value - 0.5F) * 1.002F + 0.5F;
+                vertices[index] = Float.floatToIntBits(value);
+            }
+        }
+    };
+
+    private final BlockModel baseModel;
+    private final ResourceLocation baseTrimTexture;
+
+    private TrimmedArmorModel(BlockModel baseModel, ResourceLocation baseTrimTexture) {
+        this.baseModel = baseModel;
+        this.baseTrimTexture = baseTrimTexture;
+    }
+
+    @Override
+    public BakedModel bake(IGeometryBakingContext context, ModelBaker baker, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelState, ItemOverrides overrides) {
+        BakedModel bakedModel = baseModel.bake(baker, baseModel, spriteGetter, modelState, context.useBlockLight());
+        TrimmedArmorOverrideHandler trimOverrides = new TrimmedArmorOverrideHandler(bakedModel, baseTrimTexture, modelState);
+        return new UntrimmedBaked(bakedModel, trimOverrides);
+    }
+
+    @Override
+    public void resolveParents(Function<ResourceLocation, UnbakedModel> modelGetter, IGeometryBakingContext context) {
+        baseModel.resolveParents(modelGetter);
+    }
+
+    private static List<BakedQuad> createTrimLayer(ResourceLocation trimTexture, ModelState modelState) {
+        TextureAtlasSprite sprite = new Material(TextureAtlas.LOCATION_BLOCKS, trimTexture).sprite();
+        List<BlockElement> elements = UnbakedGeometryHelper.createUnbakedItemElements(-1, sprite);
+        List<BakedQuad> quads = UnbakedGeometryHelper.bakeElements(elements, mat -> sprite, modelState);
+        TRIM_TRANSFORM.processInPlace(quads);
+        return quads;
+    }
+
+    private static class UntrimmedBaked extends PropagatingBakedModelWrapper<BakedModel> {
+        private final TrimmedArmorOverrideHandler overrides;
+
+        public UntrimmedBaked(BakedModel originalModel, TrimmedArmorOverrideHandler overrides) {
+            super(originalModel);
+            this.overrides = overrides;
+        }
+
+        @Override
+        public ItemOverrides getOverrides() {
+            return overrides;
+        }
+
+        protected BakedModel rewrap(BakedModel model) {
+            return model == originalModel ? this : new UntrimmedBaked(model, overrides.withModel(model));
+        }
+    }
+
+    private static class TrimmedBaked extends PropagatingBakedModelWrapper<BakedModel> {
+        private final List<BakedQuad> trimQuads;
+
+        public TrimmedBaked(BakedModel originalModel, List<BakedQuad> trimQuads) {
+            super(originalModel);
+            this.trimQuads = trimQuads;
+        }
+
+        @Override
+        public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, RandomSource rand) {
+            return addTrimQuads(side, super.getQuads(state, side, rand));
+        }
+
+        @Override
+        public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, RandomSource rand, ModelData extraData, @Nullable RenderType renderType) {
+            return addTrimQuads(side, super.getQuads(state, side, rand, extraData, renderType));
+        }
+
+        @Override
+        protected BakedModel rewrap(BakedModel model) {
+            return model == originalModel ? this : new TrimmedBaked(model, trimQuads);
+        }
+
+        private List<BakedQuad> addTrimQuads(@Nullable Direction side, List<BakedQuad> quads) {
+            return side == null ? ConcatenatedListView.of(List.of(quads, trimQuads)) : quads;
+        }
+    }
+
+    public static class Loader implements IGeometryLoader<TrimmedArmorModel> {
+        public static final Loader INSTANCE = new Loader();
+
+        private Loader() {}
+
+        @Override
+        public TrimmedArmorModel read(JsonObject jsonObject, JsonDeserializationContext deserializationContext) {
+            if (!jsonObject.has("base_model"))
+                throw new JsonParseException("A trimmed armor model must have a \"base_model\" member.");
+
+            BlockModel baseModel = ExtendedBlockModelDeserializer.INSTANCE.fromJson(jsonObject.getAsJsonObject("base_model"), BlockModel.class);
+
+            if (!jsonObject.has("base_trim_texture"))
+                throw new JsonParseException("A trimmed armor model must have a \"base_trim_texture\" member.");
+
+            ResourceLocation baseTrimTexture = ResourceLocation.parse(jsonObject.get("base_trim_texture").getAsString());
+
+            return new TrimmedArmorModel(baseModel, baseTrimTexture);
+        }
+    }
+
+    private static final class TrimmedArmorOverrideHandler extends ItemOverrides {
+        private final Object2ObjectMap<String, List<BakedQuad>> trimQuadLists = new Object2ObjectOpenHashMap<>();
+
+        private final BakedModel baseModel;
+        private final ResourceLocation baseTrimTexture;
+        private final ModelState modelState;
+
+        private TrimmedArmorOverrideHandler(BakedModel baseModel, ResourceLocation baseTrimTexture, ModelState modelState) {
+            this.baseModel = baseModel;
+            this.baseTrimTexture = baseTrimTexture;
+            this.modelState = modelState;
+        }
+
+        @Override
+        public @Nullable BakedModel resolve(BakedModel originalModel, ItemStack stack, @Nullable ClientLevel level, @Nullable LivingEntity entity, int seed) {
+            BakedModel override = baseModel.getOverrides().resolve(baseModel, stack, level, entity, seed);
+            ArmorTrim trim = stack.get(DataComponents.TRIM);
+            if (override == null || trim == null || !(stack.getItem() instanceof ArmorItem armorItem)) {
+                return override;
+            }
+
+            String suffix = ArmorTrim.getColorPaletteSuffix(trim.material(), armorItem.getMaterial());
+            List<BakedQuad> trimQuads = trimQuadLists.computeIfAbsent(suffix, s -> createTrimLayer(baseTrimTexture.withSuffix("_" + suffix), modelState));
+            return new TrimmedBaked(override, trimQuads);
+        }
+
+        private TrimmedArmorOverrideHandler withModel(BakedModel model) {
+            return new TrimmedArmorOverrideHandler(model, baseTrimTexture, modelState);
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/ItemModelProvider.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/ItemModelProvider.java
@@ -9,8 +9,11 @@ import java.util.Objects;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ArmorMaterials;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.client.model.generators.loaders.TrimmedArmorModelBuilder;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 
 /**
@@ -57,6 +60,21 @@ public abstract class ItemModelProvider extends ModelProvider<ItemModelBuilder> 
 
     public ItemModelBuilder simpleBlockItem(ResourceLocation block) {
         return withExistingParent(block.toString(), ResourceLocation.fromNamespaceAndPath(block.getNamespace(), "block/" + block.getPath()));
+    }
+
+    public TrimmedArmorModelBuilder<ItemModelBuilder> dynamicTrimmableItem(ArmorItem armor) {
+        ResourceLocation armorId = Objects.requireNonNull(BuiltInRegistries.ITEM.getKey(armor));
+        ResourceLocation armorTexture = armorId.withPrefix("item/");
+
+        ItemModelBuilder baseModel = nested().parent(new ModelFile.UncheckedModelFile("item/generated")).texture("layer0", armorTexture);
+        if (armor.getMaterial() == ArmorMaterials.LEATHER)
+            baseModel = baseModel.texture("layer1", armorTexture.withSuffix("_overlay"));
+
+        return dynamicTrimmableItem(armorId, baseModel, mcLoc("trims/items/" + armor.getType().getName() + "_trim"));
+    }
+
+    public TrimmedArmorModelBuilder<ItemModelBuilder> dynamicTrimmableItem(ResourceLocation armor, ItemModelBuilder baseModel, ResourceLocation baseTrimTexture) {
+        return getBuilder(armor.toString()).customLoader(TrimmedArmorModelBuilder::begin).baseModel(baseModel).baseTrimTexture(baseTrimTexture);
     }
 
     @Override

--- a/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/TrimmedArmorModelBuilder.java
+++ b/src/main/java/net/neoforged/neoforge/client/model/generators/loaders/TrimmedArmorModelBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.model.generators.loaders;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.client.model.generators.CustomLoaderBuilder;
+import net.neoforged.neoforge.client.model.generators.ModelBuilder;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.Nullable;
+
+public class TrimmedArmorModelBuilder<T extends ModelBuilder<T>> extends CustomLoaderBuilder<T> {
+    public static <T extends ModelBuilder<T>> TrimmedArmorModelBuilder<T> begin(T parent, ExistingFileHelper existingFileHelper) {
+        return new TrimmedArmorModelBuilder<>(parent, existingFileHelper);
+    }
+
+    private @Nullable ModelBuilder<?> baseModel;
+    private @Nullable ResourceLocation baseTrimTexture;
+
+    protected TrimmedArmorModelBuilder(T parent, ExistingFileHelper existingFileHelper) {
+        super(ResourceLocation.fromNamespaceAndPath("neoforge", "trimmed_armor"), parent, existingFileHelper, false);
+    }
+
+    public TrimmedArmorModelBuilder<T> baseModel(ModelBuilder<?> baseModel) {
+        Preconditions.checkNotNull(baseModel, "Base model must not be null");
+        this.baseModel = baseModel;
+        return this;
+    }
+
+    public TrimmedArmorModelBuilder<T> baseTrimTexture(ResourceLocation baseTrimTexture) {
+        Preconditions.checkNotNull(baseTrimTexture, "Base trim texture must not be null");
+        this.baseTrimTexture = baseTrimTexture;
+        return this;
+    }
+
+    @Override
+    public JsonObject toJson(JsonObject json) {
+        json = super.toJson(json);
+
+        Preconditions.checkNotNull(baseModel, "Base model must not be null");
+
+        json.add("base_model", baseModel.toJson());
+
+        Preconditions.checkNotNull(baseTrimTexture, "Base trim texture must not be null");
+
+        json.addProperty("base_trim_texture", baseTrimTexture.toString());
+
+        return json;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/client/textures/DirectoryPalettedPermutations.java
+++ b/src/main/java/net/neoforged/neoforge/client/textures/DirectoryPalettedPermutations.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.textures;
+
+import com.google.common.base.Suppliers;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.IntUnaryOperator;
+import java.util.function.Supplier;
+import net.minecraft.client.renderer.texture.atlas.SpriteSource;
+import net.minecraft.client.renderer.texture.atlas.SpriteSourceType;
+import net.minecraft.client.renderer.texture.atlas.sources.LazyLoadedImage;
+import net.minecraft.client.renderer.texture.atlas.sources.PalettedPermutations;
+import net.minecraft.resources.FileToIdConverter;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.neoforged.neoforge.internal.versions.neoforge.NeoForgeVersion;
+
+/// An implementation of vanilla's {@link PalettedPermutations} loader that uses a whole directory instead of just a list of contents.
+/// If you wish to use the PalettedPermutations system for something, using this would be preferred as it allows other mods to also utilize your system to its fullest extent.
+///
+/// The problem with vanilla's system is that if Mod A adds a texture and Mod B adds a palette, the game will not recognize the additions of both and won't generate files for Mod A's texture using mod B's palette.
+/// Because Mod A doesn't list Mod B's materials in their atlas JSON, and Mod B doesn't list Mod A's pattern in their atlas JSON, the 2 don't work together.
+///
+/// This system makes it so only the owner of the atlas needs to create a JSON file, all other mods will be supported by default if they put their textures in the proper directory.
+public record DirectoryPalettedPermutations(String texturePath, ResourceLocation paletteKey, String palettePath) implements SpriteSource {
+
+    public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(NeoForgeVersion.MOD_ID, "directory_paletted_permutations");
+    public static final MapCodec<DirectoryPalettedPermutations> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            Codec.STRING.fieldOf("textures").forGetter(DirectoryPalettedPermutations::texturePath),
+            ResourceLocation.CODEC.fieldOf("palette_key").forGetter(DirectoryPalettedPermutations::paletteKey),
+            Codec.STRING.fieldOf("palettes").forGetter(DirectoryPalettedPermutations::palettePath))
+            .apply(instance, DirectoryPalettedPermutations::new));
+    public static final SpriteSourceType TYPE = new SpriteSourceType(CODEC);
+    @Override
+    public void run(ResourceManager manager, SpriteSource.Output output) {
+        Map<ResourceLocation, Resource> trimTextures = new HashMap<>();
+
+        FileToIdConverter trimID = new FileToIdConverter("textures/" + this.texturePath(), ".png");
+        trimID.listMatchingResources(manager).forEach((identifier, resource) -> {
+            ResourceLocation id = trimID.fileToId(identifier).withPrefix(this.texturePath() + "/");
+            trimTextures.put(id, resource);
+        });
+
+        Map<String, ResourceLocation> paletteTextures = new HashMap<>();
+
+        FileToIdConverter paletteID = new FileToIdConverter("textures/" + this.palettePath(), ".png");
+        paletteID.listMatchingResources(manager).forEach((identifier, resource) -> {
+            ResourceLocation id = paletteID.fileToId(identifier).withPrefix(this.palettePath() + "/");
+            String path = paletteID.fileToId(identifier).getPath();
+            paletteTextures.put(path, id);
+        });
+
+        Supplier<int[]> palette = Suppliers.memoize(() -> PalettedPermutations.loadPaletteEntryFromImage(manager, this.paletteKey()));
+        Map<String, Supplier<IntUnaryOperator>> mappedTextures = new HashMap<>();
+        paletteTextures.forEach((name, location) -> mappedTextures.put(name, Suppliers.memoize(() -> PalettedPermutations.createPaletteMapping(palette.get(), PalettedPermutations.loadPaletteEntryFromImage(manager, location)))));
+
+        for (Map.Entry<ResourceLocation, Resource> trimEntry : trimTextures.entrySet()) {
+            ResourceLocation trimLocation = TEXTURE_ID_CONVERTER.idToFile(trimEntry.getKey());
+
+            LazyLoadedImage lazyloadedimage = new LazyLoadedImage(trimLocation, trimEntry.getValue(), mappedTextures.size());
+
+            for (Map.Entry<String, Supplier<IntUnaryOperator>> mappedEntry : mappedTextures.entrySet()) {
+                ResourceLocation mappedTrimLocation = trimEntry.getKey().withSuffix("_" + mappedEntry.getKey());
+                output.add(mappedTrimLocation, new PalettedPermutations.PalettedSpriteSupplier(lazyloadedimage, mappedEntry.getValue(), mappedTrimLocation));
+            }
+        }
+    }
+
+    @Override
+    public SpriteSourceType type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -120,6 +120,7 @@ import net.neoforged.neoforge.common.data.internal.NeoForgeRecipeProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeRegistryOrderReportProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeSpriteSourceProvider;
 import net.neoforged.neoforge.common.data.internal.NeoForgeStructureTagsProvider;
+import net.neoforged.neoforge.common.data.internal.VanillaItemModelProvider;
 import net.neoforged.neoforge.common.data.internal.VanillaSoundDefinitionsProvider;
 import net.neoforged.neoforge.common.extensions.IPlayerExtension;
 import net.neoforged.neoforge.common.loot.AddTableLootModifier;
@@ -643,6 +644,7 @@ public class NeoForgeMod {
         gen.addProvider(event.includeServer(), new NeoForgeDataMapsProvider(packOutput, lookupProvider));
 
         gen.addProvider(event.includeClient(), new NeoForgeSpriteSourceProvider(packOutput, lookupProvider, existingFileHelper));
+        gen.addProvider(event.includeClient(), new VanillaItemModelProvider(packOutput, existingFileHelper));
         gen.addProvider(event.includeClient(), new VanillaSoundDefinitionsProvider(packOutput, existingFileHelper));
         gen.addProvider(event.includeClient(), new NeoForgeLanguageProvider(packOutput));
     }

--- a/src/main/java/net/neoforged/neoforge/common/data/SpriteSourceProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/SpriteSourceProvider.java
@@ -31,6 +31,7 @@ public abstract class SpriteSourceProvider extends JsonCodecProvider<List<Sprite
     protected static final ResourceLocation CHESTS_ATLAS = ResourceLocation.withDefaultNamespace("chests");
     protected static final ResourceLocation SHIELD_PATTERNS_ATLAS = ResourceLocation.withDefaultNamespace("shield_patterns");
     protected static final ResourceLocation SHULKER_BOXES_ATLAS = ResourceLocation.withDefaultNamespace("shulker_boxes");
+    protected static final ResourceLocation ARMOR_TRIMS_ATLAS = ResourceLocation.withDefaultNamespace("armor_trims");
     protected static final ResourceLocation SIGNS_ATLAS = ResourceLocation.withDefaultNamespace("signs");
     protected static final ResourceLocation MOB_EFFECTS_ATLAS = ResourceLocation.withDefaultNamespace("mob_effects");
     protected static final ResourceLocation PAINTINGS_ATLAS = ResourceLocation.withDefaultNamespace("paintings");

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeSpriteSourceProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/NeoForgeSpriteSourceProvider.java
@@ -11,6 +11,7 @@ import net.minecraft.client.renderer.texture.atlas.sources.SingleFile;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.client.textures.DirectoryPalettedPermutations;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import net.neoforged.neoforge.common.data.SpriteSourceProvider;
 
@@ -21,6 +22,9 @@ public class NeoForgeSpriteSourceProvider extends SpriteSourceProvider {
 
     @Override
     protected void gather() {
-        atlas(SpriteSourceProvider.BLOCKS_ATLAS).addSource(new SingleFile(ResourceLocation.fromNamespaceAndPath("neoforge", "white"), Optional.empty()));
+        atlas(SpriteSourceProvider.BLOCKS_ATLAS)
+                .addSource(new SingleFile(ResourceLocation.fromNamespaceAndPath("neoforge", "white"), Optional.empty()))
+                .addSource(new DirectoryPalettedPermutations("trims/items", ResourceLocation.withDefaultNamespace("trims/color_palettes/trim_palette"), "trims/color_palettes"));
+        atlas(SpriteSourceProvider.ARMOR_TRIMS_ATLAS).addSource(new DirectoryPalettedPermutations("trims/models", ResourceLocation.withDefaultNamespace("trims/color_palettes/trim_palette"), "trims/color_palettes"));
     }
 }

--- a/src/main/java/net/neoforged/neoforge/common/data/internal/VanillaItemModelProvider.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/internal/VanillaItemModelProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.common.data.internal;
+
+import net.minecraft.data.PackOutput;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.Items;
+import net.neoforged.neoforge.client.model.generators.ItemModelProvider;
+import net.neoforged.neoforge.common.data.ExistingFileHelper;
+
+public class VanillaItemModelProvider extends ItemModelProvider {
+    public VanillaItemModelProvider(PackOutput output, ExistingFileHelper helper) {
+        super(output, "minecraft", helper);
+    }
+
+    @Override
+    protected void registerModels() {
+        dynamicTrimmableItem((ArmorItem) Items.TURTLE_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.LEATHER_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.LEATHER_CHESTPLATE);
+        dynamicTrimmableItem((ArmorItem) Items.LEATHER_LEGGINGS);
+        dynamicTrimmableItem((ArmorItem) Items.LEATHER_BOOTS);
+        dynamicTrimmableItem((ArmorItem) Items.CHAINMAIL_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.CHAINMAIL_CHESTPLATE);
+        dynamicTrimmableItem((ArmorItem) Items.CHAINMAIL_LEGGINGS);
+        dynamicTrimmableItem((ArmorItem) Items.CHAINMAIL_BOOTS);
+        dynamicTrimmableItem((ArmorItem) Items.IRON_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.IRON_CHESTPLATE);
+        dynamicTrimmableItem((ArmorItem) Items.IRON_LEGGINGS);
+        dynamicTrimmableItem((ArmorItem) Items.IRON_BOOTS);
+        dynamicTrimmableItem((ArmorItem) Items.DIAMOND_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.DIAMOND_CHESTPLATE);
+        dynamicTrimmableItem((ArmorItem) Items.DIAMOND_LEGGINGS);
+        dynamicTrimmableItem((ArmorItem) Items.DIAMOND_BOOTS);
+        dynamicTrimmableItem((ArmorItem) Items.GOLDEN_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.GOLDEN_CHESTPLATE);
+        dynamicTrimmableItem((ArmorItem) Items.GOLDEN_LEGGINGS);
+        dynamicTrimmableItem((ArmorItem) Items.GOLDEN_BOOTS);
+        dynamicTrimmableItem((ArmorItem) Items.NETHERITE_HELMET);
+        dynamicTrimmableItem((ArmorItem) Items.NETHERITE_CHESTPLATE);
+        dynamicTrimmableItem((ArmorItem) Items.NETHERITE_LEGGINGS);
+        dynamicTrimmableItem((ArmorItem) Items.NETHERITE_BOOTS);
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -100,6 +100,7 @@ public net.minecraft.client.renderer.entity.LivingEntityRenderer addLayer(Lnet/m
 public net.minecraft.client.renderer.texture.SpriteContents byMipLevel # byMipLevel
 default net.minecraft.client.renderer.texture.SpriteContents animatedTexture # animatedTexture
 public net.minecraft.client.renderer.texture.atlas.sources.PalettedPermutations <init>(Ljava/util/List;Lnet/minecraft/resources/ResourceLocation;Ljava/util/Map;)V # constructor
+public net.minecraft.client.renderer.texture.atlas.sources.PalettedPermutations createPaletteMapping([I[I)Ljava/util/function/IntUnaryOperator; # createPaletteMapping
 public net.minecraft.client.renderer.texture.atlas.sources.PalettedPermutations$PalettedSpriteSupplier
 public net.minecraft.client.renderer.texture.atlas.sources.PalettedPermutations$PalettedSpriteSupplier <init>(Lnet/minecraft/client/renderer/texture/atlas/sources/LazyLoadedImage;Ljava/util/function/Supplier;Lnet/minecraft/resources/ResourceLocation;)V # constructor
 public net.minecraft.client.renderer.texture.atlas.sources.Unstitcher$Region

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -257,6 +257,7 @@ public net.minecraft.world.item.SwordItem createToolProperties()Lnet/minecraft/w
 public net.minecraft.world.item.Item getPlayerPOVHitResult(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/level/ClipContext$Fluid;)Lnet/minecraft/world/phys/BlockHitResult; # getPlayerPOVHitResult
 public net.minecraft.world.item.ItemStack addToTooltip(Lnet/minecraft/core/component/DataComponentType;Lnet/minecraft/world/item/Item$TooltipContext;Ljava/util/function/Consumer;Lnet/minecraft/world/item/TooltipFlag;)V
 public net.minecraft.world.item.ItemStackLinkedSet TYPE_AND_TAG # TYPE_AND_TAG
+public net.minecraft.world.item.armortrim.ArmorTrim getColorPaletteSuffix(Lnet/minecraft/core/Holder;Lnet/minecraft/core/Holder;)Ljava/lang/String; # getColorPaletteSuffix
 public net.minecraft.world.item.context.BlockPlaceContext <init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V # constructor
 public net.minecraft.world.item.context.UseOnContext <init>(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/player/Player;Lnet/minecraft/world/InteractionHand;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/phys/BlockHitResult;)V # constructor
 public net.minecraft.world.item.crafting.Ingredient fromValues(Ljava/util/stream/Stream;)Lnet/minecraft/world/item/crafting/Ingredient; # fromValues


### PR DESCRIPTION
This PR backports #3038, which adds a system for dynamically generating armor trim models and textures, to 1.21.1. This system consists of two different parts whose porting processes were very different, so I'll be covering them separately.

The first part is `DirectoryPalettedPermutations`, a `SpriteSource` similar to `PalettedPermutations` that lists its textures and palettes by reading from a directory rather than reading a data-driven list. Most of the classes surrounding `SpriteSource` haven't changed since 1.21.1, so this class's code is largely unchanged from Gizmo's original PR.

The second part is `TrimmedArmorModel`, a custom model type that automatically renders an `ItemStack`'s appropriate armor trim based on its data. Unfortunately, the path to doing this on 1.21.1 is not nearly as straightforward as on 26.1, so much of this class had to be reimplemented from scratch. It still does the same thing at the end of the day, but instead of simply rendering an extra model in `ItemModel.update`, we have to:

- Bake the original model, then wrap it in a class that provides a custom `ItemOverrides` handler
- Within the `ItemOverrides` handler, check the rendered stack if has a trim and generate its trim model if so
  - (Note: like in Gizmo's original PR, generated trim models are cached for each item-trim pair)
- Wrap the original model and trim model within a class that will render both parts together

With all that said, although this port generally follows the same design as the original, it has a lot of changes to account for 1.21.1's model architecture, so don't hesitate to ask questions if anything needs clarification.