### PR TITLE
Rename config types

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
 # For PR testing
-fancy_mod_loader_version=11.0.18-pr-436-configrename
+fancy_mod_loader_version=11.0.19-pr-436-configrename
 typetools_version=0.6.3
 mixin_extras_version=0.5.4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,8 @@ nightconfig_version=3.8.3
 jetbrains_annotations_version=24.0.1
 apache_maven_artifact_version=3.9.9
 jarjar_version=0.4.1
-fancy_mod_loader_version=11.0.13
+# For PR testing
+fancy_mod_loader_version=11.0.18-pr-436-configrename
 typetools_version=0.6.3
 mixin_extras_version=0.5.4
 

--- a/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -34,7 +34,7 @@
  
          this.saveEverything(false, true, true);
          this.notificationManager().serverStarted();
-+        if (net.neoforged.neoforge.common.config.NeoForgeServerConfig.INSTANCE.advertiseDedicatedServerToLan.get()) {
++        if (net.neoforged.neoforge.common.config.NeoForgeSyncedConfig.INSTANCE.advertiseDedicatedServerToLan.get()) {
 +            this.dediLanPinger = new net.neoforged.neoforge.server.dedicated.DedicatedLanServerPinger(this.getMotd(), String.valueOf(this.getServerPort()));
 +            this.dediLanPinger.start();
 +        }

--- a/patches/net/minecraft/world/level/Level.java.patch
+++ b/patches/net/minecraft/world/level/Level.java.patch
@@ -112,7 +112,7 @@
              CrashReport report = CrashReport.forThrowable(t, "Ticking entity");
              CrashReportCategory category = report.addCategory("Entity being ticked");
              entity.fillCrashReportCategory(category);
-+            if (net.neoforged.neoforge.common.config.NeoForgeServerConfig.INSTANCE.removeErroringEntities.get()) {
++            if (net.neoforged.neoforge.common.config.NeoForgeSyncedConfig.INSTANCE.removeErroringEntities.get()) {
 +                com.mojang.logging.LogUtils.getLogger().error("{}", report.getFriendlyReport(net.minecraft.ReportType.CRASH));
 +                entity.discard();
 +            } else

--- a/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
+++ b/patches/net/minecraft/world/level/chunk/LevelChunk.java.patch
@@ -143,7 +143,7 @@
                          CrashReport report = CrashReport.forThrowable(t, "Ticking block entity");
                          CrashReportCategory category = report.addCategory("Block entity being ticked");
                          this.blockEntity.fillCrashReportCategory(category);
-+                        if (net.neoforged.neoforge.common.config.NeoForgeServerConfig.INSTANCE.removeErroringBlockEntities.get()) {
++                        if (net.neoforged.neoforge.common.config.NeoForgeSyncedConfig.INSTANCE.removeErroringBlockEntities.get()) {
 +                            LOGGER.error("{}", report.getFriendlyReport(net.minecraft.ReportType.CRASH));
 +                            blockEntity.setRemoved();
 +                            LevelChunk.this.removeBlockEntity(blockEntity.getBlockPos());

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,16 @@ dependencyResolutionManagement {
     rulesMode = RulesMode.FAIL_ON_PROJECT_RULES
     repositories {
         mavenCentral()
+        // For PR testing
+        maven {
+            name = "Maven for PR #436" // https://github.com/neoforged/FancyModLoader/pull/436
+            url = uri("https://prmaven.neoforged.net/FancyModLoader/pr436")
+            content {
+                includeModule("net.neoforged.fancymodloader", "earlydisplay")
+                includeModule("net.neoforged.fancymodloader", "junit-fml")
+                includeModule("net.neoforged.fancymodloader", "loader")
+            }
+        }
     }
 }
 

--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -115,9 +115,9 @@ public class ClientNeoForgeMod {
                 }
             });
 
-            // Unload SERVER configs only when disconnecting from a remote server
+            // Unload SHARED configs only when disconnecting from a remote server
             if (event.getConnection() != null && !event.getConnection().isMemoryConnection()) {
-                ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SERVER);
+                ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SHARED);
             }
         });
 

--- a/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientNeoForgeMod.java
@@ -115,9 +115,9 @@ public class ClientNeoForgeMod {
                 }
             });
 
-            // Unload SHARED configs only when disconnecting from a remote server
+            // Unload SYNCED configs only when disconnecting from a remote server
             if (event.getConnection() != null && !event.getConnection().isMemoryConnection()) {
-                ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SHARED);
+                ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SYNCED);
             }
         });
 

--- a/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
@@ -96,7 +96,7 @@ import org.lwjgl.glfw.GLFW;
  * In any case, register your configuration screen in your client mod class like this:
  * 
  * {@snippet :
- * @Mod(value = "examplemod", dist = Dist.CLIENT)
+ * &#64;Mod(value = "examplemod", dist = Dist.CLIENT)
  * public class ExampleMod {
  *     public ExampleMod(ModContainer container) {
  *         container.registerExtensionPoint(IConfigScreenFactory.class, (mc, parent) -> new ConfigurationScreen(container, parent));

--- a/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
@@ -96,7 +96,7 @@ import org.lwjgl.glfw.GLFW;
  * In any case, register your configuration screen in your client mod class like this:
  * 
  * {@snippet :
- * &#64;Mod(value = "examplemod", dist = Dist.CLIENT)
+ * @Mod(value = "examplemod", dist = Dist.CLIENT)
  * public class ExampleMod {
  *     public ExampleMod(ModContainer container) {
  *         container.registerExtensionPoint(IConfigScreenFactory.class, (mc, parent) -> new ConfigurationScreen(container, parent));
@@ -291,11 +291,11 @@ public final class ConfigurationScreen extends OptionsSubScreen {
                         tooltip.append(TOOLTIP_CANNOT_EDIT_NOT_LOADED).append(EMPTY_LINE);
                         btn.active = false;
                         count = 99; // prevent autoClose
-                    } else if (type == Type.SERVER && minecraft.getCurrentServer() != null && (!minecraft.hasSingleplayerServer() || !minecraft.getSingleplayerServer().isPublished())) {
+                    } else if (type == Type.SHARED && minecraft.getCurrentServer() != null && (!minecraft.hasSingleplayerServer() || !minecraft.getSingleplayerServer().isPublished())) {
                         tooltip.append(TOOLTIP_CANNOT_EDIT_THIS_WHILE_ONLINE).append(EMPTY_LINE);
                         btn.active = false;
                         count = 99; // prevent autoClose
-                    } else if (type == Type.SERVER && minecraft.hasSingleplayerServer() && minecraft.getSingleplayerServer().isPublished()) {
+                    } else if (type == Type.SHARED && minecraft.hasSingleplayerServer() && minecraft.getSingleplayerServer().isPublished()) {
                         tooltip.append(TOOLTIP_CANNOT_EDIT_THIS_WHILE_OPEN_TO_LAN).append(EMPTY_LINE);
                         btn.active = false;
                         count = 99; // prevent autoClose

--- a/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/ConfigurationScreen.java
@@ -291,11 +291,11 @@ public final class ConfigurationScreen extends OptionsSubScreen {
                         tooltip.append(TOOLTIP_CANNOT_EDIT_NOT_LOADED).append(EMPTY_LINE);
                         btn.active = false;
                         count = 99; // prevent autoClose
-                    } else if (type == Type.SHARED && minecraft.getCurrentServer() != null && (!minecraft.hasSingleplayerServer() || !minecraft.getSingleplayerServer().isPublished())) {
+                    } else if (type == Type.SYNCED && minecraft.getCurrentServer() != null && (!minecraft.hasSingleplayerServer() || !minecraft.getSingleplayerServer().isPublished())) {
                         tooltip.append(TOOLTIP_CANNOT_EDIT_THIS_WHILE_ONLINE).append(EMPTY_LINE);
                         btn.active = false;
                         count = 99; // prevent autoClose
-                    } else if (type == Type.SHARED && minecraft.hasSingleplayerServer() && minecraft.getSingleplayerServer().isPublished()) {
+                    } else if (type == Type.SYNCED && minecraft.hasSingleplayerServer() && minecraft.getSingleplayerServer().isPublished()) {
                         tooltip.append(TOOLTIP_CANNOT_EDIT_THIS_WHILE_OPEN_TO_LAN).append(EMPTY_LINE);
                         btn.active = false;
                         count = 99; // prevent autoClose

--- a/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
@@ -251,7 +251,7 @@ public final class ClientNetworkRegistry extends NetworkRegistry {
         }
 
         // We are on the client, connected to a vanilla server, We have to load the default configs.
-        ConfigTracker.INSTANCE.loadDefaultSharedConfigs();
+        ConfigTracker.INSTANCE.loadDefaultSyncedConfigs();
 
         NetworkFilters.injectIfNecessary(listener.getConnection());
 

--- a/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
@@ -251,7 +251,7 @@ public final class ClientNetworkRegistry extends NetworkRegistry {
         }
 
         // We are on the client, connected to a vanilla server, We have to load the default configs.
-        ConfigTracker.INSTANCE.loadDefaultServerConfigs();
+        ConfigTracker.INSTANCE.loadDefaultSharedConfigs();
 
         NetworkFilters.injectIfNecessary(listener.getConnection());
 

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -174,7 +174,7 @@ import net.neoforged.fml.i18n.MavenVersionTranslator;
 import net.neoforged.fml.loading.toposort.CyclePresentException;
 import net.neoforged.fml.loading.toposort.TopologicalSort;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
-import net.neoforged.neoforge.common.config.NeoForgeSharedConfig;
+import net.neoforged.neoforge.common.config.NeoForgeSyncedConfig;
 import net.neoforged.neoforge.common.damagesource.DamageContainer;
 import net.neoforged.neoforge.common.extensions.IBlockExtension;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
@@ -409,7 +409,7 @@ public class CommonHooks {
         boolean isSpectator = (entity instanceof Player && entity.isSpectator());
         if (isSpectator)
             return Optional.empty();
-        if (!NeoForgeSharedConfig.INSTANCE.fullBoundingBoxLadders.get()) {
+        if (!NeoForgeSyncedConfig.INSTANCE.fullBoundingBoxLadders.get()) {
             return state.isLadder(level, pos, entity) ? Optional.of(pos) : Optional.empty();
         } else {
             AABB bb = entity.getBoundingBox();

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -174,7 +174,7 @@ import net.neoforged.fml.i18n.MavenVersionTranslator;
 import net.neoforged.fml.loading.toposort.CyclePresentException;
 import net.neoforged.fml.loading.toposort.TopologicalSort;
 import net.neoforged.neoforge.common.conditions.ConditionalOps;
-import net.neoforged.neoforge.common.config.NeoForgeServerConfig;
+import net.neoforged.neoforge.common.config.NeoForgeSharedConfig;
 import net.neoforged.neoforge.common.damagesource.DamageContainer;
 import net.neoforged.neoforge.common.extensions.IBlockExtension;
 import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
@@ -409,7 +409,7 @@ public class CommonHooks {
         boolean isSpectator = (entity instanceof Player && entity.isSpectator());
         if (isSpectator)
             return Optional.empty();
-        if (!NeoForgeServerConfig.INSTANCE.fullBoundingBoxLadders.get()) {
+        if (!NeoForgeSharedConfig.INSTANCE.fullBoundingBoxLadders.get()) {
             return state.isLadder(level, pos, entity) ? Optional.of(pos) : Optional.empty();
         } else {
             AABB bb = entity.getBoundingBox();

--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -1397,9 +1397,9 @@ public class ModConfigSpec implements IConfigSpec {
         /**
          * Require a game restart.
          * <p>
-         * Cannot be used for {@linkplain ModConfig.Type#SERVER server configs}.
+         * Cannot be used for {@linkplain ModConfig.Type#SHARED server configs}.
          */
-        GAME(ModConfig.Type.SERVER);
+        GAME(ModConfig.Type.SHARED);
 
         private final Set<ModConfig.Type> invalidTypes;
 

--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -1397,9 +1397,9 @@ public class ModConfigSpec implements IConfigSpec {
         /**
          * Require a game restart.
          * <p>
-         * Cannot be used for {@linkplain ModConfig.Type#SHARED server configs}.
+         * Cannot be used for {@linkplain ModConfig.Type#SYNCED server configs}.
          */
-        GAME(ModConfig.Type.SHARED);
+        GAME(ModConfig.Type.SYNCED);
 
         private final Set<ModConfig.Type> invalidTypes;
 

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -595,8 +595,8 @@ public class NeoForgeMod {
         ENVIRONMENT_ATTRIBUTES.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
         ConfigSync.registerEventListeners();
-        container.registerConfig(ModConfig.Type.SHARED, NeoForgeSyncedConfig.SPEC);
-        container.registerConfig(ModConfig.Type.STANDARD, NeoForgeLocalConfig.SPEC);
+        container.registerConfig(ModConfig.Type.SYNCED, NeoForgeSyncedConfig.SPEC);
+        container.registerConfig(ModConfig.Type.LOCAL, NeoForgeLocalConfig.SPEC);
         NeoForgeRegistriesSetup.setup(modEventBus);
         StartupNotificationManager.addModMessage("NeoForge version " + NeoForgeVersion.getVersion());
 

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -105,8 +105,8 @@ import net.neoforged.neoforge.common.conditions.NotCondition;
 import net.neoforged.neoforge.common.conditions.OrCondition;
 import net.neoforged.neoforge.common.conditions.RegisteredCondition;
 import net.neoforged.neoforge.common.conditions.TagEmptyCondition;
-import net.neoforged.neoforge.common.config.NeoForgeStandardConfig;
-import net.neoforged.neoforge.common.config.NeoForgeSharedConfig;
+import net.neoforged.neoforge.common.config.NeoForgeLocalConfig;
+import net.neoforged.neoforge.common.config.NeoForgeSyncedConfig;
 import net.neoforged.neoforge.common.crafting.BlockTagIngredient;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.CustomDisplayIngredient;
@@ -595,8 +595,8 @@ public class NeoForgeMod {
         ENVIRONMENT_ATTRIBUTES.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
         ConfigSync.registerEventListeners();
-        container.registerConfig(ModConfig.Type.SHARED, NeoForgeSharedConfig.SPEC);
-        container.registerConfig(ModConfig.Type.STANDARD, NeoForgeStandardConfig.SPEC);
+        container.registerConfig(ModConfig.Type.SHARED, NeoForgeSyncedConfig.SPEC);
+        container.registerConfig(ModConfig.Type.STANDARD, NeoForgeLocalConfig.SPEC);
         NeoForgeRegistriesSetup.setup(modEventBus);
         StartupNotificationManager.addModMessage("NeoForge version " + NeoForgeVersion.getVersion());
 

--- a/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
+++ b/src/main/java/net/neoforged/neoforge/common/NeoForgeMod.java
@@ -105,8 +105,8 @@ import net.neoforged.neoforge.common.conditions.NotCondition;
 import net.neoforged.neoforge.common.conditions.OrCondition;
 import net.neoforged.neoforge.common.conditions.RegisteredCondition;
 import net.neoforged.neoforge.common.conditions.TagEmptyCondition;
-import net.neoforged.neoforge.common.config.NeoForgeCommonConfig;
-import net.neoforged.neoforge.common.config.NeoForgeServerConfig;
+import net.neoforged.neoforge.common.config.NeoForgeStandardConfig;
+import net.neoforged.neoforge.common.config.NeoForgeSharedConfig;
 import net.neoforged.neoforge.common.crafting.BlockTagIngredient;
 import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.CustomDisplayIngredient;
@@ -595,8 +595,8 @@ public class NeoForgeMod {
         ENVIRONMENT_ATTRIBUTES.register(modEventBus);
         NeoForge.EVENT_BUS.addListener(this::serverStopping);
         ConfigSync.registerEventListeners();
-        container.registerConfig(ModConfig.Type.SERVER, NeoForgeServerConfig.SPEC);
-        container.registerConfig(ModConfig.Type.COMMON, NeoForgeCommonConfig.SPEC);
+        container.registerConfig(ModConfig.Type.SHARED, NeoForgeSharedConfig.SPEC);
+        container.registerConfig(ModConfig.Type.STANDARD, NeoForgeStandardConfig.SPEC);
         NeoForgeRegistriesSetup.setup(modEventBus);
         StartupNotificationManager.addModMessage("NeoForge version " + NeoForgeVersion.getVersion());
 

--- a/src/main/java/net/neoforged/neoforge/common/config/NeoForgeLocalConfig.java
+++ b/src/main/java/net/neoforged/neoforge/common/config/NeoForgeLocalConfig.java
@@ -12,14 +12,14 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * General configuration that doesn't need to be synchronized but needs to be available before server startup
  */
-public final class NeoForgeStandardConfig {
+public final class NeoForgeLocalConfig {
     @ApiStatus.Internal
     public static final ModConfigSpec SPEC;
-    public static final NeoForgeStandardConfig INSTANCE;
+    public static final NeoForgeLocalConfig INSTANCE;
 
     public final ModConfigSpec.BooleanValue attributeAdvancedTooltipDebugInfo;
 
-    private NeoForgeStandardConfig(ModConfigSpec.Builder builder) {
+    private NeoForgeLocalConfig(ModConfigSpec.Builder builder) {
         attributeAdvancedTooltipDebugInfo = builder
                 .comment("Set this to true to enable showing debug information about attributes on an item when advanced tooltips is on.")
                 .translation("neoforge.configgui.attributeAdvancedTooltipDebugInfo")
@@ -27,7 +27,7 @@ public final class NeoForgeStandardConfig {
     }
 
     static {
-        final Pair<NeoForgeStandardConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeStandardConfig::new);
+        final Pair<NeoForgeLocalConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeLocalConfig::new);
         SPEC = specPair.getRight();
         INSTANCE = specPair.getLeft();
     }

--- a/src/main/java/net/neoforged/neoforge/common/config/NeoForgeSharedConfig.java
+++ b/src/main/java/net/neoforged/neoforge/common/config/NeoForgeSharedConfig.java
@@ -13,10 +13,10 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * General configuration that needs to be synchronized to the server and/or is desirable to be configurable per world
  */
-public final class NeoForgeServerConfig {
+public final class NeoForgeSharedConfig {
     @ApiStatus.Internal
     public static final ModConfigSpec SPEC;
-    public static final NeoForgeServerConfig INSTANCE;
+    public static final NeoForgeSharedConfig INSTANCE;
 
     public final ModConfigSpec.BooleanValue removeErroringBlockEntities;
 
@@ -28,7 +28,7 @@ public final class NeoForgeServerConfig {
 
     public final ModConfigSpec.BooleanValue advertiseDedicatedServerToLan;
 
-    private NeoForgeServerConfig(ModConfigSpec.Builder builder) {
+    private NeoForgeSharedConfig(ModConfigSpec.Builder builder) {
         removeErroringBlockEntities = builder
                 .comment("Set this to true to remove any BlockEntity that throws an error in its update method instead of closing the server and reporting a crash log. BE WARNED THIS COULD SCREW UP EVERYTHING USE SPARINGLY WE ARE NOT RESPONSIBLE FOR DAMAGES.")
                 .translation("neoforge.configgui.removeErroringBlockEntities")
@@ -59,7 +59,7 @@ public final class NeoForgeServerConfig {
     }
 
     static {
-        final Pair<NeoForgeServerConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeServerConfig::new);
+        final Pair<NeoForgeSharedConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeSharedConfig::new);
         SPEC = specPair.getRight();
         INSTANCE = specPair.getLeft();
     }

--- a/src/main/java/net/neoforged/neoforge/common/config/NeoForgeStandardConfig.java
+++ b/src/main/java/net/neoforged/neoforge/common/config/NeoForgeStandardConfig.java
@@ -12,14 +12,14 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * General configuration that doesn't need to be synchronized but needs to be available before server startup
  */
-public final class NeoForgeCommonConfig {
+public final class NeoForgeStandardConfig {
     @ApiStatus.Internal
     public static final ModConfigSpec SPEC;
-    public static final NeoForgeCommonConfig INSTANCE;
+    public static final NeoForgeStandardConfig INSTANCE;
 
     public final ModConfigSpec.BooleanValue attributeAdvancedTooltipDebugInfo;
 
-    private NeoForgeCommonConfig(ModConfigSpec.Builder builder) {
+    private NeoForgeStandardConfig(ModConfigSpec.Builder builder) {
         attributeAdvancedTooltipDebugInfo = builder
                 .comment("Set this to true to enable showing debug information about attributes on an item when advanced tooltips is on.")
                 .translation("neoforge.configgui.attributeAdvancedTooltipDebugInfo")
@@ -27,7 +27,7 @@ public final class NeoForgeCommonConfig {
     }
 
     static {
-        final Pair<NeoForgeCommonConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeCommonConfig::new);
+        final Pair<NeoForgeStandardConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeStandardConfig::new);
         SPEC = specPair.getRight();
         INSTANCE = specPair.getLeft();
     }

--- a/src/main/java/net/neoforged/neoforge/common/config/NeoForgeSyncedConfig.java
+++ b/src/main/java/net/neoforged/neoforge/common/config/NeoForgeSyncedConfig.java
@@ -13,10 +13,10 @@ import org.jetbrains.annotations.ApiStatus;
 /**
  * General configuration that needs to be synchronized to the server and/or is desirable to be configurable per world
  */
-public final class NeoForgeSharedConfig {
+public final class NeoForgeSyncedConfig {
     @ApiStatus.Internal
     public static final ModConfigSpec SPEC;
-    public static final NeoForgeSharedConfig INSTANCE;
+    public static final NeoForgeSyncedConfig INSTANCE;
 
     public final ModConfigSpec.BooleanValue removeErroringBlockEntities;
 
@@ -28,7 +28,7 @@ public final class NeoForgeSharedConfig {
 
     public final ModConfigSpec.BooleanValue advertiseDedicatedServerToLan;
 
-    private NeoForgeSharedConfig(ModConfigSpec.Builder builder) {
+    private NeoForgeSyncedConfig(ModConfigSpec.Builder builder) {
         removeErroringBlockEntities = builder
                 .comment("Set this to true to remove any BlockEntity that throws an error in its update method instead of closing the server and reporting a crash log. BE WARNED THIS COULD SCREW UP EVERYTHING USE SPARINGLY WE ARE NOT RESPONSIBLE FOR DAMAGES.")
                 .translation("neoforge.configgui.removeErroringBlockEntities")
@@ -59,7 +59,7 @@ public final class NeoForgeSharedConfig {
     }
 
     static {
-        final Pair<NeoForgeSharedConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeSharedConfig::new);
+        final Pair<NeoForgeSyncedConfig, ModConfigSpec> specPair = new ModConfigSpec.Builder().configure(NeoForgeSyncedConfig::new);
         SPEC = specPair.getRight();
         INSTANCE = specPair.getLeft();
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IAttributeExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IAttributeExtension.java
@@ -24,7 +24,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.neoforge.common.NeoForgeMod;
-import net.neoforged.neoforge.common.config.NeoForgeCommonConfig;
+import net.neoforged.neoforge.common.config.NeoForgeStandardConfig;
 import net.neoforged.neoforge.common.util.AttributeUtil;
 import org.jspecify.annotations.Nullable;
 
@@ -84,7 +84,7 @@ public interface IAttributeExtension {
     default Component getDebugInfo(AttributeModifier modif, TooltipFlag flag) {
         Component debugInfo = CommonComponents.EMPTY;
 
-        if (flag.isAdvanced() && NeoForgeCommonConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
+        if (flag.isAdvanced() && NeoForgeStandardConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
             // Advanced Tooltips show the underlying operation and the "true" value. We offset MULTIPLY_TOTAL by 1 due to how the operation is calculated.
             double advValue = (modif.operation() == Operation.ADD_MULTIPLIED_TOTAL ? 1 : 0) + modif.amount();
             String valueStr = FORMAT.format(advValue);
@@ -132,7 +132,7 @@ public interface IAttributeExtension {
 
         // Emit both the value of the modifier, and the entity's base value as debug information, since both are flattened into the modifier.
         // Skip showing debug information here when displaying a merged modifier, since it will be shown if the user holds shift to display the un-merged modifier.
-        if (flag.isAdvanced() && !merged && NeoForgeCommonConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
+        if (flag.isAdvanced() && !merged && NeoForgeStandardConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
             double baseBonus = value - entityBase;
             String baseBonusText = String.format(Locale.ROOT, baseBonus > 0 ? " + %s" : " - %s", FORMAT.format(Math.abs(baseBonus)));
             Component debugInfo = Component.translatable("neoforge.attribute.debug.base", FORMAT.format(entityBase), baseBonusText).withStyle(ChatFormatting.GRAY);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IAttributeExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IAttributeExtension.java
@@ -24,7 +24,7 @@ import net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.neoforge.common.NeoForgeMod;
-import net.neoforged.neoforge.common.config.NeoForgeStandardConfig;
+import net.neoforged.neoforge.common.config.NeoForgeLocalConfig;
 import net.neoforged.neoforge.common.util.AttributeUtil;
 import org.jspecify.annotations.Nullable;
 
@@ -84,7 +84,7 @@ public interface IAttributeExtension {
     default Component getDebugInfo(AttributeModifier modif, TooltipFlag flag) {
         Component debugInfo = CommonComponents.EMPTY;
 
-        if (flag.isAdvanced() && NeoForgeStandardConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
+        if (flag.isAdvanced() && NeoForgeLocalConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
             // Advanced Tooltips show the underlying operation and the "true" value. We offset MULTIPLY_TOTAL by 1 due to how the operation is calculated.
             double advValue = (modif.operation() == Operation.ADD_MULTIPLIED_TOTAL ? 1 : 0) + modif.amount();
             String valueStr = FORMAT.format(advValue);
@@ -132,7 +132,7 @@ public interface IAttributeExtension {
 
         // Emit both the value of the modifier, and the entity's base value as debug information, since both are flattened into the modifier.
         // Skip showing debug information here when displaying a merged modifier, since it will be shown if the user holds shift to display the un-merged modifier.
-        if (flag.isAdvanced() && !merged && NeoForgeStandardConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
+        if (flag.isAdvanced() && !merged && NeoForgeLocalConfig.INSTANCE.attributeAdvancedTooltipDebugInfo.get()) {
             double baseBonus = value - entityBase;
             String baseBonusText = String.format(Locale.ROOT, baseBonus > 0 ? " + %s" : " - %s", FORMAT.format(Math.abs(baseBonus)));
             Component debugInfo = Component.translatable("neoforge.attribute.debug.base", FORMAT.format(entityBase), baseBonusText).withStyle(ChatFormatting.GRAY);

--- a/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
@@ -61,7 +61,7 @@ public abstract class CommonModLoader {
                 if (FMLEnvironment.getDist() == Dist.CLIENT) {
                     ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get());
                 }
-                ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.STANDARD, FMLPaths.CONFIGDIR.get());
+                ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.LOCAL, FMLPaths.CONFIGDIR.get());
             });
         }
 

--- a/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
+++ b/src/main/java/net/neoforged/neoforge/internal/CommonModLoader.java
@@ -61,7 +61,7 @@ public abstract class CommonModLoader {
                 if (FMLEnvironment.getDist() == Dist.CLIENT) {
                     ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.CLIENT, FMLPaths.CONFIGDIR.get());
                 }
-                ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
+                ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.STANDARD, FMLPaths.CONFIGDIR.get());
             });
         }
 

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -52,7 +52,7 @@ public final class ConfigSync {
             configsToSync.put(connection, new LinkedHashMap<>());
         }
 
-        final Map<String, byte[]> configData = ModConfigs.getConfigSet(ModConfig.Type.SERVER).stream().collect(Collectors.toMap(ModConfig::getFileName, mc -> {
+        final Map<String, byte[]> configData = ModConfigs.getConfigSet(ModConfig.Type.SHARED).stream().collect(Collectors.toMap(ModConfig::getFileName, mc -> {
             try {
                 return Files.readAllBytes(mc.getFullPath());
             } catch (IOException e) {
@@ -67,7 +67,7 @@ public final class ConfigSync {
 
     /**
      * Registers a listener for {@link ModConfigEvent.Reloading} for all mod busses,
-     * that will sync changes to server configs to connected clients.
+     * that will sync changes to server's shared configs to connected clients.
      */
     public static void registerEventListeners() {
         for (var modContainer : ModList.get().getSortedMods()) {
@@ -75,7 +75,7 @@ public final class ConfigSync {
             if (modBus != null) {
                 modBus.addListener(ModConfigEvent.Reloading.class, event -> {
                     var config = event.getConfig();
-                    if (config.getType() != ModConfig.Type.SERVER) {
+                    if (config.getType() != ModConfig.Type.SHARED) {
                         return;
                     }
                     var loadedConfig = config.getLoadedConfig();

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -52,7 +52,7 @@ public final class ConfigSync {
             configsToSync.put(connection, new LinkedHashMap<>());
         }
 
-        final Map<String, byte[]> configData = ModConfigs.getConfigSet(ModConfig.Type.SHARED).stream().collect(Collectors.toMap(ModConfig::getFileName, mc -> {
+        final Map<String, byte[]> configData = ModConfigs.getConfigSet(ModConfig.Type.SYNCED).stream().collect(Collectors.toMap(ModConfig::getFileName, mc -> {
             try {
                 return Files.readAllBytes(mc.getFullPath());
             } catch (IOException e) {

--- a/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
+++ b/src/main/java/net/neoforged/neoforge/network/ConfigSync.java
@@ -67,7 +67,7 @@ public final class ConfigSync {
 
     /**
      * Registers a listener for {@link ModConfigEvent.Reloading} for all mod busses,
-     * that will sync changes to server's shared configs to connected clients.
+     * that will sync changes to server's synced configs to connected clients.
      */
     public static void registerEventListeners() {
         for (var modContainer : ModList.get().getSortedMods()) {
@@ -75,7 +75,7 @@ public final class ConfigSync {
             if (modBus != null) {
                 modBus.addListener(ModConfigEvent.Reloading.class, event -> {
                     var config = event.getConfig();
-                    if (config.getType() != ModConfig.Type.SHARED) {
+                    if (config.getType() != ModConfig.Type.SYNCED) {
                         return;
                     }
                     var loadedConfig = config.getLoadedConfig();

--- a/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
@@ -90,7 +90,7 @@ public class ServerLifecycleHooks {
     public static void handleServerAboutToStart(final MinecraftServer server) {
         currentServer = server;
         // on the dedi server we need to force the stuff to setup properly
-        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SHARED, FMLPaths.CONFIGDIR.get(), getSyncedConfigPath(server));
+        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SYNCED, FMLPaths.CONFIGDIR.get(), getSyncedConfigPath(server));
         runModifiers(server);
         NeoForge.EVENT_BUS.post(new ServerAboutToStartEvent(server));
     }
@@ -124,7 +124,7 @@ public class ServerLifecycleHooks {
             latch.countDown();
             exitLatch = null;
         }
-        ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SHARED);
+        ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SYNCED);
     }
 
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
@@ -57,14 +57,14 @@ import org.jspecify.annotations.Nullable;
 public class ServerLifecycleHooks {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker SERVERHOOKS = MarkerManager.getMarker("SERVERHOOKS");
-    private static final LevelResource SHAREDCONFIG = new LevelResource("sharedconfig");
+    private static final LevelResource SYNCEDCONFIG = new LevelResource("syncedconfig");
     @Nullable
     private static volatile CountDownLatch exitLatch = null;
     @Nullable
     private static MinecraftServer currentServer;
 
-    private static Path getSharedConfigPath(final MinecraftServer server) {
-        final Path serverConfig = server.getWorldPath(SHAREDCONFIG);
+    private static Path getSyncedConfigPath(final MinecraftServer server) {
+        final Path serverConfig = server.getWorldPath(SYNCEDCONFIG);
         if (!Files.isDirectory(serverConfig)) {
             try {
                 Files.createDirectories(serverConfig);
@@ -76,9 +76,9 @@ public class ServerLifecycleHooks {
         if (!Files.exists(explanation)) {
             try {
                 Files.writeString(explanation, """
-                        Any shared configs put in this folder will override the corresponding shared config from <instance path>/config/<config path>.
+                        Any synced configs put in this folder will override the corresponding synced config from <instance path>/config/<config path>.
                         If the config being transferred is in a subfolder of the base config folder make sure to include that folder here in the path to the file you are overwriting.
-                        For example if you are overwriting a config with the path <instance path>/config/ExampleMod/config-shared.toml, you would need to put it in serverconfig/ExampleMod/config-shared.toml
+                        For example if you are overwriting a config with the path <instance path>/config/ExampleMod/config-synced.toml, you would need to put it in serverconfig/ExampleMod/config-shared.toml
                         """, StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -90,7 +90,7 @@ public class ServerLifecycleHooks {
     public static void handleServerAboutToStart(final MinecraftServer server) {
         currentServer = server;
         // on the dedi server we need to force the stuff to setup properly
-        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SHARED, FMLPaths.CONFIGDIR.get(), getSharedConfigPath(server));
+        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SHARED, FMLPaths.CONFIGDIR.get(), getSyncedConfigPath(server));
         runModifiers(server);
         NeoForge.EVENT_BUS.post(new ServerAboutToStartEvent(server));
     }

--- a/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
+++ b/src/main/java/net/neoforged/neoforge/server/ServerLifecycleHooks.java
@@ -57,14 +57,14 @@ import org.jspecify.annotations.Nullable;
 public class ServerLifecycleHooks {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker SERVERHOOKS = MarkerManager.getMarker("SERVERHOOKS");
-    private static final LevelResource SERVERCONFIG = new LevelResource("serverconfig");
+    private static final LevelResource SHAREDCONFIG = new LevelResource("sharedconfig");
     @Nullable
     private static volatile CountDownLatch exitLatch = null;
     @Nullable
     private static MinecraftServer currentServer;
 
-    private static Path getServerConfigPath(final MinecraftServer server) {
-        final Path serverConfig = server.getWorldPath(SERVERCONFIG);
+    private static Path getSharedConfigPath(final MinecraftServer server) {
+        final Path serverConfig = server.getWorldPath(SHAREDCONFIG);
         if (!Files.isDirectory(serverConfig)) {
             try {
                 Files.createDirectories(serverConfig);
@@ -76,9 +76,9 @@ public class ServerLifecycleHooks {
         if (!Files.exists(explanation)) {
             try {
                 Files.writeString(explanation, """
-                        Any server configs put in this folder will override the corresponding server config from <instance path>/config/<config path>.
+                        Any shared configs put in this folder will override the corresponding shared config from <instance path>/config/<config path>.
                         If the config being transferred is in a subfolder of the base config folder make sure to include that folder here in the path to the file you are overwriting.
-                        For example if you are overwriting a config with the path <instance path>/config/ExampleMod/config-server.toml, you would need to put it in serverconfig/ExampleMod/config-server.toml
+                        For example if you are overwriting a config with the path <instance path>/config/ExampleMod/config-shared.toml, you would need to put it in serverconfig/ExampleMod/config-shared.toml
                         """, StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -90,7 +90,7 @@ public class ServerLifecycleHooks {
     public static void handleServerAboutToStart(final MinecraftServer server) {
         currentServer = server;
         // on the dedi server we need to force the stuff to setup properly
-        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SERVER, FMLPaths.CONFIGDIR.get(), getServerConfigPath(server));
+        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.SHARED, FMLPaths.CONFIGDIR.get(), getSharedConfigPath(server));
         runModifiers(server);
         NeoForge.EVENT_BUS.post(new ServerAboutToStartEvent(server));
     }
@@ -124,7 +124,7 @@ public class ServerLifecycleHooks {
             latch.countDown();
             exitLatch = null;
         }
-        ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SERVER);
+        ConfigTracker.INSTANCE.unloadConfigs(ModConfig.Type.SHARED);
     }
 
     @Nullable

--- a/src/main/java/net/neoforged/neoforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/neoforged/neoforge/server/permission/PermissionAPI.java
@@ -13,7 +13,7 @@ import net.minecraft.IdentifierException;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.config.NeoForgeSharedConfig;
+import net.neoforged.neoforge.common.config.NeoForgeSyncedConfig;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
 import net.neoforged.neoforge.server.permission.exceptions.UnregisteredPermissionException;
@@ -98,7 +98,7 @@ public final class PermissionAPI {
         Map<Identifier, IPermissionHandlerFactory> availableHandlers = handlerEvent.getAvailablePermissionHandlerFactories();
 
         try {
-            Identifier selectedPermissionHandler = Identifier.parse(NeoForgeSharedConfig.INSTANCE.permissionHandler.get());
+            Identifier selectedPermissionHandler = Identifier.parse(NeoForgeSyncedConfig.INSTANCE.permissionHandler.get());
             if (!availableHandlers.containsKey(selectedPermissionHandler)) {
                 LOGGER.error("Unable to find configured permission handler {}, will use {}", selectedPermissionHandler, DefaultPermissionHandler.IDENTIFIER);
                 selectedPermissionHandler = DefaultPermissionHandler.IDENTIFIER;

--- a/src/main/java/net/neoforged/neoforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/neoforged/neoforge/server/permission/PermissionAPI.java
@@ -13,7 +13,7 @@ import net.minecraft.IdentifierException;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.common.NeoForge;
-import net.neoforged.neoforge.common.config.NeoForgeServerConfig;
+import net.neoforged.neoforge.common.config.NeoForgeSharedConfig;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
 import net.neoforged.neoforge.server.permission.exceptions.UnregisteredPermissionException;
@@ -98,7 +98,7 @@ public final class PermissionAPI {
         Map<Identifier, IPermissionHandlerFactory> availableHandlers = handlerEvent.getAvailablePermissionHandlerFactories();
 
         try {
-            Identifier selectedPermissionHandler = Identifier.parse(NeoForgeServerConfig.INSTANCE.permissionHandler.get());
+            Identifier selectedPermissionHandler = Identifier.parse(NeoForgeSharedConfig.INSTANCE.permissionHandler.get());
             if (!availableHandlers.containsKey(selectedPermissionHandler)) {
                 LOGGER.error("Unable to find configured permission handler {}, will use {}", selectedPermissionHandler, DefaultPermissionHandler.IDENTIFIER);
                 selectedPermissionHandler = DefaultPermissionHandler.IDENTIFIER;

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/StartupConfigTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/StartupConfigTest.java
@@ -18,15 +18,15 @@ import org.junit.jupiter.api.TestMethodOrder;
 public class StartupConfigTest {
     private static final String MOD_ID = "startup_config_test";
     private static boolean wasLoadedAtInitStartupConfig = false;
-    private static boolean wasLoadedAtInitStandardConfig = false;
-    private static boolean wasLoadedAtInitSharedConfig = false;
+    private static boolean wasLoadedAtInitLocalConfig = false;
+    private static boolean wasLoadedAtInitSyncedConfig = false;
     private static boolean wasLoadedAtInitClientConfig = false;
 
     @Test
     void testStartupConfigs() {
         Assertions.assertTrue(wasLoadedAtInitStartupConfig, "Startup Config was supposed to be loaded at mod init.");
-        Assertions.assertFalse(wasLoadedAtInitStandardConfig, "Standard Config was NOT supposed to be loaded at mod init.");
-        Assertions.assertFalse(wasLoadedAtInitSharedConfig, "Shared Config was NOT supposed to be loaded at mod init.");
+        Assertions.assertFalse(wasLoadedAtInitLocalConfig, "Local Config was NOT supposed to be loaded at mod init.");
+        Assertions.assertFalse(wasLoadedAtInitSyncedConfig, "Synced Config was NOT supposed to be loaded at mod init.");
         Assertions.assertFalse(wasLoadedAtInitClientConfig, "Client Config was NOT supposed to be loaded at mod init.");
     }
 
@@ -34,12 +34,12 @@ public class StartupConfigTest {
     public static class StartupConfigTestMod {
         public StartupConfigTestMod(ModContainer modContainer) {
             modContainer.registerConfig(ModConfig.Type.STARTUP, StartupConfig.SPEC);
-            modContainer.registerConfig(ModConfig.Type.STANDARD, StandardConfig.SPEC);
-            modContainer.registerConfig(ModConfig.Type.SHARED, SharedConfig.SPEC);
+            modContainer.registerConfig(ModConfig.Type.LOCAL, LocalConfig.SPEC);
+            modContainer.registerConfig(ModConfig.Type.SYNCED, SyncedConfig.SPEC);
             modContainer.registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
             wasLoadedAtInitStartupConfig = StartupConfig.SPEC.isLoaded();
-            wasLoadedAtInitStandardConfig = StandardConfig.SPEC.isLoaded();
-            wasLoadedAtInitSharedConfig = SharedConfig.SPEC.isLoaded();
+            wasLoadedAtInitLocalConfig = LocalConfig.SPEC.isLoaded();
+            wasLoadedAtInitSyncedConfig = SyncedConfig.SPEC.isLoaded();
             wasLoadedAtInitClientConfig = ClientConfig.SPEC.isLoaded();
         }
 
@@ -49,13 +49,13 @@ public class StartupConfigTest {
             static final ModConfigSpec SPEC = BUILDER.build();
         }
 
-        public static class StandardConfig {
+        public static class LocalConfig {
             private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
             private static final ModConfigSpec.BooleanValue TEST_MARKER = BUILDER.define("testMarker2", true);
             static final ModConfigSpec SPEC = BUILDER.build();
         }
 
-        public static class SharedConfig {
+        public static class SyncedConfig {
             private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
             private static final ModConfigSpec.BooleanValue TEST_MARKER = BUILDER.define("testMarker3", true);
             static final ModConfigSpec SPEC = BUILDER.build();

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/StartupConfigTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/StartupConfigTest.java
@@ -18,15 +18,15 @@ import org.junit.jupiter.api.TestMethodOrder;
 public class StartupConfigTest {
     private static final String MOD_ID = "startup_config_test";
     private static boolean wasLoadedAtInitStartupConfig = false;
-    private static boolean wasLoadedAtInitCommonConfig = false;
-    private static boolean wasLoadedAtInitServerConfig = false;
+    private static boolean wasLoadedAtInitStandardConfig = false;
+    private static boolean wasLoadedAtInitSharedConfig = false;
     private static boolean wasLoadedAtInitClientConfig = false;
 
     @Test
     void testStartupConfigs() {
         Assertions.assertTrue(wasLoadedAtInitStartupConfig, "Startup Config was supposed to be loaded at mod init.");
-        Assertions.assertFalse(wasLoadedAtInitCommonConfig, "Common Config was NOT supposed to be loaded at mod init.");
-        Assertions.assertFalse(wasLoadedAtInitServerConfig, "Server Config was NOT supposed to be loaded at mod init.");
+        Assertions.assertFalse(wasLoadedAtInitStandardConfig, "Standard Config was NOT supposed to be loaded at mod init.");
+        Assertions.assertFalse(wasLoadedAtInitSharedConfig, "Shared Config was NOT supposed to be loaded at mod init.");
         Assertions.assertFalse(wasLoadedAtInitClientConfig, "Client Config was NOT supposed to be loaded at mod init.");
     }
 
@@ -34,12 +34,12 @@ public class StartupConfigTest {
     public static class StartupConfigTestMod {
         public StartupConfigTestMod(ModContainer modContainer) {
             modContainer.registerConfig(ModConfig.Type.STARTUP, StartupConfig.SPEC);
-            modContainer.registerConfig(ModConfig.Type.COMMON, CommonConfig.SPEC);
-            modContainer.registerConfig(ModConfig.Type.SERVER, ServerConfig.SPEC);
+            modContainer.registerConfig(ModConfig.Type.STANDARD, StandardConfig.SPEC);
+            modContainer.registerConfig(ModConfig.Type.SHARED, SharedConfig.SPEC);
             modContainer.registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
             wasLoadedAtInitStartupConfig = StartupConfig.SPEC.isLoaded();
-            wasLoadedAtInitCommonConfig = CommonConfig.SPEC.isLoaded();
-            wasLoadedAtInitServerConfig = ServerConfig.SPEC.isLoaded();
+            wasLoadedAtInitStandardConfig = StandardConfig.SPEC.isLoaded();
+            wasLoadedAtInitSharedConfig = SharedConfig.SPEC.isLoaded();
             wasLoadedAtInitClientConfig = ClientConfig.SPEC.isLoaded();
         }
 
@@ -49,13 +49,13 @@ public class StartupConfigTest {
             static final ModConfigSpec SPEC = BUILDER.build();
         }
 
-        public static class CommonConfig {
+        public static class StandardConfig {
             private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
             private static final ModConfigSpec.BooleanValue TEST_MARKER = BUILDER.define("testMarker2", true);
             static final ModConfigSpec SPEC = BUILDER.build();
         }
 
-        public static class ServerConfig {
+        public static class SharedConfig {
             private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
             private static final ModConfigSpec.BooleanValue TEST_MARKER = BUILDER.define("testMarker3", true);
             static final ModConfigSpec SPEC = BUILDER.build();

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/ConfigUITest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/ConfigUITest.java
@@ -26,13 +26,13 @@ import net.neoforged.neoforge.common.TranslatableEnum;
 public class ConfigUITest {
     public ConfigUITest(final ModContainer container) {
         container.registerConfig(ModConfig.Type.CLIENT, Client.SPEC);
-        container.registerConfig(ModConfig.Type.COMMON, Common.SPEC);
-        container.registerConfig(ModConfig.Type.SERVER, Server.SPEC);
+        container.registerConfig(ModConfig.Type.STANDARD, Standard.SPEC);
+        container.registerConfig(ModConfig.Type.SHARED, Shared.SPEC);
         container.registerConfig(ModConfig.Type.STARTUP, Startup.SPEC);
         container.registerConfig(ModConfig.Type.CLIENT, MDKConfig.SPEC, "mdk");
 
-        // Test: Accessing this COMMON config value during startup should work:
-        final var a = Common.value.get().size();
+        // Test: Accessing this STANDARD config value during startup should work:
+        final var a = Standard.value.get().size();
         // Test: Accessing a STARTUP config value should also work:
         final var b = Startup.value.get();
     }
@@ -68,7 +68,7 @@ public class ConfigUITest {
         }
     }
 
-    public static class Server {
+    public static class Shared {
         public static final ModConfigSpec SPEC;
 
         static {
@@ -80,20 +80,20 @@ public class ConfigUITest {
         }
     }
 
-    public static class Common {
+    public static class Standard {
         public static final ModConfigSpec SPEC;
         public static Supplier<List<? extends Integer>> value;
 
         static {
             final var builder = new ModConfigSpec.Builder();
 
-            builder.translation("configuitest.common.section1")
+            builder.translation("configuitest.standard.section1")
                     .push("section1");
 
-            builder.translation("configuitest.common.section2")
+            builder.translation("configuitest.standard.section2")
                     .push("section2");
 
-            value = wrap(builder.translation("configuitest.common.numbers").defineListAllowEmpty("numbers", List.of(1, 2), () -> 0, e -> true));
+            value = wrap(builder.translation("configuitest.standard.numbers").defineListAllowEmpty("numbers", List.of(1, 2), () -> 0, e -> true));
 
             builder.pop(2);
 
@@ -144,12 +144,12 @@ public class ConfigUITest {
         private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
         static {
-            BUILDER.comment("Whether to log the dirt block on common setup").define("logDirtBlock", true);
+            BUILDER.comment("Whether to log the dirt block on standard setup").define("logDirtBlock", true);
 
             BUILDER.comment("Where all the wild booleans live").translation("key.random").push("subsection1");
-            BUILDER.comment("Whether to log the dirt block on common setup").define("val1", true);
-            BUILDER.comment("Whether to log the dirt block on common setup").define("val2", true);
-            BUILDER.comment("Whether to log the dirt block on common setup").define("val3", true);
+            BUILDER.comment("Whether to log the dirt block on standard setup").define("val1", true);
+            BUILDER.comment("Whether to log the dirt block on standard setup").define("val2", true);
+            BUILDER.comment("Whether to log the dirt block on standard setup").define("val3", true);
 
             BUILDER.comment("Where all the wild ints live").translation("key.randomint").push("subsection2");
             BUILDER.comment("A weird number").defineInRange("eridNumber", 43, 43, 53);
@@ -162,7 +162,7 @@ public class ConfigUITest {
             BUILDER.defineEnum("dir2", Direction.SOUTH, Direction.SOUTH, Direction.EAST, Direction.WEST, Direction.NORTH);
 
             BUILDER.pop();
-            BUILDER.comment("Whether to log the dirt block on common setup").define("outer2", true);
+            BUILDER.comment("Whether to log the dirt block on standard setup").define("outer2", true);
 
             BUILDER.comment("A magic number").defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
 
@@ -171,7 +171,7 @@ public class ConfigUITest {
             BUILDER.comment("What you want the introduction message to be for the magic number").define("magicNumberIntroduction", "The magic number is... ");
 
             // a list of strings that are treated as resource locations for items
-            BUILDER.comment("A list of items to log on common setup.").defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), () -> "minecraft:",
+            BUILDER.comment("A list of items to log on standard setup.").defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), () -> "minecraft:",
                     obj -> obj instanceof final String itemName && BuiltInRegistries.ITEM.containsKey(Identifier.tryParse(itemName)));
 
             BUILDER.comment("A list of int for no reason.").defineListAllowEmpty("intlist", List.of(1, 2, 3), () -> 0,

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/ConfigUITest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/ConfigUITest.java
@@ -26,13 +26,13 @@ import net.neoforged.neoforge.common.TranslatableEnum;
 public class ConfigUITest {
     public ConfigUITest(final ModContainer container) {
         container.registerConfig(ModConfig.Type.CLIENT, Client.SPEC);
-        container.registerConfig(ModConfig.Type.STANDARD, Standard.SPEC);
-        container.registerConfig(ModConfig.Type.SHARED, Shared.SPEC);
+        container.registerConfig(ModConfig.Type.LOCAL, Local.SPEC);
+        container.registerConfig(ModConfig.Type.SYNCED, Synced.SPEC);
         container.registerConfig(ModConfig.Type.STARTUP, Startup.SPEC);
         container.registerConfig(ModConfig.Type.CLIENT, MDKConfig.SPEC, "mdk");
 
-        // Test: Accessing this STANDARD config value during startup should work:
-        final var a = Standard.value.get().size();
+        // Test: Accessing this LOCAL config value during startup should work:
+        final var a = Local.value.get().size();
         // Test: Accessing a STARTUP config value should also work:
         final var b = Startup.value.get();
     }
@@ -68,7 +68,7 @@ public class ConfigUITest {
         }
     }
 
-    public static class Shared {
+    public static class Synced {
         public static final ModConfigSpec SPEC;
 
         static {
@@ -80,20 +80,20 @@ public class ConfigUITest {
         }
     }
 
-    public static class Standard {
+    public static class Local {
         public static final ModConfigSpec SPEC;
         public static Supplier<List<? extends Integer>> value;
 
         static {
             final var builder = new ModConfigSpec.Builder();
 
-            builder.translation("configuitest.standard.section1")
+            builder.translation("configuitest.local.section1")
                     .push("section1");
 
-            builder.translation("configuitest.standard.section2")
+            builder.translation("configuitest.local.section2")
                     .push("section2");
 
-            value = wrap(builder.translation("configuitest.standard.numbers").defineListAllowEmpty("numbers", List.of(1, 2), () -> 0, e -> true));
+            value = wrap(builder.translation("configuitest.local.numbers").defineListAllowEmpty("numbers", List.of(1, 2), () -> 0, e -> true));
 
             builder.pop(2);
 
@@ -144,12 +144,12 @@ public class ConfigUITest {
         private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
 
         static {
-            BUILDER.comment("Whether to log the dirt block on standard setup").define("logDirtBlock", true);
+            BUILDER.comment("Whether to log the dirt block on local setup").define("logDirtBlock", true);
 
             BUILDER.comment("Where all the wild booleans live").translation("key.random").push("subsection1");
-            BUILDER.comment("Whether to log the dirt block on standard setup").define("val1", true);
-            BUILDER.comment("Whether to log the dirt block on standard setup").define("val2", true);
-            BUILDER.comment("Whether to log the dirt block on standard setup").define("val3", true);
+            BUILDER.comment("Whether to log the dirt block on local setup").define("val1", true);
+            BUILDER.comment("Whether to log the dirt block on local setup").define("val2", true);
+            BUILDER.comment("Whether to log the dirt block on local setup").define("val3", true);
 
             BUILDER.comment("Where all the wild ints live").translation("key.randomint").push("subsection2");
             BUILDER.comment("A weird number").defineInRange("eridNumber", 43, 43, 53);
@@ -162,7 +162,7 @@ public class ConfigUITest {
             BUILDER.defineEnum("dir2", Direction.SOUTH, Direction.SOUTH, Direction.EAST, Direction.WEST, Direction.NORTH);
 
             BUILDER.pop();
-            BUILDER.comment("Whether to log the dirt block on standard setup").define("outer2", true);
+            BUILDER.comment("Whether to log the dirt block on local setup").define("outer2", true);
 
             BUILDER.comment("A magic number").defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
 
@@ -171,7 +171,7 @@ public class ConfigUITest {
             BUILDER.comment("What you want the introduction message to be for the magic number").define("magicNumberIntroduction", "The magic number is... ");
 
             // a list of strings that are treated as resource locations for items
-            BUILDER.comment("A list of items to log on standard setup.").defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), () -> "minecraft:",
+            BUILDER.comment("A list of items to log on local setup.").defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), () -> "minecraft:",
                     obj -> obj instanceof final String itemName && BuiltInRegistries.ITEM.containsKey(Identifier.tryParse(itemName)));
 
             BUILDER.comment("A list of int for no reason.").defineListAllowEmpty("intlist", List.of(1, 2, 3), () -> 0,


### PR DESCRIPTION
Continuation of https://github.com/neoforged/FancyModLoader/pull/436

> SERVER -> SYNCED
> COMMON -> LOCAL
> 
> The idea here is making it clear that the was SERVER configs are synced between client and server (with the comment on it > explaining the sync direction). And changing COMMON to LOCAL makes it clears COMMON is not a synced config. Rather just a regular default standard config with no sync involved.
> 
> Changes were limited to renames to keep PR as small as possible. Any alternative names will need a very strong reason to convince me to change it.
> 
> If you wish for a different setup such as sync-ness as part of the config setup or removal of an entire config type, please make a separate PR and post it in comment here so implementations can be judged. Also helps to reduce bikeshedding by pushing forth a "less-talking, more-doing" stance to this.
> 
> Ideally we would target 26.3 for this. Once merged, NeoForge will get a PR to use new FML and make the same config name changes (including to the config files and folders to match new name).
> 
> This is a large scale breaking change and will need a dev announcement when NeoForge updates.
> 
> Closes: https://github.com/neoforged/FancyModLoader/issues/276

NOTE: Do not release with the experimental FML lines. Revert that commit and update to newly released FML once the relevant PR is merged and 26.3 is out. Be sure to retarget this branch to 26.3 and undraft