### PR TITLE
Fix bossbar gaps being too large

### DIFF
--- a/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/gui/components/BossHealthOverlay.java
 +++ b/net/minecraft/client/gui/components/BossHealthOverlay.java
-@@ -68,6 +_,8 @@
+@@ -68,13 +_,17 @@
              for (LerpingBossEvent event : this.events.values()) {
                  int xLeft = screenWidth / 2 - 91;
                  int yo = yOffset;
@@ -9,10 +9,11 @@
                  this.extractBar(graphics, xLeft, yo, event);
                  Component msg = event.getName();
                  int width = this.minecraft.font.width(msg);
-@@ -75,6 +_,8 @@
+                 int x = screenWidth / 2 - width / 2;
                  int y = yo - 9;
                  graphics.text(this.minecraft.font, msg, x, y, -1);
-                 yOffset += 10 + 9;
+-                yOffset += 10 + 9;
++                // Neo: Remove the vanilla increment in favor of the increment from the event (defaults to the vanilla increment)
 +                }
 +                yOffset += customizeEvent.getIncrement();
                  if (yOffset >= graphics.guiHeight() / 3) {


### PR DESCRIPTION
This PR fixes #3278 by removing the vanilla increment, as it is entirely replaced by the increment from the event. See my comment on the linked issue for more details.

