### PR TITLE
Remove EditBox filter functionality

### DIFF
--- a/patches/net/minecraft/client/gui/components/EditBox.java.patch
+++ b/patches/net/minecraft/client/gui/components/EditBox.java.patch
@@ -1,53 +1,13 @@
 --- a/net/minecraft/client/gui/components/EditBox.java
 +++ b/net/minecraft/client/gui/components/EditBox.java
-@@ -60,6 +_,7 @@
-     private long focusedTime = Util.getMillis();
-     private int textX;
-     private int textY;
-+    private java.util.function.Predicate<String> filter = _ -> true; // Neo: Add back text input filtering
- 
-     public EditBox(Font font, Component narration) {
-         this(font, 150, 20, narration);
-@@ -98,6 +_,8 @@
-     }
- 
-     public void setValue(String value) {
-+        if (!this.filter.test(value)) return; // Neo: Allow value filtering
-+
-         if (value.length() > this.maxLength) {
-             this.value = value.substring(0, this.maxLength);
-         } else {
-@@ -131,6 +_,14 @@
-         this.updateTextPosition();
-     }
- 
-+    /**
-+     * Sets a filter on the edit box that will only allow strings that pass the given predicate to be
-+     * inserted.
-+     */
-+    public void setFilter(java.util.function.Predicate<String> filter) {
-+        this.filter = filter;
-+    }
-+
-     public void insertText(String input) {
-         int start = Math.min(this.cursorPos, this.highlightPos);
-         int end = Math.max(this.cursorPos, this.highlightPos);
-@@ -147,6 +_,7 @@
-                 insertionLength = maxInsertionLength;
-             }
- 
-+            if (!filter.test(text)) return; // Neo: filter inputs
-             this.value = new StringBuilder(this.value).replace(start, end, text).toString();
-             this.setCursorPosition(start + insertionLength);
-             this.setHighlightPos(this.cursorPos);
-@@ -628,6 +_,10 @@
-     public void setHint(Component hint) {
-         boolean hasNoStyle = hint.getStyle().equals(Style.EMPTY);
+@@ -630,6 +_,10 @@
          this.hint = hasNoStyle ? hint.copy().withStyle(DEFAULT_HINT_STYLE) : hint;
-+    }
-+
+     }
+ 
 +    public boolean getTextShadow() {
 +        return this.textShadow;
-     }
- 
++    }
++
      @FunctionalInterface
+     public interface TextFormatter {
+         @Nullable FormattedCharSequence format(final String text, final int offset);

--- a/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
@@ -852,14 +852,6 @@ public final class ConfigurationScreen extends OptionsSubScreen {
 
             final EditBox box = new EditBox(font, Button.DEFAULT_WIDTH, Button.DEFAULT_HEIGHT, getTranslationComponent(key));
             box.setEditable(true);
-            box.setFilter(newValueString -> {
-                try {
-                    parser.apply(newValueString);
-                    return true;
-                } catch (final NumberFormatException e) {
-                    return isPartialNumber(newValueString, (range == null || range.getMin().compareTo(zero) < 0));
-                }
-            });
             box.setTooltip(Tooltip.create(getTooltipComponent(key, range)));
             box.setValue(source.get() + "");
             box.setResponder(newValueString -> {
@@ -884,23 +876,6 @@ public final class ConfigurationScreen extends OptionsSubScreen {
                 box.setTextColor(0xFFFF0000);
             });
             return new Element(getTranslationComponent(key), getTooltipComponent(key, null), box);
-        }
-
-        protected boolean isPartialNumber(String value, boolean allowNegative) {
-            return switch (value) {
-                case "" -> true;
-                case "0" -> true;
-                case "0x" -> true;
-                case "0X" -> true;
-                case "#" -> true; // not valid for doubles, but not worth making a special case
-                case "-" -> allowNegative;
-                case "-0" -> allowNegative;
-                case "-0x" -> allowNegative;
-                case "-0X" -> allowNegative;
-                // case "-#" -> allowNegative; // Java allows this, but no thanks, that's just cursed.
-                // doubles can also do NaN, inf, and 0e0. Again, not worth making a special case for those, I say.
-                default -> false;
-            };
         }
 
         @Nullable


### PR DESCRIPTION
This PR fixes #3262 by removing the filter functionality from `EditBox`, which is then correspondingly removed from `ConfigurationScreen`.

Minecraft used to provide this functionality in 26.1, before it was removed in 26.1. During porting, it was reintroduced, probably because our `ConfigurationScreen` depended on it. There are two reasons for removing this now rather than keeping this indefinitely.

First, it is more proper for mods to gracefully handle invalid values, such as through showing an error, and/or disabling any associated action. This avoids the inputs of the user seemingly being 'disregaded' (which may be considered bad user experience).

Second, the current implementation has a bug because when text is being inserted, the filter only receives the inserted text rather than the full modified text (that would be stored if the filter allows it through).

I was considering fixing that bug alone, but it comes with the extra consideration of what to do if the text box is resized on the fly, causing the value to be truncated and thus being invalid. Perhaps the answer would be to empty the text box, but that could also be an invalid value according to the filter.

It is better to pass the responsibility of validating the value (and perhaps reverting it to the previous valid value) to the user of `EditBox`.