### PR TITLE
Allow querying the full data map via RegistryLookup

### DIFF
--- a/patches/net/minecraft/core/HolderLookup.java.patch
+++ b/patches/net/minecraft/core/HolderLookup.java.patch
@@ -1,25 +1,31 @@
 --- a/net/minecraft/core/HolderLookup.java
 +++ b/net/minecraft/core/HolderLookup.java
-@@ -96,6 +_,18 @@
+@@ -96,6 +_,24 @@
              };
          }
  
-+        /**
-+         * {@return the data map value attached with the object with the key, or {@code null} if there's no attached value}
-+         *
-+         * @param type the type of the data map
-+         * @param key  the object to get the value for
-+         * @param <A>  the data type
-+         */
++        /// {@return the data map value attached with the object with the key, or {@code null} if there's no attached value}
++        ///
++        /// @param type the type of the data map
++        /// @param key  the object to get the value for
++        /// @param <A>  the data type
 +        @org.jspecify.annotations.Nullable
 +        default <A> A getData(net.neoforged.neoforge.registries.datamaps.DataMapType<T, A> type, ResourceKey<T> key) {
 +            return null;
 +        }
 +
++        /// {@return the data map of the given `type`}
++        ///
++        /// @param type the type of the data map
++        /// @param <A>  the data type
++        default <A> Map<ResourceKey<T>, A> getDataMap(net.neoforged.neoforge.registries.datamaps.DataMapType<T, A> type) {
++            return Map.of();
++        }
++
          interface Delegate<T> extends HolderLookup.RegistryLookup<T> {
              HolderLookup.RegistryLookup<T> parent();
  
-@@ -127,6 +_,12 @@
+@@ -127,6 +_,17 @@
              @Override
              default Stream<HolderSet.Named<T>> listTags() {
                  return this.parent().listTags();
@@ -27,8 +33,13 @@
 +
 +            @Override
 +            @org.jspecify.annotations.Nullable
-+            default <A> A getData(net.neoforged.neoforge.registries.datamaps.DataMapType<T, A> attachment, ResourceKey<T> key) {
-+                return parent().getData(attachment, key);
++            default <A> A getData(net.neoforged.neoforge.registries.datamaps.DataMapType<T, A> type, ResourceKey<T> key) {
++                return parent().getData(type, key);
++            }
++
++            @Override
++            default <A> Map<ResourceKey<T>, A> getDataMap(net.neoforged.neoforge.registries.datamaps.DataMapType<T, A> type) {
++                return parent().getDataMap(type);
              }
          }
      }

--- a/patches/net/minecraft/core/Registry.java.patch
+++ b/patches/net/minecraft/core/Registry.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/core/Registry.java
 +++ b/net/minecraft/core/Registry.java
-@@ -49,7 +_,7 @@
+@@ -49,10 +_,13 @@
      }
  
      private DataResult<Holder.Reference<T>> safeCastToReference(Holder<T> holder) {
@@ -9,3 +9,9 @@
              ? DataResult.success(reference)
              : DataResult.error(() -> "Unregistered holder in " + this.key() + ": " + holder);
      }
++
++    @Override//Neo: Force Implementation of the method from IRegistryExtension rather than defaulting to the empty map implementation from RegistryLookup
++    <A> java.util.Map<ResourceKey<T>, A> getDataMap(net.neoforged.neoforge.registries.datamaps.DataMapType<T, A> type);
+ 
+     @Override
+     default <U> Stream<U> keys(DynamicOps<U> ops) {


### PR DESCRIPTION
We already proxy getting the data for a specific element's data from a `RegistryLookup`, but when creating recipes to display in JEI I am currently forced to look registry up from the level's `RegistryAccess`, instead of from the `ContextMap` that provides me access to a `RegistryLookup`. This change just exposes the method to `RegistryLookup` that `BaseMappedRegistry` already implements.