### PR TITLE
Skip logoFile warning if bannerFile or iconFile is present

### DIFF
--- a/src/main/java/net/neoforged/neoforge/internal/LogoFileWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/internal/LogoFileWarningsHandler.java
@@ -26,9 +26,12 @@ public class LogoFileWarningsHandler {
                     .or(() -> info.getOwningFile().getConfig().getConfigElement("logoFile"));
             var bannerFile = info.getConfig().getConfigElement("bannerFile")
                     .or(() -> info.getOwningFile().getConfig().getConfigElement("bannerFile"));
+            // See DefaultModDisplayInfo#icon()
+            var iconFile = info.getConfig().getConfigElement("iconFile")
+                    .or(() -> info.getOwningFile().getConfig().getConfigElement("iconFile"));
 
-            // Skip warning if bannerFile is present, since it means the developer consciously kept the old property (for multi-version compat)
-            if (logoFile.isPresent() && bannerFile.isEmpty()) {
+            // Skip warning if bannerFile or iconFile is present, since it means the developer consciously kept the old property (for multi-version compat)
+            if (logoFile.isPresent() && bannerFile.isEmpty() && iconFile.isEmpty()) {
                 // This shouldn't need to be translated, as it will only ever show for developers
                 //noinspection UnstableApiUsage
                 ModLoader.addLoadingIssue(ModLoadingIssue.warning("Mod %s uses the deprecated `logoFile` property; change to `bannerFile` and/or (for square icons) `iconFile`", info.getModId()).withAffectedMod(info));

--- a/src/main/java/net/neoforged/neoforge/internal/LogoFileWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/internal/LogoFileWarningsHandler.java
@@ -24,6 +24,10 @@ public class LogoFileWarningsHandler {
             // See DefaultModDisplayInfo#banner()
             var logoFile = info.getLogoFile()
                     .or(() -> info.getOwningFile().getConfig().getConfigElement("logoFile"));
+
+            // If logoFile is not set, there is nothing to warn about
+            if (logoFile.isEmpty()) return;
+
             var bannerFile = info.getConfig().getConfigElement("bannerFile")
                     .or(() -> info.getOwningFile().getConfig().getConfigElement("bannerFile"));
             // See DefaultModDisplayInfo#icon()
@@ -31,7 +35,7 @@ public class LogoFileWarningsHandler {
                     .or(() -> info.getOwningFile().getConfig().getConfigElement("iconFile"));
 
             // Skip warning if bannerFile or iconFile is present, since it means the developer consciously kept the old property (for multi-version compat)
-            if (logoFile.isPresent() && bannerFile.isEmpty() && iconFile.isEmpty()) {
+            if (bannerFile.isEmpty() && iconFile.isEmpty()) {
                 // This shouldn't need to be translated, as it will only ever show for developers
                 //noinspection UnstableApiUsage
                 ModLoader.addLoadingIssue(ModLoadingIssue.warning("Mod %s uses the deprecated `logoFile` property; change to `bannerFile` and/or (for square icons) `iconFile`", info.getModId()).withAffectedMod(info));

--- a/src/main/java/net/neoforged/neoforge/internal/LogoFileWarningsHandler.java
+++ b/src/main/java/net/neoforged/neoforge/internal/LogoFileWarningsHandler.java
@@ -24,8 +24,11 @@ public class LogoFileWarningsHandler {
             // See DefaultModDisplayInfo#banner()
             var logoFile = info.getLogoFile()
                     .or(() -> info.getOwningFile().getConfig().getConfigElement("logoFile"));
+            var bannerFile = info.getConfig().getConfigElement("bannerFile")
+                    .or(() -> info.getOwningFile().getConfig().getConfigElement("bannerFile"));
 
-            if (logoFile.isPresent()) {
+            // Skip warning if bannerFile is present, since it means the developer consciously kept the old property (for multi-version compat)
+            if (logoFile.isPresent() && bannerFile.isEmpty()) {
                 // This shouldn't need to be translated, as it will only ever show for developers
                 //noinspection UnstableApiUsage
                 ModLoader.addLoadingIssue(ModLoadingIssue.warning("Mod %s uses the deprecated `logoFile` property; change to `bannerFile` and/or (for square icons) `iconFile`", info.getModId()).withAffectedMod(info));


### PR DESCRIPTION
This PR closes #3412 by skipping the `logoFile` presence warning when either `bannerFile` or `iconFile` (the intended replacements for that property) are present.