### PR TITLE
Accept zero ticks of invulnerability in DamageContainer

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
+++ b/src/main/java/net/neoforged/neoforge/common/damagesource/DamageContainer.java
@@ -133,7 +133,7 @@ public class DamageContainer {
      * @param ticks Ticks of invulnerability after this damage sequence
      */
     public void setPostAttackInvulnerabilityTicks(int ticks) {
-        Preconditions.checkArgument(ticks > 0, "Ticks cannot be negative.");
+        Preconditions.checkArgument(ticks >= 0, "Ticks cannot be negative.");
         this.invulnerabilityTicksAfterAttack = ticks;
     }
 


### PR DESCRIPTION
This PR fixes #3348 by changing the precondition in `DamageContainer#setPostAttackInvulnerabilityTicks` to accept a zero value, which seems to be intended according to the message.