### PR TITLE
[26.2] Fix certain trim quads being invisible on trimmed armor items

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/item/TrimmedArmorModel.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/item/TrimmedArmorModel.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.client.model.item;
 
-import com.mojang.math.Transformation;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
@@ -14,7 +13,6 @@ import java.util.List;
 import java.util.Objects;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.block.dispatch.BlockModelRotation;
-import net.minecraft.client.renderer.block.dispatch.ModelState;
 import net.minecraft.client.renderer.item.CuboidItemModelWrapper;
 import net.minecraft.client.renderer.item.ItemModel;
 import net.minecraft.client.renderer.item.ItemModelResolver;
@@ -36,10 +34,7 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.equipment.Equippable;
 import net.minecraft.world.item.equipment.trim.TrimMaterial;
-import net.neoforged.neoforge.client.model.ComposedModelState;
 import org.joml.Matrix4fc;
-import org.joml.Quaternionf;
-import org.joml.Vector3f;
 import org.jspecify.annotations.Nullable;
 
 /// A dynamic model that applies an armor trim texture on top of an existing model when the trim component exists.
@@ -54,9 +49,7 @@ import org.jspecify.annotations.Nullable;
 ///
 /// This issue can be avoided by making your material path more unique. We would encourage you to prefix your material with your mod id or something along those lines.
 public class TrimmedArmorModel implements ItemModel {
-    private static final Transformation TRIM_TRANSFORM = new Transformation(new Vector3f(), new Quaternionf(), new Vector3f(1.002F, 1.002F, 1.002F), new Quaternionf());
     private static final ModelDebugName DEBUG_NAME = () -> "TrimmedArmorModel";
-    private static final ModelState TRIM_STATE = new ComposedModelState(BlockModelRotation.IDENTITY, TRIM_TRANSFORM);
 
     private final Object2ObjectMap<String, ItemModel> itemsWithTrims = new Object2ObjectOpenHashMap<>();
 
@@ -97,7 +90,7 @@ public class TrimmedArmorModel implements ItemModel {
 
         Material.Baked overlayMat = materials.get(new Material(this.baseTrimTexture.withSuffix("_" + suffix)), DEBUG_NAME);
         ModelRenderProperties overlayRenderProps = new ModelRenderProperties(false, overlayMat, this.itemTransforms);
-        QuadCollection overlayQuads = baker.compute(new ItemModelGenerator.ItemLayerKey(overlayMat, TRIM_STATE, 0));
+        QuadCollection overlayQuads = baker.compute(new ItemModelGenerator.ItemLayerKey(overlayMat, BlockModelRotation.IDENTITY, 0));
         return new CuboidItemModelWrapper(List.of(), overlayQuads, overlayRenderProps, this.transformation);
     }
 


### PR DESCRIPTION
This PR fixes certain pixels of armor trims being invisible on trimmed armor items.

To avoid z-fighting with the "base" model, the `TrimmedArmorModel` dynamic item model slightly increased the size of the trim model. For outward facing quads (i.e. quads facing the direction in which they are offset from the model's center) this works perfectly fine. However for inward facing quads (i.e. quads facing opposite the direction in which they are offset from the model's center) such as the inner quads between the legs of leggings this breaks because the trim quads get put slightly behind the base quads instead of slightly more "in front" of them.
Presumably for similar reasons related to z-fighting, vanilla's item model generator no longer tries to find the longest possible span of pixels on the texture and instead generates an individual quad for each "pixel" on the side/top/bottom faces of the item model (see RenderDoc screenshot below). Due to this, the slight expansion can be removed with no loss of functionality.

Fixes #3299

<img width="642" height="596" alt="grafik" src="https://github.com/user-attachments/assets/31519b70-00c5-4b33-9f86-8c3a3471d513" />