### PR TITLE
[26.2] Implement PlayerSwitchHotbarSlotEvent

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -96,7 +96,7 @@
              ServerLevel level = this.player.level();
              InteractionHand hand = packet.getHand();
              ItemStack itemStack = this.player.getItemInHand(hand);
-@@ -1487,6 +_,10 @@
+@@ -1487,6 +_,9 @@
      @Override
      public void handleSetCarriedItem(ServerboundSetCarriedItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -96,6 +96,28 @@
              ServerLevel level = this.player.level();
              InteractionHand hand = packet.getHand();
              ItemStack itemStack = this.player.getItemInHand(hand);
+@@ -1487,6 +_,10 @@
+     @Override
+     public void handleSetCarriedItem(ServerboundSetCarriedItemPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
++
++        var preEvent = net.neoforged.neoforge.common.CommonHooks.onSwitchHotbarSlotPre(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot());
++        if (preEvent.isCanceled()) return;
++
+         if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {
+             if (this.player.getInventory().getSelectedSlot() != packet.getSlot() && this.player.getUsedItemHand() == InteractionHand.MAIN_HAND) {
+                 this.player.stopUsingItem();
+@@ -1494,6 +_,10 @@
+ 
+             this.player.getInventory().setSelectedSlot(packet.getSlot());
+             this.player.resetLastActionTime();
++
++            if (this.player.getInventory().getSelectedSlot() != packet.getSlot()) {
++                net.neoforged.neoforge.common.CommonHooks.onSwitchHotbarSlotPost(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot());
++            }
+         } else {
+             LOGGER.warn("{} tried to set an invalid carried item", this.player.getPlainTextName());
+         }
 @@ -1513,8 +_,9 @@
                  }
  

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -101,8 +101,7 @@
      public void handleSetCarriedItem(ServerboundSetCarriedItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
 +
-+        var preEvent = net.neoforged.neoforge.common.CommonHooks.onSwitchHotbarSlotPre(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot());
-+        if (preEvent.isCanceled()) return;
++        if (net.neoforged.neoforge.event.EventHooks.onSwitchHotbarSlotPre(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot())) return;
 +
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {
              if (this.player.getInventory().getSelectedSlot() != packet.getSlot() && this.player.getUsedItemHand() == InteractionHand.MAIN_HAND) {
@@ -113,7 +112,7 @@
              this.player.resetLastActionTime();
 +
 +            if (this.player.getInventory().getSelectedSlot() != packet.getSlot()) {
-+                net.neoforged.neoforge.common.CommonHooks.onSwitchHotbarSlotPost(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot());
++                net.neoforged.neoforge.event.EventHooks.onSwitchHotbarSlotPost(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot());
 +            }
          } else {
              LOGGER.warn("{} tried to set an invalid carried item", this.player.getPlainTextName());

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -216,7 +216,6 @@ import net.neoforged.neoforge.event.entity.player.CustomClickActionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEnchantItemEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
-import net.neoforged.neoforge.event.entity.player.PlayerSwitchHotbarSlotEvent;
 import net.neoforged.neoforge.event.entity.player.SweepAttackEvent;
 import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
@@ -882,15 +881,6 @@ public class CommonHooks {
 
     public static void onEmptyLeftClick(Player player) {
         NeoForge.EVENT_BUS.post(new PlayerInteractEvent.LeftClickEmpty(player));
-    }
-
-    public static PlayerSwitchHotbarSlotEvent.Pre onSwitchHotbarSlotPre(Player player, int oldSlotIndex, int newSlotIndex) {
-        var preEvent = new PlayerSwitchHotbarSlotEvent.Pre(player, oldSlotIndex, newSlotIndex);
-        return NeoForge.EVENT_BUS.post(preEvent);
-    }
-
-    public static void onSwitchHotbarSlotPost(Player player, int oldSlotIndex, int newSlotIndex) {
-        NeoForge.EVENT_BUS.post(new PlayerSwitchHotbarSlotEvent.Post(player, oldSlotIndex, newSlotIndex));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -216,6 +216,7 @@ import net.neoforged.neoforge.event.entity.player.CustomClickActionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEnchantItemEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerSwitchHotbarSlotEvent;
 import net.neoforged.neoforge.event.entity.player.SweepAttackEvent;
 import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
@@ -881,6 +882,15 @@ public class CommonHooks {
 
     public static void onEmptyLeftClick(Player player) {
         NeoForge.EVENT_BUS.post(new PlayerInteractEvent.LeftClickEmpty(player));
+    }
+
+    public static PlayerSwitchHotbarSlotEvent.Pre onSwitchHotbarSlotPre(Player player, int oldSlotIndex, int newSlotIndex) {
+        var preEvent = new PlayerSwitchHotbarSlotEvent.Pre(player, oldSlotIndex, newSlotIndex);
+        return NeoForge.EVENT_BUS.post(preEvent);
+    }
+
+    public static void onSwitchHotbarSlotPost(Player player, int oldSlotIndex, int newSlotIndex) {
+        NeoForge.EVENT_BUS.post(new PlayerSwitchHotbarSlotEvent.Post(player, oldSlotIndex, newSlotIndex));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -170,6 +170,7 @@ import net.neoforged.neoforge.event.entity.player.PlayerFlyableFallEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerRespawnPositionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerSetSpawnEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerSpawnPhantomsEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerSwitchHotbarSlotEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerWakeUpEvent;
 import net.neoforged.neoforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.neoforged.neoforge.event.level.AlterGroundEvent;
@@ -647,6 +648,14 @@ public class EventHooks {
     public static float onLivingHeal(LivingEntity entity, float amount) {
         LivingHealEvent event = new LivingHealEvent(entity, amount);
         return (NeoForge.EVENT_BUS.post(event).isCanceled() ? 0 : event.getAmount());
+    }
+
+    public static boolean onSwitchHotbarSlotPre(Player player, int oldSlotIndex, int newSlotIndex) {
+        return NeoForge.EVENT_BUS.post(new PlayerSwitchHotbarSlotEvent.Pre(player, oldSlotIndex, newSlotIndex)).isCanceled();
+    }
+
+    public static void onSwitchHotbarSlotPost(Player player, int oldSlotIndex, int newSlotIndex) {
+        NeoForge.EVENT_BUS.post(new PlayerSwitchHotbarSlotEvent.Post(player, oldSlotIndex, newSlotIndex));
     }
 
     public static boolean onPotionAttemptBrew(NonNullList<ItemStack> stacks) {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSwitchHotbarSlotEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSwitchHotbarSlotEvent.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.player;
+
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.bus.api.ICancellableEvent;
+
+/**
+ * Fired when a player switches the hotbar slot either by
+ * mouse scroll or keyboard input. If the server doesn't
+ * receive the packet, neither of the two events will be
+ * fired.
+ *
+ * @see PlayerSwitchHotbarSlotEvent.Pre
+ * @see PlayerSwitchHotbarSlotEvent.Post
+ */
+public abstract sealed class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
+    private final int oldSlotIndex;
+    private final int newSlotIndex;
+
+    public PlayerSwitchHotbarSlotEvent(Player player, int oldSlotIndex, int newSlotIndex) {
+        super(player);
+        this.oldSlotIndex = oldSlotIndex;
+        this.newSlotIndex = newSlotIndex;
+    }
+
+    public int getOldSlotIndex() {
+        return oldSlotIndex;
+    }
+
+    public int getNewSlotIndex() {
+        return newSlotIndex;
+    }
+
+    /**
+     * Fired after the server receives the packet and is about to perform
+     * the slot switching logic. If you cancel this event, you will be
+     * expected to handle the logic yourself.
+     * <p>
+     * Vanilla logic is shown as follows:
+     *
+     * <pre>{@code
+     * if (newSlotIndex >= 0 && newSlotIndex <= Inventory.getSelectionSize()) {
+     *     if (oldSlotIndex != newSlotIndex
+     *             && player.getUsedItemHand() == InteractionHand.MAIN_HAND) {
+     *         player.stopUsingItem();
+     *     }
+     *     player.getInventory().setSelectedSlot(newSlotIndex);
+     *     player.resetLastActionTime();
+     * } else {
+     *     // Invalid newSlotIndex, either warn in the logger, or throw an exception
+     * }
+     * }</pre>
+     */
+    public static non-sealed class Pre extends PlayerSwitchHotbarSlotEvent implements ICancellableEvent {
+        public Pre(Player player, int oldSlotIndex, int newSlotIndex) {
+            super(player, oldSlotIndex, newSlotIndex);
+        }
+
+        /**
+         * Cancels the event, preventing any further slot switching logic to
+         * be performed.
+         */
+        @Override
+        public void setCanceled(boolean canceled) {
+            ICancellableEvent.super.setCanceled(canceled);
+        }
+    }
+
+    /**
+     * Fired after all the slot switching logic is successfully
+     * performed.
+     */
+    public static non-sealed class Post extends PlayerSwitchHotbarSlotEvent {
+        public Post(Player player, int oldSlotIndex, int newSlotIndex) {
+            super(player, oldSlotIndex, newSlotIndex);
+        }
+    }
+}

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSwitchHotbarSlotEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSwitchHotbarSlotEvent.java
@@ -9,15 +9,15 @@ import net.minecraft.world.entity.player.Player;
 import net.neoforged.bus.api.ICancellableEvent;
 import org.jetbrains.annotations.ApiStatus;
 
-/**
- * Fired when a player switches the hotbar slot either by
- * mouse scroll or keyboard input. If the server doesn't
- * receive the packet, neither of the two events will be
- * fired.
- *
- * @see PlayerSwitchHotbarSlotEvent.Pre
- * @see PlayerSwitchHotbarSlotEvent.Post
- */
+/// Fired when a player switches the hotbar slot either by
+/// mouse scroll or keyboard input.
+///
+/// This event is fired on the game bus on the server side.
+/// If the server doesn't receive the packet, neither of
+/// the two events will be fired.
+///
+/// @see PlayerSwitchHotbarSlotEvent.Pre
+/// @see PlayerSwitchHotbarSlotEvent.Post
 public abstract class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
     private final int oldSlotIndex;
     private final int newSlotIndex;
@@ -36,46 +36,31 @@ public abstract class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
         return newSlotIndex;
     }
 
-    /**
-     * Fired after the server receives the packet and is about to perform
-     * the slot switching logic. If you cancel this event, you will be
-     * expected to handle the logic yourself.
-     * <p>
-     * Vanilla logic is shown as follows:
-     *
-     * <pre>{@code
-     * if (newSlotIndex >= 0 && newSlotIndex <= Inventory.getSelectionSize()) {
-     *     if (oldSlotIndex != newSlotIndex
-     *             && player.getUsedItemHand() == InteractionHand.MAIN_HAND) {
-     *         player.stopUsingItem();
-     *     }
-     *     player.getInventory().setSelectedSlot(newSlotIndex);
-     *     player.resetLastActionTime();
-     * } else {
-     *     // Invalid newSlotIndex, either warn in the logger, or throw an exception
-     * }
-     * }</pre>
-     */
+    /// Fired after the server receives the packet and is about
+    /// to perform the slot switching logic. If you cancel this
+    /// event, the logic will not be performed, and listeners
+    /// will receive neither the pre event nor the post event.
+    ///
+    /// Vanilla logic is shown [here][net.minecraft.server.network.ServerGamePacketListenerImpl#handleSetCarriedItem(net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket)].
     public static class Pre extends PlayerSwitchHotbarSlotEvent implements ICancellableEvent {
         @ApiStatus.Internal
         public Pre(Player player, int oldSlotIndex, int newSlotIndex) {
             super(player, oldSlotIndex, newSlotIndex);
         }
 
-        /**
-         * Cancels the event, preventing any further slot switching logic to
-         * be performed.
-         */
+        /// Cancels the event, preventing any further slot
+        /// switching logic to be performed. Listeners will not
+        /// receive this event after the cancellation.
         @Override
         public void setCanceled(boolean canceled) {
             ICancellableEvent.super.setCanceled(canceled);
         }
     }
 
-    /**
-     * Fired after all the slot switching logic is successfully
-     * performed.
-     */
+    /// Fired after all the slot switching logic is
+    /// successfully performed. This event is not cancellable.
+    /// If you cancelled the pre event, this event will not
+    /// be received by listeners as well.
     public static class Post extends PlayerSwitchHotbarSlotEvent {
         @ApiStatus.Internal
         public Post(Player player, int oldSlotIndex, int newSlotIndex) {

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSwitchHotbarSlotEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerSwitchHotbarSlotEvent.java
@@ -7,6 +7,7 @@ package net.neoforged.neoforge.event.entity.player;
 
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.bus.api.ICancellableEvent;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * Fired when a player switches the hotbar slot either by
@@ -17,11 +18,11 @@ import net.neoforged.bus.api.ICancellableEvent;
  * @see PlayerSwitchHotbarSlotEvent.Pre
  * @see PlayerSwitchHotbarSlotEvent.Post
  */
-public abstract sealed class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
+public abstract class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
     private final int oldSlotIndex;
     private final int newSlotIndex;
 
-    public PlayerSwitchHotbarSlotEvent(Player player, int oldSlotIndex, int newSlotIndex) {
+    private PlayerSwitchHotbarSlotEvent(Player player, int oldSlotIndex, int newSlotIndex) {
         super(player);
         this.oldSlotIndex = oldSlotIndex;
         this.newSlotIndex = newSlotIndex;
@@ -55,7 +56,8 @@ public abstract sealed class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
      * }
      * }</pre>
      */
-    public static non-sealed class Pre extends PlayerSwitchHotbarSlotEvent implements ICancellableEvent {
+    public static class Pre extends PlayerSwitchHotbarSlotEvent implements ICancellableEvent {
+        @ApiStatus.Internal
         public Pre(Player player, int oldSlotIndex, int newSlotIndex) {
             super(player, oldSlotIndex, newSlotIndex);
         }
@@ -74,7 +76,8 @@ public abstract sealed class PlayerSwitchHotbarSlotEvent extends PlayerEvent {
      * Fired after all the slot switching logic is successfully
      * performed.
      */
-    public static non-sealed class Post extends PlayerSwitchHotbarSlotEvent {
+    public static class Post extends PlayerSwitchHotbarSlotEvent {
+        @ApiStatus.Internal
         public Post(Player player, int oldSlotIndex, int newSlotIndex) {
             super(player, oldSlotIndex, newSlotIndex);
         }


### PR DESCRIPTION
A quick MC 26.2 follow-up from #3194.
The fishing rod fix part will not be submitted as an independent vanilla fix PR later on, because there are some unexpected behavior changes. There should be a better solution before a PR can be made.