### PR TITLE
Remove neoforge:nametag_distance attribute

### DIFF
--- a/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/EntityRenderer.java.patch
@@ -39,7 +39,7 @@
 -            boolean shouldShowName = state.distanceToCameraSq < Mth.square(nameTagDistance) && this.shouldShowName(entity, state.distanceToCameraSq);
 +            var event = new net.neoforged.neoforge.client.event.RenderNameTagEvent.CanRender(entity, state, this.getNameTag(entity), this, partialTicks);
 +            net.neoforged.neoforge.common.NeoForge.EVENT_BUS.post(event);
-+            boolean shouldShowName = event.canRender().isTrue() || (event.canRender().isDefault() && state.distanceToCameraSq < 4096.0 && this.shouldShowName(entity, state.distanceToCameraSq));
++            boolean shouldShowName = event.canRender().isTrue() || (event.canRender().isDefault() && state.distanceToCameraSq < Mth.square(nameTagDistance) && this.shouldShowName(entity, state.distanceToCameraSq));
              if (shouldShowName) {
 -                state.nameTag = this.getNameTag(entity);
 +                state.nameTag = event.getContent();

--- a/patches/net/minecraft/client/renderer/entity/LivingEntityRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/entity/LivingEntityRenderer.java.patch
@@ -16,12 +16,3 @@
      }
  
      protected boolean shouldRenderLayers(S state) {
-@@ -201,7 +_,7 @@
-     protected boolean shouldShowName(T entity, double distanceToCameraSq) {
-         if (entity.isDiscrete()) {
-             float maxDist = 32.0F;
--            if (distanceToCameraSq >= 1024.0) {
-+            if (!net.neoforged.neoforge.client.ClientHooks.isNameplateInRenderDistance(entity, distanceToCameraSq)) {
-                 return false;
-             }
-         }

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -34,12 +34,11 @@
  
      protected LivingEntity(EntityType<? extends LivingEntity> type, Level level) {
          super(type, level);
-@@ -358,12 +_,16 @@
+@@ -358,12 +_,15 @@
              .add(Attributes.AIR_DRAG_MODIFIER)
              .add(Attributes.FRICTION_MODIFIER)
              .add(Attributes.NAME_TAG_DISTANCE)
 +            .add(net.neoforged.neoforge.common.NeoForgeMod.SWIM_SPEED)
-+            .add(net.neoforged.neoforge.common.NeoForgeMod.NAMETAG_DISTANCE)
 +            .add(net.neoforged.neoforge.common.NeoForgeMod.GLIDING_FLIGHT)
              .add(Attributes.BELOW_NAME_DISTANCE);
      }

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -129,7 +129,6 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Avatar;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.HumanoidArm;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.ItemStack;
@@ -569,11 +568,6 @@ public class ClientHooks {
         InputEvent.InteractionKeyMappingTriggered event = new InputEvent.InteractionKeyMappingTriggered(button, keyBinding, hand);
         NeoForge.EVENT_BUS.post(event);
         return event;
-    }
-
-    public static boolean isNameplateInRenderDistance(LivingEntity entity, double squareDistance) {
-        double value = entity.getAttributeValue(NeoForgeMod.NAMETAG_DISTANCE);
-        return !(squareDistance > value * value);
     }
 
     public static boolean shouldRenderEffect(MobEffectInstance effectInstance) {

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -48,9 +48,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.ai.attributes.Attribute;
-import net.minecraft.world.entity.ai.attributes.Attribute.Sentiment;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
-import net.minecraft.world.entity.ai.attributes.RangedAttribute;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -203,7 +201,6 @@ public class NeoForgeMod {
             SingletonArgumentInfo.contextFree(ModIdArgument::modIdArgument)));
 
     public static final Holder<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new PercentageAttribute("neoforge.swim_speed", 1.0D, 0.0D, 1024.0D).setSyncable(true));
-    public static final Holder<Attribute> NAMETAG_DISTANCE = ATTRIBUTES.register("nametag_distance", () -> new RangedAttribute("neoforge.name_tag_distance", 32.0D, 0.0D, 32.0).setSyncable(true).setSentiment(Sentiment.NEUTRAL));
 
     /**
      * This attribute controls if the player may use creative flight when not in creative mode.


### PR DESCRIPTION
This PR resolves #3261 by removing NeoForge's `neoforge:nametag_distance` entityattribute, in favor of vanilla's `minecraft:name_tag_distance` attribute.

There is one difference between the Neo-added attribute and the vanilla attribute: the maximum render distance of nametags for entities being discreet (named 'discrete' in code, probably a typo; such as players shifting/sneaking) is fixed at a distance of 32 blocks under the vanilla attribute.

This PR also includes a fix for the vanilla attribute not being respected as the value was simply ignored in the `EntityRenderer#extractNameTags` patch, likely due to being missed during porting. As the vanilla attribute was added in 26.2, backporting is not necessary.