### PR TITLE
[26.2] Add support for inline models to conditional model loader

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/model/ConditionalModelLoader.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/ConditionalModelLoader.java
@@ -7,8 +7,10 @@ package net.neoforged.neoforge.client.model;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
 import com.mojang.serialization.JsonOps;
 import java.io.IOException;
 import java.io.Reader;
@@ -35,6 +37,8 @@ import net.neoforged.neoforge.common.conditions.ICondition;
 public final class ConditionalModelLoader implements UnbakedModelLoader<UnbakedModel> {
     public static final Identifier ID = Identifier.fromNamespaceAndPath(NeoForgeMod.MOD_ID, "conditional");
     public static final ConditionalModelLoader INSTANCE = new ConditionalModelLoader();
+    public static final String INLINE_KEY = "model";
+    public static final String FALLBACK_KEY = "fallback";
     private static final FileToIdConverter MODEL_LISTER = FileToIdConverter.json("models");
 
     private ConditionalModelLoader() {}
@@ -46,11 +50,21 @@ public final class ConditionalModelLoader implements UnbakedModelLoader<UnbakedM
                 err -> new JsonParseException("Failed to parse conditions: " + err)).getFirst();
 
         if (conditions.stream().allMatch(cond -> cond.test(ICondition.IContext.EMPTY))) {
+            if (json.has(INLINE_KEY)) {
+                return GsonHelper.getAsObject(json, INLINE_KEY, ctx, UnbakedModel.class);
+            }
+
             json.remove("loader");
             return ctx.deserialize(json, CuboidModel.class);
         }
 
-        Identifier fallback = Identifier.parse(GsonHelper.getAsString(json, "fallback"));
+        JsonElement fallbackElem = GsonHelper.getNonNull(json, FALLBACK_KEY);
+        if (fallbackElem.isJsonObject()) {
+            return ctx.deserialize(fallbackElem, UnbakedModel.class);
+        } else if (!fallbackElem.isJsonPrimitive()) {
+            throw new JsonSyntaxException("Expected fallback to be a string or JsonObject, was " + GsonHelper.getType(fallbackElem));
+        }
+        Identifier fallback = Identifier.parse(GsonHelper.getAsString(json, FALLBACK_KEY));
         // Missing model must be special-cased as it's a "synthetic" model and cannot be loaded from a file
         if (fallback.equals(MissingCuboidModel.LOCATION)) {
             return MissingCuboidModel.missingModel();

--- a/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
@@ -41,7 +41,7 @@ public final class ConditionalModelBuilder extends CustomLoaderBuilder {
         return this;
     }
 
-    /// Specify the model to use when all conditions succeed as a nested object.
+    /// Specify the model to use when all conditions succeed, as a nested object.
     ///
     /// This is intended to be used when the guarded model uses yet another model loader.
     /// Models which do not need another loader should instead specify their elements/textures/etc.
@@ -50,23 +50,29 @@ public final class ConditionalModelBuilder extends CustomLoaderBuilder {
     /// @param template The template to generate the model from
     /// @param textures The texture mapping to generate the model with
     public ConditionalModelBuilder setInlineModel(ModelTemplate template, TextureMapping textures) {
+        Preconditions.checkNotNull(template, "Template must not be null");
+        Preconditions.checkNotNull(textures, "Textures must not be null");
         this.inlineModel = new InlineModel(template, textures);
         return this;
     }
 
-    /// Specify the model to fall back to when any condition fails as a reference to another file.
+    /// Specify the model to fall back to when any condition fails, as a reference to another file.
     ///
     /// @param fallback The fallback model
+    ///                 
+    /// @see #setInlineFallback(ModelTemplate, TextureMapping)
     public ConditionalModelBuilder setFallback(Identifier fallback) {
         Preconditions.checkNotNull(fallback, "Fallback must not be null");
         this.fallback = Either.left(fallback);
         return this;
     }
 
-    /// Specify the model to fall back to when any condition fails inlined into this model.
+    /// Specify the model to fall back to when any condition fails, inlined into this model.
     ///
     /// @param template The template to generate the fallback model from
     /// @param textures The texture mapping to generate the fallback model with
+    ///
+    /// @see #setFallback(Identifier)
     public ConditionalModelBuilder setInlineFallback(ModelTemplate template, TextureMapping textures) {
         Preconditions.checkNotNull(template, "Template must not be null");
         Preconditions.checkNotNull(textures, "Textures must not be null");

--- a/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
@@ -7,20 +7,26 @@ package net.neoforged.neoforge.client.model.generators.loaders;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.JsonOps;
 import java.util.ArrayList;
 import java.util.List;
+import net.minecraft.client.data.models.model.ModelTemplate;
+import net.minecraft.client.data.models.model.TextureMapping;
 import net.minecraft.client.resources.model.cuboid.MissingCuboidModel;
 import net.minecraft.resources.Identifier;
 import net.neoforged.neoforge.client.model.ConditionalModelLoader;
 import net.neoforged.neoforge.client.model.generators.template.CustomLoaderBuilder;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
 import net.neoforged.neoforge.common.conditions.ICondition;
+import org.jspecify.annotations.Nullable;
 
 /// @see ConditionalModelLoader
 public final class ConditionalModelBuilder extends CustomLoaderBuilder {
     private final List<ICondition> conditions = new ArrayList<>();
-    private Identifier fallback = MissingCuboidModel.LOCATION;
+    @Nullable
+    private InlineModel inlineModel = null;
+    private Either<Identifier, InlineModel> fallback = Either.left(MissingCuboidModel.LOCATION);
 
     public ConditionalModelBuilder() {
         super(ConditionalModelLoader.ID, true);
@@ -35,12 +41,35 @@ public final class ConditionalModelBuilder extends CustomLoaderBuilder {
         return this;
     }
 
-    /// Specify the model to fall back to when any condition fails.
+    /// Specify the model to use when all conditions succeed as a nested object.
+    ///
+    /// This is intended to be used when the guarded model uses yet another model loader.
+    /// Models which do not need another loader should instead specify their elements/textures/etc.
+    /// on the model template this builder is attached to.
+    ///
+    /// @param template The template to generate the model from
+    /// @param textures The texture mapping to generate the model with
+    public ConditionalModelBuilder setInlineModel(ModelTemplate template, TextureMapping textures) {
+        this.inlineModel = new InlineModel(template, textures);
+        return this;
+    }
+
+    /// Specify the model to fall back to when any condition fails as a reference to another file.
     ///
     /// @param fallback The fallback model
     public ConditionalModelBuilder setFallback(Identifier fallback) {
         Preconditions.checkNotNull(fallback, "Fallback must not be null");
-        this.fallback = fallback;
+        this.fallback = Either.left(fallback);
+        return this;
+    }
+
+    /// Specify the model to fall back to when any condition fails inlined into this model.
+    ///
+    /// @param template The template to generate the fallback model from
+    /// @param textures The texture mapping to generate the fallback model with
+    public ConditionalModelBuilder setInlineFallback(ModelTemplate template, TextureMapping textures) {
+        Preconditions.checkNotNull(fallback, "Fallback must not be null");
+        this.fallback = Either.right(new InlineModel(template, textures));
         return this;
     }
 
@@ -56,9 +85,16 @@ public final class ConditionalModelBuilder extends CustomLoaderBuilder {
     public JsonObject toJson(JsonObject json) {
         Preconditions.checkState(!conditions.isEmpty(), "No conditions specified");
 
-        json = super.toJson(json);
-        json.add(ConditionalOps.DEFAULT_CONDITIONS_KEY, ICondition.LIST_CODEC.encodeStart(JsonOps.INSTANCE, conditions).getOrThrow());
-        json.addProperty("fallback", fallback.toString());
-        return json;
+        JsonObject jsonObj = super.toJson(json);
+        jsonObj.add(ConditionalOps.DEFAULT_CONDITIONS_KEY, ICondition.LIST_CODEC.encodeStart(JsonOps.INSTANCE, conditions).getOrThrow());
+        if (inlineModel != null) {
+            serializeNestedTemplate(inlineModel.template, inlineModel.textures, inlineJson -> jsonObj.add(ConditionalModelLoader.INLINE_KEY, inlineJson));
+        }
+        fallback.ifLeft(id -> jsonObj.addProperty(ConditionalModelLoader.FALLBACK_KEY, id.toString()))
+                .ifRight(inline -> serializeNestedTemplate(
+                        inline.template, inline.textures, inlineJson -> jsonObj.add(ConditionalModelLoader.FALLBACK_KEY, inlineJson)));
+        return jsonObj;
     }
+
+    private record InlineModel(ModelTemplate template, TextureMapping textures) {}
 }

--- a/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
+++ b/src/client/java/net/neoforged/neoforge/client/model/generators/loaders/ConditionalModelBuilder.java
@@ -68,7 +68,8 @@ public final class ConditionalModelBuilder extends CustomLoaderBuilder {
     /// @param template The template to generate the fallback model from
     /// @param textures The texture mapping to generate the fallback model with
     public ConditionalModelBuilder setInlineFallback(ModelTemplate template, TextureMapping textures) {
-        Preconditions.checkNotNull(fallback, "Fallback must not be null");
+        Preconditions.checkNotNull(template, "Template must not be null");
+        Preconditions.checkNotNull(textures, "Textures must not be null");
         this.fallback = Either.right(new InlineModel(template, textures));
         return this;
     }


### PR DESCRIPTION
This PR expands the conditional model loader added in #3184 to support inlined "primary" and fallback models.
For the fallback model this is just a nice-to-have to avoid needing a second file. For the primary model this is required when the guarded model uses yet another model loader (i.e. a loader from an optional dependency which does not support being marked as optional).

A file specifying both models inline would look as follows:
```json5
{
  "loader": "neoforge:conditional",
  "neoforge:conditions": [
    {
      "type": "neoforge:mod_loaded",
      "modid": "othermod"
    }
  ],
  "model": {
    "loader": "othermod:fancy_loader",
    // loader-specific stuff
  },
  "fallback": {
    // vanilla model or other custom loader
  }
}
```

I intended to add this to the original PR but it was merged "too early" (at nobody's fault except my own).