### PR TITLE
[26.2] Add missing display property to `ItemTooltipEvent`

### DIFF
--- a/patches/net/minecraft/world/item/ItemStack.java.patch
+++ b/patches/net/minecraft/world/item/ItemStack.java.patch
@@ -191,7 +191,7 @@
              List<Component> lines = Lists.newArrayList();
              lines.add(this.getStyledHoverName());
              this.addDetailsToTooltip(context, display, player, tooltipFlag, lines::add);
-+            net.neoforged.neoforge.event.EventHooks.onItemTooltip(this, player, lines, tooltipFlag, context);
++            net.neoforged.neoforge.event.EventHooks.onItemTooltip(this, player, lines, tooltipFlag, context, display);
              return lines;
          }
      }

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -79,6 +79,7 @@ import net.minecraft.world.item.ItemInstance;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ItemStackLinkedSet;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -454,8 +455,8 @@ public class EventHooks {
         return event.getNewState();
     }
 
-    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags, Item.TooltipContext context) {
-        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, list, flags, context);
+    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable Player entityPlayer, List<Component> list, TooltipFlag flags, Item.TooltipContext context, TooltipDisplay display) {
+        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, list, flags, context, display);
         NeoForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ItemTooltipEvent.java
@@ -6,11 +6,17 @@
 package net.neoforged.neoforge.event.entity.player;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+import net.minecraft.world.item.component.TooltipProvider;
+import net.neoforged.neoforge.common.extensions.IDataComponentHolderExtension;
 import org.jspecify.annotations.Nullable;
 
 public class ItemTooltipEvent extends PlayerEvent {
@@ -18,17 +24,19 @@ public class ItemTooltipEvent extends PlayerEvent {
     private final ItemStack itemStack;
     private final List<Component> toolTip;
     private final TooltipContext context;
+    private final TooltipDisplay display;
 
     /**
      * This event is fired in {@link ItemStack#getTooltipLines(TooltipContext, Player, TooltipFlag)}, which in turn is called from its respective GUIContainer.
      * Tooltips are also gathered with a null player during startup by {@link Minecraft#createSearchTrees()}.
      */
-    public ItemTooltipEvent(ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags, TooltipContext context) {
+    public ItemTooltipEvent(ItemStack itemStack, @Nullable Player player, List<Component> list, TooltipFlag flags, TooltipContext context, TooltipDisplay display) {
         super(player);
         this.itemStack = itemStack;
         this.toolTip = list;
         this.flags = flags;
         this.context = context;
+        this.display = display;
     }
 
     /**
@@ -66,5 +74,21 @@ public class ItemTooltipEvent extends PlayerEvent {
      */
     public TooltipContext getContext() {
         return context;
+    }
+
+    /// Used to determine what components on the item tooltip should be hidden
+    public TooltipDisplay getDisplay() {
+        return display;
+    }
+
+    /// Handy utility to quickly append a component to the items tooltip
+    /// @see IDataComponentHolderExtension#addToTooltip(DataComponentType, TooltipContext, TooltipDisplay, Consumer, TooltipFlag)
+    public <T extends TooltipProvider> void addToTooltip(DataComponentType<T> type) {
+        itemStack.addToTooltip(type, context, display, toolTip::add, flags);
+    }
+
+    /// Handy utility to quickly append a component to the items tooltip
+    public <T extends TooltipProvider> void addToTooltip(Supplier<? extends DataComponentType<T>> type) {
+        addToTooltip(type.get());
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/ItemTooltipEvent.java
@@ -6,17 +6,12 @@
 package net.neoforged.neoforge.event.entity.player;
 
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.TooltipDisplay;
-import net.minecraft.world.item.component.TooltipProvider;
-import net.neoforged.neoforge.common.extensions.IDataComponentHolderExtension;
 import org.jspecify.annotations.Nullable;
 
 public class ItemTooltipEvent extends PlayerEvent {
@@ -79,16 +74,5 @@ public class ItemTooltipEvent extends PlayerEvent {
     /// Used to determine what components on the item tooltip should be hidden
     public TooltipDisplay getDisplay() {
         return display;
-    }
-
-    /// Handy utility to quickly append a component to the items tooltip
-    /// @see IDataComponentHolderExtension#addToTooltip(DataComponentType, TooltipContext, TooltipDisplay, Consumer, TooltipFlag)
-    public <T extends TooltipProvider> void addToTooltip(DataComponentType<T> type) {
-        itemStack.addToTooltip(type, context, display, toolTip::add, flags);
-    }
-
-    /// Handy utility to quickly append a component to the items tooltip
-    public <T extends TooltipProvider> void addToTooltip(Supplier<? extends DataComponentType<T>> type) {
-        addToTooltip(type.get());
     }
 }


### PR DESCRIPTION
Adds missing `TooltipDisplay` property to the `ItemTooltipEvent`, which is used when appending component based tooltips (which allows users to hide a given components tooltip).

While this can currently be looked up via the given `ItemStack` since it is stored as a component
`event.getItemStack().getOrDefault(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.DEFAULT)`
this should not be relied on as the event could be posted from a external source for custom display properties.