### PR TITLE
Fix registry alias loop detection

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/BaseMappedRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/registries/BaseMappedRegistry.java
@@ -69,7 +69,7 @@ public abstract class BaseMappedRegistry<T> implements Registry<T> {
             if (!old.equals(to))
                 throw new IllegalStateException("Duplicate alias with key \"" + from + "\" attempting to map to \"" + to + "\", found existing mapping \"" + old + "\"");
         }
-        if (resolve(from).equals(to))
+        if (resolve(to).equals(from))
             throw new IllegalStateException("Infinite alias loop detected: from " + from + " to " + to);
         this.aliases.put(from, to);
     }

--- a/src/main/java/net/neoforged/neoforge/registries/BaseMappedRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/registries/BaseMappedRegistry.java
@@ -67,10 +67,10 @@ public abstract class BaseMappedRegistry<T> implements Registry<T> {
         if (this.aliases.containsKey(from)) {
             Identifier old = this.aliases.get(from);
             if (!old.equals(to))
-                throw new IllegalStateException("Duplicate alias with key \"" + from + "\" attempting to map to \"" + to + "\", found existing mapping \"" + old + "\"");
+                throw new IllegalArgumentException("Duplicate alias with key \"" + from + "\" attempting to map to \"" + to + "\", found existing mapping \"" + old + "\"");
         }
         if (resolve(to).equals(from))
-            throw new IllegalStateException("Infinite alias loop detected: from " + from + " to " + to);
+            throw new IllegalArgumentException("Infinite alias loop detected: from " + from + " to " + to);
         this.aliases.put(from, to);
     }
 

--- a/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
+++ b/src/main/java/net/neoforged/neoforge/registries/IRegistryExtension.java
@@ -64,14 +64,14 @@ public interface IRegistryExtension<T> {
         addCallback(callback);
     }
 
-    /**
-     * Adds an alias that maps from the name specified by <code>from</code> to the name specified by <code>to</code>.
-     * <p>
-     * Any registry lookups that target the first name will resolve as the second name, if the first name is not present.
-     *
-     * @param from the source registry name to alias from
-     * @param to   the target registry name to alias to
-     */
+    /// Adds an alias that maps from the name specified by `from` to the name specified by `to`.
+    ///
+    /// Any registry lookups that target the first name will resolve as the second name, if the first name is not present.
+    ///
+    /// @param from the source registry name to alias from
+    /// @param to   the target registry name to alias to
+    /// @throws IllegalArgumentException if an alias already exists for the source registry name that does not point to the
+    ///                                  same target registry name, or if the alias would cause a resolution loop
     void addAlias(Identifier from, Identifier to);
 
     /**

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/RegistryTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/RegistryTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.mojang.serialization.Lifecycle;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.Unit;
+import org.junit.jupiter.api.Test;
+
+public class RegistryTests {
+    static ResourceKey<Registry<Unit>> REGISTRY_KEY = ResourceKey.createRegistryKey(id("registry_test"));
+
+    static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath("test", path);
+    }
+
+    MappedRegistry<Unit> createRegistry() {
+        var registry = new MappedRegistry<>(REGISTRY_KEY, Lifecycle.experimental());
+        registry.addAlias(id("a"), id("b"));
+        registry.addAlias(id("b"), id("c"));
+        registry.addAlias(id("c"), id("d"));
+        // A -> B -> C -> D -> E
+        return registry;
+    }
+
+    @Test
+    void testFullDuplicateAlias() {
+        //  /---v (full duplicate, should be ignored)
+        // A -> B -> C -> D
+        var registry = createRegistry();
+        assertDoesNotThrow(
+                () -> registry.addAlias(id("a"), id("b")),
+                "Full duplicate alias registration should not throw an exception");
+    }
+
+    @Test
+    void testDuplicateAliasRegisterThrows() {
+        //  /--------v (duplicate)
+        // A -> B -> C -> D
+        var registry = createRegistry();
+        var ex = assertThrows(
+                IllegalStateException.class,
+                () -> registry.addAlias(id("a"), id("c")),
+                "Duplicate alias registration should throw an exception");
+        assertEquals(
+                "Duplicate alias with key \"%s\" attempting to map to \"%s\", found existing mapping \"%s\"".formatted(
+                        id("a"), id("c"), id("b")),
+                ex.getMessage(),
+                "Exception did not have the expected message for duplicate alias");
+    }
+
+    @Test
+    void testAliasLoopRegisterThrows() {
+        //      v--------\
+        // A -> B -> C -> D
+        var registry = createRegistry();
+        var ex = assertThrows(
+                IllegalStateException.class,
+                () -> registry.addAlias(id("d"), id("b")),
+                "Alias loop registration should throw an exception");
+        assertEquals(
+                "Infinite alias loop detected: from %s to %s".formatted(
+                        id("d"), id("b")),
+                ex.getMessage(),
+                "Exception did not have expected message for alias loop");
+    }
+}

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/RegistryTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/RegistryTests.java
@@ -49,7 +49,7 @@ public class RegistryTests {
         // A -> B -> C -> D
         var registry = createRegistry();
         var ex = assertThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> registry.addAlias(id("a"), id("c")),
                 "Duplicate alias registration should throw an exception");
         assertEquals(
@@ -65,7 +65,7 @@ public class RegistryTests {
         // A -> B -> C -> D
         var registry = createRegistry();
         var ex = assertThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> registry.addAlias(id("d"), id("b")),
                 "Alias loop registration should throw an exception");
         assertEquals(

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/RegistryTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/RegistryTests.java
@@ -6,7 +6,6 @@
 package net.neoforged.neoforge.unittest;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.mojang.serialization.Lifecycle;
@@ -48,15 +47,10 @@ public class RegistryTests {
         //  /--------v (duplicate)
         // A -> B -> C -> D
         var registry = createRegistry();
-        var ex = assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> registry.addAlias(id("a"), id("c")),
                 "Duplicate alias registration should throw an exception");
-        assertEquals(
-                "Duplicate alias with key \"%s\" attempting to map to \"%s\", found existing mapping \"%s\"".formatted(
-                        id("a"), id("c"), id("b")),
-                ex.getMessage(),
-                "Exception did not have the expected message for duplicate alias");
     }
 
     @Test
@@ -64,14 +58,9 @@ public class RegistryTests {
         //      v--------\
         // A -> B -> C -> D
         var registry = createRegistry();
-        var ex = assertThrows(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> registry.addAlias(id("d"), id("b")),
                 "Alias loop registration should throw an exception");
-        assertEquals(
-                "Infinite alias loop detected: from %s to %s".formatted(
-                        id("d"), id("b")),
-                ex.getMessage(),
-                "Exception did not have expected message for alias loop");
     }
 }


### PR DESCRIPTION
This PR fixes #3255 and implements tests to ensure the alias loop detection works.

To detect a loop, the check must first begin at the alias target and see if it reaches the alias source when resolving down the alias chain. It cannot begin at the alias source, since at that point the alias does not exist yet so it will always give the alias source itself.

This adds tests to ensure the loop detection works, and that duplicate aliases that aren't full duplicates are rejected.

This PR also changes the exception thrown from `IllegalStateException` (though consistent with `WritableRegistry#register`) to `IllegalArgumentException`, which is more appropriate. The tests also check for this, and the javadoc for `addAlias` is updated with the thrown exceptions.