### PR TITLE
Update FluidStackSlotDisplay to keep track of a FluidStackTemplate to mirror SlotDisplay.ItemStackSlotDisplay

### DIFF
--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/DataComponentFluidIngredient.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/DataComponentFluidIngredient.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.material.Fluid;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.common.crafting.DataComponentIngredient;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidStackTemplate;
 import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.fluids.crafting.display.FluidStackSlotDisplay;
 
@@ -49,22 +50,22 @@ public class DataComponentFluidIngredient extends FluidIngredient {
     private final HolderSet<Fluid> fluids;
     private final DataComponentExactPredicate components;
     private final boolean strict;
-    private final FluidStack[] stacks;
+    private final FluidStackTemplate[] templates;
 
     public DataComponentFluidIngredient(HolderSet<Fluid> fluids, DataComponentExactPredicate components, boolean strict) {
         this.fluids = fluids;
         this.components = components;
         this.strict = strict;
-        this.stacks = fluids.stream()
-                .map(i -> new FluidStack(i, FluidType.BUCKET_VOLUME, components.asPatch()))
-                .toArray(FluidStack[]::new);
+        this.templates = fluids.stream()
+                .map(i -> new FluidStackTemplate(i, FluidType.BUCKET_VOLUME, components.asPatch()))
+                .toArray(FluidStackTemplate[]::new);
     }
 
     @Override
     public boolean test(FluidStack stack) {
         if (strict) {
-            for (FluidStack stack2 : this.stacks) {
-                if (FluidStack.isSameFluidSameComponents(stack, stack2)) return true;
+            for (FluidStackTemplate template : this.templates) {
+                if (FluidStack.isSameFluidSameComponents(stack, template)) return true;
             }
             return false;
         } else {
@@ -72,14 +73,15 @@ public class DataComponentFluidIngredient extends FluidIngredient {
         }
     }
 
+    @Override
     public Stream<Holder<Fluid>> generateFluids() {
         return fluids.stream();
     }
 
     @Override
     public SlotDisplay display() {
-        return new SlotDisplay.Composite(Stream.of(stacks)
-                .map(stack -> (SlotDisplay) new FluidStackSlotDisplay(stack))
+        return new SlotDisplay.Composite(Stream.of(templates)
+                .map(template -> (SlotDisplay) new FluidStackSlotDisplay(template))
                 .toList());
     }
 

--- a/src/main/java/net/neoforged/neoforge/fluids/crafting/display/FluidStackSlotDisplay.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/crafting/display/FluidStackSlotDisplay.java
@@ -14,18 +14,18 @@ import net.minecraft.util.context.ContextMap;
 import net.minecraft.world.item.crafting.display.DisplayContentsFactory;
 import net.minecraft.world.item.crafting.display.SlotDisplay;
 import net.neoforged.neoforge.common.NeoForgeMod;
-import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidStackTemplate;
 
 /**
  * Slot display for a given fluid stack, including fluid amount and data components.
  *
  * @param stack The fluid stack to be displayed.
  */
-public record FluidStackSlotDisplay(FluidStack stack) implements SlotDisplay {
-    public static final MapCodec<FluidStackSlotDisplay> MAP_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(FluidStack.CODEC.fieldOf("fluid").forGetter(FluidStackSlotDisplay::stack))
-            .apply(instance, FluidStackSlotDisplay::new));
+public record FluidStackSlotDisplay(FluidStackTemplate stack) implements SlotDisplay {
+    public static final MapCodec<FluidStackSlotDisplay> MAP_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+            FluidStackTemplate.CODEC.fieldOf("fluid").forGetter(FluidStackSlotDisplay::stack)).apply(instance, FluidStackSlotDisplay::new));
     public static final StreamCodec<RegistryFriendlyByteBuf, FluidStackSlotDisplay> STREAM_CODEC = StreamCodec.composite(
-            FluidStack.STREAM_CODEC, FluidStackSlotDisplay::stack, FluidStackSlotDisplay::new);
+            FluidStackTemplate.STREAM_CODEC, FluidStackSlotDisplay::stack, FluidStackSlotDisplay::new);
 
     @Override
     public SlotDisplay.Type<FluidStackSlotDisplay> type() {
@@ -34,19 +34,6 @@ public record FluidStackSlotDisplay(FluidStack stack) implements SlotDisplay {
 
     @Override
     public <T> Stream<T> resolve(ContextMap context, DisplayContentsFactory<T> factory) {
-        return switch (factory) {
-            case ForFluidStacks<T> fluids -> Stream.of(fluids.forStack(stack));
-            default -> Stream.empty();
-        };
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (this == other) {
-            return true;
-        } else {
-            return other instanceof FluidStackSlotDisplay fluidStackDisplay
-                    && FluidStack.matches(this.stack, fluidStackDisplay.stack);
-        }
+        return factory instanceof ForFluidStacks<T> stacks ? Stream.of(stacks.forStack(stack.create())) : Stream.empty();
     }
 }


### PR DESCRIPTION
In 26.1, Mojang changed `SlotDisplay.ItemStackSlotDisplay` to store a reference to an `ItemStackTemplate` instead of an `ItemStack`. When adjusting my recipes to implement displays for fluid outputs, I noticed that Neo is still using a `FluidStack` for it; while this can be worked around by calling `FluidStackTemplate#create`, the better solution is to update it to once again mirror vanilla.