### PR TITLE
Fire PlayerContainerEvent.Open for nautilus inventory menu

### DIFF
--- a/patches/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/patches/net/minecraft/server/level/ServerPlayer.java.patch
@@ -247,6 +247,14 @@
      }
  
      @Override
+@@ -1385,6 +_,7 @@
+         this.connection.send(new ClientboundMountScreenOpenPacket(this.containerCounter, inventoryColumns, nautilus.getId()));
+         this.containerMenu = new NautilusInventoryMenu(this.containerCounter, this.getInventory(), container, nautilus, inventoryColumns);
+         this.initMenu(this.containerMenu);
++        net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(new net.neoforged.neoforge.event.entity.player.PlayerContainerEvent.Open(this, this.containerMenu));
+     }
+ 
+     @Override
 @@ -1413,6 +_,7 @@
      public void doCloseContainer() {
          this.containerMenu.removed(this);


### PR DESCRIPTION
This PR fixes #3325 by firing `PlayerContainerEvent.Open` for the nautilus inventory menu, in the same way that it is fired for the horse inventory menu.