### PR TITLE
[26.2] Filter ItemAttributeModifiers sent to non-NeoForge clients

### DIFF
--- a/patches/net/minecraft/world/item/component/ItemAttributeModifiers.java.patch
+++ b/patches/net/minecraft/world/item/component/ItemAttributeModifiers.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/item/component/ItemAttributeModifiers.java
++++ b/net/minecraft/world/item/component/ItemAttributeModifiers.java
+@@ -38,7 +_,7 @@
+     public static final Codec<ItemAttributeModifiers> CODEC = ItemAttributeModifiers.Entry.CODEC
+         .listOf()
+         .xmap(ItemAttributeModifiers::new, ItemAttributeModifiers::modifiers);
+-    public static final StreamCodec<RegistryFriendlyByteBuf, ItemAttributeModifiers> STREAM_CODEC = StreamCodec.composite(
++    public static final StreamCodec<RegistryFriendlyByteBuf, ItemAttributeModifiers> STREAM_CODEC = net.neoforged.neoforge.common.CommonHooks.makeItemAttributesStreamCodec(
+         ItemAttributeModifiers.Entry.STREAM_CODEC.apply(ByteBufCodecs.list()), ItemAttributeModifiers::modifiers, ItemAttributeModifiers::new
+     );
+     public static final DecimalFormat ATTRIBUTE_MODIFIER_FORMAT = new DecimalFormat("#.##", DecimalFormatSymbols.getInstance(Locale.ROOT));

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1898,8 +1898,13 @@ public class CommonHooks {
             public void encode(RegistryFriendlyByteBuf output, ItemAttributeModifiers value) {
                 List<ItemAttributeModifiers.Entry> modifiers = entryGetter.apply(value);
                 if (output.getConnectionType().isOther()) {
-                    modifiers = new ArrayList<>(modifiers);
-                    modifiers.removeIf(entry -> !entry.attribute().getKey().identifier().getNamespace().equals(Identifier.DEFAULT_NAMESPACE));
+                    List<ItemAttributeModifiers.Entry> filteredModifiers = new ArrayList<>(modifiers.size());
+                    for (ItemAttributeModifiers.Entry entry : modifiers) {
+                        if (entry.attribute().getKey().identifier().getNamespace().equals(Identifier.DEFAULT_NAMESPACE)) {
+                            filteredModifiers.add(entry);
+                        }
+                    }
+                    modifiers = filteredModifiers;
                 }
                 entriesStreamCodec.encode(output, modifiers);
             }

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -1883,4 +1883,26 @@ public class CommonHooks {
             throw new IllegalArgumentException(sb.toString());
         }
     }
+
+    public static StreamCodec<RegistryFriendlyByteBuf, ItemAttributeModifiers> makeItemAttributesStreamCodec(
+            StreamCodec<RegistryFriendlyByteBuf, List<ItemAttributeModifiers.Entry>> entriesStreamCodec,
+            Function<ItemAttributeModifiers, List<ItemAttributeModifiers.Entry>> entryGetter,
+            Function<List<ItemAttributeModifiers.Entry>, ItemAttributeModifiers> constructor) {
+        return new StreamCodec<>() {
+            @Override
+            public ItemAttributeModifiers decode(RegistryFriendlyByteBuf input) {
+                return constructor.apply(entriesStreamCodec.decode(input));
+            }
+
+            @Override
+            public void encode(RegistryFriendlyByteBuf output, ItemAttributeModifiers value) {
+                List<ItemAttributeModifiers.Entry> modifiers = entryGetter.apply(value);
+                if (output.getConnectionType().isOther()) {
+                    modifiers = new ArrayList<>(modifiers);
+                    modifiers.removeIf(entry -> !entry.attribute().getKey().identifier().getNamespace().equals(Identifier.DEFAULT_NAMESPACE));
+                }
+                entriesStreamCodec.encode(output, modifiers);
+            }
+        };
+    }
 }

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -200,23 +200,26 @@ public class NeoForgeMod {
     private static final DeferredHolder<ArgumentTypeInfo<?, ?>, SingletonArgumentInfo<ModIdArgument>> MODID_COMMAND_ARGUMENT_TYPE = COMMAND_ARGUMENT_TYPES.register("modid", () -> ArgumentTypeInfos.registerByClass(ModIdArgument.class,
             SingletonArgumentInfo.contextFree(ModIdArgument::modIdArgument)));
 
+    /// If the server is intended to be vanilla-compatible then this attribute must not be applied via item attribute modifiers.
     public static final Holder<Attribute> SWIM_SPEED = ATTRIBUTES.register("swim_speed", () -> new PercentageAttribute("neoforge.swim_speed", 1.0D, 0.0D, 1024.0D).setSyncable(true));
 
-    /**
-     * This attribute controls if the player may use creative flight when not in creative mode.
-     * <p>
-     * This is a {@link BooleanAttribute}, and should only be modified using the standards established by that class.
-     * <p>
-     * To determine if a player may fly (either via game mode or attribute), use {@link IPlayerExtension#mayFly}
-     * <p>
-     * Game mode flight cannot be disabled via this attribute.
-     */
+    /// This attribute controls if the player may use creative flight when not in creative mode.
+    ///
+    /// This is a [BooleanAttribute], and should only be modified using the standards established by that class.
+    ///
+    /// To determine if a player may fly (either via game mode or attribute), use [IPlayerExtension#mayFly]
+    ///
+    /// Game mode flight cannot be disabled via this attribute.
+    ///
+    /// If the server is intended to be vanilla-compatible then this attribute must not be applied via item attribute modifiers.
     public static final Holder<Attribute> CREATIVE_FLIGHT = ATTRIBUTES.register("creative_flight", () -> new BooleanAttribute("neoforge.creative_flight", false).setSyncable(true));
 
     /// This attribute controls if an entity may use gliding flight (elytra).
     /// The [`glider` data component][net.minecraft.core.component.DataComponents#GLIDER] is modified to use this attribute.
     ///
     /// This is a [BooleanAttribute], and should only be modified using the standards established by that class.
+    ///
+    /// If the server is intended to be vanilla-compatible then this attribute must not be applied via item attribute modifiers.
     public static final Holder<Attribute> GLIDING_FLIGHT = ATTRIBUTES.register("gliding_flight", () -> new BooleanAttribute("neoforge.gliding_flight", false).setSyncable(true));
 
     /**


### PR DESCRIPTION
This PR adds filtering to the `ItemAttributeModifiers` stream codec to prevent modded attributes from being sent to non-NeoForge clients. This is very similar to what `VanillaConnectionNetworkFilter` already does for `ClientboundUpdateAttributesPacket`.

It is important to note that this PR only ensures that receiving an item with an unknown attribute as part of the entity data does not lock the player out of the server, requiring manual save file editing to resolve. It does not solve disconnects in scenarios where the stream codec is "bypassed" such as the `Gave N X to Y` message of the `/give` command broadcasted to OPs (the itemstack display name in that message contains a `HoverEvent.ShowItem` which contains a stack template serialized by a DFU codec which the client will fail to deserialize).

Fixes #3266