### PR TITLE
Fix FakePlayer leaking CriteriaTrigger listener entries

### DIFF
--- a/patches/net/minecraft/server/PlayerAdvancements.java.patch
+++ b/patches/net/minecraft/server/PlayerAdvancements.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/server/PlayerAdvancements.java
 +++ b/net/minecraft/server/PlayerAdvancements.java
-@@ -166,6 +_,8 @@
-     }
- 
-     public boolean award(AdvancementHolder p_300979_, String p_135990_) {
-+        // Forge: don't grant advancements for fake players
-+        if (this.player instanceof net.neoforged.neoforge.common.util.FakePlayer) return false;
-         boolean flag = false;
-         AdvancementProgress advancementprogress = this.getOrStartProgress(p_300979_);
-         boolean flag1 = advancementprogress.isDone();
 @@ -173,12 +_,14 @@
              this.unregisterListeners(p_300979_);
              this.progressChanged.add(p_300979_);

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -141,15 +141,19 @@
  
              serverstatscounter = new ServerStatsCounter(this.server, file2);
              this.stats.put(uuid, serverstatscounter);
-@@ -832,6 +_,8 @@
-             this.advancements.put(uuid, playeradvancements);
-         }
- 
-+        // Forge: don't overwrite active player with a fake one.
-+        if (!(p_11297_ instanceof net.neoforged.neoforge.common.util.FakePlayer))
-         playeradvancements.setPlayer(p_11297_);
-         return playeradvancements;
+@@ -824,6 +_,12 @@
      }
+ 
+     public PlayerAdvancements getPlayerAdvancements(ServerPlayer p_11297_) {
++        // Neo: return a no-op PlayerAdvancements for fake players to avoid leaking CriteriaTrigger entries (#1487)
++        if (p_11297_.isFakePlayer()) {
++            Path path = this.server.getWorldPath(LevelResource.PLAYER_ADVANCEMENTS_DIR).resolve("_fake.json");
++            return new net.neoforged.neoforge.common.util.FakePlayer.FakePlayerAdvancements(
++                    this.server.getFixerUpper(), this, this.server.getAdvancements(), path, p_11297_);
++        }
+         UUID uuid = p_11297_.getUUID();
+         PlayerAdvancements playeradvancements = this.advancements.get(uuid);
+         if (playeradvancements == null) {
 @@ -859,7 +_,7 @@
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
@@ -6,10 +6,14 @@
 package net.neoforged.neoforge.common.util;
 
 import com.mojang.authlib.GameProfile;
+import com.mojang.datafixers.DataFixer;
+import java.nio.file.Path;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Consumer;
 import javax.annotation.ParametersAreNonnullByDefault;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.network.Connection;
 import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.network.PacketListener;
@@ -68,11 +72,14 @@ import net.minecraft.network.protocol.game.ServerboundTeleportToEntityPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.ServerAdvancementManager;
 import net.minecraft.server.level.ClientInformation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.stats.Stat;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
@@ -140,6 +147,48 @@ public class FakePlayer extends ServerPlayer {
     @Override
     public boolean isFakePlayer() {
         return true;
+    }
+
+    public static class FakePlayerAdvancements extends PlayerAdvancements {
+        public FakePlayerAdvancements(DataFixer fixer, PlayerList playerList, ServerAdvancementManager manager, Path path, ServerPlayer player) {
+            super(fixer, playerList, manager, path, player);
+        }
+
+        @Override
+        protected void load(ServerAdvancementManager manager) {}
+
+        @Override
+        public void setPlayer(ServerPlayer player) {}
+
+        @Override
+        public void stopListening() {}
+
+        @Override
+        public void reload(ServerAdvancementManager manager) {}
+
+        @Override
+        public void save() {}
+
+        @Override
+        public boolean award(AdvancementHolder advancement, String criterion) {
+            return false;
+        }
+
+        @Override
+        public boolean revoke(AdvancementHolder advancement, String criterion) {
+            return false;
+        }
+
+        @Override
+        public void flushDirty(ServerPlayer player) {}
+
+        @Override
+        public void setSelectedTab(@Nullable AdvancementHolder advancement) {}
+
+        @Override
+        public AdvancementProgress getOrStartProgress(AdvancementHolder advancement) {
+            return new AdvancementProgress();
+        }
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -165,6 +165,7 @@ public net.minecraft.resources.RegistryOps lookupProvider
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter lookupProvider
 public net.minecraft.resources.ResourceLocation validNamespaceChar(C)Z # validNamespaceChar
+protected net.minecraft.server.PlayerAdvancements load(Lnet/minecraft/server/ServerAdvancementManager;)V # load
 protected net.minecraft.server.MinecraftServer nextTickTimeNanos # nextTickTimeNanos
 public net.minecraft.server.MinecraftServer$ReloadableResources
 public net.minecraft.server.MinecraftServer$ReloadableResources <init>(Lnet/minecraft/server/packs/resources/CloseableResourceManager;Lnet/minecraft/server/ReloadableServerResources;)V

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/FakePlayerTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/FakePlayerTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.entity.player;
+
+import com.mojang.authlib.GameProfile;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.server.PlayerAdvancements;
+import net.neoforged.neoforge.common.util.FakePlayer;
+import net.neoforged.neoforge.common.util.FakePlayerFactory;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
+
+@ForEachTest(groups = PlayerTests.GROUP + ".fakeplayer")
+public class FakePlayerTests {
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that FakePlayer does not leak CriteriaTrigger listener entries (#1487)")
+    static void fakePlayerAdvancementsDoNotLeak(final ExtendedGameTestHelper helper) {
+        var trigger = CriteriaTriggers.TICK;
+        int sizeBefore = getListenerCount(trigger);
+
+        var level = helper.getLevel();
+        for (int i = 0; i < 10; i++) {
+            FakePlayerFactory.get(level, new GameProfile(UUID.randomUUID(), "Fake" + i));
+        }
+
+        int sizeAfter = getListenerCount(trigger);
+
+        helper.assertTrue(
+                sizeAfter == sizeBefore,
+                "CriteriaTrigger listener count grew from " + sizeBefore + " to " + sizeAfter + " after creating 10 fake players");
+
+        helper.succeed();
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that FakePlayer gets FakePlayerAdvancements even when sharing a UUID with a real player")
+    static void fakePlayerGetsFakePlayerAdvancements(final ExtendedGameTestHelper helper) {
+        var level = helper.getLevel();
+        var realPlayer = helper.makeTickingMockServerPlayerInCorner(net.minecraft.world.level.GameType.SURVIVAL);
+
+        var fakePlayer = FakePlayerFactory.get(level, realPlayer.getGameProfile());
+
+        helper.assertTrue(
+                fakePlayer.getAdvancements() instanceof FakePlayer.FakePlayerAdvancements,
+                "FakePlayer should hold FakePlayerAdvancements");
+
+        helper.succeed();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int getListenerCount(SimpleCriterionTrigger<?> trigger) {
+        try {
+            Field field = SimpleCriterionTrigger.class.getDeclaredField("players");
+            field.setAccessible(true);
+            return ((Map<PlayerAdvancements, ?>) field.get(trigger)).size();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1487

The `ServerPlayer` super constructor calls `PlayerList.getPlayerAdvancements()`, which creates a `PlayerAdvancements` and registers listeners on every `CriteriaTrigger`. FakePlayer never uses advancements (awards are already no-oped), but the listeners are never unregistered, so they accumulate for the lifetime of the server.

On modded servers where mods frequently create FakePlayer instances (Create, Applied Energistics, etc.), this causes a gradual memory leak. Over hours of uptime the orphaned listener entries increase GC pressure, eventually leading to long GC pauses that can trigger the Server Watchdog.

The fix calls `stopListening()` at the end of the `FakePlayer` constructor to immediately unregister the listeners that the super constructor registered. This covers both `FakePlayerFactory` usage and direct subclasses of `FakePlayer`.

The same issue exists on all 1.21.x branches (1.21.3 through 1.21.11). Happy to open backport PRs if needed.

All existing game tests pass.

**MAINTAINER EDIT:** Backport of #3268.