### PR TITLE
Update NeoForm 26.2 to ver. 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ diffpatch_version=2.1.0.43
 java_version=25
 
 minecraft_version=26.2
-neoform_version=1
+neoform_version=2
 # on snapshot versions, used to prefix the version
 # should always have 3 components (major.minor.hotfix)
 neoforge_snapshot_next_stable=26.2


### PR DESCRIPTION
This PR fixes #3295 by updating NeoForm 26.2 to version 2, which includes a fix for `PeriodicNotificationManager.Notification`, whose canonical constructor was missing based off the bytecode.

Tested by launching the game with `-Duser.country=KR` and observing the hourly periodic notification does not appear on game load or on resource reload.