### PR TITLE
Fix: Make yOffset increment customizable in BossHealthOverlay

### DIFF
--- a/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
@@ -12,9 +12,9 @@
 @@ -75,6 +_,8 @@
                  int y = yo - 9;
                  graphics.text(this.minecraft.font, msg, x, y, -1);
-                 yOffset += 10 + 9;
-+                }
+-                yOffset += 10 + 9;
 +                yOffset += customizeEvent.getIncrement();
++                }
                  if (yOffset >= graphics.guiHeight() / 3) {
                      break;
                  }

--- a/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/gui/components/BossHealthOverlay.java
 +++ b/net/minecraft/client/gui/components/BossHealthOverlay.java
-@@ -68,6 +_,8 @@
+@@ -68,13 +_,16 @@
              for (LerpingBossEvent event : this.events.values()) {
                  int xLeft = screenWidth / 2 - 91;
                  int yo = yOffset;
@@ -9,7 +9,7 @@
                  this.extractBar(graphics, xLeft, yo, event);
                  Component msg = event.getName();
                  int width = this.minecraft.font.width(msg);
-@@ -75,6 +_,8 @@
+                 int x = screenWidth / 2 - width / 2;
                  int y = yo - 9;
                  graphics.text(this.minecraft.font, msg, x, y, -1);
 -                yOffset += 10 + 9;


### PR DESCRIPTION
Replace fixed yOffset increment with customizable event increment.

Vanilla:
<img width="1034" height="215" alt="7c9550aa0ba096f6aaebeed26994f3c4" src="https://github.com/user-attachments/assets/12ee17f7-6685-4014-909b-6d9315c4224b" />

NeoForge with buggy code:
<img width="471" height="153" alt="97e78905afdcf5543a3979f3a9d6070a" src="https://github.com/user-attachments/assets/d87dfdb3-1956-4b74-b39a-642e80e6769f" />

