### PR TITLE
fix RegisterSpawnPlacementsEvent conflicting on multiple mods attempting to register camel

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/entity/RegisterSpawnPlacementsEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/RegisterSpawnPlacementsEvent.java
@@ -77,9 +77,6 @@ public class RegisterSpawnPlacementsEvent extends Event implements IModBusEvent 
             }
             map.put(entityType, new MergedSpawnPredicate<>(predicate, placementType, heightmap));
         } else {
-            if (operation != Operation.REPLACE && (heightmap != null || placementType != null)) {
-                throw new IllegalStateException("Nonnull heightmap types or spawn placement types may only be used with the REPLACE operation. Entity Type: " + BuiltInRegistries.ENTITY_TYPE.getKey(entityType));
-            }
             ((MergedSpawnPredicate<T>) map.get(entityType)).merge(operation, predicate, placementType, heightmap);
         }
     }


### PR DESCRIPTION
Hello! i did some research while trying to figure out why NoMan'sLand x VanillaBackport crashed when both mods attempted to register the camel...

both mods attempt to register a vanilla entity that lacks a spawn placement, the camel.

NoMan'sLand does it the following way, which works as intended as it registers the vanilla placement and uses OR so it supports other conditions
```java
event.register(EntityType.CAMEL, SpawnPlacementTypes.ON_GROUND, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, Camel::checkAnimalSpawnRules, RegisterSpawnPlacementsEvent.Operation.OR);
```
however, when i attempt to register the camel, no matter what operation i use, it would trigger the following crash:
```
[19:27:09] [modloading-sync-worker/ERROR]: Caught exception during event net.neoforged.neoforge.event.entity.RegisterSpawnPlacementsEvent@3d1f1a22 dispatch for modid nomansland
java.lang.IllegalStateException: Nonnull heightmap types or spawn placement types may only be used with the REPLACE operation. Entity Type: minecraft:camel
```

it seems that the only way to get it to work is if both mods use REPLACE, leaving AND/OR unusable for this sort of context, additionally, the throw on attempting to replace an entity while providing non null `heightmap` and `placementType` seems redundant as they're completely ignored by the **merge** method:
```java
private void merge(Operation operation, SpawnPlacements.SpawnPredicate<T> predicate, @Nullable SpawnPlacementType spawnType, @Nullable Heightmap.Types heightmapType) {
      if (operation == Operation.AND) {
          andPredicates.add(predicate);
      } else if (operation == Operation.OR) {
          orPredicates.add(predicate);
      } else if (operation == Operation.REPLACE) {
          replacementPredicate = predicate;
          if (spawnType != null) {
              this.spawnType = spawnType;
          }
          if (heightmapType != null) {
              this.heightmapType = heightmapType;
          }
      }
  }
```
and after removing the throw, both mods are able to register the camel and coexist while also supporting the AND/OR operations
```java
public <T extends Entity> void register(EntityType<T> entityType, @Nullable SpawnPlacementType placementType, @Nullable Heightmap.Types heightmap, SpawnPlacements.SpawnPredicate<T> predicate, Operation operation) {
    if (!map.containsKey(entityType)) {
        if (placementType == null) {
            throw new NullPointerException("Registering a new Spawn Predicate requires a nonnull placement type! Entity Type: " + BuiltInRegistries.ENTITY_TYPE.getKey(entityType));
        }
        if (heightmap == null) {
            throw new NullPointerException("Registering a new Spawn Predicate requires a nonnull heightmap type! Entity Type: " + BuiltInRegistries.ENTITY_TYPE.getKey(entityType));
        }
        map.put(entityType, new MergedSpawnPredicate<>(predicate, placementType, heightmap));
    } else {
        // The throw condition here was punishing and redundant, placementType and heightmap are fully ignored if operation != Operation.REPLACE
        ((MergedSpawnPredicate<T>) map.get(entityType)).merge(operation, predicate, placementType, heightmap);
    }
}
```