### PR TITLE
Backport to 26.1.x: Send initial listening channels to server during negotiation

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -55,7 +55,7 @@
                  {
                      Objects.requireNonNull(ClientConfigurationPacketListenerImpl.this);
                  }
-@@ -214,6 +_,53 @@
+@@ -214,6 +_,59 @@
      public void onDisconnect(DisconnectionDetails reason) {
          super.onDisconnect(reason);
          this.minecraft.clearDownloadedResourcePacks();
@@ -63,6 +63,12 @@
 +
 +    @Override
 +    public void handleCustomPayload(net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket packet) {
++        // Handle the initial registration payload by responding with the client's set of supported channels.
++        if (!this.initializedConnection && packet.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftRegisterPayload) {
++            net.neoforged.neoforge.client.network.registration.ClientNetworkRegistry.sendInitialListeningChannels(this);
++            return;
++        }
++
 +        // Handle the query payload by responding with the client's network channels. Update the connection type accordingly.
 +        if (packet.payload() instanceof net.neoforged.neoforge.network.payload.ModdedNetworkQueryPayload) {
 +            this.connectionType = net.neoforged.neoforge.network.connection.ConnectionType.NEOFORGE;

--- a/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
@@ -10,6 +10,7 @@ import com.mojang.logging.LogUtils;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.PacketFlow;
@@ -261,6 +262,19 @@ public final class ClientNetworkRegistry extends NetworkRegistry {
                 .filter(registration -> registration.getValue().optional())
                 .forEach(registration -> nowListeningOn.add(registration.getKey()));
         listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
+    }
+
+    /**
+     * Invoked by the client when it receives a {@link MinecraftRegisterPayload} during negotiation in the configuration phase.
+     * This will respond to the server with the client's set of builtin channels to indicate it supports the common protocol.
+     * <p>
+     * Invoked on the network thread.
+     * 
+     * @param listener The listener which received the brand payload.
+     */
+    public static void sendInitialListeningChannels(ClientConfigurationPacketListener listener) {
+        Set<Identifier> nowListeningOn = ImmutableSet.copyOf(getInitialListeningChannels(listener.flow()));
+        listener.send(new MinecraftRegisterPayload(nowListeningOn));
     }
 
     /**


### PR DESCRIPTION
Backport of neoforged/NeoForge#3277 to 26.1.x.

Fixes neoforged/neoforge#3275 on 26.1.x.