### PR TITLE
[26.2] Fix modded non-waterlike fluids not affecting fall distance

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -37,12 +37,14 @@
          this.updateFluidInteraction();
          this.updateSwimming();
          if (this.level() instanceof ServerLevel serverLevel) {
-@@ -550,7 +_,7 @@
+@@ -550,7 +_,9 @@
          }
  
          if (this.isInLava()) {
 -            this.fallDistance *= 0.5;
 +            this.fallDistance *= this.getFluidFallDistanceModifier(net.neoforged.neoforge.common.NeoForgeMod.LAVA_TYPE.value());
++        } else if (!this.isInWater()) {
++            this.fallDistance *= this.fluidInteraction.getFallDistanceModifier(this);
          }
  
          this.checkBelowWorld();

--- a/patches/net/minecraft/world/entity/EntityFluidInteraction.java.patch
+++ b/patches/net/minecraft/world/entity/EntityFluidInteraction.java.patch
@@ -47,7 +47,7 @@
                                          if (x == eyeBlockX && z == eyeBlockZ && eyeY >= fluidBottom && eyeY <= fluidTop) {
                                              tracker.eyesInside = true;
                                          }
-@@ -118,43 +_,154 @@
+@@ -118,43 +_,168 @@
          return hasFluid;
      }
  
@@ -125,6 +125,20 @@
 +            }
 +        }
 +        return maxHeightType;
++    }
++
++    public float getFallDistanceModifier(Entity entity) {
++        float minMod = 1F;
++        for (var entry : this.trackerByFluid.entrySet()) {
++            if (entry.getValue().height <= 0D || entry.getKey().isVanilla() || entry.getKey().getIsWaterLike()) {
++                continue;
++            }
++            float mod = entity.getFluidFallDistanceModifier(entry.getKey());
++            if (mod < minMod) {
++                minMod = mod;
++            }
++        }
++        return minMod;
 +    }
 +
 +    /// @deprecated Neo: use [#isInFluid(net.neoforged.neoforge.fluids.FluidType)] instead

--- a/patches/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/patches/net/minecraft/world/entity/LivingEntity.java.patch
@@ -34,7 +34,7 @@
  
      protected LivingEntity(EntityType<? extends LivingEntity> type, Level level) {
          super(type, level);
-@@ -358,12 +_,15 @@
+@@ -358,6 +_,8 @@
              .add(Attributes.AIR_DRAG_MODIFIER)
              .add(Attributes.FRICTION_MODIFIER)
              .add(Attributes.NAME_TAG_DISTANCE)
@@ -42,13 +42,6 @@
 +            .add(net.neoforged.neoforge.common.NeoForgeMod.GLIDING_FLIGHT)
              .add(Attributes.BELOW_NAME_DISTANCE);
      }
- 
-     @Override
-     protected void checkFallDamage(double ya, boolean onGround, BlockState onState, BlockPos pos) {
-         if (!this.isInWater()) {
-+            // TODO: prior to 26.1-snapshot-8 we called our patched in method 'this.updateInWaterStateAndDoWaterCurrentPushing(false)'
-             this.updateFluidInteraction();
-         }
  
 @@ -385,7 +_,8 @@
  

--- a/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
+++ b/testframework/src/main/java/net/neoforged/testframework/gametest/ExtendedGameTestHelper.java
@@ -358,8 +358,8 @@ public class ExtendedGameTestHelper extends GameTestHelper {
     }
 
     @Override
-    public <T> void assertValueEqual(T expected, T actual, String message) {
-        this.assertValueEqual(expected, actual, Component.translatable(message));
+    public <T> void assertValueEqual(T actual, T expected, String message) {
+        this.assertValueEqual(actual, expected, Component.translatable(message));
     }
 
     public <T, E extends Entity> void assertEntityProperty(E entity, Function<E, T> function, String message, T value) {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
@@ -89,7 +89,8 @@ public class EntityFluidInteractionTests {
      * Seed oil is a custom non-water fluid that does not override movement.
      */
     private static final FluidFixture<FluidType> SEED_OIL = new FluidFixture<>("seed_oil", () -> new FluidType(FluidType.Properties.create()
-            .descriptionId("fluid_type.neotests_entity_fluid_interaction.seed_oil")));
+            .descriptionId("fluid_type.neotests_entity_fluid_interaction.seed_oil")
+            .fallDistanceModifier(.75F)));
 
     /**
      * Named milk so the tests read like a concrete mod fluid.
@@ -352,25 +353,33 @@ public class EntityFluidInteractionTests {
     }
 
     @GameTest(timeoutTicks = 200)
-    @EmptyTemplate(value = "7x6x3", floor = true)
+    @EmptyTemplate(value = "11x6x3", floor = true)
     @TestHolder(description = "Tests vanilla fluid fall distance against a dry control")
     static void vanillaFluidFallDistance(final TestHelper helper) {
         helper.requireDifficulty(Difficulty.NORMAL);
         final BlockPos waterPos = new BlockPos(1, 2, 1);
         final BlockPos lavaPos = new BlockPos(3, 2, 1);
         final BlockPos dryPos = new BlockPos(5, 2, 1);
+        final BlockPos milkPos = new BlockPos(7, 2, 1);
+        final BlockPos seedOilPos = new BlockPos(9, 2, 1);
         helper.fillFluidColumn(WATER, waterPos);
         helper.fillFluidColumn(LAVA, lavaPos);
+        helper.fillFluidColumn(MILK, milkPos);
+        helper.fillFluidColumn(SEED_OIL, seedOilPos);
 
         final Zombie waterZombie = helper.spawnZombieWithNoFreeWill(waterPos);
         final Zombie lavaZombie = helper.spawnZombieWithNoFreeWill(lavaPos);
         final Zombie dryZombie = helper.spawnZombieWithNoFreeWill(dryPos);
+        final Zombie milkZombie = helper.spawnZombieWithNoFreeWill(milkPos);
+        final Zombie seedOilZombie = helper.spawnZombieWithNoFreeWill(seedOilPos);
 
         helper.startSequence()
                 .thenExecuteAfter(2, () -> {
                     helper.assertFallDistanceAfterBaseTick(waterZombie, 12.0D, 0.0D, "Water should reset fall distance during base tick");
                     helper.assertFallDistanceAfterBaseTick(lavaZombie, 12.0D, 6.0D, "Lava should reduce fall distance by its fluid modifier");
                     helper.assertFallDistanceAfterBaseTick(dryZombie, 12.0D, 12.0D, "Dry entity should keep fall distance during base tick");
+                    helper.assertFallDistanceAfterBaseTick(milkZombie, 12.0D, 0.0D, "Water-like fluid should reset fall distance during base tick");
+                    helper.assertFallDistanceAfterBaseTick(seedOilZombie, 12.0D, 9.0D, "Non-water-like fluid should reduce fall distance by its fluid modifier");
                 })
                 .thenSucceed();
     }
@@ -1074,7 +1083,7 @@ public class EntityFluidInteractionTests {
         void assertFallDistanceAfterBaseTick(Entity entity, double initialFallDistance, double expectedFallDistance, String message) {
             entity.fallDistance = initialFallDistance;
             entity.baseTick();
-            this.assertValueEqual(expectedFallDistance, entity.fallDistance, message);
+            this.assertValueEqual(entity.fallDistance, expectedFallDistance, message);
         }
 
         void assertNormalSkeletonHorse(CalciumAbsorbingSkeletonHorse horse, float normalWidth, float normalHeight, String fluidName) {


### PR DESCRIPTION
This PR fixes the fall distance modifier of modded non-waterlike fluids not having any effect.

I opted to also include cleanup of a related stale TODO and a flipped parameter name issue in the test framework which confused me during testing.

Fixes #3406