### PR TITLE
[26.2] Fix unsynced datamaps on synced datapack registries getting lost in singleplayer

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -42,7 +42,6 @@ import net.neoforged.neoforge.network.ConfigSync;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.payload.RegistryDataMapSyncPayload;
 import net.neoforged.neoforge.registries.DataMapLoader;
-import net.neoforged.neoforge.registries.DataPackRegistriesHooks;
 import net.neoforged.neoforge.registries.RegistryManager;
 import net.neoforged.neoforge.resource.NeoForgeReloadListeners;
 import net.neoforged.neoforge.server.command.ConfigCommand;
@@ -118,9 +117,10 @@ public class NeoForgeEventHandler {
                     return;
                 }
 
-                // Note: don't send data maps over in-memory connections for normal registries, else the client-side handling will wipe non-synced data maps.
-                // Sending them for synced datapack registries is fine and required as those registries are recreated on the client
-                if (player.connection.getConnection().isMemoryConnection() && DataPackRegistriesHooks.getSyncedRegistry((ResourceKey) registry) == null) {
+                // Note: don't send data maps over in-memory connections, else the client-side handling will wipe non-synced data maps.
+                // To prevent serialization issues with data component defaults holding datapack objects on static registries, synced
+                // datapack registries are not recreated on the client in singleplayer.
+                if (player.connection.getConnection().isMemoryConnection()) {
                     return;
                 }
                 final var playerMaps = player.connection.getConnection().channel().attr(RegistryManager.ATTRIBUTE_KNOWN_DATA_MAPS).get();


### PR DESCRIPTION
This PR fixes unsynced datamaps on synced datapack registries getting lost in singleplayer by effectively reverting #2164.

To prevent serialization issues in singleplayer with data component defaults holding datapack objects on objects in static registries (i.e. items), vanilla drops the datapack objects synced to the client and re-uses the server thread's datapack registries. When the client thread receives the datamap data for a synced datapack registry, it clears that registry's datamaps and inadvertadly drops unsynced datamaps due to the registry re-use.

Fixes #3287