### PR TITLE
Fix mod description translations & add fallback for old key

### DIFF
--- a/src/client/java/net/neoforged/neoforge/client/gui/modlist/DefaultModDisplayInfo.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/modlist/DefaultModDisplayInfo.java
@@ -9,6 +9,7 @@ import com.mojang.logging.LogUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
+import net.minecraft.locale.Language;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -66,10 +67,15 @@ public class DefaultModDisplayInfo implements ModDisplayInfo {
     }
 
     /// {@inheritDoc} This uses the translation key `neoforge.screen.mods.info.description.[modid]` if available,
+    /// falling back to the deprecated translation key `fml.menu.mods.info.description.[modid]` if available,
     /// where `[modid]` is the [mod ID][#id()], with a fallback to the `description` key of the mod info.
     @Override
     public Component description() {
-        return Component.translatableWithFallback("neoforge.screen.mods.info.description." + id(), container.getModInfo().getDescription());
+        String newKey = "neoforge.screen.mods.info.description." + id();
+        if (Language.getInstance().has(newKey)) return Component.translatable(newKey);
+
+        // TODO 26.3+: Remove the `fml.menu.mods.info` fallback and only use the new translation key.
+        return Component.translatableWithFallback("fml.menu.mods.info.description." + id(), container.getModInfo().getDescription());
     }
 
     /// {@inheritDoc} This uses the `license` key of the mod file info.

--- a/src/client/java/net/neoforged/neoforge/client/gui/modlist/DefaultModDisplayInfo.java
+++ b/src/client/java/net/neoforged/neoforge/client/gui/modlist/DefaultModDisplayInfo.java
@@ -15,7 +15,6 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.Identifier;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.ModList;
-import net.neoforged.fml.i18n.FMLTranslations;
 import net.neoforged.neoforge.resource.ResourcePackLoader;
 import net.neoforged.neoforgespi.language.IModFileInfo;
 import net.neoforged.neoforgespi.locating.IModFile;
@@ -70,8 +69,7 @@ public class DefaultModDisplayInfo implements ModDisplayInfo {
     /// where `[modid]` is the [mod ID][#id()], with a fallback to the `description` key of the mod info.
     @Override
     public Component description() {
-        //noinspection UnstableApiUsage
-        return Component.translatable(FMLTranslations.getPattern("neoforge.screen.mods.info.description." + id(), container.getModInfo()::getDescription));
+        return Component.translatableWithFallback("neoforge.screen.mods.info.description." + id(), container.getModInfo().getDescription());
     }
 
     /// {@inheritDoc} This uses the `license` key of the mod file info.

--- a/src/client/java/net/neoforged/neoforge/client/internal/ModDisplayInfoDescriptionWarningsHandler.java
+++ b/src/client/java/net/neoforged/neoforge/client/internal/ModDisplayInfoDescriptionWarningsHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.client.internal;
+
+import static java.util.Collections.singletonList;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.language.ClientLanguage;
+import net.minecraft.locale.Language;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.ModLoader;
+import net.neoforged.fml.ModLoadingIssue;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.client.event.ClientResourceLoadFinishedEvent;
+import net.neoforged.neoforge.common.NeoForgeMod;
+
+@EventBusSubscriber(Dist.CLIENT)
+@Mod(value = NeoForgeMod.MOD_ID, dist = Dist.CLIENT)
+public class ModDisplayInfoDescriptionWarningsHandler {
+    private static final boolean HIDE_WARNING_SCREEN = Boolean.getBoolean("neoforge.warnings.mods.info.description.hide");
+
+    @SubscribeEvent
+    public static void onResourceLoadFinished(ClientResourceLoadFinishedEvent event) {
+        // Only run once
+        if (!event.isInitial()) return;
+
+        // Skip if in production or if the property to skip the warnings is set
+        if (FMLEnvironment.isProduction() || HIDE_WARNING_SCREEN) return;
+
+        var languages = getLanguages();
+
+        ModList.get().getMods().forEach(info -> {
+            var modId = info.getModId();
+
+            // See DefaultModDisplayInfo#description()
+            var oldKey = "fml.menu.mods.info.description." + modId;
+            var newKey = "neoforge.screen.mods.info.description." + modId;
+
+            // Warn for languages that translate the old key, unless they also translate the new key
+            var langsToWarn = languages.stream()
+                    .filter(entry -> entry.getValue().has(oldKey) && !entry.getValue().has(newKey))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+            if (langsToWarn.isEmpty()) return;
+
+            // This shouldn't need to be translated, as it will only ever show for developers
+            var warning = ModLoadingIssue.warning(
+                    "Mod %s (%s) uses the deprecated `%s` translation key; change to `%s`",
+                    info.getModId(),
+                    String.join(", ", langsToWarn),
+                    oldKey,
+                    newKey);
+
+            //noinspection UnstableApiUsage
+            ModLoader.addLoadingIssue(warning.withAffectedMod(info));
+        });
+    }
+
+    /// Get each language currently loaded by Minecraft.
+    /// Unlike the vanilla localization system, languages are not stacked on top of `en_us`.
+    private static Set<Map.Entry<String, ? extends Language>> getLanguages() {
+        var mc = Minecraft.getInstance();
+        var resourceManager = mc.getResourceManager();
+        var languageManager = mc.getLanguageManager();
+
+        return languageManager.getLanguages()
+                .keySet()
+                .stream()
+                .map(code -> Map.entry(code, ClientLanguage.loadFrom(resourceManager, singletonList(code), false)))
+                .collect(Collectors.toSet());
+    }
+}

--- a/tests/src/main/resources/assets/neotests/lang/fr_fr.json
+++ b/tests/src/main/resources/assets/neotests/lang/fr_fr.json
@@ -1,3 +1,4 @@
 {
+  "neoforge.screen.mods.info.description.neotests": "Le mod de test de NeoForge oh la la ! J'adore vraiment le français !",
   "fml.menu.mods.info.description.neotests": "Le mod de test de NeoForge oh la la ! J'aime le français !"
 }


### PR DESCRIPTION
### 1. drop FMLTranslations usage

Since 26.2, `FMLTranslations` does not include mod-provided translations.

I'm not sure whether that is intended or a bug, but in this instance there should be no reason to use the FML-specific translation API as we have full access to Minecraft's: directly use `Component.translatableWithFallback` instead.

### 2. support old translation keys

Restore support for the old `fml.menu.mods.info.description.[modid]` translation key, which was used until 26.2.

Probe for the new key using `Language#has`, then fallback to the old key. We _could_ patch `Component` and `TranslatableContents` with extended fallback support, but probing the current language felt less invasive.

### 3. deprecate old translation keys

Added warnings similar to the `logoFile` warning, shown when any language has translation keys for the current mod's "old" translation key (unless it also has the "new" translation key).

### Tests

I initially tested the business logic against an example mod with this mixin:
<details><summary>Test mixin</summary>
<p>

```java
package net.xolt.freecam.forge.mixins;

import net.minecraft.locale.Language;
import net.neoforged.fml.ModContainer;
import net.neoforged.neoforge.client.gui.modlist.DefaultModDisplayInfo;
import org.spongepowered.asm.mixin.Final;
import org.spongepowered.asm.mixin.Mixin;
import org.spongepowered.asm.mixin.Shadow;
import org.spongepowered.asm.mixin.Unique;
import org.spongepowered.asm.mixin.injection.At;
import org.spongepowered.asm.mixin.injection.Inject;
import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;

import java.awt.*;

@Mixin(DefaultModDisplayInfo.class)
abstract class DefaultModDisplayInfoMixin {

    @Shadow public abstract String id();

    @Shadow @Final private ModContainer container;

    @Inject(method = "description", at = @At("HEAD"), cancellable = true, remap = false)
    void description(CallbackInfoReturnable<net.minecraft.network.chat.Component> cir) {
        cir.setReturnValue(freecam$description());
    }

    @Unique
    private net.minecraft.network.chat.Component freecam$description() {
        String newKey = "neoforge.screen.mods.info.description." + id();
        if (Language.getInstance().has(newKey)) return net.minecraft.network.chat.Component.translatable(newKey);

        return net.minecraft.network.chat.Component.translatableWithFallback("fml.menu.mods.info.description." + id(), container.getModInfo().getDescription());
    }
}
```


</p>
</details> 

As suggested in https://github.com/neoforged/NeoForge/pull/3407#issuecomment-5348329082, one can also apply the logic to their own mod using an extension point:

<details><summary>Example extension point</summary>
<p>

```java
import net.neoforged.api.distmarker.Dist;
import net.neoforged.fml.ModContainer;
import net.neoforged.fml.common.Mod;
import net.neoforged.neoforge.client.gui.modlist.ModDisplayInfo;

@Mod(value = "my_mod_id", dist = Dist.CLIENT)
public class ModDisplayInfoHandler {
    public ModDisplayInfoHandler(ModContainer container) {
        try {
            container.registerExtensionPoint(ModDisplayInfo.class, new ModDisplayInfoCompat(container));
        } catch (NoClassDefFoundError _) {
            // Before 26.2.0.50-beta, NeoForge did not have a ModDisplayInfo class
        }
    }
}
```

```java
import net.minecraft.locale.Language;
import net.minecraft.network.chat.Component;
import net.neoforged.fml.ModContainer;
import net.neoforged.neoforge.client.gui.modlist.DefaultModDisplayInfo;

public class ModDisplayInfoCompat extends DefaultModDisplayInfo {

    public ModDisplayInfoCompat(ModContainer container) {
        super(container);
    }

    /**
     * NeoForge 26.2.0.50-beta introduced the new ModListScreen and associated ModDisplayInfo,
     * however description translations were initially broken.
     *
     * @see <a href="https://github.com/neoforged/NeoForge/pull/3407">#3407</a>
     */
    @Override
    public Component description() {
        String newKey = "neoforge.screen.mods.info.description." + id();
        if (Language.getInstance().has(newKey)) return Component.translatable(newKey);

        // TODO 26.3+: Remove the `fml.menu.mods.info` fallback and only use the new translation key.
        return Component.translatableWithFallback("fml.menu.mods.info.description." + id(), container().getModInfo().getDescription());
    }
}
```

</p>
</details> 



### Unit tests

I'd also like to add unit tests for `DefaultModDisplayInfo#description` correctly finding translations in mod resource files. How does NeoForge typically implement those kinda tests? Is there a relevant example in `tests/src/junit`?
