### PR TITLE
Fix network compatibility with fabric during configuration phase

### DIFF
--- a/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
+++ b/patches/net/minecraft/client/multiplayer/ClientConfigurationPacketListenerImpl.java.patch
@@ -55,7 +55,7 @@
                  @Override
                  public boolean hasInfiniteMaterials() {
                      return true;
-@@ -206,6 +_,59 @@
+@@ -206,6 +_,61 @@
      public void onDisconnect(DisconnectionDetails reason) {
          super.onDisconnect(reason);
          this.minecraft.clearDownloadedResourcePacks();
@@ -65,6 +65,8 @@
 +    public void handleCustomPayload(net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket packet) {
 +        // Handle the initial registration payload by responding with the client's set of supported channels.
 +        if (!this.initializedConnection && packet.payload() instanceof net.neoforged.neoforge.network.payload.MinecraftRegisterPayload) {
++            // Handle the registration packet before we respond, so that implementations like fabric that only send it once, don't have the values ignored
++            super.handleCustomPayload(packet);
 +            net.neoforged.neoforge.client.network.registration.ClientNetworkRegistry.sendInitialListeningChannels(this);
 +            return;
 +        }

--- a/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
+++ b/src/client/java/net/neoforged/neoforge/client/network/registration/ClientNetworkRegistry.java
@@ -10,7 +10,6 @@ import com.mojang.logging.LogUtils;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.PacketFlow;
@@ -255,6 +254,16 @@ public final class ClientNetworkRegistry extends NetworkRegistry {
 
         NetworkFilters.injectIfNecessary(listener.getConnection());
 
+        sendInitialListeningChannels(listener);
+    }
+
+    /// Invoked by the client when it receives a [MinecraftRegisterPayload] during negotiation in the configuration phase.
+    /// This will respond to the server with the client's set of builtin and optional channels to indicate it supports the common protocol.
+    ///
+    /// Invoked on the network thread.
+    ///
+    /// @param listener The listener which received the brand payload.
+    public static void sendInitialListeningChannels(ClientConfigurationPacketListener listener) {
         ImmutableSet.Builder<Identifier> nowListeningOn = ImmutableSet.builder();
         nowListeningOn.addAll(getInitialListeningChannels(listener.flow()));
         PAYLOAD_REGISTRATIONS.get(ConnectionProtocol.CONFIGURATION).entrySet().stream()
@@ -262,19 +271,6 @@ public final class ClientNetworkRegistry extends NetworkRegistry {
                 .filter(registration -> registration.getValue().optional())
                 .forEach(registration -> nowListeningOn.add(registration.getKey()));
         listener.send(new MinecraftRegisterPayload(nowListeningOn.build()));
-    }
-
-    /**
-     * Invoked by the client when it receives a {@link MinecraftRegisterPayload} during negotiation in the configuration phase.
-     * This will respond to the server with the client's set of builtin channels to indicate it supports the common protocol.
-     * <p>
-     * Invoked on the network thread.
-     * 
-     * @param listener The listener which received the brand payload.
-     */
-    public static void sendInitialListeningChannels(ClientConfigurationPacketListener listener) {
-        Set<Identifier> nowListeningOn = ImmutableSet.copyOf(getInitialListeningChannels(listener.flow()));
-        listener.send(new MinecraftRegisterPayload(nowListeningOn));
     }
 
     /**

--- a/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
+++ b/src/main/java/net/neoforged/neoforge/network/registration/NetworkRegistry.java
@@ -429,11 +429,11 @@ public class NetworkRegistry {
                 return;
             }
 
-            if (hasChannel(listener, customPayloadPacket.payload().type().id())) {
+            if (hasChannel(listener, id)) {
                 return;
             }
 
-            throw new UnsupportedOperationException("Payload %s may not be sent to the client!".formatted(customPayloadPacket.payload().type().id()));
+            throw new UnsupportedOperationException("Payload %s may not be sent to the client!".formatted(id));
         }
     }
 
@@ -451,11 +451,11 @@ public class NetworkRegistry {
                 return;
             }
 
-            if (hasChannel(listener, customPayloadPacket.payload().type().id())) {
+            if (hasChannel(listener, id)) {
                 return;
             }
 
-            throw new UnsupportedOperationException("Payload %s may not be sent to the server!".formatted(customPayloadPacket.payload().type().id()));
+            throw new UnsupportedOperationException("Payload %s may not be sent to the server!".formatted(id));
         }
     }
 
@@ -541,10 +541,10 @@ public class NetworkRegistry {
                 return;
             }
 
-            NetworkChannel channel = payloadSetup.getChannel(ConnectionProtocol.PLAY, customPayloadPacket.payload().type().id());
+            NetworkChannel channel = payloadSetup.getChannel(ConnectionProtocol.PLAY, id);
 
             if (channel == null) {
-                LOGGER.trace("Somebody tried to send: {} to a client which cannot accept it. Not sending packet.", customPayloadPacket.payload().type().id());
+                LOGGER.trace("Somebody tried to send: {} to a client which cannot accept it. Not sending packet.", id);
                 return;
             }
 
@@ -612,7 +612,7 @@ public class NetworkRegistry {
         nowForgottenChannels.add(MinecraftRegisterPayload.ID);
         nowForgottenChannels.add(MinecraftUnregisterPayload.ID);
         PAYLOAD_REGISTRATIONS.get(ConnectionProtocol.PLAY).entrySet().stream()
-                .filter(registration -> registration.getValue().flow().isEmpty() || registration.getValue().flow().get() == PacketFlow.SERVERBOUND)
+                .filter(registration -> registration.getValue().matchesFlow(PacketFlow.SERVERBOUND))
                 .filter(registration -> registration.getValue().optional())
                 .forEach(registration -> nowForgottenChannels.add(registration.getKey()));
         return nowForgottenChannels.build();


### PR DESCRIPTION
This PR follows up #3277, by sending all optional configuration channels in addition to the builtin ones so that fabric can detect the presence of configuration channels provided by a neo mod (#1913)

Additionally this PR fixes another bug that is exposed by the above fix, where we are ignoring the channels that are initially sent to us via the `minecraft:register` packet, instead of keeping track of them. This would lead to a neo client failing to respond to a fabric server configuration packet due to the neo client not knowing the fabric server supports the response channel.

(I also did a tiny bit of misc code cleanup to `NetworkRegistry` while poking through it trying to track down the bugs this PR fixes)