### PR TITLE
Handle component click events ourselves in mod list screen

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/modlist/ModListScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/modlist/ModListScreen.java
@@ -553,7 +553,7 @@ public class ModListScreen extends Screen {
                 case ClickEvent.OpenUrl(URI uri) -> ConfirmLinkScreen.confirmLinkNow(ModListScreen.this, uri);
                 case ClickEvent.OpenFile openFile -> Util.getPlatform().openFile(openFile.file());
                 case ClickEvent.CopyToClipboard(String value) -> minecraft.keyboardHandler.setClipboard(value);
-                default -> LOGGER.error("Don't know how to handle {}", event);
+                default -> LOGGER.error("Unable to handle click event ‘{}’", event);
             }
         }
 

--- a/src/client/java/net/neoforged/neoforge/client/gui/modlist/ModListScreen.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/modlist/ModListScreen.java
@@ -57,6 +57,7 @@ import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.PlainTextContents;
 import net.minecraft.resources.Identifier;
@@ -469,12 +470,7 @@ public class ModListScreen extends Screen {
                     .build()
                     .setCentered(true),
                     contentLayout.newCellSettings().paddingVertical(3));
-            this.newerVersionWidget.setComponentClickHandler(style -> {
-                ClickEvent clickEvent = style.getClickEvent();
-                if (clickEvent != null) {
-                    defaultHandleClickEvent(clickEvent, ModListScreen.this.minecraft, ModListScreen.this);
-                }
-            });
+            this.newerVersionWidget.setComponentClickHandler(this::handleClickEvent);
             this.newerVersionButton = contentLayout.addChild(Button.builder(translatable("neoforge.screen.mods.button.changelog"),
                     _ -> {
                         if (this.selected != null && this.selected.checkResult != null) {
@@ -546,13 +542,19 @@ public class ModListScreen extends Screen {
                     .maxWidth(width)
                     .build()
                     .setCentered(false));
-            widget.setComponentClickHandler(style -> {
-                ClickEvent clickEvent = style.getClickEvent();
-                if (clickEvent != null) {
-                    defaultHandleClickEvent(clickEvent, ModListScreen.this.minecraft, ModListScreen.this);
-                }
-            });
+            widget.setComponentClickHandler(this::handleClickEvent);
             return widget;
+        }
+
+        private void handleClickEvent(Style style) {
+            ClickEvent event = style.getClickEvent();
+            if (event == null) return;
+            switch (event) {
+                case ClickEvent.OpenUrl(URI uri) -> ConfirmLinkScreen.confirmLinkNow(ModListScreen.this, uri);
+                case ClickEvent.OpenFile openFile -> Util.getPlatform().openFile(openFile.file());
+                case ClickEvent.CopyToClipboard(String value) -> minecraft.keyboardHandler.setClipboard(value);
+                default -> LOGGER.error("Don't know how to handle {}", event);
+            }
         }
 
         public LinearLayout getMainLayout() {


### PR DESCRIPTION
This PR changes `ModListScreen` to use our own logic in handling click events from components, rather than deferring to Minecraft's default click event logic.

This fixes an issue where all components' links were treated as 'untrusted' and given the untrusted link confirmation screen. This brings it in line with the homepage and issue buttons, which always use the 'trusted' link confirm screen.

Aside from the fix, this also removes the handling for the `SuggestCommand` click action, which has no use on the mod list screen.