### PR TITLE
Add a boolean to DamageContainer to disable damage side effects

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -212,7 +212,7 @@
 +        this.damageContainers.peek().setNewDamage(damage); // Update container with vanilla changes
  
 -        boolean tookFullDamage = true;
-+        boolean performSideEffects = true;// Neo: Rename local variable to be more clear on its behavior
++        boolean performSideEffects = true; // Neo: Rename local variable to be more clear on its behavior
          if (this.invulnerableTime > 10.0F && !source.is(DamageTypeTags.BYPASSES_COOLDOWN)) {
              if (damage <= this.lastHurt) {
 +                // Neo: Pop the container when vanilla would abort the incoming damage due to the invulnerability ticks.
@@ -221,7 +221,7 @@
              }
 +
 +            // If we are going to do damage despite invulnerability (due to the damage being higher than prior), we need to setup the container differently.
-+            this.damageContainers.peek().setDamageSideEffects(false);
++            this.damageContainers.peek().setShouldCauseSideEffects(false);
 +            this.damageContainers.peek().setPostAttackInvulnerabilityTicks(this.invulnerableTime);
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.INVULNERABILITY, this.lastHurt);
  
@@ -241,7 +241,7 @@
              this.hurtDuration = 10;
              this.hurtTime = this.hurtDuration;
          }
-+        performSideEffects = this.damageContainers.peek().getDamageSideEffects();
++        performSideEffects = this.damageContainers.peek().shouldCauseSideEffects();
  
          this.resolveMobResponsibleForDamage(source);
          this.resolvePlayerResponsibleForDamage(source);
@@ -273,7 +273,7 @@
  
 +        // Neo: Fire our post-damage event hooks. As usual, fire the extension method first, then the event version.
 +        this.onDamageTaken(this.damageContainers.peek());
-+        net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek());
++        net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek(), performSideEffects);
 +        this.damageContainers.pop();
          return success;
      }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -273,7 +273,7 @@
  
 +        // Neo: Fire our post-damage event hooks. As usual, fire the extension method first, then the event version.
 +        this.onDamageTaken(this.damageContainers.peek());
-+        net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek(), performSideEffects);
++        net.neoforged.neoforge.common.CommonHooks.onLivingDamagePost(this, this.damageContainers.peek());
 +        this.damageContainers.pop();
          return success;
      }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -205,13 +205,14 @@
          if (damage < 0.0F) {
              damage = 0.0F;
          }
-@@ -1214,20 +_,30 @@
+@@ -1214,27 +_,38 @@
          if (Float.isNaN(damage) || Float.isInfinite(damage)) {
              damage = Float.MAX_VALUE;
          }
 +        this.damageContainers.peek().setNewDamage(damage); // Update container with vanilla changes
  
-         boolean tookFullDamage = true;
+-        boolean tookFullDamage = true;
++        boolean performSideEffects = true;// Neo: Rename local variable to be more clear on its behavior
          if (this.invulnerableTime > 10.0F && !source.is(DamageTypeTags.BYPASSES_COOLDOWN)) {
              if (damage <= this.lastHurt) {
 +                // Neo: Pop the container when vanilla would abort the incoming damage due to the invulnerability ticks.
@@ -220,16 +221,17 @@
              }
 +
 +            // If we are going to do damage despite invulnerability (due to the damage being higher than prior), we need to setup the container differently.
++            this.damageContainers.peek().setDamageSideEffects(false);
 +            this.damageContainers.peek().setPostAttackInvulnerabilityTicks(this.invulnerableTime);
 +            this.damageContainers.peek().setReduction(net.neoforged.neoforge.common.damagesource.DamageContainer.Reduction.INVULNERABILITY, this.lastHurt);
  
              this.actuallyHurt(level, source, damage - this.lastHurt);
 -            this.lastHurt = damage;
+-            tookFullDamage = false;
 +            // lastHurt, in both blocks, needs to always be set to the value of `damage` since it is pre-reduction. Using a post reduction value invalidates iframes.
 +            // Since we're in the "damage while invuln is active" block, we need to make sure we don't reduce the lastHurt amount.
 +            this.lastHurt = java.lang.Math.max(this.lastHurt, damage);
 +            this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
-             tookFullDamage = false;
          } else {
 -            this.lastHurt = damage;
 -            this.invulnerableTime = 20;
@@ -238,6 +240,32 @@
 +            this.invulnerableTime = this.damageContainers.peek().getPostAttackInvulnerabilityTicks();
              this.hurtDuration = 10;
              this.hurtTime = this.hurtDuration;
+         }
++        performSideEffects = this.damageContainers.peek().getDamageSideEffects();
+ 
+         this.resolveMobResponsibleForDamage(source);
+         this.resolvePlayerResponsibleForDamage(source);
+-        if (tookFullDamage) {
++        if (performSideEffects) {
+             BlocksAttacks blocksAttacks = itemInUse.get(DataComponents.BLOCKS_ATTACKS);
+             if (blocked && blocksAttacks != null) {
+                 blocksAttacks.onBlocked(level, this);
+@@ -1253,14 +_,14 @@
+ 
+         if (this.isDeadOrDying()) {
+             if (!this.checkTotemDeathProtection(source)) {
+-                if (tookFullDamage) {
++                if (performSideEffects) {
+                     this.makeSound(this.getDeathSound());
+                     this.playSecondaryHurtSound(source);
+                 }
+ 
+                 this.die(source);
+             }
+-        } else if (tookFullDamage) {
++        } else if (performSideEffects) {
+             this.playHurtSound(source);
+             this.playSecondaryHurtSound(source);
          }
 @@ -1286,6 +_,10 @@
              CriteriaTriggers.PLAYER_HURT_ENTITY.trigger(sourcePlayer, this, source, originalDamage, damage, blocked);

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -342,17 +342,15 @@ public class CommonHooks {
         return NeoForge.EVENT_BUS.post(new LivingDamageEvent.Pre(entity, container)).getNewDamage();
     }
 
-    /**
-     * Creates and posts a {@link LivingDamageEvent.Post}. This is invoked in
-     * {@link LivingEntity#actuallyHurt(DamageSource, float)} and {@link Player#actuallyHurt(DamageSource, float)}
-     * and requires access to the internal field {@link LivingEntity#damageContainers} as a parameter.
-     *
-     * @param entity    the entity to receive damage
-     * @param container the container object holding the truly final values of the damage pipeline. The values
-     *                  of this container and used to instantiate final fields in the event.
-     */
-    public static void onLivingDamagePost(LivingEntity entity, DamageContainer container) {
-        NeoForge.EVENT_BUS.post(new LivingDamageEvent.Post(entity, container));
+    /// Creates and posts a [LivingDamageEvent.Post]. This is invoked in [LivingEntity#actuallyHurt(DamageSource, float)] and [Player#actuallyHurt(DamageSource, float)]
+    /// and requires access to the internal field [LivingEntity#damageContainers] as a parameter.
+    ///
+    /// @param entity             the entity to receive damage
+    /// @param container          the container object holding the truly final values of the damage pipeline. The values of this container and used to instantiate final
+    /// fields in the event.
+    /// @param performSideEffects whether side effects should be performed
+    public static void onLivingDamagePost(LivingEntity entity, DamageContainer container, boolean performSideEffects) {
+        NeoForge.EVENT_BUS.post(new LivingDamageEvent.Post(entity, container, performSideEffects));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -342,15 +342,17 @@ public class CommonHooks {
         return NeoForge.EVENT_BUS.post(new LivingDamageEvent.Pre(entity, container)).getNewDamage();
     }
 
-    /// Creates and posts a [LivingDamageEvent.Post]. This is invoked in [LivingEntity#actuallyHurt(DamageSource, float)] and [Player#actuallyHurt(DamageSource, float)]
-    /// and requires access to the internal field [LivingEntity#damageContainers] as a parameter.
-    ///
-    /// @param entity             the entity to receive damage
-    /// @param container          the container object holding the truly final values of the damage pipeline. The values of this container and used to instantiate final
-    /// fields in the event.
-    /// @param performSideEffects whether side effects should be performed
-    public static void onLivingDamagePost(LivingEntity entity, DamageContainer container, boolean performSideEffects) {
-        NeoForge.EVENT_BUS.post(new LivingDamageEvent.Post(entity, container, performSideEffects));
+    /**
+     * Creates and posts a {@link LivingDamageEvent.Post}. This is invoked in
+     * {@link LivingEntity#actuallyHurt(DamageSource, float)} and {@link Player#actuallyHurt(DamageSource, float)}
+     * and requires access to the internal field {@link LivingEntity#damageContainers} as a parameter.
+     *
+     * @param entity    the entity to receive damage
+     * @param container the container object holding the truly final values of the damage pipeline. The values
+     *                  of this container and used to instantiate final fields in the event.
+     */
+    public static void onLivingDamagePost(LivingEntity entity, DamageContainer container) {
+        NeoForge.EVENT_BUS.post(new LivingDamageEvent.Post(entity, container));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
+++ b/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
@@ -147,7 +147,7 @@ public class DamageContainer {
     /// - Motion should be synced to the client [LivingEntity#markHurt]
     /// - Knockback performed on the entity
     /// - Hurt/death sounds should be played
-    ///@param sideEffects `true` if damage side effects should be performed.
+    /// @param sideEffects `true` if damage side effects should be performed.
     public void setShouldCauseSideEffects(boolean sideEffects) {
         this.damageSideEffects = sideEffects;
     }

--- a/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
+++ b/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
@@ -148,12 +148,12 @@ public class DamageContainer {
     /// - Knockback performed on the entity
     /// - Hurt/death sounds should be played
     ///@param sideEffects `true` if damage side effects should be performed.
-    public void setDamageSideEffects(boolean sideEffects) {
+    public void setShouldCauseSideEffects(boolean sideEffects) {
         this.damageSideEffects = sideEffects;
     }
 
     /// {@return `true` if damage side effects should be performed}
-    public boolean getDamageSideEffects() {
+    public boolean shouldCauseSideEffects() {
         return this.damageSideEffects;
     }
 

--- a/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
+++ b/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
@@ -62,6 +62,7 @@ public class DamageContainer {
     private float blockedDamage = 0f;
     private float shieldDamage = 0;
     private int invulnerabilityTicksAfterAttack = 20;
+    private boolean damageSideEffects = true;
     private float inflictedDamage = 0;
 
     public DamageContainer(DamageSource source, float originalDamage) {
@@ -139,6 +140,21 @@ public class DamageContainer {
     /** {@return the number of ticks this entity will be invulnerable after damage is applied} */
     public int getPostAttackInvulnerabilityTicks() {
         return invulnerabilityTicksAfterAttack;
+    }
+
+    /// Sets whether damage side effects should be performed:
+    /// - If the attack was blocked so [net.minecraft.world.item.component.BlocksAttacks#onBlocked] should be called, or if it wasn't and [net.minecraft.server.level.ServerLevel#broadcastDamageEvent] should be called instead.
+    /// - Motion should be synced to the client [LivingEntity#markHurt]
+    /// - Knockback performed on the entity
+    /// - Hurt/death sounds should be played
+    ///@param sideEffects `true` if damage side effects should be performed.
+    public void setDamageSideEffects(boolean sideEffects) {
+        this.damageSideEffects = sideEffects;
+    }
+
+    /// {@return `true` if damage side effects should be performed}
+    public boolean getDamageSideEffects() {
+        return this.damageSideEffects;
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java
@@ -105,9 +105,9 @@ public abstract class LivingDamageEvent extends LivingEvent {
         private final boolean performSideEffects;
         private final EnumMap<DamageContainer.Reduction, Float> reductions;
 
-        public Post(LivingEntity entity, DamageContainer container, boolean performSideEffects) {
+        public Post(LivingEntity entity, DamageContainer container) {
             super(entity);
-            this.performSideEffects = performSideEffects;
+            this.performSideEffects = container.shouldCauseSideEffects();
             this.originalDamage = container.getOriginalDamage();
             this.source = container.getSource();
             this.inflictedDamage = container.getInflictedDamage();

--- a/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/living/LivingDamageEvent.java
@@ -102,10 +102,12 @@ public abstract class LivingDamageEvent extends LivingEvent {
         private final float blockedDamage;
         private final float shieldDamage;
         private final int postAttackInvulnerabilityTicks;
+        private final boolean performSideEffects;
         private final EnumMap<DamageContainer.Reduction, Float> reductions;
 
-        public Post(LivingEntity entity, DamageContainer container) {
+        public Post(LivingEntity entity, DamageContainer container, boolean performSideEffects) {
             super(entity);
+            this.performSideEffects = performSideEffects;
             this.originalDamage = container.getOriginalDamage();
             this.source = container.getSource();
             this.inflictedDamage = container.getInflictedDamage();
@@ -116,6 +118,11 @@ public abstract class LivingDamageEvent extends LivingEvent {
             this.reductions = new EnumMap<DamageContainer.Reduction, Float>(Arrays.stream(DamageContainer.Reduction.values())
                     .map(type -> new AbstractMap.SimpleEntry<>(type, container.getReduction(type)))
                     .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+        }
+
+        /// {@return `true` if side effects like sound and knockback should be performed}
+        public boolean shouldCauseSideEffects() {
+            return performSideEffects;
         }
 
         /** {@return the original damage when {@link LivingEntity#hurt} was invoked} */


### PR DESCRIPTION
Allows skipping various side effects for damage completing. My use case is to allow high damage reduction (lowering damage to zero), but still marking the entity as responsible for damage, and incrementing the iFrame, but if it reduces the damage to zero, then not having the entity get knocked back.