### PR TITLE
[26.2] Reimplement missing `AbstractGameRulesScreen` patch

### DIFF
--- a/patches/net/minecraft/client/gui/screens/worldselection/AbstractGameRulesScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/worldselection/AbstractGameRulesScreen.java.patch
@@ -1,0 +1,15 @@
+--- a/net/minecraft/client/gui/screens/worldselection/AbstractGameRulesScreen.java
++++ b/net/minecraft/client/gui/screens/worldselection/AbstractGameRulesScreen.java
+@@ -293,6 +_,12 @@
+                             this.addEntry(gameRule, (x$0, x$1, x$2, x$3) -> AbstractGameRulesScreen.this.new IntegerRuleEntry(x$0, x$1, x$2, x$3));
+                         }
+ 
++                        @Override
++                        public <T> void visit(GameRule<T> gameRule) {
++                            // Neo: Append custom entries for none bool/int game rules
++                            net.neoforged.neoforge.client.gamerules.GameRuleEntryFactoryManager.appendGameRuleEntry(AbstractGameRulesScreen.this, gameRule, this::addEntry);
++                        }
++
+                         private <T> void addEntry(GameRule<T> gameRule, AbstractGameRulesScreen.EntryFactory<T> factory) {
+                             Component readableName = Component.translatable(gameRule.getDescriptionId());
+                             String descriptionKey = gameRule.getDescriptionId() + ".description";


### PR DESCRIPTION
This PR reimplements the missing `AbstractGameRulesScreen` patch, which calls `GameRuleEntryFactoryManager.appendGameRuleEntry`.

This allows the custom registered entries via `RegisterGameRuleEntryFactoryEvent` to be correctly appended and used when editing gamerules in game.

While this was introduced during the `26.1` port and worked fine, a future snapshot seems to have caused the patch to be rejected and lost. Will need downporting to `26.1`.

Fixes #3296