### PR TITLE
Override context-aware getPlaceSound in SolidBucketItem

### DIFF
--- a/patches/net/minecraft/world/item/SolidBucketItem.java.patch
+++ b/patches/net/minecraft/world/item/SolidBucketItem.java.patch
@@ -1,0 +1,14 @@
+--- a/net/minecraft/world/item/SolidBucketItem.java
++++ b/net/minecraft/world/item/SolidBucketItem.java
+@@ -39,6 +_,11 @@
+     }
+ 
+     @Override
++    protected SoundEvent getPlaceSound(BlockState state, Level level, BlockPos pos, Player entity) {
++        return this.getPlaceSound(state);
++    }
++
++    @Override
+     public boolean emptyContents(@Nullable LivingEntity user, Level level, BlockPos pos, @Nullable BlockHitResult hitResult) {
+         if (level.isInWorldBounds(pos) && level.isEmptyBlock(pos)) {
+             if (!level.isClientSide()) {


### PR DESCRIPTION
This PR fixes #3372 by overriding the NeoForge-added context-aware `getPlaceSound` method in `SolidBucketItem`.

Tested by placing a powder snow bucket with captions enabled, and (a) hearing a bucket emptying sound and (b) seeing `Bucket empties` as the caption.