### PR TITLE
Fix FakePlayer leaking CriteriaTrigger listener entries

### DIFF
--- a/patches/net/minecraft/server/PlayerAdvancements.java.patch
+++ b/patches/net/minecraft/server/PlayerAdvancements.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/server/PlayerAdvancements.java
 +++ b/net/minecraft/server/PlayerAdvancements.java
-@@ -162,6 +_,8 @@
-     }
- 
-     public boolean award(AdvancementHolder holder, String criterion) {
-+        // Forge: don't grant advancements for fake players
-+        if (this.player instanceof net.neoforged.neoforge.common.util.FakePlayer) return false;
-         boolean result = false;
-         AdvancementProgress progress = this.getOrStartProgress(holder);
-         boolean wasDone = progress.isDone();
 @@ -169,12 +_,14 @@
              this.unregisterListeners(holder);
              this.progressChanged.add(holder);

--- a/patches/net/minecraft/server/players/PlayerList.java.patch
+++ b/patches/net/minecraft/server/players/PlayerList.java.patch
@@ -111,15 +111,19 @@
      }
  
      public void sendAllPlayerInfo(ServerPlayer player) {
-@@ -794,6 +_,8 @@
-             this.advancements.put(uuid, result);
-         }
- 
-+        // Forge: don't overwrite active player with a fake one.
-+        if (!(player instanceof net.neoforged.neoforge.common.util.FakePlayer))
-         result.setPlayer(player);
-         return result;
+@@ -786,6 +_,12 @@
      }
+ 
+     public PlayerAdvancements getPlayerAdvancements(ServerPlayer player) {
++        // Neo: return a no-op PlayerAdvancements for fake players to avoid leaking CriteriaTrigger entries (#1487)
++        if (player.isFakePlayer()) {
++            Path path = this.server.getWorldPath(LevelResource.PLAYER_ADVANCEMENTS_DIR).resolve("_fake.json");
++            return new net.neoforged.neoforge.common.util.FakePlayer.FakePlayerAdvancements(
++                    this.server.getFixerUpper(), this, this.server.getAdvancements(), path, player);
++        }
+         UUID uuid = player.getUUID();
+         PlayerAdvancements result = this.advancements.get(uuid);
+         if (result == null) {
 @@ -817,7 +_,7 @@
      }
  

--- a/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/FakePlayer.java
@@ -6,10 +6,14 @@
 package net.neoforged.neoforge.common.util;
 
 import com.mojang.authlib.GameProfile;
+import com.mojang.datafixers.DataFixer;
 import io.netty.channel.ChannelFutureListener;
+import java.nio.file.Path;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Consumer;
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.network.DisconnectionDetails;
 import net.minecraft.network.PacketListener;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -66,11 +70,14 @@ import net.minecraft.network.protocol.game.ServerboundUseItemOnPacket;
 import net.minecraft.network.protocol.game.ServerboundUseItemPacket;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.ServerAdvancementManager;
 import net.minecraft.server.level.ClientInformation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.CommonListenerCookie;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.stats.Stat;
 import net.minecraft.world.Container;
 import net.minecraft.world.MenuProvider;
@@ -128,6 +135,48 @@ public class FakePlayer extends ServerPlayer {
     @Override
     public boolean isFakePlayer() {
         return true;
+    }
+
+    public static class FakePlayerAdvancements extends PlayerAdvancements {
+        public FakePlayerAdvancements(DataFixer fixer, PlayerList playerList, ServerAdvancementManager manager, Path path, ServerPlayer player) {
+            super(fixer, playerList, manager, path, player);
+        }
+
+        @Override
+        protected void load(ServerAdvancementManager manager) {}
+
+        @Override
+        public void setPlayer(ServerPlayer player) {}
+
+        @Override
+        public void clearTriggers() {}
+
+        @Override
+        public void reload(ServerAdvancementManager manager) {}
+
+        @Override
+        public void save() {}
+
+        @Override
+        public boolean award(AdvancementHolder advancement, String criterion) {
+            return false;
+        }
+
+        @Override
+        public boolean revoke(AdvancementHolder advancement, String criterion) {
+            return false;
+        }
+
+        @Override
+        public void flushDirty(ServerPlayer player, boolean showAdvancements) {}
+
+        @Override
+        public void setSelectedTab(@Nullable AdvancementHolder advancement) {}
+
+        @Override
+        public AdvancementProgress getOrStartProgress(AdvancementHolder advancement) {
+            return new AdvancementProgress();
+        }
     }
 
     private static class FakePlayerNetHandler extends ServerGamePacketListenerImpl {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -142,6 +142,7 @@ public net.minecraft.resources.RegistryOps lookupProvider
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter
 public net.minecraft.resources.RegistryOps$HolderLookupAdapter lookupProvider
 public net.minecraft.resources.Identifier validNamespaceChar(C)Z # validNamespaceChar
+protected net.minecraft.server.PlayerAdvancements load(Lnet/minecraft/server/ServerAdvancementManager;)V # load
 protected net.minecraft.server.MinecraftServer nextTickTimeNanos # nextTickTimeNanos
 protected net.minecraft.server.MinecraftServer updateEffectiveRespawnData()V
 public net.minecraft.server.MinecraftServer$ReloadableResources

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/FakePlayerTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/FakePlayerTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.debug.entity.player;
+
+import com.mojang.authlib.GameProfile;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.players.PlayerList;
+import net.neoforged.neoforge.common.util.FakePlayer;
+import net.neoforged.neoforge.common.util.FakePlayerFactory;
+import net.neoforged.testframework.annotation.ForEachTest;
+import net.neoforged.testframework.annotation.TestHolder;
+import net.neoforged.testframework.gametest.EmptyTemplate;
+import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
+import net.neoforged.testframework.gametest.GameTest;
+
+@ForEachTest(groups = PlayerTests.GROUP + ".fakeplayer")
+public class FakePlayerTests {
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that FakePlayer does not leak PlayerAdvancements entries in the cache (#1487)")
+    static void fakePlayerAdvancementsDoNotLeak(final ExtendedGameTestHelper helper) {
+        var level = helper.getLevel();
+        int sizeBefore = getAdvancementsCacheSize(level.getServer().getPlayerList());
+
+        for (int i = 0; i < 10; i++) {
+            FakePlayerFactory.get(level, new GameProfile(UUID.randomUUID(), "Fake" + i));
+        }
+
+        int sizeAfter = getAdvancementsCacheSize(level.getServer().getPlayerList());
+
+        helper.assertTrue(
+                sizeAfter == sizeBefore,
+                "PlayerList advancements cache grew from " + sizeBefore + " to " + sizeAfter + " after creating 10 fake players");
+
+        helper.succeed();
+    }
+
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that FakePlayer gets FakePlayerAdvancements even when sharing a UUID with a real player")
+    static void fakePlayerGetsFakePlayerAdvancements(final ExtendedGameTestHelper helper) {
+        var level = helper.getLevel();
+        var realPlayer = helper.makeTickingMockServerPlayerInCorner(net.minecraft.world.level.GameType.SURVIVAL);
+
+        var fakePlayer = FakePlayerFactory.get(level, realPlayer.getGameProfile());
+
+        helper.assertTrue(
+                fakePlayer.getAdvancements() instanceof FakePlayer.FakePlayerAdvancements,
+                "FakePlayer should hold FakePlayerAdvancements");
+
+        helper.succeed();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static int getAdvancementsCacheSize(PlayerList playerList) {
+        try {
+            Field field = PlayerList.class.getDeclaredField("advancements");
+            field.setAccessible(true);
+            return ((Map<UUID, PlayerAdvancements>) field.get(playerList)).size();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1487

The `ServerPlayer` super constructor calls `PlayerList.getPlayerAdvancements()`, which creates a `PlayerAdvancements` and registers listeners via `load()`. FakePlayer never uses advancements, but the listeners are never unregistered, so they accumulate for the lifetime of the server.

On modded servers where mods frequently create FakePlayer instances (Create, Applied Energistics, etc.), this causes a gradual memory leak. Over hours of uptime the orphaned entries increase GC pressure, eventually leading to long GC pauses that can trigger the Server Watchdog.

Changes:
- AT `PlayerAdvancements.load()` to `protected` to allow overriding
- Add `FakePlayer.FakePlayerAdvancements` that overrides `load()` to no-op and dummies out all other methods (same pattern as `FakePlayerNetHandler`)
- Patch `PlayerList.getPlayerAdvancements()` to return `FakePlayerAdvancements` for fake players (checked via `isFakePlayer()`), not stored in the cache
- Remove the now-unnecessary `instanceof FakePlayer` guard in `PlayerAdvancements.award()`

A 1.21.1 backport is available at #3260.

All existing game tests pass. Two new tests verify the fix:
- `fakePlayerAdvancementsDoNotLeak`: creates 10 FakePlayers and asserts the advancements cache does not grow
- `fakePlayerDoesNotBreakRealPlayerAdvancements`: creates a FakePlayer with a real player's UUID and asserts the real player's advancements are unaffected