### PR TITLE
[26.2] Combine PlayerEvent.EntityInteract and PlayerEvent.EntityInteractSpecific into one event

### DIFF
--- a/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
+++ b/patches/net/minecraft/client/multiplayer/MultiPlayerGameMode.java.patch
@@ -173,13 +173,3 @@
              }
  
              interactionResult.setValue(resultHolder);
-@@ -443,6 +_,9 @@
-         this.ensureHasSentCarriedItem();
-         Vec3 location = hitResult.getLocation().subtract(entity.getX(), entity.getY(), entity.getZ());
-         this.connection.send(new ServerboundInteractPacket(entity.getId(), hand, location, player.isShiftKeyDown()));
-+        if (this.localPlayerMode == GameType.SPECTATOR) return InteractionResult.PASS; // don't fire for spectators to match non-specific EntityInteract
-+        InteractionResult cancelResult = net.neoforged.neoforge.common.CommonHooks.onInteractEntityAt(player, entity, hitResult, hand);
-+        if(cancelResult != null) return cancelResult;
-         return this.localPlayerMode == GameType.SPECTATOR ? InteractionResult.PASS : player.interactOn(entity, hand, location);
-     }
- 

--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -107,19 +107,6 @@
                      PlayerChatMessage filteredMessage = signedMessage.withUnsignedContent(decorated).filter(filtered.mask());
                      this.broadcastChatMessage(filteredMessage);
                  });
-@@ -1853,7 +_,11 @@
-                     ItemStack tool = this.player.getItemInHand(hand);
-                     if (tool.isItemEnabled(level.enabledFeatures())) {
-                         ItemStack usedItemStack = tool.copy();
--                        if (this.player.interactOn(target, hand, location) instanceof InteractionResult.Success success) {
-+                        var interactionResult = net.neoforged.neoforge.common.CommonHooks.onInteractEntityAt(player, target, location, hand);
-+                        if (interactionResult == null) {
-+                            interactionResult = this.player.interactOn(target, hand, location);
-+                        }
-+                        if (interactionResult instanceof InteractionResult.Success success) {
-                             ItemStack awardedForStack = success.wasItemInteraction() ? usedItemStack : ItemStack.EMPTY;
-                             CriteriaTriggers.PLAYER_INTERACTED_WITH_ENTITY.trigger(this.player, awardedForStack, target);
-                             if (success.swingSource() == InteractionResult.SwingSource.SERVER) {
 @@ -2075,14 +_,16 @@
      @Override
      public void handlePlayerAbilities(ServerboundPlayerAbilitiesPacket packet) {

--- a/patches/net/minecraft/world/entity/player/Player.java.patch
+++ b/patches/net/minecraft/world/entity/player/Player.java.patch
@@ -173,7 +173,7 @@
  
              return InteractionResult.PASS;
          } else {
-+            InteractionResult cancelResult = net.neoforged.neoforge.common.CommonHooks.onInteractEntity(this, entity, hand);
++            InteractionResult cancelResult = net.neoforged.neoforge.common.CommonHooks.onInteractEntity(this, entity, hand, location);
 +            if (cancelResult != null) return cancelResult;
              ItemStack itemStack = this.getItemInHand(hand);
              ItemStack itemStackClone = itemStack.copy();

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -167,7 +167,6 @@ import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootPool;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModLoader;
@@ -836,21 +835,8 @@ public class CommonHooks {
     }
 
     @Nullable
-    public static InteractionResult onInteractEntityAt(Player player, Entity entity, HitResult ray, InteractionHand hand) {
-        Vec3 vec3d = ray.getLocation().subtract(entity.position());
-        return onInteractEntityAt(player, entity, vec3d, hand);
-    }
-
-    @Nullable
-    public static InteractionResult onInteractEntityAt(Player player, Entity entity, Vec3 vec3d, InteractionHand hand) {
-        PlayerInteractEvent.EntityInteractSpecific evt = new PlayerInteractEvent.EntityInteractSpecific(player, hand, entity, vec3d);
-        NeoForge.EVENT_BUS.post(evt);
-        return evt.isCanceled() ? evt.getCancellationResult() : null;
-    }
-
-    @Nullable
-    public static InteractionResult onInteractEntity(Player player, Entity entity, InteractionHand hand) {
-        PlayerInteractEvent.EntityInteract evt = new PlayerInteractEvent.EntityInteract(player, hand, entity);
+    public static InteractionResult onInteractEntity(Player player, Entity entity, InteractionHand hand, Vec3 location) {
+        PlayerInteractEvent.EntityInteract evt = new PlayerInteractEvent.EntityInteract(player, hand, entity, location);
         NeoForge.EVENT_BUS.post(evt);
         return evt.isCanceled() ? evt.getCancellationResult() : null;
     }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInteractEvent.java
@@ -74,11 +74,9 @@ public abstract class PlayerInteractEvent extends PlayerEvent {
             return target;
         }
 
-        /// Returns the local interaction position. This is a 3D vector, where (0, 0, 0) is centered exactly at the
+        /// {@return the local interaction position} This is a 3D vector, where (0, 0, 0) is centered exactly at the
         /// center of the entity's bounding box at their feet. This means the X and Z values will be in the range
-        /// [-width / 2, width / 2] while Y values will be in the range [0, height]
-        ///
-        /// @return The local position
+        /// [-width / 2, width / 2] while Y values will be in the range [0, height].
         public Vec3 getLocation() {
             return location;
         }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInteractEvent.java
@@ -48,85 +48,39 @@ public abstract class PlayerInteractEvent extends PlayerEvent {
         this.face = face;
     }
 
-    /**
-     * This event is fired on both sides whenever a player right clicks an entity.
-     *
-     * "Interact at" is an interact where the local vector (which part of the entity you clicked) is known.
-     * The state of this event affects whether {@link Entity#interactAt(Player, Vec3, InteractionHand)} is called.
-     *
-     * Let result be the return value of {@link Entity#interactAt(Player, Vec3, InteractionHand)}, or {@link #cancellationResult} if the event is cancelled.
-     * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link EntityInteract}.
-     */
-    public static class EntityInteractSpecific extends PlayerInteractEvent implements ICancellableEvent {
-        private InteractionResult cancellationResult = InteractionResult.PASS;
-
-        private final Vec3 localPos;
-        private final Entity target;
-
-        public EntityInteractSpecific(Player player, InteractionHand hand, Entity target, Vec3 localPos) {
-            super(player, hand, target.blockPosition(), null);
-            this.localPos = localPos;
-            this.target = target;
-        }
-
-        /**
-         * Returns the local interaction position. This is a 3D vector, where (0, 0, 0) is centered exactly at the
-         * center of the entity's bounding box at their feet. This means the X and Z values will be in the range
-         * [-width / 2, width / 2] while Y values will be in the range [0, height]
-         * 
-         * @return The local position
-         */
-        public Vec3 getLocalPos() {
-            return localPos;
-        }
-
-        public Entity getTarget() {
-            return target;
-        }
-
-        /**
-         * @return The InteractionResult that will be returned to vanilla if the event is cancelled, instead of calling the relevant
-         *         method of the event. By default, this is {@link InteractionResult#PASS}, meaning cancelled events will cause
-         *         the client to keep trying more interactions until something works.
-         */
-        public InteractionResult getCancellationResult() {
-            return cancellationResult;
-        }
-
-        /**
-         * Set the InteractionResult that will be returned to vanilla if the event is cancelled, instead of calling the relevant
-         * method of the event.
-         */
-        public void setCancellationResult(InteractionResult result) {
-            this.cancellationResult = result;
-        }
-    }
-
-    /**
-     * This event is fired on both sides when the player right clicks an entity.
-     * It is responsible for all general entity interactions.
-     *
-     * This event is fired only if the result of the above {@link EntityInteractSpecific} is not {@link InteractionResult#SUCCESS}.
-     * This event's state affects whether {@link Entity#interact(Player, InteractionHand)} and
-     * {@link Item#interactLivingEntity(ItemStack, Player, LivingEntity, InteractionHand)} are called.
-     *
-     * Let result be {@link InteractionResult#SUCCESS} if {@link Entity#interact(Player, InteractionHand)} or
-     * {@link Item#interactLivingEntity(ItemStack, Player, LivingEntity, InteractionHand)} return true,
-     * or {@link #cancellationResult} if the event is cancelled.
-     * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then try {@link RightClickItem}.
-     */
+    /// This event is fired on both sides when a non-spectator player right-clicks an entity.
+    /// It is responsible for all entity interactions.
+    ///
+    /// This event's state affects whether [Entity#interact(Player, InteractionHand, Vec3)] and
+    /// [Item#interactLivingEntity(ItemStack, Player, LivingEntity, InteractionHand)] are called.
+    ///
+    /// Let result be [InteractionResult#SUCCESS] if [Entity#interact(Player, InteractionHand, Vec3)] or
+    /// [Item#interactLivingEntity(ItemStack, Player, LivingEntity, InteractionHand)] return true,
+    /// or [#cancellationResult] if the event is cancelled.
+    /// If we are on the client and result is not [InteractionResult#SUCCESS], the client will then try [RightClickItem].
     public static class EntityInteract extends PlayerInteractEvent implements ICancellableEvent {
         private InteractionResult cancellationResult = InteractionResult.PASS;
 
         private final Entity target;
+        private final Vec3 location;
 
-        public EntityInteract(Player player, InteractionHand hand, Entity target) {
+        public EntityInteract(Player player, InteractionHand hand, Entity target, Vec3 location) {
             super(player, hand, target.blockPosition(), null);
             this.target = target;
+            this.location = location;
         }
 
         public Entity getTarget() {
             return target;
+        }
+
+        /// Returns the local interaction position. This is a 3D vector, where (0, 0, 0) is centered exactly at the
+        /// center of the entity's bounding box at their feet. This means the X and Z values will be in the range
+        /// [-width / 2, width / 2] while Y values will be in the range [0, height]
+        ///
+        /// @return The local position
+        public Vec3 getLocation() {
+            return location;
         }
 
         /**
@@ -241,7 +195,7 @@ public abstract class PlayerInteractEvent extends PlayerEvent {
 
     /**
      * This event is fired on both sides before the player triggers {@link Item#use(Level, Player, InteractionHand)}.
-     * Note that this is NOT fired if the player is targeting a block {@link RightClickBlock} or entity {@link EntityInteract} {@link EntityInteractSpecific}.
+     * Note that this is NOT fired if the player is targeting a block {@link RightClickBlock} or entity {@link EntityInteract}.
      *
      * Let result be the return value of {@link Item#use(Level, Player, InteractionHand)}, or {@link #cancellationResult} if the event is cancelled.
      * If we are on the client and result is not {@link InteractionResult#SUCCESS}, the client will then continue to other hands.

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/player/PlayerEventTests.java
@@ -117,7 +117,7 @@ public class PlayerEventTests {
     @EmptyTemplate
     @TestHolder(description = "Tests if the on entity interact event is fired")
     static void entityInteractEvent(final DynamicTest test) {
-        test.eventListeners().forge().addListener((final PlayerInteractEvent.EntityInteractSpecific event) -> {
+        test.eventListeners().forge().addListener((final PlayerInteractEvent.EntityInteract event) -> {
             if (event.getTarget().getType() == EntityTypes.ILLUSIONER) {
                 String oldName = event.getTarget().getName().getString();
                 event.getTarget().setCustomName(Component.literal(oldName + " entityInteractEventTest"));


### PR DESCRIPTION
This PR combines `PlayerEvent.EntityInteract` and `PlayerEvent.EntityInteractSpecific` into one location-aware event to adjust to vanilla combining `Entity#interact()` and `Entity#interactAt()` into one method.

Closes #3124