### PR TITLE
Add cancellation result to `ItemStackedOnOtherEvent`

### DIFF
--- a/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -4,7 +4,7 @@
      }
  
      private boolean tryItemClickBehaviourOverride(Player player, ClickAction clickAction, Slot slot, ItemStack clicked, ItemStack carried) {
-+        // Neo: Fire the ItemStackedOnOtherEvent, and return the event's handled value if it was cancelled. Returning true will trigger the container to stop processing further logic.
++        // Neo: Fire the ItemStackedOnOtherEvent, and return the event's cancel result if it was cancelled. Returning true will trigger the container to stop processing further logic.
 +        // The first parameter to onItemStackedOn is the "carried" (under-mouse) item, which is the second ItemStack parameter to this method.
 +        var event = net.neoforged.neoforge.common.CommonHooks.onItemStackedOn(carried, clicked, slot, clickAction, player, createCarriedSlotAccess());
 +        if (event.isCanceled()) {

--- a/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -1,13 +1,14 @@
 --- a/net/minecraft/world/inventory/AbstractContainerMenu.java
 +++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
-@@ -558,6 +_,12 @@
+@@ -558,6 +_,13 @@
      }
  
      private boolean tryItemClickBehaviourOverride(Player player, ClickAction clickAction, Slot slot, ItemStack clicked, ItemStack carried) {
-+        // Neo: Fire the ItemStackedOnOtherEvent, and return true if it was cancelled (meaning the event was handled). Returning true will trigger the container to stop processing further logic.
++        // Neo: Fire the ItemStackedOnOtherEvent, and return the event's handled value if it was cancelled. Returning true will trigger the container to stop processing further logic.
 +        // The first parameter to onItemStackedOn is the "carried" (under-mouse) item, which is the second ItemStack parameter to this method.
-+        if (net.neoforged.neoforge.common.CommonHooks.onItemStackedOn(carried, clicked, slot, clickAction, player, createCarriedSlotAccess())) {
-+            return true;
++        var event = net.neoforged.neoforge.common.CommonHooks.onItemStackedOn(carried, clicked, slot, clickAction, player, createCarriedSlotAccess());
++        if (event.isCanceled()) {
++            return event.getCancellationResult();
 +        }
 +
          FeatureFlagSet enabledFeatures = player.level().enabledFeatures();

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -282,10 +282,10 @@ public class CommonHooks {
      * @param action            The click action being performed
      * @param player            The player who clicked the slot
      * @param carriedSlotAccess A slot access permitting changing the carried item.
-     * @return True if the event was cancelled, indicating that a mod has handled the click; false otherwise
+     * @return the event itself
      */
-    public static boolean onItemStackedOn(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess) {
-        return NeoForge.EVENT_BUS.post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess)).isCanceled();
+    public static ItemStackedOnOtherEvent onItemStackedOn(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess) {
+        return NeoForge.EVENT_BUS.post(new ItemStackedOnOtherEvent(carriedItem, stackedOnItem, slot, action, player, carriedSlotAccess));
     }
 
     public static void onDifficultyChange(Difficulty difficulty, Difficulty oldDifficulty) {

--- a/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
@@ -16,21 +16,23 @@ import net.neoforged.bus.api.ICancellableEvent;
 import net.neoforged.fml.LogicalSide;
 import org.jetbrains.annotations.ApiStatus;
 
-/**
- * This event provides the functionality of the pair of functions used for the Bundle, in one event:
- * <ul>
- * <li>{@link Item#overrideOtherStackedOnMe(ItemStack, ItemStack, Slot, ClickAction, Player, SlotAccess)}</li>
- * <li>{@link Item#overrideStackedOnOther(ItemStack, Slot, ClickAction, Player)}</li>
- * </ul>
- *
- * This event is fired before either of the above are called, when a carried item is clicked on top of another in a GUI slot.
- * This event (and items stacking on others in general) is fired on both {@linkplain LogicalSide sides}, but only on {@linkplain LogicalSide#CLIENT the client} in the creative menu.
- * Practically, that means that listeners of this event should require the player to be in survival mode if using capabilities that are not synced.
- * <p>
- * This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
- * If the event is cancelled, the container's logic halts, the carried item and the slot will not be swapped, and handling is assumed to have been done by the mod.
- * This also means that the two vanilla checks described above will not be called.
- */
+/// This event provides the functionality of the pair of functions used for the Bundle, in one event:
+///
+///   - [Item#overrideOtherStackedOnMe(ItemStack, ItemStack, Slot, ClickAction, Player, SlotAccess)]
+///   - [Item#overrideStackedOnOther(ItemStack, Slot, ClickAction, Player)]
+///
+/// This event is fired before either of the above are called, when a carried item is clicked on top of another in a GUI slot.
+///
+/// This event (and items stacking on others in general) is fired on both [sides][LogicalSide], but only on [the client][LogicalSide#CLIENT]
+/// in the creative menu. Practically, that means that listeners of this event should require the player to be in
+/// survival mode if using capabilities that are not synced.
+///
+/// This event is [cancellable][ICancellableEvent]. If the event is cancelled, the two vanilla methods described above
+/// will not be called. The remaining logic depends on the [cancellation result][#getCancellationResult()]:
+///
+///   - If it is `true`, then the container's logic halts, the carried item and the slot will not be swapped, and
+///     handling is assumed to have been done by the mod.
+///   - If it is `false`, vanilla processing continues except for the two vanilla methods mentioned above.
 public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent {
     private final ItemStack carriedItem;
     private final ItemStack stackedOnItem;
@@ -38,6 +40,8 @@ public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent 
     private final ClickAction action;
     private final Player player;
     private final SlotAccess carriedSlotAccess;
+    // Default to true to skip vanilla processing
+    private boolean cancelResult = true;
 
     @ApiStatus.Internal
     public ItemStackedOnOtherEvent(ItemStack carriedItem, ItemStack stackedOnItem, Slot slot, ClickAction action, Player player, SlotAccess carriedSlotAccess) {
@@ -89,5 +93,19 @@ public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent 
      */
     public SlotAccess getCarriedSlotAccess() {
         return carriedSlotAccess;
+    }
+
+    /// Sets the cancellation result of this event, which is used to determine further processing of the click when this
+    /// event is [cancelled][#setCanceled(boolean)]. See the javadocs of this class for more details.
+    ///
+    /// @param cancelResult the cancel result
+    public void setCancellationResult(boolean cancelResult) {
+        this.cancelResult = cancelResult;
+    }
+
+    /// {@return the cancellation result}. This is used only when the event is [cancelled][#setCanceled(boolean)]; see
+    /// the javadocs of this class for more details.
+    public boolean getCancellationResult() {
+        return this.cancelResult;
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
@@ -88,6 +88,7 @@ public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent 
     /// event is [cancelled][#setCanceled(boolean)]. See the javadocs of this class for more details.
     ///
     /// @param cancelResult the cancel result
+    /// @see #cancelWithResult(boolean)
     public void setCancellationResult(boolean cancelResult) {
         this.cancelResult = cancelResult;
     }
@@ -96,5 +97,14 @@ public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent 
     /// the javadocs of this class for more details.
     public boolean getCancellationResult() {
         return this.cancelResult;
+    }
+
+    /// [Cancels](ICancellableEvent#setCanceled(boolean)) this event and [sets the cancellation result](#setCancellationResult(boolean)).
+    ///
+    /// @param cancelResult the cancel result
+    /// @see #setCancellationResult(boolean)
+    public void cancelWithResult(boolean cancelResult) {
+        this.setCancellationResult(cancelResult);
+        this.setCanceled(true);
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
@@ -53,44 +53,34 @@ public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent 
         this.carriedSlotAccess = carriedSlotAccess;
     }
 
-    /**
-     * {@return the stack being carried by the mouse} This may be empty!
-     */
+    /// {@return the stack being carried by the mouse, which may be empty}
     public ItemStack getCarriedItem() {
         return carriedItem;
     }
 
-    /**
-     * {@return the stack currently in the slot being clicked on} This may be empty!
-     */
+    /// {@return the stack currently in the slot being clicked on, which may be empty}
     public ItemStack getStackedOnItem() {
         return stackedOnItem;
     }
 
-    /**
-     * {@return the slot being clicked on}
-     */
+    /// {@return the slot being clicked on}
     public Slot getSlot() {
         return slot;
     }
 
-    /**
-     * {@return the click action being used} By default {@linkplain ClickAction#PRIMARY} corresponds to left-click, and {@linkplain ClickAction#SECONDARY} is right-click.
-     */
+    /// {@return the click action being used} The click actions do not necessarily map to specific mouse buttons, as
+    /// they may be rebound by the client. For default key mappings, [the primary click action][ClickAction#PRIMARY]
+    /// corresponds to a mouse left-click, and [the secondary click action][ClickAction#SECONDARY] to a mouse right-click.
     public ClickAction getClickAction() {
         return action;
     }
 
-    /**
-     * {@return the player doing the item swap attempt}
-     */
+    /// {@return the player doing the item swap attempt}
     public Player getPlayer() {
         return player;
     }
 
-    /**
-     * {@return a fake slot allowing the listener to see and change what item is being carried}
-     */
+    /// {@return a fake slot allowing the listener to see and change what item is being carried}
     public SlotAccess getCarriedSlotAccess() {
         return carriedSlotAccess;
     }

--- a/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
@@ -24,8 +24,7 @@ import org.jetbrains.annotations.ApiStatus;
 /// This event is fired before either of the above are called, when a carried item is clicked on top of another in a GUI slot.
 ///
 /// This event (and items stacking on others in general) is fired on both [sides][LogicalSide], but only on [the client][LogicalSide#CLIENT]
-/// in the creative menu. Practically, that means that listeners of this event should require the player to be in
-/// survival mode if using capabilities that are not synced.
+/// in the creative menu.
 ///
 /// This event is [cancellable][ICancellableEvent]. If the event is cancelled, the two vanilla methods described above
 /// will not be called. The remaining logic depends on the [cancellation result][#getCancellationResult()]:

--- a/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/ItemStackedOnOtherEvent.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus;
 /// will not be called. The remaining logic depends on the [cancellation result][#getCancellationResult()]:
 ///
 ///   - If it is `true`, then the container's logic halts, the carried item and the slot will not be swapped, and
-///     handling is assumed to have been done by the mod.
+///     handling is assumed to have been done by the event listener.
 ///   - If it is `false`, vanilla processing continues except for the two vanilla methods mentioned above.
 public class ItemStackedOnOtherEvent extends Event implements ICancellableEvent {
     private final ItemStack carriedItem;


### PR DESCRIPTION
This PR resolves #3387 by adding a cancellation result to `ItemStackedOnOtherEvent`, which controls whether further vanilla processing (except the two vanilla methods `Item#overrideOtherStackedOnMe` and `Item#overrideStackedOnOther`) continues after the event is cancelled.

This allows mods to skip the vanilla handling for the stacking behavior, while continuing with the menu logic for processing normal clicks.

I originally suggested the property name `handled` in the issue, but I used `cancellationResult` instead to make it clear that it is only used when the event is cancelled; the relevant information about what exactly happens is put into the class javadoc.

This PR also does cleanup and conversion of the javadocs of the class, to conform with our goal of moving to Markdown javadocs. Notably, I amended the javadoc for `getClickAction()` to make it clear that the click actions may be caused by other keys if remapped away from mouse clicks.
