### PR TITLE
Added Menu Validity Event

### DIFF
--- a/patches/net/minecraft/world/Container.java.patch
+++ b/patches/net/minecraft/world/Container.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/Container.java
++++ b/net/minecraft/world/Container.java
+@@ -99,7 +_,7 @@
+         if (level == null) {
+             return false;
+         } else {
+-            return level.getBlockEntity(worldPosition) != blockEntity ? false : player.isWithinBlockInteractionRange(worldPosition, distanceBuffer);
++            return level.getBlockEntity(worldPosition) != blockEntity ? false : net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, level, worldPosition, distanceBuffer);
+         }
+     }
+ 

--- a/patches/net/minecraft/world/entity/Mob.java.patch
+++ b/patches/net/minecraft/world/entity/Mob.java.patch
@@ -89,6 +89,15 @@
          if (this.level().getDifficulty() == Difficulty.PEACEFUL && !this.getType().isAllowedInPeaceful()) {
              this.discard();
          } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
+@@ -881,7 +_,7 @@
+ 
+             @Override
+             public boolean stillValid(Player player) {
+-                return player.getVehicle() == Mob.this || player.isWithinEntityInteractionRange(Mob.this, 4.0);
++                return player.getVehicle() == Mob.this || net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, Mob.this, 4.0);
+             }
+         };
+     }
 @@ -1078,6 +_,11 @@
          }
      }

--- a/patches/net/minecraft/world/entity/npc/villager/AbstractVillager.java.patch
+++ b/patches/net/minecraft/world/entity/npc/villager/AbstractVillager.java.patch
@@ -8,3 +8,11 @@
      }
  
      protected abstract void rewardTradeXp(final MerchantOffer offer);
+@@ -300,6 +_,6 @@
+ 
+     @Override
+     public boolean stillValid(Player player) {
+-        return this.getTradingPlayer() == player && this.isAlive() && player.isWithinEntityInteractionRange(this, 4.0);
++        return this.getTradingPlayer() == player && this.isAlive() && net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, this, 4.0);
+     }
+ }

--- a/patches/net/minecraft/world/entity/vehicle/ContainerEntity.java.patch
+++ b/patches/net/minecraft/world/entity/vehicle/ContainerEntity.java.patch
@@ -10,3 +10,11 @@
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
              }
+@@ -166,6 +_,6 @@
+     }
+ 
+     default boolean isChestVehicleStillValid(Player player) {
+-        return !this.isRemoved() && player.isWithinEntityInteractionRange(this.getBoundingBox(), 4.0);
++        return !this.isRemoved() && net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, this, 4.0);
+     }
+ }

--- a/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AbstractContainerMenu.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/inventory/AbstractContainerMenu.java
 +++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -91,7 +_,7 @@
+     }
+ 
+     protected static boolean stillValid(ContainerLevelAccess access, Player player, Block block) {
+-        return access.evaluate((level, pos) -> !level.getBlockState(pos).is(block) ? false : player.isWithinBlockInteractionRange(pos, 4.0), true);
++        return access.evaluate((level, pos) -> !level.getBlockState(pos).is(block) ? false : net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, level, pos, 4.0), true);
+     }
+ 
+     public MenuType<?> getType() {
 @@ -558,6 +_,13 @@
      }
  

--- a/patches/net/minecraft/world/inventory/AbstractMountInventoryMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/AbstractMountInventoryMenu.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/inventory/AbstractMountInventoryMenu.java
++++ b/net/minecraft/world/inventory/AbstractMountInventoryMenu.java
+@@ -28,7 +_,7 @@
+         return !this.hasInventoryChanged(this.mountContainer)
+             && this.mountContainer.stillValid(player)
+             && this.mount.isAlive()
+-            && player.isWithinEntityInteractionRange(this.mount, 4.0);
++            && net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, this.mount, 4.0);
+     }
+ 
+     @Override

--- a/patches/net/minecraft/world/inventory/ItemCombinerMenu.java.patch
+++ b/patches/net/minecraft/world/inventory/ItemCombinerMenu.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/inventory/ItemCombinerMenu.java
++++ b/net/minecraft/world/inventory/ItemCombinerMenu.java
+@@ -105,7 +_,7 @@
+     @Override
+     public boolean stillValid(Player player) {
+         return this.access
+-            .evaluate((level, pos) -> !this.isValidBlock(level.getBlockState(pos)) ? false : player.isWithinBlockInteractionRange(pos, 4.0), true);
++            .evaluate((level, pos) -> !this.isValidBlock(level.getBlockState(pos)) ? false : net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(player, level, pos, 4.0), true);
+     }
+ 
+     @Override

--- a/patches/net/minecraft/world/level/block/entity/SignBlockEntity.java.patch
+++ b/patches/net/minecraft/world/level/block/entity/SignBlockEntity.java.patch
@@ -9,3 +9,12 @@
                      hasAnyClickCommand = true;
                      break;
                  case null:
+@@ -259,7 +_,7 @@
+ 
+     public boolean playerIsTooFarAwayToEdit(UUID player) {
+         Player editingPlayer = this.level.getPlayerByUUID(player);
+-        return editingPlayer == null || !editingPlayer.isWithinBlockInteractionRange(this.getBlockPos(), 4.0);
++        return editingPlayer == null || !net.neoforged.neoforge.common.CommonHooks.menuRangeValidity(editingPlayer, this, 4.0);
+     }
+ 
+     public static void tick(Level level, BlockPos blockPos, BlockState blockState, SignBlockEntity signBlockEntity) {

--- a/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
+++ b/src/main/java/net/neoforged/neoforge/common/CommonHooks.java
@@ -119,6 +119,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.vehicle.ContainerEntity;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.inventory.ClickAction;
@@ -226,6 +227,7 @@ import net.neoforged.neoforge.event.entity.player.CriticalHitEvent;
 import net.neoforged.neoforge.event.entity.player.CustomClickActionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEnchantItemEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInMenuRangeEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.neoforge.event.entity.player.SweepAttackEvent;
 import net.neoforged.neoforge.event.level.BlockDropsEvent;
@@ -1903,5 +1905,21 @@ public class CommonHooks {
                 entriesStreamCodec.encode(output, modifiers);
             }
         };
+    }
+
+    public static boolean menuRangeValidity(Player player, Level level, BlockPos blockPos, double distance) {
+        return NeoForge.EVENT_BUS.post(new PlayerInMenuRangeEvent.BlockMenu(player, level, blockPos, distance, player.isWithinBlockInteractionRange(blockPos, distance))).getStillValid();
+    }
+
+    public static boolean menuRangeValidity(Player player, Entity entity, double distance) {
+        return NeoForge.EVENT_BUS.post(new PlayerInMenuRangeEvent.EntityMenu(player, entity, distance)).getStillValid();
+    }
+
+    public static boolean menuRangeValidity(Player player, ContainerEntity containerEntity, double distance) {
+        return NeoForge.EVENT_BUS.post(new PlayerInMenuRangeEvent.ContainerEntityMenu(player, containerEntity, distance, player.isWithinEntityInteractionRange(containerEntity.getBoundingBox(), distance))).getStillValid();
+    }
+
+    public static boolean menuRangeValidity(Player player, BlockEntity blockEntity, double distance) {
+        return NeoForge.EVENT_BUS.post(new PlayerInMenuRangeEvent.BlockEntityMenu(player, blockEntity, distance, player.isWithinBlockInteractionRange(blockEntity.getBlockPos(), distance))).getStillValid();
     }
 }

--- a/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInMenuRangeEvent.java
+++ b/src/main/java/net/neoforged/neoforge/event/entity/player/PlayerInMenuRangeEvent.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.event.entity.player;
+
+import java.util.Optional;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.vehicle.ContainerEntity;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.neoforge.common.CommonHooks;
+import net.neoforged.neoforge.common.NeoForge;
+import org.jetbrains.annotations.ApiStatus;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Event to check if a menu can stay open or if the player has moved too far away from it.
+ * <p>
+ * This is not used for the initial opening of a GUI. Manipulate player reach or open menus
+ * directly for that.
+ * <p>
+ * This is intended for mods that allow a player remote access to blocks and their menus,
+ * but it also can be used to forcibly kick them out of menus.
+ * <p>
+ * You can query the result of the original distance check with {@link #getOriginallyValid()}
+ * and set your override with {@link #setStillValid(boolean)}.
+ * <p>
+ * This base class is never posted (but it can be subscribed to, as it is not abstract),
+ * only one of its subclasses:
+ * <ul>
+ * <li>{@link PlayerInMenuRangeEvent.BlockMenu} for menus that have a {@link BlockPos} and may or may not be container-based,
+ * <li>{@link PlayerInMenuRangeEvent.ContainerEntityMenu} for {@link ContainerEntity}-based menus, or
+ * <li>{@link PlayerInMenuRangeEvent.EntityMenu} for menus attached to an {@link Entity}, or
+ * <li>{@link PlayerInMenuRangeEvent.BlockEntityMenu} for the checks done by signs which don't use menus but a Screen.
+ * Modded menu-like Screens can also fire this, but using a menu instead of copying its behaviour using custom code is highly recommended.
+ * </ul>
+ * {@link PlayerInMenuRangeEvent.BlockBased} can also be subscribed to if you only need the {@link BlockPos} and distance.
+ * <p>
+ * This event is fired server-side on the {@link NeoForge#EVENT_BUS} by all vanilla superclass implementations ({@link Container},
+ * {@link ContainerEntity}, {@link AbstractContainerMenu}, etc.). Modded menus/container should either call their superclass's
+ * implementation or the appropriate {@link CommonHooks#menuValidity}.
+ */
+public class PlayerInMenuRangeEvent extends PlayerEvent {
+    private final double distance;
+    private final boolean originallyValid;
+    private Optional<Boolean> stillValid = Optional.empty();
+
+    protected PlayerInMenuRangeEvent(Player player, double distance, boolean originallyValid) {
+        super(player);
+        this.distance = distance;
+        this.originallyValid = originallyValid;
+    }
+
+    public double getDistance() {
+        return distance;
+    }
+
+    public boolean getOriginallyValid() {
+        return originallyValid;
+    }
+
+    public void setStillValid(boolean result) {
+        this.stillValid = Optional.of(result);
+    }
+
+    public boolean getStillValid() {
+        return stillValid.orElse(originallyValid);
+    }
+
+    public static class BlockBased extends PlayerInMenuRangeEvent {
+        private final Level level;
+        private final BlockPos blockPos;
+
+        protected BlockBased(Player player, Level level, BlockPos blockPos, double distance, boolean originallyValid) {
+            super(player, distance, originallyValid);
+            this.level = level;
+            this.blockPos = blockPos;
+        }
+
+        public Level getLevel() {
+            return level;
+        }
+
+        public BlockPos getBlockPos() {
+            return blockPos;
+        }
+    }
+
+    public static class BlockMenu extends BlockBased {
+        @ApiStatus.Internal
+        public BlockMenu(Player player, Level level, BlockPos blockPos, double distance, boolean originallyValid) {
+            super(player, level, blockPos, distance, originallyValid);
+        }
+    }
+
+    public static class BlockEntityMenu extends BlockBased {
+        private final BlockEntity blockEntity;
+
+        @ApiStatus.Internal
+        public BlockEntityMenu(Player player, BlockEntity blockEntity, double distance, boolean originallyValid) {
+            super(player, blockEntity.getLevel(), blockEntity.getBlockPos(), distance, originallyValid);
+            this.blockEntity = blockEntity;
+        }
+
+        public BlockEntity getBlockEntity() {
+            return blockEntity;
+        }
+    }
+
+    public static class EntityMenu extends PlayerInMenuRangeEvent {
+        private final Entity entity;
+
+        @ApiStatus.Internal
+        public EntityMenu(Player player, Entity entity, double distance) {
+            super(player, distance, player.isWithinEntityInteractionRange(entity, distance));
+            this.entity = entity;
+        }
+
+        public @Nullable Entity getMenuEntity() {
+            return entity;
+        }
+    }
+
+    public static class ContainerEntityMenu extends PlayerInMenuRangeEvent {
+        private final ContainerEntity entity;
+
+        @ApiStatus.Internal
+        public ContainerEntityMenu(Player player, ContainerEntity containerEntity, double distance, boolean originallyValid) { // ContainerEntity is a Container, not an Entity
+            super(player, distance, originallyValid);
+            this.entity = containerEntity;
+        }
+
+        public @Nullable ContainerEntity getContainerEntity() {
+            return entity;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a `PlayerInMenuRangeEvent` which can be used to override the distance check that closes a menu when the player is too far away.

This can be used by mods to provide a way to remote access menus.

This PR is an updated version of https://github.com/neoforged/NeoForge/pull/1323 but updated to 26.2.x

An example of a usecase is an item that can be bound to a block to open the menu from anywhere (as long as the chunk is loaded):

https://github.com/user-attachments/assets/47cf31f6-a131-48c2-9d94-16e4289caa9d

