### PR TITLE
[26.1] Fix window resize events happening outside the tick loop getting lost

### DIFF
--- a/patches/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -41,6 +41,21 @@
              hurt /= cameraState.entityRenderState.hurtDuration;
              hurt = Mth.sin(hurt * hurt * hurt * hurt * (float) Math.PI);
              float rr = cameraState.entityRenderState.hurtDir;
+@@ -423,11 +_,12 @@
+     public void render(DeltaTracker deltaTracker, boolean advanceGameTime) {
+         ProfilerFiller profiler = Profiler.get();
+         profiler.push("render");
+-        if (this.gameRenderState.windowRenderState.isResized) {
++        RenderTarget mainRenderTarget = this.minecraft.getMainRenderTarget();
++        // Neo: compare sizes instead of using the "resized" flag to correctly capture resizes happening before entering the tick loop
++        if (this.gameRenderState.windowRenderState.width != mainRenderTarget.width || this.gameRenderState.windowRenderState.height != mainRenderTarget.height) {
+             this.resize(this.gameRenderState.windowRenderState.width, this.gameRenderState.windowRenderState.height);
+         }
+ 
+-        RenderTarget mainRenderTarget = this.minecraft.getMainRenderTarget();
+         RenderSystem.getDevice()
+             .createCommandEncoder()
+             .clearColorAndDepthTextures(
 @@ -507,7 +_,8 @@
              profiler.push("screen");
  


### PR DESCRIPTION
This PR fixes window resize events (including but not limited to maximizing the window) happening during startup, specifically after window init and before entering the tick loop, getting lost, causing the window to consist of three quarters ELS (specifically the last two frames whose remnants reside in the front/back buffer) and one quarter vanilla "content".

The underlying cause of this is technically a vanilla bug but one that is not humanly possible to trigger without the ELS: when the game window is resized, vanilla sets a flag which is checked by the `GameRenderer` before it starts rendering the current frame. Before triggering the game tick (which includes rendering the frame), vanilla clears this flag and then polls window events. This causes the resize event that happened outside the tick loop to get lost.
The fix being applied here is effectively a backport of how vanilla handles the "needs resize" check in 26.2, therefore neither this bug nor the fix are applicable to versions past 26.1.

The bug can be reliably triggered by adding `GLFW.glfwMaximizeWindow(Minecraft.getInstance().getWindow().handle());` at the head of `ClientModLoader.finish()`.

Fixes #3186