### PR TITLE
[1.21.1] Improve the MC-43968 fix

### DIFF
--- a/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/block/ModelBlockRenderer.java.patch
@@ -221,3 +221,27 @@
              );
              boolean flag3 = !blockstate7.isViewBlocking(p_111168_, blockpos$mutableblockpos)
                  || blockstate7.getLightBlock(p_111168_, blockpos$mutableblockpos) == 0;
+@@ -770,8 +_,9 @@
+             float f6;
+             int k1;
+             if (!flag2 && !flag1) {
+-                f6 = f;
+-                k1 = i;
++                // Neo: f6 is flanked by corner1, not corner0, so we must use corner1's edge values
++                f6 = f1;
++                k1 = j;
+             } else {
+                 blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[1]).move(modelblockrenderer$adjacencyinfo.corners[2]);
+                 BlockState blockstate11 = p_111168_.getBlockState(blockpos$mutableblockpos);
+@@ -782,8 +_,9 @@
+             float f7;
+             int l1;
+             if (!flag3 && !flag1) {
+-                f7 = f;
+-                l1 = i;
++                // Neo: f7 is flanked by corner1, not corner0, so we must use corner1's edge values
++                f7 = f1;
++                l1 = j;
+             } else {
+                 blockpos$mutableblockpos.setWithOffset(blockpos, modelblockrenderer$adjacencyinfo.corners[1]).move(modelblockrenderer$adjacencyinfo.corners[3]);
+                 BlockState blockstate12 = p_111168_.getBlockState(blockpos$mutableblockpos);


### PR DESCRIPTION
Vanilla has had issues with its smooth lighting/AO implementation for a long time. In 2024, I added a [patch](https://github.com/neoforged/NeoForge/pull/1370) to fix one of the most glaring issues where AO samples the wrong blocks and thus applies darkening on the wrong corners.

This fix has a couple flaws. ~~Oversampling in vanilla only happens if the quad is flush with the block's outer face and lighting is therefore sampled from the neighbouring block position. In that case `blockpos` has already been offset one block in the face direction, so the extra `.move(p_111171_)` shifts a second, spurious block over. For inset or non-full-cube faces `blockpos` is not offset ahead of time, so the `.move()` was actually correct. In this PR we take that into account and only conditionally skip the move.~~ EDIT: The aforementioned change restores vanilla behavior under certain conditions but the behavior is overall not ideal. It is better to consistently never move. See [the discussion on Discord](https://discord.com/channels/313125603924639766/1154167065519861831/1521981382312591541) for more context.

Additionally, fixing the oversampling reveals another bug with how vanilla samples corners. When both edges flanking a corner are opaque, vanilla substitutes an edge's light/shade for the hidden corner, but all four corners reuse `corner0`'s values (`f`/`i` in the 1.21.1 LVT). `corner0` is only adjacent to two of the four corners (`f4`, `f5`). The other two (`f6`, `f7`) are flanked by `corner1`, so reusing `corner0` pulls in a non-adjacent edge, often leaving those corners unshaded as seen in #1613. In this PR we route `f6`, `f7`, etc. to `corner1`'s values (`f1`/`j`), mirroring what `f4`/`f5` already do for `corner0`. (As an aside, the lack of local variable names makes this quite painful to trace by hand.)

I tested and confirmed the original issue fixed by #1370 is still fixed, and #1613 is now also fixed for 1.21.1.

The change is not relevant to newer versions because we sidestep the vanilla pipeline entirely and use our own enhanced AO pipeline by default.

AI disclosure: fix was done with assistance from Claude Opus 4.8; all changes have been reviewed and tested by hand.