### PR TITLE
Update parameters that get proxied through RenderArmEvent

### DIFF
--- a/patches/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/ItemInHandRenderer.java.patch
@@ -28,10 +28,10 @@
          Identifier skinTexture = player.getSkin().body().texturePath();
          if (isRightArm) {
 -            avatarRenderer.renderRightHand(poseStack, submitNodeCollector, lightCoords, skinTexture, player.isModelPartShown(PlayerModelPart.RIGHT_SLEEVE));
-+            avatarRenderer.renderRightHand(poseStack, submitNodeCollector, lightCoords, skinTexture, player.isModelPartShown(PlayerModelPart.RIGHT_SLEEVE), this.minecraft.player);
++            avatarRenderer.renderRightHand(poseStack, submitNodeCollector, lightCoords, skinTexture, player.isModelPartShown(PlayerModelPart.RIGHT_SLEEVE), player);
          } else {
 -            avatarRenderer.renderLeftHand(poseStack, submitNodeCollector, lightCoords, skinTexture, player.isModelPartShown(PlayerModelPart.LEFT_SLEEVE));
-+            avatarRenderer.renderLeftHand(poseStack, submitNodeCollector, lightCoords, skinTexture, player.isModelPartShown(PlayerModelPart.LEFT_SLEEVE), this.minecraft.player);
++            avatarRenderer.renderLeftHand(poseStack, submitNodeCollector, lightCoords, skinTexture, player.isModelPartShown(PlayerModelPart.LEFT_SLEEVE), player);
          }
      }
  

--- a/patches/net/minecraft/client/renderer/entity/player/AvatarRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/player/AvatarRenderer.java.patch
@@ -36,38 +36,33 @@
                  this.itemModelResolver.updateForLiving(state.heldOnHead, useItem, ItemDisplayContext.HEAD, entity);
              }
          }
-@@ -236,12 +_,30 @@
+@@ -236,11 +_,29 @@
          state.capeFlap = state.capeFlap + Mth.sin(walkDistance * 6.0F) * 32.0F * pow;
      }
  
 +    /**
-+     * @deprecated Neo: use {@link #renderRightHand(PoseStack, SubmitNodeCollector, int, Identifier, boolean, net.minecraft.client.player.AbstractClientPlayer)} instead
++     * @deprecated Neo: use {@link #renderRightHand(PoseStack, SubmitNodeCollector, int, Identifier, boolean, Avatar)} instead
 +     */
 +    @Deprecated
      public void renderRightHand(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier skinTexture, boolean hasSleeve) {
--        this.renderHand(poseStack, submitNodeCollector, lightCoords, skinTexture, this.model.rightArm, hasSleeve);
--    }
--
-+        this.renderRightHand(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, net.minecraft.client.Minecraft.getInstance().player);
++        this.renderRightHand(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, (AvatarlikeEntity) net.minecraft.client.Minecraft.getInstance().player);
 +    }
 +
-+    public void renderRightHand(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier p_445487_, boolean hasSleeve, net.minecraft.client.player.AbstractClientPlayer player) {
-+        if(!net.neoforged.neoforge.client.ClientHooks.renderSpecificFirstPersonArm(poseStack, submitNodeCollector, lightCoords, player, HumanoidArm.RIGHT))
-+        this.renderHand(poseStack, submitNodeCollector, lightCoords, p_445487_, this.model.rightArm, hasSleeve);
-+    }
-+
++    public void renderRightHand(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier skinTexture, boolean hasSleeve, AvatarlikeEntity avatar) {
++        if(!net.neoforged.neoforge.client.ClientHooks.renderSpecificFirstPersonArm(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, avatar, HumanoidArm.RIGHT, this.model.rightArm))
+         this.renderHand(poseStack, submitNodeCollector, lightCoords, skinTexture, this.model.rightArm, hasSleeve);
+     }
+ 
 +    /**
-+     * @deprecated Neo: use {@link #renderLeftHand(PoseStack, SubmitNodeCollector, int, Identifier, boolean, net.minecraft.client.player.AbstractClientPlayer)} instead
++     * @deprecated Neo: use {@link #renderLeftHand(PoseStack, SubmitNodeCollector, int, Identifier, boolean, Avatar)} instead
 +     */
 +    @Deprecated
      public void renderLeftHand(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier skinTexture, boolean hasSleeve) {
--        this.renderHand(poseStack, submitNodeCollector, lightCoords, skinTexture, this.model.leftArm, hasSleeve);
-+        this.renderLeftHand(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, net.minecraft.client.Minecraft.getInstance().player);
++        this.renderLeftHand(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, (AvatarlikeEntity) net.minecraft.client.Minecraft.getInstance().player);
 +    }
 +
-+    public void renderLeftHand(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier p_446675_, boolean hasSleeve, net.minecraft.client.player.AbstractClientPlayer player) {
-+        if(!net.neoforged.neoforge.client.ClientHooks.renderSpecificFirstPersonArm(poseStack, submitNodeCollector, lightCoords, player, HumanoidArm.LEFT))
-+        this.renderHand(poseStack, submitNodeCollector, lightCoords, p_446675_, this.model.leftArm, hasSleeve);
++    public void renderLeftHand(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier skinTexture, boolean hasSleeve, AvatarlikeEntity avatar) {
++        if(!net.neoforged.neoforge.client.ClientHooks.renderSpecificFirstPersonArm(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, avatar, HumanoidArm.LEFT, this.model.leftArm))
+         this.renderHand(poseStack, submitNodeCollector, lightCoords, skinTexture, this.model.leftArm, hasSleeve);
      }
  
-     private void renderHand(

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -48,6 +48,7 @@ import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.MouseHandler;
 import net.minecraft.client.Options;
+import net.minecraft.client.entity.ClientAvatarEntity;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.Hud;
@@ -77,7 +78,6 @@ import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.multiplayer.PlayerInfo;
 import net.minecraft.client.particle.ParticleResources;
-import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.player.ClientInput;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.GameRenderer;
@@ -121,6 +121,7 @@ import net.minecraft.util.ARGB;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Avatar;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.LivingEntity;
@@ -249,8 +250,9 @@ public class ClientHooks {
         return NeoForge.EVENT_BUS.post(new RenderHandEvent(hand, poseStack, submitNodeCollector, packedLight, partialTick, interpPitch, swingProgress, equipProgress, stack)).isCanceled();
     }
 
-    public static boolean renderSpecificFirstPersonArm(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int packedLight, AbstractClientPlayer player, HumanoidArm arm) {
-        return NeoForge.EVENT_BUS.post(new RenderArmEvent(poseStack, submitNodeCollector, packedLight, player, arm)).isCanceled();
+    public static <AvatarlikeEntity extends Avatar & ClientAvatarEntity> boolean renderSpecificFirstPersonArm(PoseStack poseStack, SubmitNodeCollector submitNodeCollector,
+            int lightCoords, Identifier skinTexture, boolean hasSleeve, AvatarlikeEntity avatar, HumanoidArm arm, ModelPart armPart) {
+        return NeoForge.EVENT_BUS.post(new RenderArmEvent<>(poseStack, submitNodeCollector, lightCoords, skinTexture, hasSleeve, avatar, arm, armPart)).isCanceled();
     }
 
     public static void onTextureAtlasStitched(TextureAtlas atlas) {

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
@@ -6,8 +6,11 @@
 package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.entity.ClientAvatarEntity;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.Avatar;
 import net.minecraft.world.entity.HumanoidArm;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -26,20 +29,27 @@ import org.jetbrains.annotations.ApiStatus;
  * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
  * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
  */
-public class RenderArmEvent extends Event implements ICancellableEvent {
+public class RenderArmEvent<AvatarlikeEntity extends Avatar & ClientAvatarEntity> extends Event implements ICancellableEvent {
     private final PoseStack poseStack;
     private final SubmitNodeCollector submitNodeCollector;
-    private final int packedLight;
-    private final AbstractClientPlayer player;
+    private final int lightCoords;
+    private final Identifier skinTexture;
+    private final boolean hasSleeve;
+    private final AvatarlikeEntity avatar;
     private final HumanoidArm arm;
+    private final ModelPart armPart;
 
     @ApiStatus.Internal
-    public RenderArmEvent(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int packedLight, AbstractClientPlayer player, HumanoidArm arm) {
+    public RenderArmEvent(PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, Identifier skinTexture, boolean hasSleeve,
+            AvatarlikeEntity avatar, HumanoidArm arm, ModelPart armPart) {
         this.poseStack = poseStack;
         this.submitNodeCollector = submitNodeCollector;
-        this.packedLight = packedLight;
-        this.player = player;
+        this.lightCoords = lightCoords;
+        this.skinTexture = skinTexture;
+        this.hasSleeve = hasSleeve;
+        this.avatar = avatar;
         this.arm = arm;
+        this.armPart = armPart;
     }
 
     /**
@@ -68,15 +78,27 @@ public class RenderArmEvent extends Event implements ICancellableEvent {
      *
      * @see net.minecraft.util.LightCoordsUtil
      */
-    public int getPackedLight() {
-        return packedLight;
+    public int getLightCoords() {
+        return lightCoords;
     }
 
-    /**
-     * {@return the client player that is having their arm rendered} In general, this will be the same as
-     * {@link net.minecraft.client.Minecraft#player}.
-     */
-    public AbstractClientPlayer getPlayer() {
-        return player;
+    /// {@return the avatar's skin texture}
+    public Identifier getSkinTexture() {
+        return skinTexture;
+    }
+
+    /// {@return whether the avatar's sleeves are showing}
+    public boolean hasSleeve() {
+        return hasSleeve;
+    }
+
+    /// {@return the model part for the arm being rendered}
+    public ModelPart getArmPart() {
+        return armPart;
+    }
+
+    /// {@return the avatar that is having their arm rendered} In general, this will be the same as [net.minecraft.client.Minecraft#player].
+    public AvatarlikeEntity getAvatar() {
+        return avatar;
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
 ///
 /// This event is [cancellable][ICancellableEvent]. If this event is cancelled, then the arm will not be rendered.
 ///
-/// This event is fired on the [main Forge event bus][NeoForge#EVENT_BUS], only on the [logical client][LogicalSide#CLIENT].
+/// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS], only on the [logical client][LogicalSide#CLIENT].
 ///
 /// @param <AvatarlikeEntity> This generic parameter **cannot** be used to target specific subclasses of [Avatar], nor narrow the type in any other way (i.e. it must be specified as a wild card).
 public class RenderArmEvent<AvatarlikeEntity extends Avatar & ClientAvatarEntity> extends Event implements ICancellableEvent {

--- a/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/RenderArmEvent.java
@@ -18,17 +18,15 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
 
-/**
- * Fired before the player's arm is rendered in first person. This is a more targeted version of {@link RenderHandEvent},
- * and can be used to replace the rendering of the player's arm, such as for rendering armor on the arm or outright
- * replacing the arm with armor.
- *
- * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
- * If this event is cancelled, then the arm will not be rendered.</p>
- *
- * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
- * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
- */
+/// Fired before the player's arm is rendered in first person. This is a more targeted version of [RenderHandEvent],
+/// and can be used to replace the rendering of the player's arm, such as for rendering armor on the arm or outright
+/// replacing the arm with armor.
+///
+/// This event is [cancellable][ICancellableEvent]. If this event is cancelled, then the arm will not be rendered.
+///
+/// This event is fired on the [main Forge event bus][NeoForge#EVENT_BUS], only on the [logical client][LogicalSide#CLIENT].
+///
+/// @param <AvatarlikeEntity> This generic parameter **cannot** be used to target specific subclasses of [Avatar], nor narrow the type in any other way (i.e. it must be specified as a wild card).
 public class RenderArmEvent<AvatarlikeEntity extends Avatar & ClientAvatarEntity> extends Event implements ICancellableEvent {
     private final PoseStack poseStack;
     private final SubmitNodeCollector submitNodeCollector;


### PR DESCRIPTION
Passes new params that didn't exist at the time of the event being created to the RenderArmEvent, and broadens it to the same generics that are in AvatarRenderer.