### PR TITLE
Increment Y offset when BossEventProgress is canceled

### DIFF
--- a/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
+++ b/patches/net/minecraft/client/gui/components/BossHealthOverlay.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/gui/components/BossHealthOverlay.java
 +++ b/net/minecraft/client/gui/components/BossHealthOverlay.java
-@@ -68,13 +_,16 @@
+@@ -68,13 +_,17 @@
              for (LerpingBossEvent event : this.events.values()) {
                  int xLeft = screenWidth / 2 - 91;
                  int yo = yOffset;
@@ -13,8 +13,9 @@
                  int y = yo - 9;
                  graphics.text(this.minecraft.font, msg, x, y, -1);
 -                yOffset += 10 + 9;
-+                yOffset += customizeEvent.getIncrement();
 +                }
++                // Neo: Always increment the yOffset, to make room for any custom rendered elements
++                yOffset += customizeEvent.getIncrement();
                  if (yOffset >= graphics.guiHeight() / 3) {
                      break;
                  }

--- a/src/client/java/net/neoforged/neoforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/CustomizeGuiOverlayEvent.java
@@ -45,15 +45,11 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
         return partialTick;
     }
 
-    /**
-     * Fired <b>before</b> a boss health bar is rendered to the screen.
-     *
-     * <p>This event is {@linkplain ICancellableEvent cancellable}, and does not {@linkplain HasResult have a result}.
-     * Cancelling this event will prevent the given bar from rendering.</p>
-     *
-     * <p>This event is fired on the {@linkplain NeoForge#EVENT_BUS main Forge event bus},
-     * only on the {@linkplain LogicalSide#CLIENT logical client}.</p>
-     */
+    /// Fired **before** a boss health bar is rendered to the screen.
+    ///
+    /// This event is [cancellable][ICancellableEvent]. Cancelling this event will prevent the given bar from rendering.
+    ///
+    /// This event is fired on the [game event bus][NeoForge#EVENT_BUS], only on the [logical client][LogicalSide#CLIENT].
     public static class BossEventProgress extends CustomizeGuiOverlayEvent implements ICancellableEvent {
         private final LerpingBossEvent bossEvent;
         private final int x;
@@ -69,39 +65,29 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
             this.increment = increment;
         }
 
-        /**
-         * @return the boss health bar currently being rendered
-         */
+        /// {@return the boss health bar currently being rendered}
         public LerpingBossEvent getBossEvent() {
             return bossEvent;
         }
 
-        /**
-         * {@return the X position of the boss health bar}
-         */
+        /// {@return the X position of the boss health bar}
         public int getX() {
             return x;
         }
 
-        /**
-         * {@return the Y position of the boss health bar}
-         */
+        /// {@return the Y position of the boss health bar}
         public int getY() {
             return y;
         }
 
-        /**
-         * {@return the Y position increment before rendering the next boss health bar}
-         */
+        /// {@return the Y position increment, applied before rendering the next boss health bar}
         public int getIncrement() {
             return increment;
         }
 
-        /**
-         * Sets the Y position increment before rendering the next boss health bar.
-         *
-         * @param increment the new Y position increment
-         */
+        /// Sets the Y position increment, which is applied before rendering the next boss health bar.
+        ///
+        /// @param increment the new Y position increment
         public void setIncrement(int increment) {
             this.increment = increment;
         }

--- a/src/client/java/net/neoforged/neoforge/client/event/CustomizeGuiOverlayEvent.java
+++ b/src/client/java/net/neoforged/neoforge/client/event/CustomizeGuiOverlayEvent.java
@@ -48,6 +48,8 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
     /// Fired **before** a boss health bar is rendered to the screen.
     ///
     /// This event is [cancellable][ICancellableEvent]. Cancelling this event will prevent the given bar from rendering.
+    /// The [Y position increment][#getIncrement()] is always applied, even if the event is canceled, to give way for any
+    /// custom elements rendered in place of vanilla's bar rendering.
     ///
     /// This event is fired on the [game event bus][NeoForge#EVENT_BUS], only on the [logical client][LogicalSide#CLIENT].
     public static class BossEventProgress extends CustomizeGuiOverlayEvent implements ICancellableEvent {
@@ -81,6 +83,7 @@ public abstract class CustomizeGuiOverlayEvent extends Event {
         }
 
         /// {@return the Y position increment, applied before rendering the next boss health bar}
+        /// This is always applied, even if the event is [canceled][#setCanceled(boolean)].
         public int getIncrement() {
             return increment;
         }


### PR DESCRIPTION
This PR fixes #3386 by changing the hook for `CustomizeGuiOverlayEvent.BossEventProgress` to always apply the Y position increment, even if the event is canceled. This allows for space to be given for custom elements rendered by mods (in place of the vanilla rendering, which is why they cancelled the event).

The increment was reimplemented in #3269, but it made the mistake of moving the increment to be affected by the event cancellation. We didn't catch that in review, whoops. To prevent this from occurring again, a comment is placed in the patch.

This PR also cleans up and converts to Markdown the javadocs for that event, and also documents the behavior of the always-applied Y position increment.