### PR TITLE
Hotfix PlayerSwitchHotbarSlotEvent firing logic

### DIFF
--- a/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/patches/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -96,23 +96,27 @@
              ServerLevel level = this.player.level();
              InteractionHand hand = packet.getHand();
              ItemStack itemStack = this.player.getItemInHand(hand);
-@@ -1487,6 +_,9 @@
+@@ -1487,13 +_,24 @@
      @Override
      public void handleSetCarriedItem(ServerboundSetCarriedItemPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
 +
-+        if (net.neoforged.neoforge.event.EventHooks.onSwitchHotbarSlotPre(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot())) return;
++        if (this.player.getInventory().getSelectedSlot() != packet.getSlot()) {
++            if (net.neoforged.neoforge.event.EventHooks.onSwitchHotbarSlotPre(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot())) return;
++        }
 +
          if (packet.getSlot() >= 0 && packet.getSlot() < Inventory.getSelectionSize()) {
              if (this.player.getInventory().getSelectedSlot() != packet.getSlot() && this.player.getUsedItemHand() == InteractionHand.MAIN_HAND) {
                  this.player.stopUsingItem();
-@@ -1494,6 +_,10 @@
+             }
  
++            int cachedOldSlotIndex = this.player.getInventory().getSelectedSlot();
++
              this.player.getInventory().setSelectedSlot(packet.getSlot());
              this.player.resetLastActionTime();
 +
-+            if (this.player.getInventory().getSelectedSlot() != packet.getSlot()) {
-+                net.neoforged.neoforge.event.EventHooks.onSwitchHotbarSlotPost(this.player, this.player.getInventory().getSelectedSlot(), packet.getSlot());
++            if (cachedOldSlotIndex != packet.getSlot()) {
++                net.neoforged.neoforge.event.EventHooks.onSwitchHotbarSlotPost(this.player, cachedOldSlotIndex, packet.getSlot());
 +            }
          } else {
              LOGGER.warn("{} tried to set an invalid carried item", this.player.getPlainTextName());


### PR DESCRIPTION
Hotfixes two minor bugs of how `PlayerSwitchHotbarSlotEvent.Pre` and `PlayerSwitchHotbarSlotEvent.Post` are fired.
- `Pre` event firing: When a player joins a server (either built-in or third-party), `ServerGamePacketListenerImpl#handleSetCarriedItem()` is fired once to initialize the player data, where `this.player.getInventory().getSelectedSlot()` is identical to `packet.getSlot()`. In order to prevent the `Pre` event from being fired at this stage, we should also add an if statement guard.
- `Post` event firing: The `this.player.getInventory().setSelectedSlot(packet.getSlot())` statement directly reassigns the `int selected` field of `Inventory`, which makes the if statement below always false, and the `Post` event is never fired. Adding a cache should help.