### PR TITLE
[26.2] Fix custom fluid movement only working when eyes are in fluid

### DIFF
--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -591,14 +591,12 @@
              )
              : 1.0F;
          Vec3 movement = this.handleRelativeFrictionAndCalculateMovement(input, blockFriction);
-@@ -2487,10 +_,15 @@
+@@ -2487,10 +_,13 @@
          boolean isFalling = this.getDeltaMovement().y <= 0.0;
          double oldY = this.getY();
          double baseGravity = this.getEffectiveGravity();
-+        if (this.isInFluidType((entity, type, _) -> !type.isVanilla() && entity.isEyeInFluid(type))) {
-+            if (this.moveInFluid(this.level().getFluidState(BlockPos.containing(this.getEyePosition())), input, baseGravity)) {
-+                return;
-+            }
++        if (this.getFluidInteraction().isInFluidMatching(this, (entity, type, _) -> !type.isVanilla() && entity.moveInFluid(type, input, baseGravity))) {
++            return;
 +        }
          if (this.isInWater()) {
              this.travelInWater(input, baseGravity, isFalling, oldY);

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidExtension.java
@@ -66,7 +66,10 @@ public interface IFluidExtension {
      * @param movementVector the velocity of how the entity wants to move
      * @param gravity        the gravity to apply to the entity
      * @return {@code true} if custom movement logic is performed, {@code false} otherwise
+     *
+     * @deprecated Use {@link FluidType#move(LivingEntity, Vec3, double)} instead
      */
+    @Deprecated(forRemoval = true, since = "26.2")
     default boolean move(FluidState state, LivingEntity entity, Vec3 movementVector, double gravity) {
         return getFluidType().move(state, entity, movementVector, gravity);
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/IFluidStateExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/IFluidStateExtension.java
@@ -55,7 +55,10 @@ public interface IFluidStateExtension {
      * @param movementVector the velocity of how the entity wants to move
      * @param gravity        the gravity to apply to the entity
      * @return {@code true} if custom movement logic is performed, {@code false} otherwise
+     *
+     * @deprecated Use {@link FluidType#move(LivingEntity, Vec3, double)} instead
      */
+    @Deprecated(forRemoval = true, since = "26.2")
     default boolean move(LivingEntity entity, Vec3 movementVector, double gravity) {
         return self().getType().move(self(), entity, movementVector, gravity);
     }

--- a/src/main/java/net/neoforged/neoforge/common/extensions/ILivingEntityExtension.java
+++ b/src/main/java/net/neoforged/neoforge/common/extensions/ILivingEntityExtension.java
@@ -67,9 +67,25 @@ public interface ILivingEntityExtension extends IEntityExtension {
      * @param movementVector the velocity of how the entity wants to move
      * @param gravity        the gravity to apply to the entity
      * @return {@code true} if custom movement logic is performed, {@code false} otherwise
+     *
+     * @deprecated Use {@link #moveInFluid(FluidType, Vec3, double)} instead
      */
+    @Deprecated(forRemoval = true, since = "26.2")
     default boolean moveInFluid(FluidState state, Vec3 movementVector, double gravity) {
-        return state.move(self(), movementVector, gravity);
+        return moveInFluid(state.getFluidType(), movementVector, gravity);
+    }
+
+    /// Performs how an entity moves when within the fluid. If using custom
+    /// movement logic, the method should return `true`. Otherwise, the
+    /// movement logic will default to water if [FluidType#getIsWaterLike()] returns
+    /// `true` or no movement if it returns `false`.
+    ///
+    /// @param type           the type of the fluid
+    /// @param movementVector the velocity of how the entity wants to move
+    /// @param gravity        the gravity to apply to the entity
+    /// @return `true` if custom movement logic is performed, `false` otherwise
+    default boolean moveInFluid(FluidType type, Vec3 movementVector, double gravity) {
+        return type.move(self(), movementVector, gravity);
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/fluids/FluidType.java
+++ b/src/main/java/net/neoforged/neoforge/fluids/FluidType.java
@@ -303,8 +303,24 @@ public class FluidType {
      * @param movementVector the velocity of how the entity wants to move
      * @param gravity        the gravity to apply to the entity
      * @return {@code true} if custom movement logic is performed, {@code false} otherwise
+     *
+     * @deprecated Use {@link #move(LivingEntity, Vec3, double)} instead
      */
+    @Deprecated(forRemoval = true, since = "26.2")
     public boolean move(FluidState state, LivingEntity entity, Vec3 movementVector, double gravity) {
+        return move(entity, movementVector, gravity);
+    }
+
+    /// Performs how an entity moves when within the fluid. If using custom
+    /// movement logic, the method should return `true`. Otherwise, the
+    /// movement logic will default to water if [#getIsWaterLike()] returns
+    /// `true` or no movement if it returns `false`.
+    ///
+    /// @param entity         the entity moving within the fluid
+    /// @param movementVector the velocity of how the entity wants to move
+    /// @param gravity        the gravity to apply to the entity
+    /// @return `true` if custom movement logic is performed, `false` otherwise
+    public boolean move(LivingEntity entity, Vec3 movementVector, double gravity) {
         return false;
     }
 

--- a/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
@@ -50,7 +50,6 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
-import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.event.entity.living.LivingDrownEvent;
@@ -235,6 +234,17 @@ public class EntityFluidInteractionTests {
                     honeyZombie.get().travel(Vec3.ZERO);
                     helper.assertTrue(honeyType.livingMovementCalls.get() > livingMovementCalls.get(), "Custom movement fluid should use the living movement hook");
                     helper.assertTrue(honeyZombie.get().getDeltaMovement().y > 0.0D, "Custom movement fluid living movement should affect velocity");
+                })
+                .thenExecute(() -> {
+                    honeyZombie.get().remove(Entity.RemovalReason.DISCARDED);
+                    livingMovementCalls.set(honeyType.livingMovementCalls.get());
+                    honeyZombie.set(helper.spawnZombieWithNoFreeWill(honeyPos.above(2)));
+                })
+                .thenExecuteAfter(2, () -> {
+                    honeyZombie.get().setDeltaMovement(Vec3.ZERO);
+                    honeyZombie.get().travel(Vec3.ZERO);
+                    helper.assertTrue(honeyType.livingMovementCalls.get() > livingMovementCalls.get(), "Custom movement fluid should use the living movement hook despite eyes outside of fluid");
+                    helper.assertTrue(honeyZombie.get().getDeltaMovement().y > 0.0D, "Custom movement fluid living movement should affect velocity despite eyes outside of fluid");
                 })
                 .thenSucceed();
     }
@@ -1246,7 +1256,7 @@ public class EntityFluidInteractionTests {
         }
 
         @Override
-        public boolean move(FluidState state, LivingEntity entity, Vec3 movementVector, double gravity) {
+        public boolean move(LivingEntity entity, Vec3 movementVector, double gravity) {
             this.livingMovementCalls.incrementAndGet();
             entity.setDeltaMovement(0.0D, 0.125D, 0.0D);
             return true;


### PR DESCRIPTION
This PR fixes custom fluid movement only working when the affected entity's eyes are in the custom fluid.

When checking against the fluid(s) an entity is in outside of `EntityFluidInteractions`, there is no way to determine which block position around the entity a given fluid was encountered at. This means that the custom movement hook cannot provide the specific `FluidState` nor can it be called on the `Fluid` that state (not that either of these are particularly useful since an entity might be touching multiple different states of the same fluid or even both "variants" [i.e. still and flowing] grouped by a given `FluidType` simultaneously. Instead the movement hook is now only called on the `FluidType` without providing any `FluidState`.

Fixes #3400