### PR TITLE
Send initial listening channels to server during negotiation

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -55,7 +55,7 @@
                  @Override
                  public boolean hasInfiniteMaterials() {
                      return true;
-@@ -206,6 +_,53 @@
+@@ -206,6 +_,59 @@
      public void onDisconnect(DisconnectionDetails reason) {
          super.onDisconnect(reason);
          this.minecraft.clearDownloadedResourcePacks();
@@ -63,6 +63,12 @@
 +
 +    @Override
 +    public void handleCustomPayload(net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket packet) {
++        // Handle the initial registration payload by responding with the client's set of supported channels.
++        if (!this.initializedConnection && packet.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftRegisterPayload) {
++            net.neoforged.neoforge.client.network.registration.ClientNetworkRegistry.sendInitialListeningChannels(this);
++            return;
++        }
++
 +        // Handle the query payload by responding with the client's network channels. Update the connection type accordingly.
 +        if (packet.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload) {
 +            this.connectionType = net.neoforged.neoforge.network.connection.ConnectionType.NEOFORGE;

--- a/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
@@ -10,6 +10,7 @@ import com.mojang.logging.LogUtils;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.PacketFlow;
@@ -261,6 +262,19 @@ public final class ClientNetworkRegistry extends NetworkRegistry {
                 .filter(registration -> registration.getValue().optional())
                 .forEach(registration -> nowListeningOn.add(registration.getKey()));
         listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
+    }
+
+    /**
+     * Invoked by the client when it receives a {@link MinecraftRegisterPayload} during negotiation in the configuration phase.
+     * This will respond to the server with the client's set of builtin channels to indicate it supports the common protocol.
+     * <p>
+     * Invoked on the network thread.
+     * 
+     * @param listener The listener which received the brand payload.
+     */
+    public static void sendInitialListeningChannels(ClientConfigurationPacketListener listener) {
+        Set<Identifier> nowListeningOn = ImmutableSet.copyOf(getInitialListeningChannels(listener.flow()));
+        listener.send(new MinecraftRegisterPayload(nowListeningOn));
     }
 
     /**


### PR DESCRIPTION
## The issue

- neoforged/NeoForge#3275

## The proposal

As proposed in the issue, we modify the client configuration flow to respond to the server with its own set of supported channels upon receiving the initial registration payload. This is how we ensure both sides are aware of each other's supported channels.

The updated flow diagram will look as follows:
```
Server                                           Client
======                                           ======
  |                                                 |
  | -------- REGISTER ----------------------------> |
  | -------- QUERY -------------------------------> |
  | -------- PING --------------------------------> |
  |                                                 |
  | <---------------------------- REGISTER -------- |  <-- (NEW) Send builtin channels
  | <------------------------------- QUERY -------- |
  | <-------------------------------- PONG -------- |
  | -------- PAYLOAD -----------------------------> | 
  | -------- REGISTER ----------------------------> | 
  |                                                 |
  | (Handles PONG and                               |  <-- This is safe now, server already
  |  schedules registration tasks)                  |      knows we support common
  |                                                 |
  | <---------------------------- REGISTER -------- |  <-- (UNCHANGED) Send all supported channels
  | (Processes client registration                  |
  |  safely)                                        |
  |                                                 |
```

## Possible side effects

None. The only method that is now additionally called on the server is `NetworkRegistry::onMinecraftRegister`, which adds channels to the adhoc channels set. It makes no checks or removals, so existing behavior is left unaffected.

## Testing

I tested this by following the reproduction steps described in the issue. As expected, without the change, the server did not receive the channels in time to register its configuration tasks. With the changes, the channels were received successfully.

| Before changes | After changes |
|--------|--------|
| <img width="1262" height="574" alt="Screenshot 2026-07-04 at 11 54 30" src="https://github.com/user-attachments/assets/26e57143-6be5-47a6-a128-d4c58cd9a1e9" /> | <img width="1174" height="645" alt="Screenshot 2026-07-04 at 11 55 13" src="https://github.com/user-attachments/assets/3fe2bb41-19b4-480b-bde4-69c42e8b8b34" /> |
| Server did not receive any channels from the client. Configuration task registration is skipped. | Server is aware of channels supported by the client. Configuration task registration runs. |

## Ports

Once this is approved, I'll open a backport PR for 26.1.x

#### Magic text

Fixes #3275.