### PR TITLE
Create new damage container when blocking a goat's attack

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -287,17 +287,18 @@
              if (source.getDirectEntity() instanceof AbstractArrow abstractArrow && abstractArrow.getPierceLevel() > 0) {
                  return 0.0F;
              } else {
-@@ -1334,7 +_,14 @@
+@@ -1334,7 +_,15 @@
                  }
  
                  float damageBlocked = blocksAttacks.resolveBlockedDamage(source, damage, angle);
 -                blocksAttacks.hurtBlockingItem(this.level(), blockingWith, this, this.getUsedItemHand(), damageBlocked);
 +
-+                var ev = net.neoforged.neoforge.common.CommonHooks.onDamageBlock(this, this.damageContainers.peek(), damageBlocked, !blocksAttacks.bypassedBy().map(t -> t.contains(source.typeHolder())).orElse(false));
++                var damageContainer = this.damageContainers.empty() ? new net.neoforged.neoforge.common.damagesource.DamageContainer(source, damage) : this.damageContainers.peek();
++                var ev = net.neoforged.neoforge.common.CommonHooks.onDamageBlock(this, damageContainer, damageBlocked, !blocksAttacks.bypassedBy().map(t -> t.contains(source.typeHolder())).orElse(false));
 +                if (!ev.getBlocked()) return 0.0F;
 +
 +                damageBlocked = ev.getBlockedDamage();
-+                this.damageContainers.peek().setBlockedDamage(ev);
++                damageContainer.setBlockedDamage(ev);
 +                blocksAttacks.hurtBlockingItem(this.level(), blockingWith, this, this.getUsedItemHand(), damageBlocked, ev.shieldDamage());
 +
                  if (damageBlocked > 0.0F && !source.is(DamageTypeTags.IS_PROJECTILE) && source.getDirectEntity() instanceof LivingEntity livingEntity) {


### PR DESCRIPTION
This PR fixes #2918 by modifying `LivingEntity#applyItemBlocking` to create a transient damage container when there is none, so `LivingShieldBlockEvent` still receives a valid one even if it is discarded after, as suggested by @Caltinor [in a Discord conversation](https://discord.com/channels/313125603924639766/852298000042164244/1492144981203488768).

`LivingEntity#applyItemBlocking` is called by `RamTarget`, at which point there is no damage container. This causes a game crash when `applyItemBlocking` tries to get the damage container.

This preserves the contract of the shield block event with an always non-null damage container, rather than making that event potentially be bereft of a damage container in certain cases.