### PR TITLE
Add ScreenEvent.Preedit event

### DIFF
--- a/patches/net/minecraft/client/KeyboardHandler.java.patch
+++ b/patches/net/minecraft/client/KeyboardHandler.java.patch
@@ -45,3 +45,14 @@
                  } catch (Throwable t) {
                      CrashReport report = CrashReport.forThrowable(t, "charTyped event handler");
                      screen.fillCrashDetails(report);
+@@ -598,7 +_,9 @@
+ 
+     public static void submitPreeditEvent(GuiEventListener element, @Nullable PreeditEvent event) {
+         try {
+-            element.preeditUpdated(event);
++            if (element instanceof Screen screen && net.neoforged.neoforge.client.ClientHooks.onScreenPreeditPre(screen, event)) return;
++            if (element.preeditUpdated(event)) return;
++            if (element instanceof Screen screen) net.neoforged.neoforge.client.ClientHooks.onScreenPreeditPost(screen, event);
+         } catch (Throwable t) {
+             CrashReport report = CrashReport.forThrowable(t, "IME pre-edit event handler");
+             if (element instanceof Screen screen) {

--- a/patches/net/minecraft/client/KeyboardHandler.java.patch
+++ b/patches/net/minecraft/client/KeyboardHandler.java.patch
@@ -50,9 +50,9 @@
      public static void submitPreeditEvent(GuiEventListener element, @Nullable PreeditEvent event) {
          try {
 -            element.preeditUpdated(event);
-+            if (element instanceof Screen screen && net.neoforged.neoforge.client.ClientHooks.onScreenPreeditPre(screen, event)) return;
++            if (net.neoforged.neoforge.client.ClientHooks.onPreeditPre(element, event)) return;
 +            if (element.preeditUpdated(event)) return;
-+            if (element instanceof Screen screen) net.neoforged.neoforge.client.ClientHooks.onScreenPreeditPost(screen, event);
++            net.neoforged.neoforge.client.ClientHooks.onPreeditPost(element, event);
          } catch (Throwable t) {
              CrashReport report = CrashReport.forThrowable(t, "IME pre-edit event handler");
              if (element instanceof Screen screen) {

--- a/patches/net/minecraft/client/KeyboardHandler.java.patch
+++ b/patches/net/minecraft/client/KeyboardHandler.java.patch
@@ -50,9 +50,9 @@
      public static void submitPreeditEvent(GuiEventListener element, @Nullable PreeditEvent event) {
          try {
 -            element.preeditUpdated(event);
-+            if (net.neoforged.neoforge.client.ClientHooks.onPreeditPre(element, event)) return;
++            if (element instanceof Screen screen && net.neoforged.neoforge.client.ClientHooks.onScreenPreeditPre(screen, event)) return;
 +            if (element.preeditUpdated(event)) return;
-+            net.neoforged.neoforge.client.ClientHooks.onPreeditPost(element, event);
++            if (element instanceof Screen screen) net.neoforged.neoforge.client.ClientHooks.onScreenPreeditPost(screen, event);
          } catch (Throwable t) {
              CrashReport report = CrashReport.forThrowable(t, "IME pre-edit event handler");
              if (element instanceof Screen screen) {

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -71,6 +71,7 @@ import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.input.MouseButtonInfo;
+import net.minecraft.client.input.PreeditEvent;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.model.Model;
 import net.minecraft.client.model.geom.EntityModelSet;
@@ -545,6 +546,16 @@ public class ClientHooks {
 
     public static void onScreenCharTypedPost(Screen guiScreen, CharacterEvent charEvent) {
         Event event = new ScreenEvent.CharacterTyped.Post(guiScreen, charEvent);
+        NeoForge.EVENT_BUS.post(event);
+    }
+
+    public static boolean onScreenPreeditPre(Screen guiScreen, @Nullable PreeditEvent preeditEvent) {
+        var event = new ScreenEvent.Preedit.Pre(guiScreen, preeditEvent);
+        return NeoForge.EVENT_BUS.post(event).isCanceled();
+    }
+
+    public static void onScreenPreeditPost(Screen guiScreen, @Nullable PreeditEvent preeditEvent) {
+        Event event = new ScreenEvent.Preedit.Post(guiScreen, preeditEvent);
         NeoForge.EVENT_BUS.post(event);
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -59,7 +59,6 @@ import net.minecraft.client.gui.Hud;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.client.gui.components.debug.DebugEntryCategory;
 import net.minecraft.client.gui.components.debug.DebugScreenEntries;
-import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
@@ -550,13 +549,13 @@ public class ClientHooks {
         NeoForge.EVENT_BUS.post(event);
     }
 
-    public static boolean onPreeditPre(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
-        var event = new InputEvent.Preedit.Pre(inputTarget, preeditEvent);
+    public static boolean onScreenPreeditPre(Screen guiScreen, @Nullable PreeditEvent preeditEvent) {
+        var event = new ScreenEvent.Preedit.Pre(guiScreen, preeditEvent);
         return NeoForge.EVENT_BUS.post(event).isCanceled();
     }
 
-    public static void onPreeditPost(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
-        Event event = new InputEvent.Preedit.Post(inputTarget, preeditEvent);
+    public static void onScreenPreeditPost(Screen guiScreen, @Nullable PreeditEvent preeditEvent) {
+        Event event = new ScreenEvent.Preedit.Post(guiScreen, preeditEvent);
         NeoForge.EVENT_BUS.post(event);
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
+++ b/src/client/java/net/neoforged/neoforge/client/ClientHooks.java
@@ -59,6 +59,7 @@ import net.minecraft.client.gui.Hud;
 import net.minecraft.client.gui.components.LerpingBossEvent;
 import net.minecraft.client.gui.components.debug.DebugEntryCategory;
 import net.minecraft.client.gui.components.debug.DebugScreenEntries;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
@@ -549,13 +550,13 @@ public class ClientHooks {
         NeoForge.EVENT_BUS.post(event);
     }
 
-    public static boolean onScreenPreeditPre(Screen guiScreen, @Nullable PreeditEvent preeditEvent) {
-        var event = new ScreenEvent.Preedit.Pre(guiScreen, preeditEvent);
+    public static boolean onPreeditPre(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
+        var event = new InputEvent.Preedit.Pre(inputTarget, preeditEvent);
         return NeoForge.EVENT_BUS.post(event).isCanceled();
     }
 
-    public static void onScreenPreeditPost(Screen guiScreen, @Nullable PreeditEvent preeditEvent) {
-        Event event = new ScreenEvent.Preedit.Post(guiScreen, preeditEvent);
+    public static void onPreeditPost(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
+        Event event = new InputEvent.Preedit.Post(inputTarget, preeditEvent);
         NeoForge.EVENT_BUS.post(event);
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
@@ -7,8 +7,10 @@ package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonInfo;
+import net.minecraft.client.input.PreeditEvent;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -16,6 +18,7 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
 import org.joml.Vector2ic;
+import org.jspecify.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 /**
@@ -25,6 +28,7 @@ import org.lwjgl.glfw.GLFW;
  * @see InputEvent.MouseButton
  * @see MouseScrollingEvent
  * @see Key
+ * @see Preedit
  * @see InteractionKeyMappingTriggered
  */
 public abstract class InputEvent extends Event {
@@ -298,6 +302,76 @@ public abstract class InputEvent extends Event {
          */
         public int getModifiers() {
             return this.keyEvent.modifiers();
+        }
+    }
+
+    /**
+     * Fired when an {@linkplain PreeditEvent Input Method Editor (IME) preedit event} is submitted to a GUI input target.
+     *
+     * <p>An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
+     * and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
+     * until the user commits it.</p>
+     *
+     * See the two subclasses for listening before and after the normal handling.
+     *
+     * @see Preedit.Pre
+     * @see Preedit.Post
+     */
+    public static abstract class Preedit extends InputEvent {
+        private final GuiEventListener inputTarget;
+        private final @Nullable PreeditEvent preeditEvent;
+
+        @ApiStatus.Internal
+        public Preedit(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
+            this.inputTarget = inputTarget;
+            this.preeditEvent = preeditEvent;
+        }
+
+        /**
+         * {@return the GUI input target that will receive the preedit event}
+         */
+        public GuiEventListener getInputTarget() {
+            return inputTarget;
+        }
+
+        /**
+         * {@return the current preedit composition, or {@code null} if there is no active composition}
+         */
+        public @Nullable PreeditEvent getPreeditEvent() {
+            return preeditEvent;
+        }
+
+        /**
+         * Fired <b>before</b> the preedit event is handled by the input target.
+         *
+         * <p>This event is {@linkplain ICancellableEvent cancellable}.
+         * If the event is cancelled, the input target's preedit handler will be bypassed
+         * and the corresponding {@link Preedit.Post} will not be fired.</p>
+         *
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         */
+        public static class Pre extends Preedit implements ICancellableEvent {
+            @ApiStatus.Internal
+            public Pre(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
+                super(inputTarget, preeditEvent);
+            }
+        }
+
+        /**
+         * Fired <b>after</b> the preedit event is handled, if not handled by the input target
+         * and the corresponding {@link Preedit.Pre} is not cancelled.
+         *
+         * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
+         *
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         */
+        public static class Post extends Preedit {
+            @ApiStatus.Internal
+            public Post(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
+                super(inputTarget, preeditEvent);
+            }
         }
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
@@ -7,10 +7,8 @@ package net.neoforged.neoforge.client.event;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
-import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonInfo;
-import net.minecraft.client.input.PreeditEvent;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -18,7 +16,6 @@ import net.neoforged.fml.LogicalSide;
 import net.neoforged.neoforge.common.NeoForge;
 import org.jetbrains.annotations.ApiStatus;
 import org.joml.Vector2ic;
-import org.jspecify.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 /**
@@ -28,7 +25,6 @@ import org.lwjgl.glfw.GLFW;
  * @see InputEvent.MouseButton
  * @see MouseScrollingEvent
  * @see Key
- * @see Preedit
  * @see InteractionKeyMappingTriggered
  */
 public abstract class InputEvent extends Event {
@@ -302,62 +298,6 @@ public abstract class InputEvent extends Event {
          */
         public int getModifiers() {
             return this.keyEvent.modifiers();
-        }
-    }
-
-    /// Fired when an [Input Method Editor (IME) preedit event][PreeditEvent] is submitted to a GUI input target.
-    ///
-    /// An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
-    /// and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
-    /// until the user commits it.
-    ///
-    /// See [Pre][Preedit.Pre] and [Post][Preedit.Post] for listening before and after the normal handling.
-    public static abstract class Preedit extends InputEvent {
-        private final GuiEventListener inputTarget;
-        private final @Nullable PreeditEvent preeditEvent;
-
-        @ApiStatus.Internal
-        public Preedit(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
-            this.inputTarget = inputTarget;
-            this.preeditEvent = preeditEvent;
-        }
-
-        /// {@return the GUI input target that will receive the preedit event}
-        public GuiEventListener getInputTarget() {
-            return inputTarget;
-        }
-
-        /// {@return the current preedit composition, or `null` if there is no active composition}
-        public @Nullable PreeditEvent getPreeditEvent() {
-            return preeditEvent;
-        }
-
-        /// Fired **before** the preedit event is handled by the input target.
-        ///
-        /// This event is [cancellable][ICancellableEvent]. If the event is cancelled, the input target's preedit
-        /// handler will be bypassed and the corresponding [Post][Preedit.Post] will not be fired.
-        ///
-        /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
-        /// only on the [logical client][LogicalSide#CLIENT].
-        public static class Pre extends Preedit implements ICancellableEvent {
-            @ApiStatus.Internal
-            public Pre(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
-                super(inputTarget, preeditEvent);
-            }
-        }
-
-        /// Fired **after** the preedit event is handled, if not handled by the input target
-        /// and the corresponding [Pre][Preedit.Pre] is not cancelled.
-        ///
-        /// This event is not [cancellable][ICancellableEvent].
-        ///
-        /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
-        /// only on the [logical client][LogicalSide#CLIENT].
-        public static class Post extends Preedit {
-            @ApiStatus.Internal
-            public Post(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
-                super(inputTarget, preeditEvent);
-            }
         }
     }
 

--- a/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/InputEvent.java
@@ -305,18 +305,13 @@ public abstract class InputEvent extends Event {
         }
     }
 
-    /**
-     * Fired when an {@linkplain PreeditEvent Input Method Editor (IME) preedit event} is submitted to a GUI input target.
-     *
-     * <p>An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
-     * and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
-     * until the user commits it.</p>
-     *
-     * See the two subclasses for listening before and after the normal handling.
-     *
-     * @see Preedit.Pre
-     * @see Preedit.Post
-     */
+    /// Fired when an [Input Method Editor (IME) preedit event][PreeditEvent] is submitted to a GUI input target.
+    ///
+    /// An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
+    /// and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
+    /// until the user commits it.
+    ///
+    /// See [Pre][Preedit.Pre] and [Post][Preedit.Post] for listening before and after the normal handling.
     public static abstract class Preedit extends InputEvent {
         private final GuiEventListener inputTarget;
         private final @Nullable PreeditEvent preeditEvent;
@@ -327,30 +322,23 @@ public abstract class InputEvent extends Event {
             this.preeditEvent = preeditEvent;
         }
 
-        /**
-         * {@return the GUI input target that will receive the preedit event}
-         */
+        /// {@return the GUI input target that will receive the preedit event}
         public GuiEventListener getInputTarget() {
             return inputTarget;
         }
 
-        /**
-         * {@return the current preedit composition, or {@code null} if there is no active composition}
-         */
+        /// {@return the current preedit composition, or `null` if there is no active composition}
         public @Nullable PreeditEvent getPreeditEvent() {
             return preeditEvent;
         }
 
-        /**
-         * Fired <b>before</b> the preedit event is handled by the input target.
-         *
-         * <p>This event is {@linkplain ICancellableEvent cancellable}.
-         * If the event is cancelled, the input target's preedit handler will be bypassed
-         * and the corresponding {@link Preedit.Post} will not be fired.</p>
-         *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
-         */
+        /// Fired **before** the preedit event is handled by the input target.
+        ///
+        /// This event is [cancellable][ICancellableEvent]. If the event is cancelled, the input target's preedit
+        /// handler will be bypassed and the corresponding [Post][Preedit.Post] will not be fired.
+        ///
+        /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
+        /// only on the [logical client][LogicalSide#CLIENT].
         public static class Pre extends Preedit implements ICancellableEvent {
             @ApiStatus.Internal
             public Pre(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {
@@ -358,15 +346,13 @@ public abstract class InputEvent extends Event {
             }
         }
 
-        /**
-         * Fired <b>after</b> the preedit event is handled, if not handled by the input target
-         * and the corresponding {@link Preedit.Pre} is not cancelled.
-         *
-         * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
-         *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
-         */
+        /// Fired **after** the preedit event is handled, if not handled by the input target
+        /// and the corresponding [Pre][Preedit.Pre] is not cancelled.
+        ///
+        /// This event is not [cancellable][ICancellableEvent].
+        ///
+        /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
+        /// only on the [logical client][LogicalSide#CLIENT].
         public static class Post extends Preedit {
             @ApiStatus.Internal
             public Post(GuiEventListener inputTarget, @Nullable PreeditEvent preeditEvent) {

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -18,7 +18,6 @@ import net.minecraft.client.gui.screens.inventory.EffectsInInventory;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.client.input.PreeditEvent;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -39,7 +38,6 @@ import org.lwjgl.glfw.GLFW;
  * @see Render
  * @see MouseInput
  * @see KeyInput
- * @see Preedit
  */
 public abstract class ScreenEvent extends Event {
     private final Screen screen;
@@ -964,68 +962,6 @@ public abstract class ScreenEvent extends Event {
             @ApiStatus.Internal
             public Post(Screen screen, CharacterEvent charEvent) {
                 super(screen, charEvent);
-            }
-        }
-    }
-
-    /**
-     * Fired when an {@linkplain PreeditEvent Input Method Editor (IME) preedit event} is submitted to a screen.
-     *
-     * <p>An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
-     * and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
-     * until the user commits it.</p>
-     *
-     * See the two subclasses for listening before and after the normal handling.
-     *
-     * @see Preedit.Pre
-     * @see Preedit.Post
-     */
-    public static abstract class Preedit extends ScreenEvent {
-        private final @Nullable PreeditEvent preeditEvent;
-
-        @ApiStatus.Internal
-        public Preedit(Screen screen, @Nullable PreeditEvent preeditEvent) {
-            super(screen);
-            this.preeditEvent = preeditEvent;
-        }
-
-        /**
-         * {@return the current preedit composition, or {@code null} if there is no active composition}
-         */
-        public @Nullable PreeditEvent getPreeditEvent() {
-            return preeditEvent;
-        }
-
-        /**
-         * Fired <b>before</b> the preedit event is handled by the screen.
-         *
-         * <p>This event is {@linkplain ICancellableEvent cancellable}.
-         * If the event is cancelled, the screen's preedit handler will be bypassed
-         * and the corresponding {@link Preedit.Post} will not be fired.</p>
-         *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
-         */
-        public static class Pre extends Preedit implements ICancellableEvent {
-            @ApiStatus.Internal
-            public Pre(Screen screen, @Nullable PreeditEvent preeditEvent) {
-                super(screen, preeditEvent);
-            }
-        }
-
-        /**
-         * Fired <b>after</b> the preedit event is handled, if not handled by the screen
-         * and the corresponding {@link Preedit.Pre} is not cancelled.
-         *
-         * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
-         *
-         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
-         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
-         */
-        public static class Post extends Preedit {
-            @ApiStatus.Internal
-            public Post(Screen screen, @Nullable PreeditEvent preeditEvent) {
-                super(screen, preeditEvent);
             }
         }
     }

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -18,6 +18,7 @@ import net.minecraft.client.gui.screens.inventory.EffectsInInventory;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.PreeditEvent;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -38,6 +39,7 @@ import org.lwjgl.glfw.GLFW;
  * @see Render
  * @see MouseInput
  * @see KeyInput
+ * @see Preedit
  */
 public abstract class ScreenEvent extends Event {
     private final Screen screen;
@@ -962,6 +964,56 @@ public abstract class ScreenEvent extends Event {
             @ApiStatus.Internal
             public Post(Screen screen, CharacterEvent charEvent) {
                 super(screen, charEvent);
+            }
+        }
+    }
+
+    /// Fired when an [Input Method Editor (IME) preedit event][PreeditEvent] is submitted to a screen.
+    ///
+    /// An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
+    /// and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
+    /// until the user commits it.
+    ///
+    /// See [Pre][Preedit.Pre] and [Post][Preedit.Post] for listening before and after the normal handling.
+    public static abstract class Preedit extends ScreenEvent {
+        private final @Nullable PreeditEvent preeditEvent;
+
+        @ApiStatus.Internal
+        public Preedit(Screen screen, @Nullable PreeditEvent preeditEvent) {
+            super(screen);
+            this.preeditEvent = preeditEvent;
+        }
+
+        /// {@return the current preedit composition, or `null` if there is no active composition}
+        public @Nullable PreeditEvent getPreeditEvent() {
+            return preeditEvent;
+        }
+
+        /// Fired **before** the preedit event is handled by the screen.
+        ///
+        /// This event is [cancellable][ICancellableEvent]. If the event is cancelled, the screen's preedit handler will
+        /// be bypassed and the corresponding [Post][Preedit.Post] will not be fired.
+        ///
+        /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
+        /// only on the [logical client][LogicalSide#CLIENT].
+        public static class Pre extends Preedit implements ICancellableEvent {
+            @ApiStatus.Internal
+            public Pre(Screen screen, @Nullable PreeditEvent preeditEvent) {
+                super(screen, preeditEvent);
+            }
+        }
+
+        /// Fired **after** the preedit event is handled, if not handled by the screen
+        /// and the corresponding [Pre][Preedit.Pre] is not cancelled.
+        ///
+        /// This event is not [cancellable][ICancellableEvent].
+        ///
+        /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
+        /// only on the [logical client][LogicalSide#CLIENT].
+        public static class Post extends Preedit {
+            @ApiStatus.Internal
+            public Post(Screen screen, @Nullable PreeditEvent preeditEvent) {
+                super(screen, preeditEvent);
             }
         }
     }

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -18,6 +18,7 @@ import net.minecraft.client.gui.screens.inventory.EffectsInInventory;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.PreeditEvent;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -38,6 +39,7 @@ import org.lwjgl.glfw.GLFW;
  * @see Render
  * @see MouseInput
  * @see KeyInput
+ * @see Preedit
  */
 public abstract class ScreenEvent extends Event {
     private final Screen screen;
@@ -962,6 +964,68 @@ public abstract class ScreenEvent extends Event {
             @ApiStatus.Internal
             public Post(Screen screen, CharacterEvent charEvent) {
                 super(screen, charEvent);
+            }
+        }
+    }
+
+    /**
+     * Fired when an {@linkplain PreeditEvent Input Method Editor (IME) preedit event} is submitted to a screen.
+     *
+     * <p>An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
+     * and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
+     * until the user commits it.</p>
+     *
+     * See the two subclasses for listening before and after the normal handling.
+     *
+     * @see Preedit.Pre
+     * @see Preedit.Post
+     */
+    public static abstract class Preedit extends ScreenEvent {
+        private final @Nullable PreeditEvent preeditEvent;
+
+        @ApiStatus.Internal
+        public Preedit(Screen screen, @Nullable PreeditEvent preeditEvent) {
+            super(screen);
+            this.preeditEvent = preeditEvent;
+        }
+
+        /**
+         * {@return the current preedit composition, or {@code null} if there is no active composition}
+         */
+        public @Nullable PreeditEvent getPreeditEvent() {
+            return preeditEvent;
+        }
+
+        /**
+         * Fired <b>before</b> the preedit event is handled by the screen.
+         *
+         * <p>This event is {@linkplain ICancellableEvent cancellable}.
+         * If the event is cancelled, the screen's preedit handler will be bypassed
+         * and the corresponding {@link Preedit.Post} will not be fired.</p>
+         *
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         */
+        public static class Pre extends Preedit implements ICancellableEvent {
+            @ApiStatus.Internal
+            public Pre(Screen screen, @Nullable PreeditEvent preeditEvent) {
+                super(screen, preeditEvent);
+            }
+        }
+
+        /**
+         * Fired <b>after</b> the preedit event is handled, if not handled by the screen
+         * and the corresponding {@link Preedit.Pre} is not cancelled.
+         *
+         * <p>This event is not {@linkplain ICancellableEvent cancellable}.</p>
+         *
+         * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
+         * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
+         */
+        public static class Post extends Preedit {
+            @ApiStatus.Internal
+            public Post(Screen screen, @Nullable PreeditEvent preeditEvent) {
+                super(screen, preeditEvent);
             }
         }
     }

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -976,6 +976,7 @@ public abstract class ScreenEvent extends Event {
     ///
     /// @see Preedit.Pre
     /// @see Preedit.Post
+    /// @see GuiEventListener#preeditUpdated(PreeditEvent)
     public static abstract class Preedit extends ScreenEvent {
         private final @Nullable PreeditEvent preeditEvent;
 
@@ -990,7 +991,7 @@ public abstract class ScreenEvent extends Event {
             return preeditEvent;
         }
 
-        /// Fired **before** the preedit event is received by the screen.
+        /// Fired **before** the preedit event is received by the screen's preedit handler.
         ///
         /// This event is [cancellable][ICancellableEvent]. If this event is canceled, the screen's preedit handler will
         /// be bypassed and the corresponding [Post][Preedit.Post] will not be fired.
@@ -1004,8 +1005,8 @@ public abstract class ScreenEvent extends Event {
             }
         }
 
-        /// Fired **after** the preedit event and the normal screen handler, only if the corresponding
-        /// [Pre][Preedit.Pre] event is not canceled and the normal screen handler returns `false`.
+        /// Fired **after** the screen's preedit handler, only if the corresponding [Pre][Preedit.Pre] event is not
+        /// canceled and the screen's preedit handler returns `false`.
         ///
         /// This event is not [cancellable][ICancellableEvent].
         ///

--- a/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/ScreenEvent.java
@@ -968,13 +968,14 @@ public abstract class ScreenEvent extends Event {
         }
     }
 
-    /// Fired when an [Input Method Editor (IME) preedit event][PreeditEvent] is submitted to a screen.
+    /// Fired when an [Input Method Editor (IME) preedit event][PreeditEvent] is received by a screen.
     ///
     /// An IME lets users enter text that is not directly available from their keyboard, such as Chinese, Japanese,
     /// and Korean characters. While input is being composed, the IME supplies temporary preedit text that can change
     /// until the user commits it.
     ///
-    /// See [Pre][Preedit.Pre] and [Post][Preedit.Post] for listening before and after the normal handling.
+    /// @see Preedit.Pre
+    /// @see Preedit.Post
     public static abstract class Preedit extends ScreenEvent {
         private final @Nullable PreeditEvent preeditEvent;
 
@@ -989,9 +990,9 @@ public abstract class ScreenEvent extends Event {
             return preeditEvent;
         }
 
-        /// Fired **before** the preedit event is handled by the screen.
+        /// Fired **before** the preedit event is received by the screen.
         ///
-        /// This event is [cancellable][ICancellableEvent]. If the event is cancelled, the screen's preedit handler will
+        /// This event is [cancellable][ICancellableEvent]. If this event is canceled, the screen's preedit handler will
         /// be bypassed and the corresponding [Post][Preedit.Post] will not be fired.
         ///
         /// This event is fired on the [main NeoForge event bus][NeoForge#EVENT_BUS],
@@ -1003,8 +1004,8 @@ public abstract class ScreenEvent extends Event {
             }
         }
 
-        /// Fired **after** the preedit event is handled, if not handled by the screen
-        /// and the corresponding [Pre][Preedit.Pre] is not cancelled.
+        /// Fired **after** the preedit event and the normal screen handler, only if the corresponding
+        /// [Pre][Preedit.Pre] event is not canceled and the normal screen handler returns `false`.
         ///
         /// This event is not [cancellable][ICancellableEvent].
         ///


### PR DESCRIPTION
## Problem

Text input elements added outside the normal listener hierarchy of a screen do not receive Input Method Editor (IME) preedit events. An IME builds temporary composition text, such as Chinese, Japanese, or Korean input, before committing the final characters.

Minecraft sends these events through the active screen, and screens such as `CreativeModeInventoryScreen` can override preedit handling and bypass the focused listener. 

## Motivation for the change

JEI currently needs a `KeyboardHandler` mixin to redirect composition input to its focused search field: https://github.com/mezz/JustEnoughItems/pull/4425

## Solution

Add `ScreenEvent.Preedit.Pre` and `ScreenEvent.Preedit.Post` around normal input handling.

Like other screen events, `Pre` is cancellable, allowing overlays such as the JEI search field to handle composition and bypass the screen. `Post` observes anything left over that remains unhandled.