### PR TITLE
Fix missing throw clauses in MappedRegistry

### DIFF
--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -39,13 +39,13 @@
 +
          if (this.byLocation.containsKey(p_256252_.location())) {
 -            Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
-+            // NEO: Add missing 'throw' clause (fixed in 1.21.2/24w33a)
++            // Neo: Add missing 'throw' clause (fixed in 1.21.2/24w33a)
 +            throw Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
          }
  
          if (this.byValue.containsKey(p_256591_)) {
 -            Util.pauseInIde(new IllegalStateException("Adding duplicate value '" + p_256591_ + "' to registry"));
-+            // NEO: Add missing 'throw' clause (fixed in 1.21.2/24w33a)
++            // Neo: Add missing 'throw' clause (fixed in 1.21.2/24w33a)
 +            throw Util.pauseInIde(new IllegalStateException("Adding duplicate value '" + p_256591_ + "' to registry"));
          }
  

--- a/patches/net/minecraft/core/MappedRegistry.java.patch
+++ b/patches/net/minecraft/core/MappedRegistry.java.patch
@@ -22,7 +22,7 @@
      };
      private final Object tagAdditionLock = new Object();
  
-@@ -114,9 +_,17 @@
+@@ -114,15 +_,25 @@
  
      @Override
      public Holder.Reference<T> register(ResourceKey<T> p_256252_, T p_256591_, RegistrationInfo p_326235_) {
@@ -38,8 +38,18 @@
 +            throw new IllegalStateException(String.format(java.util.Locale.ENGLISH, "Invalid id %d - maximum id range of %d exceeded.", i, this.getMaxId()));
 +
          if (this.byLocation.containsKey(p_256252_.location())) {
-             Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
+-            Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
++            // NEO: Add missing 'throw' clause (fixed in 1.21.2/24w33a)
++            throw Util.pauseInIde(new IllegalStateException("Adding duplicate key '" + p_256252_ + "' to registry"));
          }
+ 
+         if (this.byValue.containsKey(p_256591_)) {
+-            Util.pauseInIde(new IllegalStateException("Adding duplicate value '" + p_256591_ + "' to registry"));
++            // NEO: Add missing 'throw' clause (fixed in 1.21.2/24w33a)
++            throw Util.pauseInIde(new IllegalStateException("Adding duplicate value '" + p_256591_ + "' to registry"));
+         }
+ 
+         Holder.Reference<T> reference;
 @@ -135,16 +_,18 @@
              reference.bindKey(p_256252_);
          } else {


### PR DESCRIPTION
This PR fixes #3285 by inserting missing `throw` clauses in `MappedRegistry#register`, so duplicate registrations are properly thrown and handled.