### PR TITLE
[1.21.1] Fix tags in datamap values failing to deserialize

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeEventHandler.java
@@ -156,7 +156,7 @@ public class NeoForgeEventHandler {
     public void onResourceReload(AddReloadListenerEvent event) {
         INSTANCE = new LootModifierManager();
         event.addListener(INSTANCE);
-        event.addListener(DATA_MAPS = new DataMapLoader(event.getConditionContext(), event.getRegistryAccess()));
+        event.addListener(DATA_MAPS = new DataMapLoader(event.getRegistryAccess()));
     }
 
     static LootModifierManager getLootModifierManager() {

--- a/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
+++ b/src/main/java/net/neoforged/neoforge/registries/DataMapLoader.java
@@ -9,7 +9,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.mojang.datafixers.util.Either;
 import com.mojang.logging.LogUtils;
-import com.mojang.serialization.JsonOps;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -26,31 +25,34 @@ import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.conditions.ICondition;
 import net.neoforged.neoforge.registries.datamaps.AdvancedDataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapFile;
 import net.neoforged.neoforge.registries.datamaps.DataMapType;
 import net.neoforged.neoforge.registries.datamaps.DataMapValueMerger;
 import net.neoforged.neoforge.registries.datamaps.DataMapsUpdatedEvent;
+import net.neoforged.neoforge.resource.ContextAwareReloadListener;
 import org.slf4j.Logger;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class DataMapLoader implements PreparableReloadListener {
+public class DataMapLoader extends ContextAwareReloadListener {
     private static final Logger LOGGER = LogUtils.getLogger();
     public static final String PATH = "data_maps";
     private Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> results;
-    private final ICondition.IContext conditionContext;
     private final RegistryAccess registryAccess;
 
-    public DataMapLoader(ICondition.IContext conditionContext, RegistryAccess registryAccess) {
-        this.conditionContext = conditionContext;
+    /** @deprecated Use {@link #DataMapLoader(RegistryAccess)} instead */
+    @Deprecated(forRemoval = true, since = "1.21.1")
+    public DataMapLoader(@SuppressWarnings("unused") ICondition.IContext conditionContext, RegistryAccess registryAccess) {
+        this(registryAccess);
+    }
+
+    public DataMapLoader(RegistryAccess registryAccess) {
         this.registryAccess = registryAccess;
     }
 
@@ -139,15 +141,14 @@ public class DataMapLoader implements PreparableReloadListener {
     }
 
     private CompletableFuture<Map<ResourceKey<? extends Registry<?>>, LoadResult<?>>> load(ResourceManager manager, Executor executor, ProfilerFiller profiler) {
-        return CompletableFuture.supplyAsync(() -> load(manager, profiler, registryAccess, conditionContext), executor);
+        return CompletableFuture.supplyAsync(() -> load(manager, profiler), executor);
     }
 
-    private static Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> load(ResourceManager manager, ProfilerFiller profiler, RegistryAccess access, ICondition.IContext context) {
-        final RegistryOps<JsonElement> ops = new ConditionalOps<>(RegistryOps.create(JsonOps.INSTANCE, access), context);
+    private Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> load(ResourceManager manager, ProfilerFiller profiler) {
+        final RegistryOps<JsonElement> ops = makeConditionalOps();
 
         final Map<ResourceKey<? extends Registry<?>>, LoadResult<?>> values = new HashMap<>();
-        access.registries().forEach(registryEntry -> {
-            final var registryKey = registryEntry.key();
+        getRegistryLookup().listRegistries().forEach(registryKey -> {
             profiler.push("registry_data_maps/" + registryKey.location() + "/locating");
             final var fileToId = FileToIdConverter.json(PATH + "/" + getFolderLocation(registryKey.location()));
             for (Map.Entry<ResourceLocation, List<Resource>> entry : fileToId.listMatchingResourceStacks(manager).entrySet()) {

--- a/tests/src/generated/resources/data/neotests_tag_in_value_test/data_maps/item/tag_value_test.json
+++ b/tests/src/generated/resources/data/neotests_tag_in_value_test/data_maps/item/tag_value_test.json
@@ -1,0 +1,7 @@
+{
+  "values": {
+    "minecraft:stick": {
+      "blocks": "#minecraft:acacia_logs"
+    }
+  }
+}

--- a/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/data/DataMapTests.java
@@ -20,12 +20,16 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryCodecs;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.ExtraCodecs;
@@ -488,11 +492,42 @@ public class DataMapTests {
         });
     }
 
+    @GameTest
+    @EmptyTemplate
+    @TestHolder(description = "Tests that tags in datamap values can be deserialized")
+    static void tagInValueTest(final DynamicTest test, final RegistrationHelper reg) {
+        final DataMapType<Item, TagValue> dataMap = reg.registerDataMap(DataMapType.builder(
+                ResourceLocation.fromNamespaceAndPath(reg.modId(), "tag_value_test"),
+                Registries.ITEM, TagValue.CODEC)
+                .build());
+        Holder<Item> target = BuiltInRegistries.ITEM.wrapAsHolder(Items.STICK);
+        reg.addProvider(event -> new DataMapProvider(event.getGenerator().getPackOutput(), event.getLookupProvider()) {
+            @Override
+            protected void gather(HolderLookup.Provider provider) {
+                HolderSet.Named<Block> blocks = provider.lookupOrThrow(Registries.BLOCK).getOrThrow(BlockTags.ACACIA_LOGS);
+                builder(dataMap).add(target, new TagValue(blocks), false);
+            }
+        });
+        test.onGameTest(helper -> {
+            TagValue data = target.getData(dataMap);
+            helper.assertNotNull(data, "TagValue missing from stick");
+            helper.assertTrue(data.blocks.unwrapKey().isPresent(), "HolderSet is not a tag");
+            helper.succeed();
+        });
+    }
+
     public record SomeObject(
             int intValue,
             String stringValue) {
         public static final Codec<SomeObject> CODEC = RecordCodecBuilder.create(in -> in.group(
                 Codec.INT.fieldOf("intValue").forGetter(SomeObject::intValue),
                 Codec.STRING.fieldOf("stringValue").forGetter(SomeObject::stringValue)).apply(in, SomeObject::new));
+    }
+
+    public record TagValue(HolderSet<Block> blocks) {
+        public static final Codec<TagValue> CODEC = RegistryCodecs.homogeneousList(Registries.BLOCK)
+                .fieldOf("blocks")
+                .codec()
+                .xmap(TagValue::new, TagValue::blocks);
     }
 }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/entity/living/LivingEntityEventTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/entity/living/LivingEntityEventTests.java
@@ -6,7 +6,9 @@
 package net.neoforged.neoforge.debug.entity.living;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -360,7 +362,7 @@ public class LivingEntityEventTests {
                 /* The player's health and all the stored values from the events are checked to ensure they match the
                  * expected values from our reduction functions and changes to the damage value.*/
                 .thenWaitUntil(player -> {
-                    DecimalFormat formatter = new DecimalFormat("#.###");
+                    DecimalFormat formatter = new DecimalFormat("#.###", DecimalFormatSymbols.getInstance(Locale.ROOT));
                     String playerHealth = formatter.format(player.getHealth());
                     helper.assertTrue(playerHealth.equals("11"), "player health expected 11, actually " + playerHealth);
 


### PR DESCRIPTION
This PR fixes tags (or more specifically `HolderSet`s referring to tags) failing to deserialize when used in the value of a datamap.
The fix is effectively identical to the one implemented in #3130 for 26.1.

I also opted to include a tiny fix for `LivingEntityEventTests.livingDamageSequenceEvents()` using locale-dependent formatting in an assertion, causing the assertion to fail on systems using a locale which does not use a period as the decimal separator such as German.

Fixes #3319