### PR TITLE
Assign vanilla key mappings to conflict contexts

### DIFF
--- a/patches/net/minecraft/client/KeyMapping.java.patch
+++ b/patches/net/minecraft/client/KeyMapping.java.patch
@@ -124,27 +124,15 @@
      }
  
      public KeyMapping.Category getCategory() {
-@@ -159,6 +_,20 @@
+@@ -159,7 +_,7 @@
      }
  
      public boolean same(KeyMapping that) {
-+        if (getKeyConflictContext().conflicts(that.getKeyConflictContext()) || that.getKeyConflictContext().conflicts(getKeyConflictContext())) {
-+            net.neoforged.neoforge.client.settings.KeyModifier keyModifier = getKeyModifier();
-+            net.neoforged.neoforge.client.settings.KeyModifier otherKeyModifier = that.getKeyModifier();
-+            if (keyModifier.matches(that.getKey()) || otherKeyModifier.matches(getKey())) {
-+                return true;
-+            } else if (getKey().equals(that.getKey())) {
-+                // IN_GAME key contexts have a conflict when at least one modifier is NONE.
-+                // For example: If you hold shift to crouch, you can still press E to open your inventory. This means that a Shift+E hotkey is in conflict with E.
-+                // GUI and other key contexts do not have this limitation.
-+                return keyModifier == otherKeyModifier ||
-+                    (getKeyConflictContext().conflicts(net.neoforged.neoforge.client.settings.KeyConflictContext.IN_GAME) &&
-+                    (keyModifier == net.neoforged.neoforge.client.settings.KeyModifier.NONE || otherKeyModifier == net.neoforged.neoforge.client.settings.KeyModifier.NONE));
-+            }
-+        }
-         return this.key.equals(that.key);
+-        return this.key.equals(that.key);
++        return net.neoforged.neoforge.client.extensions.KeyMappingModifierHelper.hasKeyMappingConflict(this, that);
      }
  
+     public boolean isUnbound() {
 @@ -181,11 +_,13 @@
      }
  

--- a/patches/net/minecraft/client/Options.java.patch
+++ b/patches/net/minecraft/client/Options.java.patch
@@ -43,7 +43,7 @@
              }
          }
  
-@@ -1924,6 +_,23 @@
+@@ -1924,6 +_,48 @@
          }
  
          repository.setSelected(selected);
@@ -51,6 +51,9 @@
 +
 +    private void setForgeKeybindProperties() {
 +        net.neoforged.neoforge.client.settings.KeyConflictContext inGame = net.neoforged.neoforge.client.settings.KeyConflictContext.IN_GAME;
++        net.neoforged.neoforge.client.settings.KeyConflictContext spectator = net.neoforged.neoforge.client.settings.KeyConflictContext.SPECTATOR;
++        net.neoforged.neoforge.client.settings.KeyConflictContext debug = net.neoforged.neoforge.client.settings.KeyConflictContext.DEBUG;
++        net.neoforged.neoforge.client.settings.KeyConflictContext guiAndInGame = net.neoforged.neoforge.client.settings.KeyConflictContext.GUI_AND_IN_GAME;
 +        keyUp.setKeyConflictContext(inGame);
 +        keyLeft.setKeyConflictContext(inGame);
 +        keyDown.setKeyConflictContext(inGame);
@@ -59,11 +62,33 @@
 +        keyShift.setKeyConflictContext(inGame);
 +        keySprint.setKeyConflictContext(inGame);
 +        keyAttack.setKeyConflictContext(inGame);
-+        keyChat.setKeyConflictContext(inGame);
++        keyUse.setKeyConflictContext(inGame);
++        keyChat.setKeyConflictContext(guiAndInGame);
 +        keyPlayerList.setKeyConflictContext(inGame);
 +        keyCommand.setKeyConflictContext(inGame);
++        keyFriends.setKeyConflictContext(guiAndInGame);
++        keySocialInteractions.setKeyConflictContext(guiAndInGame);
 +        keyTogglePerspective.setKeyConflictContext(inGame);
 +        keySmoothCamera.setKeyConflictContext(inGame);
++        keyQuickActions.setKeyConflictContext(inGame);
++        keyToggleGui.setKeyConflictContext(inGame);
++        keyToggleSpectatorShaderEffects.setKeyConflictContext(inGame);
++        keySaveHotbarActivator.setKeyConflictContext(inGame);
++        keyLoadHotbarActivator.setKeyConflictContext(inGame);
++        keySpectatorOutlines.setKeyConflictContext(spectator);
++        keySpectatorHotbar.setKeyConflictContext(spectator);
++        keyInventory.setKeyConflictContext(guiAndInGame);
++        keySwapOffhand.setKeyConflictContext(guiAndInGame);
++        keyDrop.setKeyConflictContext(guiAndInGame);
++        keyPickItem.setKeyConflictContext(guiAndInGame);
++        keyAdvancements.setKeyConflictContext(guiAndInGame);
++        for (KeyMapping keyHotbarSlot : keyHotbarSlots) {
++            keyHotbarSlot.setKeyConflictContext(guiAndInGame);
++        }
++
++        for (KeyMapping debugKey : debugKeys) {
++            debugKey.setKeyConflictContext(debug);
++        }
      }
  
      public CameraType getCameraType() {

--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
@@ -22,7 +22,7 @@
              if (!this.key.isUnbound()) {
                  for (KeyMapping otherKey : KeyBindsList.this.minecraft.options.keyMappings) {
 -                    if (otherKey != this.key && this.key.same(otherKey) && (!otherKey.isDefault() || !this.key.isDefault())) {
-+                    if ((otherKey != this.key && this.key.same(otherKey)) || otherKey.hasKeyModifierConflict(this.key)) { // Neo: gracefully handle conflicts like SHIFT vs SHIFT+G
++                    if (otherKey != this.key && this.key.same(otherKey)) {
                          if (this.hasCollision) {
                              tooltip.append(", ");
                          }

--- a/src/client/java/net/neoforged/neoforge/client/extensions/IKeyMappingExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/IKeyMappingExtension.java
@@ -25,7 +25,7 @@ public interface IKeyMappingExtension {
      * {@return true if the key conflict context and modifier are active and the keyCode matches this binding, false otherwise}
      */
     default boolean isActiveAndMatches(InputConstants.Key keyCode) {
-        return keyCode != InputConstants.UNKNOWN && keyCode.equals(getKey()) && getKeyConflictContext().isActive() && getKeyModifier().isActive(getKeyConflictContext());
+        return KeyMappingModifierHelper.isActiveAndMatches(keyCode, getKey(), getKeyConflictContext(), getKeyModifier());
     }
 
     public default void setToDefault() {
@@ -43,19 +43,15 @@ public interface IKeyMappingExtension {
     void setKeyModifierAndCode(KeyModifier keyModifier, InputConstants.Key keyCode);
 
     default boolean isConflictContextAndModifierActive() {
-        return getKeyConflictContext().isActive() && getKeyModifier().isActive(getKeyConflictContext());
+        IKeyConflictContext keyConflictContext = getKeyConflictContext();
+        return keyConflictContext.isActive() && KeyMappingModifierHelper.isModifierActive(keyConflictContext, getKeyModifier(), getKey());
     }
 
     /**
      * Returns true when one of the bindings' key codes conflicts with the other's modifier.
      */
     default boolean hasKeyModifierConflict(KeyMapping other) {
-        if (getKeyConflictContext().conflicts(other.getKeyConflictContext()) || other.getKeyConflictContext().conflicts(getKeyConflictContext())) {
-            if (getKeyModifier().matches(other.getKey()) || other.getKeyModifier().matches(getKey())) {
-                return true;
-            }
-        }
-        return false;
+        return KeyMappingModifierHelper.hasKeyModifierConflict(self(), other);
     }
 
     /**

--- a/src/client/java/net/neoforged/neoforge/client/extensions/IKeyMappingExtension.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/IKeyMappingExtension.java
@@ -11,9 +11,7 @@ import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.client.settings.IKeyConflictContext;
 import net.neoforged.neoforge.client.settings.KeyModifier;
 
-/**
- * Extension interface for {@link KeyMapping}.
- */
+/// Extension interface for [KeyMapping].
 public interface IKeyMappingExtension {
     private KeyMapping self() {
         return (KeyMapping) this;
@@ -21,9 +19,7 @@ public interface IKeyMappingExtension {
 
     InputConstants.Key getKey();
 
-    /**
-     * {@return true if the key conflict context and modifier are active and the keyCode matches this binding, false otherwise}
-     */
+    /// {@return true if the key conflict context and modifier are active and the keyCode matches this binding, false otherwise}
     default boolean isActiveAndMatches(InputConstants.Key keyCode) {
         return KeyMappingModifierHelper.isActiveAndMatches(keyCode, getKey(), getKeyConflictContext(), getKeyModifier());
     }
@@ -47,17 +43,14 @@ public interface IKeyMappingExtension {
         return keyConflictContext.isActive() && KeyMappingModifierHelper.isModifierActive(keyConflictContext, getKeyModifier(), getKey());
     }
 
-    /**
-     * Returns true when one of the bindings' key codes conflicts with the other's modifier.
-     */
+    /// Returns true when one of the bindings' key codes conflicts with the other's modifier.
     default boolean hasKeyModifierConflict(KeyMapping other) {
         return KeyMappingModifierHelper.hasKeyModifierConflict(self(), other);
     }
 
-    /**
-     * {@return the display name of this key mapping}
-     * Defaults to a {@linkplain Component#translatable(String) translatable component} of the {@link KeyMapping#getName() name}.
-     */
+    /// {@return the display name of this key mapping}
+    /// Defaults to a [translatable component][Component#translatable(String)] of the
+    /// [name][KeyMapping#getName()].
     default Component getDisplayName() {
         return Component.translatable(self().getName());
     }

--- a/src/client/java/net/neoforged/neoforge/client/extensions/KeyMappingModifierHelper.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/KeyMappingModifierHelper.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.extensions;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.neoforged.neoforge.client.settings.IKeyConflictContext;
+import net.neoforged.neoforge.client.settings.KeyConflictContext;
+import net.neoforged.neoforge.client.settings.KeyModifier;
+
+public final class KeyMappingModifierHelper {
+    private KeyMappingModifierHelper() {}
+
+    /**
+     * Returns whether an incoming key press activates a key mapping.
+     * <p>
+     * The key press must match the mapping's bound key, the conflict context must be
+     * active, and the mapping's {@link KeyModifier} must be active.
+     * <p>
+     * {@link KeyModifier#NONE NONE} is context-sensitive. When
+     * {@link IKeyConflictContext#requiresExactKeyModifierNone()} is true, a mapping with
+     * {@link KeyModifier#NONE NONE} only matches when no modifier keys are held. When it is false,
+     * {@link KeyModifier#NONE NONE} matches even when irrelevant modifiers are held.
+     * <p>
+     * Examples:
+     * <ul>
+     * <li>In {@link KeyConflictContext#GUI}, a mapping bound to {@code A} with {@link KeyModifier#NONE NONE}
+     * matches {@code A} only when the user is not holding {@link KeyModifier#SHIFT Shift},
+     * {@link KeyModifier#CONTROL Control}, {@link KeyModifier#CONTROL_OR_COMMAND Command}, or
+     * {@link KeyModifier#ALT Alt}, because GUI contexts require exact {@link KeyModifier#NONE NONE} matching
+     * ({@link IKeyConflictContext#requiresExactKeyModifierNone()} is true).</li>
+     * <li>In {@link KeyConflictContext#IN_GAME}, the same {@code A} mapping can still match while
+     * {@link KeyModifier#SHIFT Shift}, {@link KeyModifier#CONTROL Control},
+     * {@link KeyModifier#CONTROL_OR_COMMAND Command}, or {@link KeyModifier#ALT Alt} is held, because
+     * in-game contexts treat {@link KeyModifier#NONE NONE} as no additional modifier requirement
+     * ({@link IKeyConflictContext#requiresExactKeyModifierNone()} is false).</li>
+     * <li>A mapping bound to {@code A} with {@link KeyModifier#SHIFT Shift} only matches
+     * {@code A} while {@link KeyModifier#SHIFT Shift} is active. Additional held modifiers, such as
+     * {@link KeyModifier#CONTROL Control}, do not prevent it from matching.</li>
+     * <li>A mapping bound directly to the left {@link KeyModifier#SHIFT Shift} key with {@link KeyModifier#NONE NONE}
+     * matches the left {@link KeyModifier#SHIFT Shift} key, even in {@link KeyConflictContext#GUI}. Here,
+     * {@link KeyModifier#NONE NONE} means the mapping has no additional modifier requirement; the bound key
+     * itself may still be {@link KeyModifier#SHIFT Shift}, {@link KeyModifier#CONTROL Control},
+     * {@link KeyModifier#CONTROL_OR_COMMAND Command}, or {@link KeyModifier#ALT Alt}.</li>
+     * </ul>
+     *
+     * @param keyCode         the incoming key press to test
+     * @param boundKey        the mapping's configured key
+     * @param conflictContext the mapping's conflict context
+     * @param keyModifier     the mapping's modifier requirement
+     * @return {@code true} if the key press matches the bound key, the conflict context is active, and the
+     *         modifier requirement is active
+     * @see IKeyConflictContext#requiresExactKeyModifierNone()
+     * @see KeyModifier#isActive(IKeyConflictContext)
+     * @see #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, boolean)
+     */
+    public static boolean isActiveAndMatches(InputConstants.Key keyCode, InputConstants.Key boundKey, IKeyConflictContext conflictContext, KeyModifier keyModifier) {
+        return isActiveAndMatches(keyCode, boundKey, conflictContext, isModifierActive(conflictContext, keyModifier, boundKey));
+    }
+
+    /**
+     * Variant of {@link #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, KeyModifier)}
+     * for callers that have already checked whether the mapping's modifier
+     * requirement is active.
+     *
+     * @param keyCode         the incoming key press to test
+     * @param boundKey        the mapping's configured key
+     * @param conflictContext the mapping's conflict context
+     * @param modifierActive  whether the mapping's modifier requirement is active
+     * @return {@code true} if the key press matches the bound key, the conflict context is active, and
+     *         {@code modifierActive} is true
+     * @see #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, KeyModifier)
+     */
+    public static boolean isActiveAndMatches(InputConstants.Key keyCode, InputConstants.Key boundKey, IKeyConflictContext conflictContext, boolean modifierActive) {
+        return keyCode != InputConstants.UNKNOWN && keyCode.equals(boundKey) && conflictContext.isActive() && modifierActive;
+    }
+
+    /**
+     * Returns whether two key mappings conflict in the controls screen.
+     * <p>
+     * Two mappings conflict when their contexts conflict and either:
+     * <ul>
+     * <li>one mapping's bound key is the other mapping's modifier, such as
+     * the left {@link KeyModifier#SHIFT Shift} key conflicting with an {@code A} mapping that uses
+     * {@link KeyModifier#SHIFT Shift}, or</li>
+     * <li>both mappings use the same bound key and their modifiers conflict, such as
+     * two {@code A} mappings that both use {@link KeyModifier#SHIFT Shift}.</li>
+     * </ul>
+     * A same-key bare mapping only conflicts with a modified mapping when the bare
+     * mapping's context does not require exact {@link KeyModifier#NONE NONE} matching.
+     * For example, {@code A} conflicts with an {@code A} mapping that uses
+     * {@link KeyModifier#SHIFT Shift} when {@link IKeyConflictContext#requiresExactKeyModifierNone()}
+     * returns false.
+     * When it returns true, the same two mappings can coexist because bare {@code A}
+     * does not activate while {@link KeyModifier#SHIFT Shift} is held.
+     *
+     * @param first  the first key mapping to compare
+     * @param second the second key mapping to compare
+     * @return {@code true} if the two key mappings conflict
+     * @see KeyMapping#same(KeyMapping)
+     * @see #hasKeyModifierConflict(KeyMapping, KeyMapping)
+     */
+    public static boolean hasKeyMappingConflict(KeyMapping first, KeyMapping second) {
+        return hasKeyMappingConflict(
+                first.getKey(), first.getKeyConflictContext(), first.getKeyModifier(),
+                second.getKey(), second.getKeyConflictContext(), second.getKeyModifier());
+    }
+
+    /**
+     * Returns whether either mapping uses the other mapping's bound key as its
+     * modifier key.
+     * <p>
+     * For example, a bare mapping bound directly to the left {@link KeyModifier#SHIFT Shift} key conflicts
+     * with an {@code A} mapping that uses {@link KeyModifier#SHIFT Shift} when their contexts conflict.
+     * This method does not report same-key conflicts like two {@code A} mappings; use
+     * {@link #hasKeyMappingConflict(KeyMapping, KeyMapping)} for the full conflict
+     * check used by {@link KeyMapping#same(KeyMapping)}.
+     *
+     * @param first  the first key mapping to compare
+     * @param second the second key mapping to compare
+     * @return {@code true} if either mapping uses the other mapping's bound key as its modifier
+     * @see #hasKeyMappingConflict(KeyMapping, KeyMapping)
+     */
+    public static boolean hasKeyModifierConflict(KeyMapping first, KeyMapping second) {
+        return contextsConflict(first.getKeyConflictContext(), second.getKeyConflictContext()) &&
+                keyModifierMatchesOtherKey(first.getKey(), first.getKeyModifier(), second.getKey(), second.getKeyModifier());
+    }
+
+    private static boolean hasKeyMappingConflict(InputConstants.Key firstKey, IKeyConflictContext firstContext, KeyModifier firstModifier, InputConstants.Key secondKey, IKeyConflictContext secondContext, KeyModifier secondModifier) {
+        if (!contextsConflict(firstContext, secondContext)) {
+            return false;
+        }
+
+        return keyModifierMatchesOtherKey(firstKey, firstModifier, secondKey, secondModifier) ||
+                (firstKey.equals(secondKey) && keyModifiersConflict(firstContext, firstModifier, secondContext, secondModifier));
+    }
+
+    private static boolean keyModifierMatchesOtherKey(InputConstants.Key firstKey, KeyModifier firstModifier, InputConstants.Key secondKey, KeyModifier secondModifier) {
+        return firstModifier.matches(secondKey) || secondModifier.matches(firstKey);
+    }
+
+    private static boolean isBareModifierKey(KeyModifier keyModifier, InputConstants.Key boundKey) {
+        return keyModifier == KeyModifier.NONE && KeyModifier.isKeyCodeModifier(boundKey);
+    }
+
+    static boolean isModifierActive(IKeyConflictContext conflictContext, KeyModifier keyModifier, InputConstants.Key boundKey) {
+        return isBareModifierKey(keyModifier, boundKey) || keyModifier.isActive(conflictContext);
+    }
+
+    private static boolean keyModifiersConflict(IKeyConflictContext firstContext, KeyModifier firstModifier, IKeyConflictContext secondContext, KeyModifier secondModifier) {
+        if (firstModifier == secondModifier) {
+            return true;
+        }
+
+        if (firstModifier != KeyModifier.NONE && secondModifier != KeyModifier.NONE) {
+            return false;
+        }
+
+        IKeyConflictContext noModifierContext = firstModifier == KeyModifier.NONE ? firstContext : secondContext;
+        return !noModifierContext.requiresExactKeyModifierNone();
+    }
+
+    private static boolean contextsConflict(IKeyConflictContext firstContext, IKeyConflictContext secondContext) {
+        return firstContext.conflicts(secondContext) || secondContext.conflicts(firstContext);
+    }
+}

--- a/src/client/java/net/neoforged/neoforge/client/extensions/KeyMappingModifierHelper.java
+++ b/src/client/java/net/neoforged/neoforge/client/extensions/KeyMappingModifierHelper.java
@@ -14,116 +14,109 @@ import net.neoforged.neoforge.client.settings.KeyModifier;
 public final class KeyMappingModifierHelper {
     private KeyMappingModifierHelper() {}
 
-    /**
-     * Returns whether an incoming key press activates a key mapping.
-     * <p>
-     * The key press must match the mapping's bound key, the conflict context must be
-     * active, and the mapping's {@link KeyModifier} must be active.
-     * <p>
-     * {@link KeyModifier#NONE NONE} is context-sensitive. When
-     * {@link IKeyConflictContext#requiresExactKeyModifierNone()} is true, a mapping with
-     * {@link KeyModifier#NONE NONE} only matches when no modifier keys are held. When it is false,
-     * {@link KeyModifier#NONE NONE} matches even when irrelevant modifiers are held.
-     * <p>
-     * Examples:
-     * <ul>
-     * <li>In {@link KeyConflictContext#GUI}, a mapping bound to {@code A} with {@link KeyModifier#NONE NONE}
-     * matches {@code A} only when the user is not holding {@link KeyModifier#SHIFT Shift},
-     * {@link KeyModifier#CONTROL Control}, {@link KeyModifier#CONTROL_OR_COMMAND Command}, or
-     * {@link KeyModifier#ALT Alt}, because GUI contexts require exact {@link KeyModifier#NONE NONE} matching
-     * ({@link IKeyConflictContext#requiresExactKeyModifierNone()} is true).</li>
-     * <li>In {@link KeyConflictContext#IN_GAME}, the same {@code A} mapping can still match while
-     * {@link KeyModifier#SHIFT Shift}, {@link KeyModifier#CONTROL Control},
-     * {@link KeyModifier#CONTROL_OR_COMMAND Command}, or {@link KeyModifier#ALT Alt} is held, because
-     * in-game contexts treat {@link KeyModifier#NONE NONE} as no additional modifier requirement
-     * ({@link IKeyConflictContext#requiresExactKeyModifierNone()} is false).</li>
-     * <li>A mapping bound to {@code A} with {@link KeyModifier#SHIFT Shift} only matches
-     * {@code A} while {@link KeyModifier#SHIFT Shift} is active. Additional held modifiers, such as
-     * {@link KeyModifier#CONTROL Control}, do not prevent it from matching.</li>
-     * <li>A mapping bound directly to the left {@link KeyModifier#SHIFT Shift} key with {@link KeyModifier#NONE NONE}
-     * matches the left {@link KeyModifier#SHIFT Shift} key, even in {@link KeyConflictContext#GUI}. Here,
-     * {@link KeyModifier#NONE NONE} means the mapping has no additional modifier requirement; the bound key
-     * itself may still be {@link KeyModifier#SHIFT Shift}, {@link KeyModifier#CONTROL Control},
-     * {@link KeyModifier#CONTROL_OR_COMMAND Command}, or {@link KeyModifier#ALT Alt}.</li>
-     * </ul>
-     *
-     * @param keyCode         the incoming key press to test
-     * @param boundKey        the mapping's configured key
-     * @param conflictContext the mapping's conflict context
-     * @param keyModifier     the mapping's modifier requirement
-     * @return {@code true} if the key press matches the bound key, the conflict context is active, and the
-     *         modifier requirement is active
-     * @see IKeyConflictContext#requiresExactKeyModifierNone()
-     * @see KeyModifier#isActive(IKeyConflictContext)
-     * @see #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, boolean)
-     */
+    /// Returns whether an incoming key press activates a key mapping.
+    ///
+    /// The key press must match the mapping's bound key, the conflict context must be
+    /// active, and the mapping's [KeyModifier] must be active.
+    ///
+    /// [NONE][KeyModifier#NONE] is context-sensitive. When
+    /// [requiresExactKeyModifierNone()][IKeyConflictContext#requiresExactKeyModifierNone()]
+    /// is true, a mapping with [NONE][KeyModifier#NONE] only matches when no modifier keys are held.
+    /// When it is false, [NONE][KeyModifier#NONE] matches even when irrelevant modifiers are held.
+    ///
+    /// Examples:
+    ///
+    /// - In [GUI][KeyConflictContext#GUI], a mapping bound to `A` with [NONE][KeyModifier#NONE]
+    ///   matches `A` only when the user is not holding [Shift][KeyModifier#SHIFT],
+    ///   [Control][KeyModifier#CONTROL], [Command][KeyModifier#CONTROL_OR_COMMAND], or
+    ///   [Alt][KeyModifier#ALT], because GUI contexts require exact [NONE][KeyModifier#NONE]
+    ///   matching ([requiresExactKeyModifierNone()][IKeyConflictContext#requiresExactKeyModifierNone()]
+    ///   is true).
+    /// - In [IN_GAME][KeyConflictContext#IN_GAME], the same `A` mapping can still match while
+    ///   [Shift][KeyModifier#SHIFT], [Control][KeyModifier#CONTROL],
+    ///   [Command][KeyModifier#CONTROL_OR_COMMAND], or [Alt][KeyModifier#ALT] is held, because
+    ///   in-game contexts treat [NONE][KeyModifier#NONE] as no additional modifier requirement
+    ///   ([requiresExactKeyModifierNone()][IKeyConflictContext#requiresExactKeyModifierNone()]
+    ///   is false).
+    /// - A mapping bound to `A` with [Shift][KeyModifier#SHIFT] only matches `A` while
+    ///   [Shift][KeyModifier#SHIFT] is active. Additional held modifiers, such as
+    ///   [Control][KeyModifier#CONTROL], do not prevent it from matching.
+    /// - A mapping bound directly to the left [Shift][KeyModifier#SHIFT] key with
+    ///   [NONE][KeyModifier#NONE] matches the left [Shift][KeyModifier#SHIFT] key, even in
+    ///   [GUI][KeyConflictContext#GUI]. Here, [NONE][KeyModifier#NONE] means the mapping has no
+    ///   additional modifier requirement; the bound key itself may still be [Shift][KeyModifier#SHIFT],
+    ///   [Control][KeyModifier#CONTROL], [Command][KeyModifier#CONTROL_OR_COMMAND], or
+    ///   [Alt][KeyModifier#ALT].
+    ///
+    /// @param keyCode         the incoming key press to test
+    /// @param boundKey        the mapping's configured key
+    /// @param conflictContext the mapping's conflict context
+    /// @param keyModifier     the mapping's modifier requirement
+    /// @return `true` if the key press matches the bound key, the conflict context is active, and the
+    ///         modifier requirement is active
+    /// @see IKeyConflictContext#requiresExactKeyModifierNone()
+    /// @see KeyModifier#isActive(IKeyConflictContext)
+    /// @see #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, boolean)
     public static boolean isActiveAndMatches(InputConstants.Key keyCode, InputConstants.Key boundKey, IKeyConflictContext conflictContext, KeyModifier keyModifier) {
         return isActiveAndMatches(keyCode, boundKey, conflictContext, isModifierActive(conflictContext, keyModifier, boundKey));
     }
 
-    /**
-     * Variant of {@link #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, KeyModifier)}
-     * for callers that have already checked whether the mapping's modifier
-     * requirement is active.
-     *
-     * @param keyCode         the incoming key press to test
-     * @param boundKey        the mapping's configured key
-     * @param conflictContext the mapping's conflict context
-     * @param modifierActive  whether the mapping's modifier requirement is active
-     * @return {@code true} if the key press matches the bound key, the conflict context is active, and
-     *         {@code modifierActive} is true
-     * @see #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, KeyModifier)
-     */
+    /// Variant of [#isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, KeyModifier)]
+    /// for callers that have already checked whether the mapping's modifier
+    /// requirement is active.
+    ///
+    /// @param keyCode         the incoming key press to test
+    /// @param boundKey        the mapping's configured key
+    /// @param conflictContext the mapping's conflict context
+    /// @param modifierActive  whether the mapping's modifier requirement is active
+    /// @return `true` if the key press matches the bound key, the conflict context is active, and
+    ///         `modifierActive` is true
+    /// @see #isActiveAndMatches(InputConstants.Key, InputConstants.Key, IKeyConflictContext, KeyModifier)
     public static boolean isActiveAndMatches(InputConstants.Key keyCode, InputConstants.Key boundKey, IKeyConflictContext conflictContext, boolean modifierActive) {
         return keyCode != InputConstants.UNKNOWN && keyCode.equals(boundKey) && conflictContext.isActive() && modifierActive;
     }
 
-    /**
-     * Returns whether two key mappings conflict in the controls screen.
-     * <p>
-     * Two mappings conflict when their contexts conflict and either:
-     * <ul>
-     * <li>one mapping's bound key is the other mapping's modifier, such as
-     * the left {@link KeyModifier#SHIFT Shift} key conflicting with an {@code A} mapping that uses
-     * {@link KeyModifier#SHIFT Shift}, or</li>
-     * <li>both mappings use the same bound key and their modifiers conflict, such as
-     * two {@code A} mappings that both use {@link KeyModifier#SHIFT Shift}.</li>
-     * </ul>
-     * A same-key bare mapping only conflicts with a modified mapping when the bare
-     * mapping's context does not require exact {@link KeyModifier#NONE NONE} matching.
-     * For example, {@code A} conflicts with an {@code A} mapping that uses
-     * {@link KeyModifier#SHIFT Shift} when {@link IKeyConflictContext#requiresExactKeyModifierNone()}
-     * returns false.
-     * When it returns true, the same two mappings can coexist because bare {@code A}
-     * does not activate while {@link KeyModifier#SHIFT Shift} is held.
-     *
-     * @param first  the first key mapping to compare
-     * @param second the second key mapping to compare
-     * @return {@code true} if the two key mappings conflict
-     * @see KeyMapping#same(KeyMapping)
-     * @see #hasKeyModifierConflict(KeyMapping, KeyMapping)
-     */
+    /// Returns whether two key mappings conflict in the controls screen.
+    ///
+    /// Two mappings conflict when their contexts conflict and either:
+    ///
+    /// - one mapping's bound key is the other mapping's modifier, such as
+    ///   the left [Shift][KeyModifier#SHIFT] key conflicting with an `A` mapping that uses
+    ///   [Shift][KeyModifier#SHIFT], or
+    /// - both mappings use the same bound key and their modifiers conflict, such as
+    ///   two `A` mappings that both use [Shift][KeyModifier#SHIFT].
+    ///
+    /// A same-key bare mapping only conflicts with a modified mapping when the bare
+    /// mapping's context does not require exact [NONE][KeyModifier#NONE] matching.
+    /// For example, `A` conflicts with an `A` mapping that uses [Shift][KeyModifier#SHIFT] when
+    /// [requiresExactKeyModifierNone()][IKeyConflictContext#requiresExactKeyModifierNone()]
+    /// returns false. When it returns true, the same two mappings can coexist because bare `A`
+    /// does not activate while [Shift][KeyModifier#SHIFT] is held.
+    ///
+    /// @param first  the first key mapping to compare
+    /// @param second the second key mapping to compare
+    /// @return `true` if the two key mappings conflict
+    /// @see KeyMapping#same(KeyMapping)
+    /// @see #hasKeyModifierConflict(KeyMapping, KeyMapping)
     public static boolean hasKeyMappingConflict(KeyMapping first, KeyMapping second) {
         return hasKeyMappingConflict(
                 first.getKey(), first.getKeyConflictContext(), first.getKeyModifier(),
                 second.getKey(), second.getKeyConflictContext(), second.getKeyModifier());
     }
 
-    /**
-     * Returns whether either mapping uses the other mapping's bound key as its
-     * modifier key.
-     * <p>
-     * For example, a bare mapping bound directly to the left {@link KeyModifier#SHIFT Shift} key conflicts
-     * with an {@code A} mapping that uses {@link KeyModifier#SHIFT Shift} when their contexts conflict.
-     * This method does not report same-key conflicts like two {@code A} mappings; use
-     * {@link #hasKeyMappingConflict(KeyMapping, KeyMapping)} for the full conflict
-     * check used by {@link KeyMapping#same(KeyMapping)}.
-     *
-     * @param first  the first key mapping to compare
-     * @param second the second key mapping to compare
-     * @return {@code true} if either mapping uses the other mapping's bound key as its modifier
-     * @see #hasKeyMappingConflict(KeyMapping, KeyMapping)
-     */
+    /// Returns whether either mapping uses the other mapping's bound key as its
+    /// modifier key.
+    ///
+    /// For example, a bare mapping bound directly to the left [Shift][KeyModifier#SHIFT] key conflicts
+    /// with an `A` mapping that uses [Shift][KeyModifier#SHIFT] when their contexts conflict.
+    /// This method does not report same-key conflicts like two `A` mappings; use
+    /// [#hasKeyMappingConflict(KeyMapping, KeyMapping)] for the full conflict
+    /// check used by [KeyMapping#same(KeyMapping)].
+    ///
+    /// @param first  the first key mapping to compare
+    /// @param second the second key mapping to compare
+    /// @return `true` if either mapping uses the other mapping's bound key as its modifier
+    /// @see #hasKeyMappingConflict(KeyMapping, KeyMapping)
     public static boolean hasKeyModifierConflict(KeyMapping first, KeyMapping second) {
         return contextsConflict(first.getKeyConflictContext(), second.getKeyConflictContext()) &&
                 keyModifierMatchesOtherKey(first.getKey(), first.getKeyModifier(), second.getKey(), second.getKeyModifier());

--- a/src/client/java/net/neoforged/neoforge/client/settings/IKeyConflictContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/IKeyConflictContext.java
@@ -7,34 +7,31 @@ package net.neoforged.neoforge.client.settings;
 
 import net.minecraft.client.KeyMapping;
 
-/**
- * Defines the context that a {@link KeyMapping} is used.
- * Key conflicts occur when a {@link KeyMapping} has the same {@link IKeyConflictContext} and has conflicting modifiers and keyCodes.
- */
+/// Defines the context that a [KeyMapping] is used.
+///
+/// Key conflicts occur when a [KeyMapping] has the same [IKeyConflictContext]
+/// and has conflicting modifiers and key codes.
 public interface IKeyConflictContext {
-    /**
-     * @return true if conditions are met to activate {@link KeyMapping}s with this context
-     */
+    /// @return true if conditions are met to activate [KeyMapping]s with this context
     boolean isActive();
 
-    /**
-     * @return true if the other context can have {@link KeyMapping} conflicts with this one.
-     *         This will be called on both contexts to check for conflicts.
-     */
+    /// @return true if the other context can have [KeyMapping] conflicts with this one.
+    ///         This will be called on both contexts to check for conflicts.
     boolean conflicts(IKeyConflictContext other);
 
-    /**
-     * {@return true if mappings using {@link KeyModifier#NONE} should only match
-     * when no modifier keys are held in this context}
-     * <p>
-     * When this is true, a bare key mapping such as {@code A} does not match while
-     * Shift, Control, Command, or Alt is held. This allows {@code A} and
-     * {@code Shift+A} to coexist without conflicts.
-     * <p>
-     * When this is false, {@link KeyModifier#NONE} means the mapping has no separate
-     * modifier requirement. A bare key mapping such as {@code A} can still match while
-     * Shift is held, so {@code A} conflicts with {@code Shift+A}.
-     */
+    /// {@return true if mappings using [NONE][KeyModifier#NONE] should only match
+    /// when no modifier keys are held in this context}
+    ///
+    /// When this is true, a bare key mapping such as `A` does not match while
+    /// [Shift][KeyModifier#SHIFT], [Control][KeyModifier#CONTROL],
+    /// [Command][KeyModifier#CONTROL_OR_COMMAND], or [Alt][KeyModifier#ALT] is held.
+    /// This allows a bare `A` mapping and an `A` mapping with [Shift][KeyModifier#SHIFT]
+    /// to coexist without conflicts.
+    ///
+    /// When this is false, [NONE][KeyModifier#NONE] means the mapping has no separate
+    /// modifier requirement. A bare key mapping such as `A` can still match while
+    /// [Shift][KeyModifier#SHIFT] is held, so it conflicts with an `A` mapping with
+    /// [Shift][KeyModifier#SHIFT].
     default boolean requiresExactKeyModifierNone() {
         return true;
     }

--- a/src/client/java/net/neoforged/neoforge/client/settings/IKeyConflictContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/IKeyConflictContext.java
@@ -22,4 +22,20 @@ public interface IKeyConflictContext {
      *         This will be called on both contexts to check for conflicts.
      */
     boolean conflicts(IKeyConflictContext other);
+
+    /**
+     * {@return true if mappings using {@link KeyModifier#NONE} should only match
+     * when no modifier keys are held in this context}
+     * <p>
+     * When this is true, a bare key mapping such as {@code A} does not match while
+     * Shift, Control, Command, or Alt is held. This allows {@code A} and
+     * {@code Shift+A} to coexist without conflicts.
+     * <p>
+     * When this is false, {@link KeyModifier#NONE} means the mapping has no separate
+     * modifier requirement. A bare key mapping such as {@code A} can still match while
+     * Shift is held, so {@code A} conflicts with {@code Shift+A}.
+     */
+    default boolean requiresExactKeyModifierNone() {
+        return true;
+    }
 }

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
@@ -9,14 +9,16 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 
 public enum KeyConflictContext implements IKeyConflictContext {
-    /// Universal key bindings are always active and will conflict with any other context, including custom
-    /// contexts supplied by mods.
-    ///
-    /// Use this only for bindings that must reserve their key globally. Bindings which are active in both
-    /// vanilla GUI and in-game contexts, but should not claim every custom context, should use
-    /// [GUI_AND_IN_GAME][#GUI_AND_IN_GAME] instead.
-    ///
-    /// Key bindings are universal by default.
+    /**
+     * Universal key bindings are always active and will conflict with any other context, including custom
+     * contexts supplied by mods.
+     * <p>
+     * Use this only for bindings that must reserve their key globally. Bindings which are active in both
+     * vanilla GUI and in-game contexts, but should not claim every custom context, should use
+     * {@link #GUI_AND_IN_GAME} instead.
+     * <p>
+     * Key bindings are universal by default.
+     */
     UNIVERSAL {
         @Override
         public boolean isActive() {
@@ -34,13 +36,15 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /// GUI key bindings are only active while a [Screen] is open.
-    ///
-    /// They only conflict with other GUI bindings. This allows the same key to be bound separately for
-    /// in-game use when no screen is open.
-    ///
-    /// GUI bindings require exact [NONE][KeyModifier#NONE] matching. For example, a bare key in this
-    /// context will not match while an extra modifier is held.
+    /**
+     * GUI key bindings are only active while a {@link Screen} is open.
+     * <p>
+     * They only conflict with other GUI bindings. This allows the same key to be bound separately for
+     * in-game use when no screen is open.
+     * <p>
+     * GUI bindings require exact {@link KeyModifier#NONE} matching. For example, a bare key in this
+     * context will not match while an extra modifier is held.
+     */
     GUI {
         @SuppressWarnings("ConstantValue")
         @Override
@@ -55,15 +59,17 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /// In-game key bindings are only active while no [Screen] is open.
-    ///
-    /// They only conflict with other in-game bindings. This allows the same key to be bound separately for
-    /// GUI use while a screen is open.
-    ///
-    /// In-game bindings do not require exact [NONE][KeyModifier#NONE] matching. For example, a
-    /// bare `A` mapping and an `A` mapping with [Shift][KeyModifier#SHIFT] conflict in this context
-    /// because holding [Shift][KeyModifier#SHIFT] does not stop the bare key from being active
-    /// in-game. See [#requiresExactKeyModifierNone()].
+    /**
+     * In-game key bindings are only active while no {@link Screen} is open.
+     * <p>
+     * They only conflict with other in-game bindings. This allows the same key to be bound separately for
+     * GUI use while a screen is open.
+     * <p>
+     * In-game bindings do not require exact {@link KeyModifier#NONE} matching. For example, a
+     * bare {@code A} mapping and an {@code A} mapping with {@link KeyModifier#SHIFT} conflict in this context
+     * because holding {@link KeyModifier#SHIFT} does not stop the bare key from being active
+     * in-game. See {@link #requiresExactKeyModifierNone()}.
+     */
     IN_GAME {
         @Override
         public boolean isActive() {
@@ -81,16 +87,18 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /// Key bindings used both while a [Screen] is open and while no screen is open.
-    ///
-    /// This is active in the same places as [UNIVERSAL][#UNIVERSAL], but this context's own conflict rule
-    /// only covers the standard [GUI][#GUI], [IN_GAME][#IN_GAME], and [GUI_AND_IN_GAME][#GUI_AND_IN_GAME]
-    /// contexts. It does not automatically conflict with every custom context added by mods, although a
-    /// custom context or [UNIVERSAL][#UNIVERSAL] can still choose to conflict with it.
-    ///
-    /// This context requires exact [NONE][KeyModifier#NONE] matching while a GUI is open. For example, a
-    /// bare key in this context will not match while an extra modifier is held in a GUI, unlike
-    /// [UNIVERSAL][#UNIVERSAL].
+    /**
+     * Key bindings used both while a {@link Screen} is open and while no screen is open.
+     * <p>
+     * This is active in the same places as {@link #UNIVERSAL}, but this context's own conflict rule
+     * only covers the standard {@link #GUI}, {@link #IN_GAME}, and {@link #GUI_AND_IN_GAME}
+     * contexts. It does not automatically conflict with every custom context added by mods, although a
+     * custom context or {@link #UNIVERSAL} can still choose to conflict with it.
+     * <p>
+     * This context requires exact {@link KeyModifier#NONE} matching while a GUI is open. For example, a
+     * bare key in this context will not match while an extra modifier is held in a GUI, unlike
+     * {@link #UNIVERSAL}.
+     */
     GUI_AND_IN_GAME {
         @Override
         public boolean isActive() {
@@ -108,16 +116,18 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /// Spectator key bindings are only active while no [Screen] is open and the local player is in
-    /// spectator mode.
-    ///
-    /// They only conflict with other spectator bindings. This allows bindings such as pick block and the
-    /// spectator hotbar action key to share a default key, matching vanilla's mode-specific behavior.
-    ///
-    /// Spectator bindings do not require exact [NONE][KeyModifier#NONE] matching. For example, a
-    /// bare `A` mapping and an `A` mapping with [Shift][KeyModifier#SHIFT] conflict in this context
-    /// because holding [Shift][KeyModifier#SHIFT] does not stop the bare key from being active in
-    /// spectator mode.
+    /**
+     * Spectator key bindings are only active while no {@link Screen} is open and the local player is in
+     * spectator mode.
+     * <p>
+     * They only conflict with other spectator bindings. This allows bindings such as pick block and the
+     * spectator hotbar action key to share a default key, matching vanilla's mode-specific behavior.
+     * <p>
+     * Spectator bindings do not require exact {@link KeyModifier#NONE} matching. For example, a
+     * bare {@code A} mapping and an {@code A} mapping with {@link KeyModifier#SHIFT} conflict in this context
+     * because holding {@link KeyModifier#SHIFT} does not stop the bare key from being active in
+     * spectator mode.
+     */
     SPECTATOR {
         @SuppressWarnings("ConstantValue")
         @Override
@@ -137,17 +147,19 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /// Debug key bindings are vanilla debug actions gated by the debug modifier key.
-    ///
-    /// They only conflict with other debug bindings. Vanilla gives debug shortcuts precedence while
-    /// the debug modifier is held, so `F3+A` can reload chunks without making the in-game
-    /// `A` binding unassignable.
-    ///
-    /// The debug modifier key itself remains a separate vanilla key binding rather than a NeoForge
-    /// [KeyModifier].
-    ///
-    /// Debug bindings do not require exact [NONE][KeyModifier#NONE] matching because the debug modifier
-    /// key gates the entire debug context instead of acting as each debug binding's key modifier.
+    /**
+     * Debug key bindings are vanilla debug actions gated by the debug modifier key.
+     * <p>
+     * They only conflict with other debug bindings. Vanilla gives debug shortcuts precedence while
+     * the debug modifier is held, so {@code F3+A} can reload chunks without making the in-game
+     * {@code A} binding unassignable.
+     * <p>
+     * The debug modifier key itself remains a separate vanilla key binding rather than a NeoForge
+     * {@link KeyModifier}.
+     * <p>
+     * Debug bindings do not require exact {@link KeyModifier#NONE} matching because the debug modifier
+     * key gates the entire debug context instead of acting as each debug binding's key modifier.
+     */
     DEBUG {
         @SuppressWarnings("ConstantValue")
         @Override

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
@@ -10,7 +10,13 @@ import net.minecraft.client.gui.screens.Screen;
 
 public enum KeyConflictContext implements IKeyConflictContext {
     /**
-     * Universal key bindings are used in every context and will conflict with any other context.
+     * Universal key bindings are always active and will conflict with any other context, including custom
+     * contexts supplied by mods.
+     * <p>
+     * Use this only for bindings that must reserve their key globally. Bindings which are active in both
+     * vanilla GUI and in-game contexts, but should not claim every custom context, should use
+     * {@link #GUI_AND_IN_GAME} instead.
+     * <p>
      * Key Bindings are universal by default.
      */
     UNIVERSAL {
@@ -23,15 +29,28 @@ public enum KeyConflictContext implements IKeyConflictContext {
         public boolean conflicts(IKeyConflictContext other) {
             return true;
         }
+
+        @Override
+        public boolean requiresExactKeyModifierNone() {
+            return false;
+        }
     },
 
     /**
-     * Gui key bindings are only used when a {@link Screen} is open.
+     * GUI key bindings are only active while a {@link Screen} is open.
+     * <p>
+     * They only conflict with other GUI bindings. This allows the same key to be bound separately for
+     * in-game use when no screen is open.
+     * <p>
+     * GUI bindings require exact {@link KeyModifier#NONE} matching. For example, a bare key in this
+     * context will not match while an extra modifier is held.
      */
     GUI {
+        @SuppressWarnings("ConstantValue")
         @Override
         public boolean isActive() {
-            return Minecraft.getInstance().gui.screen() != null;
+            Minecraft minecraft = Minecraft.getInstance();
+            return minecraft != null && minecraft.gui != null && minecraft.gui.screen() != null;
         }
 
         @Override
@@ -41,7 +60,14 @@ public enum KeyConflictContext implements IKeyConflictContext {
     },
 
     /**
-     * In-game key bindings are only used when a {@link Screen} is not open.
+     * In-game key bindings are only active while no {@link Screen} is open.
+     * <p>
+     * They only conflict with other in-game bindings. This allows the same key to be bound separately for
+     * GUI use while a screen is open.
+     * <p>
+     * In-game bindings do not require exact {@link KeyModifier#NONE} matching. For example, {@code A}
+     * and {@code Shift+A} conflict in this context because holding Shift does not stop the bare key from
+     * being active in-game. See {@link #requiresExactKeyModifierNone()}.
      */
     IN_GAME {
         @Override
@@ -52,6 +78,40 @@ public enum KeyConflictContext implements IKeyConflictContext {
         @Override
         public boolean conflicts(IKeyConflictContext other) {
             return this == other;
+        }
+
+        @Override
+        public boolean requiresExactKeyModifierNone() {
+            return false;
+        }
+    },
+
+    /**
+     * Key bindings used both while a {@link Screen} is open and while no screen is open.
+     * <p>
+     * This is active in the same places as {@link #UNIVERSAL}, but this context's own conflict rule only
+     * covers the standard {@link #GUI}, {@link #IN_GAME}, and {@code #GUI_AND_IN_GAME}
+     * contexts. It does not automatically conflict with every custom context added by mods, although a
+     * custom context or {@link #UNIVERSAL} can still choose to conflict with it.
+     * <p>
+     * This context requires exact {@link KeyModifier#NONE} matching while a GUI is open. For example, a
+     * bare key in this context will not match while an extra modifier is held in a GUI, unlike
+     * {@link #UNIVERSAL}.
+     */
+    GUI_AND_IN_GAME {
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+        @Override
+        public boolean conflicts(IKeyConflictContext other) {
+            return other == GUI || other == IN_GAME || other == this;
+        }
+
+        @Override
+        public boolean requiresExactKeyModifierNone() {
+            return GUI.isActive();
         }
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
@@ -9,16 +9,14 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 
 public enum KeyConflictContext implements IKeyConflictContext {
-    /**
-     * Universal key bindings are always active and will conflict with any other context, including custom
-     * contexts supplied by mods.
-     * <p>
-     * Use this only for bindings that must reserve their key globally. Bindings which are active in both
-     * vanilla GUI and in-game contexts, but should not claim every custom context, should use
-     * {@link #GUI_AND_IN_GAME} instead.
-     * <p>
-     * Key Bindings are universal by default.
-     */
+    /// Universal key bindings are always active and will conflict with any other context, including custom
+    /// contexts supplied by mods.
+    ///
+    /// Use this only for bindings that must reserve their key globally. Bindings which are active in both
+    /// vanilla GUI and in-game contexts, but should not claim every custom context, should use
+    /// [GUI_AND_IN_GAME][#GUI_AND_IN_GAME] instead.
+    ///
+    /// Key bindings are universal by default.
     UNIVERSAL {
         @Override
         public boolean isActive() {
@@ -36,15 +34,13 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /**
-     * GUI key bindings are only active while a {@link Screen} is open.
-     * <p>
-     * They only conflict with other GUI bindings. This allows the same key to be bound separately for
-     * in-game use when no screen is open.
-     * <p>
-     * GUI bindings require exact {@link KeyModifier#NONE} matching. For example, a bare key in this
-     * context will not match while an extra modifier is held.
-     */
+    /// GUI key bindings are only active while a [Screen] is open.
+    ///
+    /// They only conflict with other GUI bindings. This allows the same key to be bound separately for
+    /// in-game use when no screen is open.
+    ///
+    /// GUI bindings require exact [NONE][KeyModifier#NONE] matching. For example, a bare key in this
+    /// context will not match while an extra modifier is held.
     GUI {
         @SuppressWarnings("ConstantValue")
         @Override
@@ -59,16 +55,15 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /**
-     * In-game key bindings are only active while no {@link Screen} is open.
-     * <p>
-     * They only conflict with other in-game bindings. This allows the same key to be bound separately for
-     * GUI use while a screen is open.
-     * <p>
-     * In-game bindings do not require exact {@link KeyModifier#NONE} matching. For example, {@code A}
-     * and {@code Shift+A} conflict in this context because holding Shift does not stop the bare key from
-     * being active in-game. See {@link #requiresExactKeyModifierNone()}.
-     */
+    /// In-game key bindings are only active while no [Screen] is open.
+    ///
+    /// They only conflict with other in-game bindings. This allows the same key to be bound separately for
+    /// GUI use while a screen is open.
+    ///
+    /// In-game bindings do not require exact [NONE][KeyModifier#NONE] matching. For example, a
+    /// bare `A` mapping and an `A` mapping with [Shift][KeyModifier#SHIFT] conflict in this context
+    /// because holding [Shift][KeyModifier#SHIFT] does not stop the bare key from being active
+    /// in-game. See [#requiresExactKeyModifierNone()].
     IN_GAME {
         @Override
         public boolean isActive() {
@@ -86,18 +81,16 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /**
-     * Key bindings used both while a {@link Screen} is open and while no screen is open.
-     * <p>
-     * This is active in the same places as {@link #UNIVERSAL}, but this context's own conflict rule only
-     * covers the standard {@link #GUI}, {@link #IN_GAME}, and {@code #GUI_AND_IN_GAME}
-     * contexts. It does not automatically conflict with every custom context added by mods, although a
-     * custom context or {@link #UNIVERSAL} can still choose to conflict with it.
-     * <p>
-     * This context requires exact {@link KeyModifier#NONE} matching while a GUI is open. For example, a
-     * bare key in this context will not match while an extra modifier is held in a GUI, unlike
-     * {@link #UNIVERSAL}.
-     */
+    /// Key bindings used both while a [Screen] is open and while no screen is open.
+    ///
+    /// This is active in the same places as [UNIVERSAL][#UNIVERSAL], but this context's own conflict rule
+    /// only covers the standard [GUI][#GUI], [IN_GAME][#IN_GAME], and [GUI_AND_IN_GAME][#GUI_AND_IN_GAME]
+    /// contexts. It does not automatically conflict with every custom context added by mods, although a
+    /// custom context or [UNIVERSAL][#UNIVERSAL] can still choose to conflict with it.
+    ///
+    /// This context requires exact [NONE][KeyModifier#NONE] matching while a GUI is open. For example, a
+    /// bare key in this context will not match while an extra modifier is held in a GUI, unlike
+    /// [UNIVERSAL][#UNIVERSAL].
     GUI_AND_IN_GAME {
         @Override
         public boolean isActive() {
@@ -115,17 +108,16 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /**
-     * Spectator key bindings are only active while no {@link Screen} is open and the local player is in
-     * spectator mode.
-     * <p>
-     * They only conflict with other spectator bindings. This allows bindings such as pick block and the
-     * spectator hotbar action key to share a default key, matching vanilla's mode-specific behavior.
-     * <p>
-     * Spectator bindings do not require exact {@link KeyModifier#NONE} matching. For example,
-     * {@code A} and {@code Shift+A} conflict in this context because holding Shift does not stop the
-     * bare key from being active in spectator mode.
-     */
+    /// Spectator key bindings are only active while no [Screen] is open and the local player is in
+    /// spectator mode.
+    ///
+    /// They only conflict with other spectator bindings. This allows bindings such as pick block and the
+    /// spectator hotbar action key to share a default key, matching vanilla's mode-specific behavior.
+    ///
+    /// Spectator bindings do not require exact [NONE][KeyModifier#NONE] matching. For example, a
+    /// bare `A` mapping and an `A` mapping with [Shift][KeyModifier#SHIFT] conflict in this context
+    /// because holding [Shift][KeyModifier#SHIFT] does not stop the bare key from being active in
+    /// spectator mode.
     SPECTATOR {
         @SuppressWarnings("ConstantValue")
         @Override
@@ -145,19 +137,17 @@ public enum KeyConflictContext implements IKeyConflictContext {
         }
     },
 
-    /**
-     * Debug key bindings are vanilla debug actions gated by the debug modifier key.
-     * <p>
-     * They only conflict with other debug bindings. Vanilla gives debug shortcuts precedence while
-     * the debug modifier is held, so {@code F3+A} can reload chunks without making the in-game
-     * {@code A} binding unassignable.
-     * <p>
-     * The debug modifier key itself remains a separate vanilla key binding rather than a NeoForge
-     * {@link KeyModifier}.
-     * <p>
-     * Debug bindings do not require exact {@link KeyModifier#NONE} matching because the debug modifier
-     * key gates the entire debug context instead of acting as each debug binding's key modifier.
-     */
+    /// Debug key bindings are vanilla debug actions gated by the debug modifier key.
+    ///
+    /// They only conflict with other debug bindings. Vanilla gives debug shortcuts precedence while
+    /// the debug modifier is held, so `F3+A` can reload chunks without making the in-game
+    /// `A` binding unassignable.
+    ///
+    /// The debug modifier key itself remains a separate vanilla key binding rather than a NeoForge
+    /// [KeyModifier].
+    ///
+    /// Debug bindings do not require exact [NONE][KeyModifier#NONE] matching because the debug modifier
+    /// key gates the entire debug context instead of acting as each debug binding's key modifier.
     DEBUG {
         @SuppressWarnings("ConstantValue")
         @Override

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyConflictContext.java
@@ -113,5 +113,67 @@ public enum KeyConflictContext implements IKeyConflictContext {
         public boolean requiresExactKeyModifierNone() {
             return GUI.isActive();
         }
+    },
+
+    /**
+     * Spectator key bindings are only active while no {@link Screen} is open and the local player is in
+     * spectator mode.
+     * <p>
+     * They only conflict with other spectator bindings. This allows bindings such as pick block and the
+     * spectator hotbar action key to share a default key, matching vanilla's mode-specific behavior.
+     * <p>
+     * Spectator bindings do not require exact {@link KeyModifier#NONE} matching. For example,
+     * {@code A} and {@code Shift+A} conflict in this context because holding Shift does not stop the
+     * bare key from being active in spectator mode.
+     */
+    SPECTATOR {
+        @SuppressWarnings("ConstantValue")
+        @Override
+        public boolean isActive() {
+            Minecraft minecraft = Minecraft.getInstance();
+            return !GUI.isActive() && minecraft != null && minecraft.player != null && minecraft.player.isSpectator();
+        }
+
+        @Override
+        public boolean conflicts(IKeyConflictContext other) {
+            return this == other;
+        }
+
+        @Override
+        public boolean requiresExactKeyModifierNone() {
+            return false;
+        }
+    },
+
+    /**
+     * Debug key bindings are vanilla debug actions gated by the debug modifier key.
+     * <p>
+     * They only conflict with other debug bindings. Vanilla gives debug shortcuts precedence while
+     * the debug modifier is held, so {@code F3+A} can reload chunks without making the in-game
+     * {@code A} binding unassignable.
+     * <p>
+     * The debug modifier key itself remains a separate vanilla key binding rather than a NeoForge
+     * {@link KeyModifier}.
+     * <p>
+     * Debug bindings do not require exact {@link KeyModifier#NONE} matching because the debug modifier
+     * key gates the entire debug context instead of acting as each debug binding's key modifier.
+     */
+    DEBUG {
+        @SuppressWarnings("ConstantValue")
+        @Override
+        public boolean isActive() {
+            Minecraft minecraft = Minecraft.getInstance();
+            return minecraft != null && minecraft.options != null && minecraft.options.keyDebugModifier.isDown();
+        }
+
+        @Override
+        public boolean conflicts(IKeyConflictContext other) {
+            return other == this;
+        }
+
+        @Override
+        public boolean requiresExactKeyModifierNone() {
+            return false;
+        }
     }
 }

--- a/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
+++ b/src/client/java/net/neoforged/neoforge/client/settings/KeyModifier.java
@@ -171,7 +171,7 @@ public enum KeyModifier {
 
         @Override
         public boolean isActive(@Nullable IKeyConflictContext conflictContext) {
-            if (conflictContext != null && !conflictContext.conflicts(KeyConflictContext.IN_GAME)) {
+            if (conflictContext != null && conflictContext.requiresExactKeyModifierNone()) {
                 for (KeyModifier keyModifier : MODIFIER_VALUES) {
                     if (keyModifier.isActive(conflictContext)) {
                         return false;

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyConflictContextTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyConflictContextTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import net.neoforged.neoforge.client.settings.IKeyConflictContext;
+import net.neoforged.neoforge.client.settings.KeyConflictContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class KeyConflictContextTest {
+    @Test
+    void guiContextRequiresExactKeyModifierNone() {
+        Assertions.assertTrue(KeyConflictContext.GUI.requiresExactKeyModifierNone());
+    }
+
+    @Test
+    void guiContextOnlyConflictsWithGuiContext() {
+        Assertions.assertTrue(KeyConflictContext.GUI.conflicts(KeyConflictContext.GUI));
+        Assertions.assertFalse(KeyConflictContext.GUI.conflicts(KeyConflictContext.IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.GUI.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.GUI.conflicts(new TestKeyConflictContext()));
+    }
+
+    @Test
+    void inGameContextDoesNotRequireExactKeyModifierNone() {
+        Assertions.assertFalse(KeyConflictContext.IN_GAME.requiresExactKeyModifierNone());
+    }
+
+    @Test
+    void inGameContextOnlyConflictsWithInGameContext() {
+        Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.GUI));
+        Assertions.assertTrue(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(new TestKeyConflictContext()));
+    }
+
+    @Test
+    void universalContextDoesNotRequireExactKeyModifierNone() {
+        Assertions.assertFalse(KeyConflictContext.UNIVERSAL.requiresExactKeyModifierNone());
+    }
+
+    @Test
+    void universalContextConflictsWithEveryContext() {
+        Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.GUI));
+        Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.IN_GAME));
+        Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(new TestKeyConflictContext()));
+    }
+
+    @Test
+    void guiAndInGameContextUsesCurrentGuiState() {
+        Assertions.assertEquals(KeyConflictContext.GUI.isActive(), KeyConflictContext.GUI_AND_IN_GAME.requiresExactKeyModifierNone());
+    }
+
+    @Test
+    void guiAndInGameContextConflictsWithVanillaGuiAndInGameButNotCustomContexts() {
+        Assertions.assertTrue(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.GUI));
+        Assertions.assertTrue(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.IN_GAME));
+        Assertions.assertTrue(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.GUI_AND_IN_GAME.conflicts(new TestKeyConflictContext()));
+        Assertions.assertTrue(new TestKeyConflictContext(KeyConflictContext.GUI_AND_IN_GAME).conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+    }
+
+    @Test
+    void customContextDefaultsToExactKeyModifierNone() {
+        Assertions.assertTrue(new TestKeyConflictContext().requiresExactKeyModifierNone());
+    }
+
+    private record TestKeyConflictContext(IKeyConflictContext conflictingContext) implements IKeyConflictContext {
+        private TestKeyConflictContext() {
+            this(null);
+        }
+
+        @Override
+        public boolean isActive() {
+            return true;
+        }
+
+        @Override
+        public boolean conflicts(IKeyConflictContext other) {
+            return other == conflictingContext;
+        }
+    }
+}

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyConflictContextTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyConflictContextTest.java
@@ -21,6 +21,8 @@ class KeyConflictContextTest {
         Assertions.assertTrue(KeyConflictContext.GUI.conflicts(KeyConflictContext.GUI));
         Assertions.assertFalse(KeyConflictContext.GUI.conflicts(KeyConflictContext.IN_GAME));
         Assertions.assertFalse(KeyConflictContext.GUI.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.GUI.conflicts(KeyConflictContext.SPECTATOR));
+        Assertions.assertFalse(KeyConflictContext.GUI.conflicts(KeyConflictContext.DEBUG));
         Assertions.assertFalse(KeyConflictContext.GUI.conflicts(new TestKeyConflictContext()));
     }
 
@@ -34,6 +36,8 @@ class KeyConflictContextTest {
         Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.GUI));
         Assertions.assertTrue(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.IN_GAME));
         Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.SPECTATOR));
+        Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(KeyConflictContext.DEBUG));
         Assertions.assertFalse(KeyConflictContext.IN_GAME.conflicts(new TestKeyConflictContext()));
     }
 
@@ -47,6 +51,8 @@ class KeyConflictContextTest {
         Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.GUI));
         Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.IN_GAME));
         Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.SPECTATOR));
+        Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(KeyConflictContext.DEBUG));
         Assertions.assertTrue(KeyConflictContext.UNIVERSAL.conflicts(new TestKeyConflictContext()));
     }
 
@@ -56,12 +62,44 @@ class KeyConflictContextTest {
     }
 
     @Test
-    void guiAndInGameContextConflictsWithVanillaGuiAndInGameButNotCustomContexts() {
+    void guiAndInGameContextConflictsWithVanillaGuiAndInGameButNotCustomOrSpecialContexts() {
         Assertions.assertTrue(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.GUI));
         Assertions.assertTrue(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.IN_GAME));
         Assertions.assertTrue(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.SPECTATOR));
+        Assertions.assertFalse(KeyConflictContext.GUI_AND_IN_GAME.conflicts(KeyConflictContext.DEBUG));
         Assertions.assertFalse(KeyConflictContext.GUI_AND_IN_GAME.conflicts(new TestKeyConflictContext()));
         Assertions.assertTrue(new TestKeyConflictContext(KeyConflictContext.GUI_AND_IN_GAME).conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+    }
+
+    @Test
+    void spectatorContextDoesNotRequireExactKeyModifierNone() {
+        Assertions.assertFalse(KeyConflictContext.SPECTATOR.requiresExactKeyModifierNone());
+    }
+
+    @Test
+    void spectatorContextOnlyConflictsWithSpectatorContext() {
+        Assertions.assertFalse(KeyConflictContext.SPECTATOR.conflicts(KeyConflictContext.GUI));
+        Assertions.assertFalse(KeyConflictContext.SPECTATOR.conflicts(KeyConflictContext.IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.SPECTATOR.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertTrue(KeyConflictContext.SPECTATOR.conflicts(KeyConflictContext.SPECTATOR));
+        Assertions.assertFalse(KeyConflictContext.SPECTATOR.conflicts(KeyConflictContext.DEBUG));
+        Assertions.assertFalse(KeyConflictContext.SPECTATOR.conflicts(new TestKeyConflictContext()));
+    }
+
+    @Test
+    void debugContextDoesNotRequireExactKeyModifierNone() {
+        Assertions.assertFalse(KeyConflictContext.DEBUG.requiresExactKeyModifierNone());
+    }
+
+    @Test
+    void debugContextOnlyConflictsWithDebugContext() {
+        Assertions.assertFalse(KeyConflictContext.DEBUG.conflicts(KeyConflictContext.GUI));
+        Assertions.assertFalse(KeyConflictContext.DEBUG.conflicts(KeyConflictContext.IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.DEBUG.conflicts(KeyConflictContext.GUI_AND_IN_GAME));
+        Assertions.assertFalse(KeyConflictContext.DEBUG.conflicts(KeyConflictContext.SPECTATOR));
+        Assertions.assertTrue(KeyConflictContext.DEBUG.conflicts(KeyConflictContext.DEBUG));
+        Assertions.assertFalse(KeyConflictContext.DEBUG.conflicts(new TestKeyConflictContext()));
     }
 
     @Test

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyMappingModifierHelperTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyMappingModifierHelperTest.java
@@ -25,7 +25,12 @@ class KeyMappingModifierHelperTest {
     private static final AtomicInteger NEXT_MAPPING_ID = new AtomicInteger();
     private static final InputConstants.Key A = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_A);
     private static final InputConstants.Key B = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_B);
+    private static final InputConstants.Key F3 = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_F3);
+    private static final InputConstants.Key L = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_L);
+    private static final InputConstants.Key P = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_P);
+    private static final InputConstants.Key T = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_T);
     private static final InputConstants.Key LEFT_SHIFT = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SHIFT);
+    private static final InputConstants.Key MOUSE_3 = InputConstants.Type.MOUSE.getOrCreate(GLFW.GLFW_MOUSE_BUTTON_MIDDLE);
     private static final InputConstants.Key ACTIVE_CONTEXT_KEY = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_C);
     private static final IKeyConflictContext ACTIVE_GUI_CONTEXT = new TestKeyConflictContext("gui", true, false);
     private static final IKeyConflictContext INACTIVE_GUI_CONTEXT = new TestKeyConflictContext("gui", false, false);
@@ -243,6 +248,132 @@ class KeyMappingModifierHelperTest {
         var universalShiftA = keyMapping(KeyConflictContext.UNIVERSAL, KeyModifier.SHIFT, A);
 
         assertMappingConflict(universalA, universalShiftA);
+    }
+
+    @Test
+    void debugModifierKeyDoesNotConflictWithDebugContextBindings() {
+        var debugOverlay = keyMapping(KeyConflictContext.UNIVERSAL, KeyModifier.NONE, F3);
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+        var debugB = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, B);
+
+        assertNoMappingConflict(debugOverlay, debugA);
+        assertNoMappingConflict(debugOverlay, debugB);
+        Assertions.assertFalse(debugOverlay.hasKeyModifierConflict(debugA));
+        Assertions.assertFalse(debugA.hasKeyModifierConflict(debugOverlay));
+    }
+
+    @Test
+    void debugContextBindingsOnlyConflictWhenTheirActionKeyMatches() {
+        var firstDebugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+        var secondDebugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+        var debugB = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, B);
+
+        assertMappingConflict(firstDebugA, secondDebugA);
+        assertNoMappingConflict(firstDebugA, debugB);
+    }
+
+    @Test
+    void debugContextBareAndModifiedBindingsConflictWhenTheirActionKeyMatches() {
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+        var debugShiftA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.SHIFT, A);
+
+        assertMappingConflict(debugA, debugShiftA);
+    }
+
+    @Test
+    void debugContextBareAndModifiedBindingsDoNotConflictWhenTheirActionKeyDiffers() {
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+        var debugShiftB = keyMapping(KeyConflictContext.DEBUG, KeyModifier.SHIFT, B);
+
+        assertNoMappingConflict(debugA, debugShiftB);
+    }
+
+    @Test
+    void debugContextModifiedBindingsWithDifferentModifiersDoNotConflict() {
+        var debugShiftA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.SHIFT, A);
+        var debugControlA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.CONTROL, A);
+
+        assertNoMappingConflict(debugShiftA, debugControlA);
+    }
+
+    @Test
+    void debugProfilingDoesNotConflictWithAdvancements() {
+        var profiling = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, L);
+        var advancements = keyMapping(KeyConflictContext.GUI_AND_IN_GAME, KeyModifier.NONE, L);
+
+        assertNoMappingConflict(profiling, advancements);
+    }
+
+    @Test
+    void debugReloadResourcePacksDoesNotConflictWithChat() {
+        var reloadResourcePacks = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, T);
+        var chat = keyMapping(KeyConflictContext.GUI_AND_IN_GAME, KeyModifier.NONE, T);
+
+        assertNoMappingConflict(reloadResourcePacks, chat);
+    }
+
+    @Test
+    void debugFocusPauseDoesNotConflictWithSocialInteractions() {
+        var focusPause = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, P);
+        var socialInteractions = keyMapping(KeyConflictContext.GUI_AND_IN_GAME, KeyModifier.NONE, P);
+
+        assertNoMappingConflict(focusPause, socialInteractions);
+    }
+
+    @Test
+    void universalContextConflictsWithDebugContextWhenKeyAndModifiersOverlap() {
+        var universalA = keyMapping(KeyConflictContext.UNIVERSAL, KeyModifier.NONE, A);
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+
+        assertMappingConflict(universalA, debugA);
+    }
+
+    @Test
+    void spectatorHotbarDoesNotConflictWithPickBlock() {
+        var pickBlock = keyMapping(KeyConflictContext.GUI_AND_IN_GAME, KeyModifier.NONE, MOUSE_3);
+        var spectatorHotbar = keyMapping(KeyConflictContext.SPECTATOR, KeyModifier.NONE, MOUSE_3);
+
+        assertNoMappingConflict(pickBlock, spectatorHotbar);
+    }
+
+    @Test
+    void spectatorBindingsConflictWithSameSpectatorActionKey() {
+        var firstSpectatorHotbar = keyMapping(KeyConflictContext.SPECTATOR, KeyModifier.NONE, MOUSE_3);
+        var secondSpectatorHotbar = keyMapping(KeyConflictContext.SPECTATOR, KeyModifier.NONE, MOUSE_3);
+
+        assertMappingConflict(firstSpectatorHotbar, secondSpectatorHotbar);
+    }
+
+    @Test
+    void inGameBareKeyDoesNotConflictWithDebugContextBindingWhenActionKeyMatches() {
+        var strafeA = keyMapping(KeyConflictContext.IN_GAME, KeyModifier.NONE, A);
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+
+        assertNoMappingConflict(strafeA, debugA);
+    }
+
+    @Test
+    void inGameBareKeyDoesNotConflictWithDebugContextBindingWhenActionKeyDiffers() {
+        var strafeA = keyMapping(KeyConflictContext.IN_GAME, KeyModifier.NONE, A);
+        var debugB = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, B);
+
+        assertNoMappingConflict(strafeA, debugB);
+    }
+
+    @Test
+    void guiAndInGameBareKeyDoesNotConflictWithDebugContextBindingWhenActionKeyMatches() {
+        var inventoryA = keyMapping(KeyConflictContext.GUI_AND_IN_GAME, KeyModifier.NONE, A);
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+
+        assertNoMappingConflict(inventoryA, debugA);
+    }
+
+    @Test
+    void guiBareKeyDoesNotConflictWithDebugContextBinding() {
+        var guiA = keyMapping(KeyConflictContext.GUI, KeyModifier.NONE, A);
+        var debugA = keyMapping(KeyConflictContext.DEBUG, KeyModifier.NONE, A);
+
+        assertNoMappingConflict(guiA, debugA);
     }
 
     @Test

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyMappingModifierHelperTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/KeyMappingModifierHelperTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import static net.neoforged.neoforge.client.extensions.KeyMappingModifierHelper.hasKeyMappingConflict;
+import static net.neoforged.neoforge.client.extensions.KeyMappingModifierHelper.isActiveAndMatches;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import net.minecraft.client.KeyMapping;
+import net.neoforged.neoforge.client.settings.IKeyConflictContext;
+import net.neoforged.neoforge.client.settings.KeyConflictContext;
+import net.neoforged.neoforge.client.settings.KeyModifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.lwjgl.glfw.GLFW;
+
+class KeyMappingModifierHelperTest {
+    private static final AtomicInteger NEXT_MAPPING_ID = new AtomicInteger();
+    private static final InputConstants.Key A = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_A);
+    private static final InputConstants.Key B = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_B);
+    private static final InputConstants.Key LEFT_SHIFT = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_LEFT_SHIFT);
+    private static final InputConstants.Key ACTIVE_CONTEXT_KEY = InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_C);
+    private static final IKeyConflictContext ACTIVE_GUI_CONTEXT = new TestKeyConflictContext("gui", true, false);
+    private static final IKeyConflictContext INACTIVE_GUI_CONTEXT = new TestKeyConflictContext("gui", false, false);
+    private static final IKeyConflictContext ACTIVE_IN_GAME_LIKE_CONTEXT = new TestKeyConflictContext("in_game_like", true, true, false, false);
+    private static final IKeyConflictContext INACTIVE_IN_GAME_LIKE_CONTEXT = new TestKeyConflictContext("in_game_like", false, true, false, false);
+
+    @Test
+    void normalBareKeyWithNoExtraModifierIsActive() {
+        Assertions.assertTrue(isActiveAndMatches(A, A, ACTIVE_GUI_CONTEXT, true));
+    }
+
+    @Test
+    void normalBareKeyDoesNotMatchDifferentKey() {
+        Assertions.assertFalse(isActiveAndMatches(B, A, ACTIVE_GUI_CONTEXT, true));
+    }
+
+    @Test
+    void unknownKeyNeverMatches() {
+        Assertions.assertFalse(isActiveAndMatches(InputConstants.UNKNOWN, A, ACTIVE_GUI_CONTEXT, true));
+    }
+
+    @Test
+    void keyMappingBoundToNormalKeyCanBeDownWhenContextAllowsNoModifier() {
+        var keyMapping = keyMapping(ACTIVE_IN_GAME_LIKE_CONTEXT, KeyModifier.NONE, ACTIVE_CONTEXT_KEY);
+        keyMapping.setDown(true);
+
+        Assertions.assertTrue(keyMapping.isActiveAndMatches(ACTIVE_CONTEXT_KEY));
+        Assertions.assertFalse(keyMapping.isActiveAndMatches(A));
+        Assertions.assertTrue(keyMapping.isConflictContextAndModifierActive());
+        Assertions.assertTrue(keyMapping.isDown());
+    }
+
+    @Test
+    void keyMappingBoundToNormalKeyStillRequiresActiveContext() {
+        var keyMapping = keyMapping(INACTIVE_IN_GAME_LIKE_CONTEXT, KeyModifier.NONE, ACTIVE_CONTEXT_KEY);
+        keyMapping.setDown(true);
+
+        Assertions.assertFalse(keyMapping.isActiveAndMatches(ACTIVE_CONTEXT_KEY));
+        Assertions.assertFalse(keyMapping.isConflictContextAndModifierActive());
+        Assertions.assertFalse(keyMapping.isDown());
+    }
+
+    @ParameterizedTest
+    @MethodSource("modifierKeys")
+    void bareModifierKeyWithNoSeparateModifierIsActive(InputConstants.Key key) {
+        Assertions.assertTrue(isActiveAndMatches(key, key, ACTIVE_GUI_CONTEXT, KeyModifier.NONE));
+
+        var keyMapping = new KeyMapping("key.neoforge.test.bare_modifier." + key.getValue(), ACTIVE_GUI_CONTEXT, KeyModifier.NONE, key, KeyMapping.Category.MISC);
+        keyMapping.setDown(true);
+
+        Assertions.assertTrue(keyMapping.isActiveAndMatches(key));
+        Assertions.assertTrue(keyMapping.isConflictContextAndModifierActive());
+        Assertions.assertTrue(keyMapping.isDown());
+    }
+
+    @ParameterizedTest
+    @MethodSource("modifierKeys")
+    void bareModifierKeyStillRequiresActiveConflictContext(InputConstants.Key key) {
+        Assertions.assertFalse(isActiveAndMatches(key, key, INACTIVE_GUI_CONTEXT, KeyModifier.NONE));
+
+        var keyMapping = new KeyMapping("key.neoforge.test.inactive_bare_modifier." + key.getValue(), INACTIVE_GUI_CONTEXT, KeyModifier.NONE, key, KeyMapping.Category.MISC);
+        keyMapping.setDown(true);
+
+        Assertions.assertFalse(keyMapping.isConflictContextAndModifierActive());
+        Assertions.assertFalse(keyMapping.isDown());
+    }
+
+    @ParameterizedTest
+    @MethodSource("modifierKeys")
+    void bareModifierKeyStillRequiresMatchingKey(InputConstants.Key key) {
+        Assertions.assertFalse(isActiveAndMatches(A, key, ACTIVE_GUI_CONTEXT, KeyModifier.NONE));
+    }
+
+    @Test
+    void bareNonModifierKeyIsInactiveWhenExactNoneMatchingFails() {
+        Assertions.assertFalse(isActiveAndMatches(A, A, ACTIVE_GUI_CONTEXT, false));
+    }
+
+    @Test
+    void bareNonModifierKeyUsesNormalNoneModifierState() {
+        Assertions.assertTrue(isActiveAndMatches(A, A, ACTIVE_GUI_CONTEXT, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("modifierChordKeys")
+    void modifiedKeyRequiresModifierAndKey(InputConstants.Key modifierKey) {
+        Assertions.assertFalse(isActiveAndMatches(A, A, ACTIVE_GUI_CONTEXT, false));
+        Assertions.assertFalse(isActiveAndMatches(modifierKey, A, ACTIVE_GUI_CONTEXT, true));
+        Assertions.assertTrue(isActiveAndMatches(A, A, ACTIVE_GUI_CONTEXT, true));
+    }
+
+    @Test
+    void modifiedKeyCanMatchWhenAdditionalModifierKeysAreHeld() {
+        Assertions.assertTrue(isActiveAndMatches(A, A, ACTIVE_GUI_CONTEXT, true));
+    }
+
+    @Test
+    void modifiedKeyStillRequiresActiveContext() {
+        Assertions.assertFalse(isActiveAndMatches(A, A, INACTIVE_GUI_CONTEXT, true));
+    }
+
+    @Test
+    void sameKeyWithConflictingContextsAndSameModifierConflicts() {
+        var first = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, A);
+        var second = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, A);
+
+        assertMappingConflict(first, second);
+    }
+
+    @Test
+    void sameKeyConflictIsNotAKeyModifierConflict() {
+        var first = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, A);
+        var second = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, A);
+
+        Assertions.assertFalse(first.hasKeyModifierConflict(second));
+        Assertions.assertFalse(second.hasKeyModifierConflict(first));
+        assertMappingConflict(first, second);
+    }
+
+    @Test
+    void sameKeyWithNonConflictingContextsDoesNotConflict() {
+        var first = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, A);
+        var second = keyMapping(new TestKeyConflictContext("game", true, false), KeyModifier.NONE, A);
+
+        assertNoMappingConflict(first, second);
+    }
+
+    @Test
+    void differentKeysWithConflictingContextsDoNotConflict() {
+        var first = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, A);
+        var second = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, B);
+
+        assertNoMappingConflict(first, second);
+        Assertions.assertFalse(first.hasKeyModifierConflict(second));
+        Assertions.assertFalse(second.hasKeyModifierConflict(first));
+    }
+
+    @Test
+    void sameKeyWithSameModifierConflictsInGuiContext() {
+        var first = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, A);
+        var second = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, A);
+
+        Assertions.assertFalse(first.hasKeyModifierConflict(second));
+        Assertions.assertFalse(second.hasKeyModifierConflict(first));
+        assertMappingConflict(first, second);
+    }
+
+    @Test
+    void sameKeyWithDifferentModifiersDoesNotConflictInGuiContext() {
+        var shiftA = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, A);
+        var controlA = keyMapping(KeyConflictContext.GUI, KeyModifier.CONTROL, A);
+
+        assertNoMappingConflict(shiftA, controlA);
+    }
+
+    @Test
+    void sameKeyWithBareAndModifiedBindingsDoesNotConflictInGuiContext() {
+        var bareA = keyMapping(KeyConflictContext.GUI, KeyModifier.NONE, A);
+        var shiftA = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, A);
+
+        assertNoMappingConflict(bareA, shiftA);
+    }
+
+    @Test
+    void sameKeyWithBareAndModifiedBindingsConflictsInInGameContext() {
+        var bareA = keyMapping(KeyConflictContext.IN_GAME, KeyModifier.NONE, A);
+        var shiftA = keyMapping(KeyConflictContext.IN_GAME, KeyModifier.SHIFT, A);
+
+        assertMappingConflict(bareA, shiftA);
+    }
+
+    @Test
+    void sameKeyWithCustomNonExactKeyModifierNoneContextAndModifiedBindingConflicts() {
+        var bareA = keyMapping(new TestKeyConflictContext("custom", true, false, false, false), KeyModifier.NONE, A);
+        var shiftA = keyMapping(new TestKeyConflictContext("custom", true, false, false, false), KeyModifier.SHIFT, A);
+
+        assertMappingConflict(bareA, shiftA);
+    }
+
+    @Test
+    void sameKeyWithCustomExactKeyModifierNoneContextAndModifiedBindingDoesNotConflict() {
+        var bareA = keyMapping(new TestKeyConflictContext("custom", true, false, false, true), KeyModifier.NONE, A);
+        var shiftA = keyMapping(new TestKeyConflictContext("custom", true, false, false, true), KeyModifier.SHIFT, A);
+
+        assertNoMappingConflict(bareA, shiftA);
+    }
+
+    @Test
+    void sameKeyWithBareContextRequiringExactKeyModifierNoneAndModifiedGuiBindingsDoesNotConflict() {
+        var dualUseA = keyMapping(new TestKeyConflictContext("gui_and_in_game", true, true, true, true), KeyModifier.NONE, A);
+        var guiShiftA = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, A);
+
+        assertNoMappingConflict(dualUseA, guiShiftA);
+    }
+
+    @Test
+    void sameKeyWithBareGuiAndInGameAndModifiedInGameBindingsConflicts() {
+        var vanillaDualUseA = keyMapping(KeyConflictContext.GUI_AND_IN_GAME, KeyModifier.NONE, A);
+        var inGameShiftA = keyMapping(KeyConflictContext.IN_GAME, KeyModifier.SHIFT, A);
+
+        assertMappingConflict(vanillaDualUseA, inGameShiftA);
+    }
+
+    @Test
+    void sameKeyWithBareUniversalAndModifiedGuiBindingsConflicts() {
+        var universalA = keyMapping(KeyConflictContext.UNIVERSAL, KeyModifier.NONE, A);
+        var guiShiftA = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, A);
+
+        assertMappingConflict(universalA, guiShiftA);
+    }
+
+    @Test
+    void sameKeyWithBareAndModifiedUniversalBindingsConflict() {
+        var universalA = keyMapping(KeyConflictContext.UNIVERSAL, KeyModifier.NONE, A);
+        var universalShiftA = keyMapping(KeyConflictContext.UNIVERSAL, KeyModifier.SHIFT, A);
+
+        assertMappingConflict(universalA, universalShiftA);
+    }
+
+    @Test
+    void modifierMatchingBoundKeyIsStoredAsBareKey() {
+        var mapping = keyMapping(KeyConflictContext.GUI, KeyModifier.SHIFT, LEFT_SHIFT);
+
+        Assertions.assertEquals(KeyModifier.NONE, mapping.getKeyModifier());
+        Assertions.assertEquals(LEFT_SHIFT, mapping.getKey());
+    }
+
+    @Test
+    void bareModifierKeyConflictsWithModifiedBindingWhenContextsConflict() {
+        var bareShift = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, LEFT_SHIFT);
+        var shiftA = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.SHIFT, A);
+
+        Assertions.assertTrue(bareShift.hasKeyModifierConflict(shiftA));
+        Assertions.assertTrue(shiftA.hasKeyModifierConflict(bareShift));
+        assertMappingConflict(bareShift, shiftA);
+    }
+
+    @Test
+    void bareModifierKeyDoesNotConflictWithModifiedBindingWhenContextsDoNotConflict() {
+        var bareShift = keyMapping(new TestKeyConflictContext("menu", true, false), KeyModifier.NONE, LEFT_SHIFT);
+        var shiftA = keyMapping(new TestKeyConflictContext("game", true, false), KeyModifier.SHIFT, A);
+
+        Assertions.assertFalse(bareShift.hasKeyModifierConflict(shiftA));
+        Assertions.assertFalse(shiftA.hasKeyModifierConflict(bareShift));
+        assertNoMappingConflict(bareShift, shiftA);
+    }
+
+    private static Stream<InputConstants.Key> modifierKeys() {
+        return Stream.of(
+                GLFW.GLFW_KEY_LEFT_SHIFT,
+                GLFW.GLFW_KEY_RIGHT_SHIFT,
+                GLFW.GLFW_KEY_LEFT_CONTROL,
+                GLFW.GLFW_KEY_RIGHT_CONTROL,
+                GLFW.GLFW_KEY_LEFT_ALT,
+                GLFW.GLFW_KEY_RIGHT_ALT)
+                .map(InputConstants.Type.KEYSYM::getOrCreate);
+    }
+
+    private static Stream<InputConstants.Key> modifierChordKeys() {
+        return Stream.of(
+                GLFW.GLFW_KEY_LEFT_SHIFT,
+                GLFW.GLFW_KEY_LEFT_CONTROL,
+                GLFW.GLFW_KEY_LEFT_ALT)
+                .map(InputConstants.Type.KEYSYM::getOrCreate);
+    }
+
+    private static KeyMapping keyMapping(IKeyConflictContext keyConflictContext, KeyModifier keyModifier, InputConstants.Key key) {
+        return new KeyMapping("key.neoforge.test.key_mapping_modifier_helper." + NEXT_MAPPING_ID.incrementAndGet(), keyConflictContext, keyModifier, key, KeyMapping.Category.MISC);
+    }
+
+    private static void assertMappingConflict(KeyMapping first, KeyMapping second) {
+        Assertions.assertTrue(hasKeyMappingConflict(first, second));
+        Assertions.assertTrue(hasKeyMappingConflict(second, first));
+        Assertions.assertTrue(first.same(second));
+        Assertions.assertTrue(second.same(first));
+    }
+
+    private static void assertNoMappingConflict(KeyMapping first, KeyMapping second) {
+        Assertions.assertFalse(hasKeyMappingConflict(first, second));
+        Assertions.assertFalse(hasKeyMappingConflict(second, first));
+        Assertions.assertFalse(first.same(second));
+        Assertions.assertFalse(second.same(first));
+    }
+
+    private record TestKeyConflictContext(
+            String group,
+            boolean active,
+            boolean conflictsWithInGame,
+            boolean conflictsWithGui,
+            boolean requiresExactKeyModifierNone) implements IKeyConflictContext {
+        private TestKeyConflictContext(String group, boolean active, boolean conflictsWithInGame) {
+            this(group, active, conflictsWithInGame, false, true);
+        }
+
+        @Override
+        public boolean isActive() {
+            return active;
+        }
+
+        @Override
+        public boolean conflicts(IKeyConflictContext other) {
+            if (conflictsWithInGame && other == KeyConflictContext.IN_GAME) {
+                return true;
+            }
+            if (conflictsWithGui && other == KeyConflictContext.GUI) {
+                return true;
+            }
+            return other instanceof TestKeyConflictContext otherContext && group.equals(otherContext.group);
+        }
+
+        @Override
+        public boolean requiresExactKeyModifierNone() {
+            return requiresExactKeyModifierNone;
+        }
+    }
+}


### PR DESCRIPTION
This is built on top of the key mapping modifier helper PR, please review that one first:
* https://github.com/neoforged/NeoForge/pull/3331

## Problem

Many vanilla key mappings used the default `UNIVERSAL` conflict context, even when their behavior is only active in a normal vanilla context.

That caused false conflicts in the controls screen. For example:
* start/stop profiling + advancements
* reload resource packs + open chat
* toggle lost focus pause + social interactions screen
* pick block + select on hotbar in spectator mode

These key pairs can share defaults in vanilla because debug shortcuts take precedence while F3 is held, and spectator controls are mode-specific.

## Fix

Assign vanilla key mappings to more accurate conflict contexts.

Movement and gameplay-only bindings use `IN_GAME`. Bindings that work both in game and in vanilla GUI screens use `GUI_AND_IN_GAME`.

This also adds:
* `DEBUG`, for vanilla F3 debug action bindings
* `SPECTATOR`, for spectator-only bindings

`DEBUG` and `SPECTATOR` do not require exact `KeyModifier.NONE` matching, matching the in-game behavior where a bare key can still be active while a modifier key is held.

`UNIVERSAL` remains a true global conflict context for bindings that should reserve a key everywhere.

## Tests

Adds regression coverage for whatever I could think of:
* debug shortcuts not conflicting with matching non-debug action keys
* debug bindings still conflicting with other debug bindings on the same action key
* true universal bindings still conflicting with debug bindings
* spectator hotbar action not conflicting with pick block
* spectator bindings still conflicting with other spectator bindings on the same action key
* exact `KeyModifier.NONE` matching and conflict rules for the added contexts

This clears out most of the vanilla keybind conflicts that NeoForge reports, except F3 being used twice for debug mode an debug modifier, and the F3+C for copy and crash (if held).