### PR TITLE
[26.2] Fix fluid interactions not using fluid-dependent isPushedByFluid() method

### DIFF
--- a/patches/net/minecraft/world/entity/Entity.java.patch
+++ b/patches/net/minecraft/world/entity/Entity.java.patch
@@ -154,17 +154,19 @@
      }
  
      protected boolean updateFluidInteraction() {
-         this.fluidInteraction.update(this, !this.isPushedByFluid());
+-        this.fluidInteraction.update(this, !this.isPushedByFluid());
 -        boolean inWater = this.fluidInteraction.isInFluid(FluidTags.WATER);
 -        boolean inLava = this.fluidInteraction.isInFluid(FluidTags.LAVA);
++        this.fluidInteraction.update(this, this::isPushedByFluid);
 +        boolean inWater = this.fluidInteraction.isInFluidMatching(this, (_, type, _) -> type.getIsWaterLike());
          if (inWater) {
              this.resetFallDistance();
              if (!this.wasTouchingWater && !this.firstTick) {
-@@ -1644,17 +_,10 @@
+@@ -1643,18 +_,9 @@
+         }
  
          this.wasTouchingWater = inWater;
-         if (this.isPushedByFluid()) {
+-        if (this.isPushedByFluid()) {
 -            if (inWater) {
 -                this.fluidInteraction.applyCurrentTo(FluidTags.WATER, this, 0.014);
 -            }
@@ -173,10 +175,11 @@
 -                double lavaFlowScale = this.level.environmentAttributes().getDimensionValue(EnvironmentAttributes.FAST_LAVA) ? 0.007 : 0.0023333333333333335;
 -                this.fluidInteraction.applyCurrentTo(FluidTags.LAVA, this, lavaFlowScale);
 -            }
-+            this.fluidInteraction.applyCurrentTo(this);
-         }
- 
+-        }
+-
 -        return inWater || inLava;
++        this.fluidInteraction.applyCurrentTo(this);
++
 +        return this.fluidInteraction.isInAnyFluid();
      }
  

--- a/patches/net/minecraft/world/entity/EntityFluidInteraction.java.patch
+++ b/patches/net/minecraft/world/entity/EntityFluidInteraction.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/EntityFluidInteraction.java
 +++ b/net/minecraft/world/entity/EntityFluidInteraction.java
-@@ -21,16 +_,17 @@
+@@ -21,16 +_,23 @@
  import org.jspecify.annotations.Nullable;
  
  public class EntityFluidInteraction {
@@ -15,22 +15,29 @@
          }
      }
  
++    /// @deprecated Neo: use [#update(Entity, java.util.function.Predicate)] instead
++    @Deprecated
      public void update(Entity entity, boolean ignoreCurrent) {
 -        this.trackerByFluid.values().forEach(EntityFluidInteraction.Tracker::reset);
++        update(entity, _ -> !ignoreCurrent);
++    }
++
++    public void update(Entity entity, java.util.function.Predicate<net.neoforged.neoforge.fluids.FluidType> typePushPredicate) {
 +        this.trackerByFluid.values().removeIf(EntityFluidInteraction.Tracker::resetAndCheckUnused);
          AABB box = entity.getFluidInteractionBox();
          if (box != null) {
              int x0 = Mth.floor(box.minX);
-@@ -44,7 +_,7 @@
+@@ -44,7 +_,8 @@
                  int eyeBlockX = entity.getBlockX();
                  double eyeY = entity.getEyeY();
                  int eyeBlockZ = entity.getBlockZ();
 -                Fluid lastFluidType = null;
 +                net.neoforged.neoforge.fluids.FluidType lastFluidType = null;
++                boolean ignoreCurrent = false;
                  EntityFluidInteraction.Tracker tracker = null;
                  BlockGetter level = entity.level();
                  BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
-@@ -58,13 +_,15 @@
+@@ -58,13 +_,16 @@
                                  double fluidBottom = mutablePos.getY();
                                  double fluidTop = fluidBottom + fluidState.getHeight(level, mutablePos);
                                  if (!(fluidTop < box.minY)) {
@@ -39,6 +46,7 @@
                                      if (fluidType != lastFluidType) {
                                          lastFluidType = fluidType;
                                          tracker = this.getTrackerFor(fluidType);
++                                        ignoreCurrent = !typePushPredicate.test(fluidType);
                                      }
  
                                      if (tracker != null) {
@@ -86,7 +94,7 @@
  
 +    public void applyCurrentTo(Entity entity) {
 +        for (var entry : this.trackerByFluid.entrySet()) {
-+            if (entry.getValue().height > 0D) {
++            if (entry.getValue().height > 0D && entity.isPushedByFluid(entry.getKey())) {
 +                entry.getValue().applyCurrentTo(entity, entity.getFluidMotionScale(entry.getKey()));
 +            }
 +        }

--- a/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
@@ -1014,9 +1014,11 @@ public class EntityFluidInteractionTests {
                 .fill(0, 1, 4, 6, 1, 4, Blocks.STONE));
 
         test.onGameTest(TestHelper.class, helper -> {
-            final BlockPos pushablePos = new BlockPos(2, 1, 1);
-            final BlockPos centerPos = new BlockPos(2, 1, 2);
-            final BlockPos nonPushablePos = new BlockPos(2, 1, 3);
+            final BlockPos pushablePos = new BlockPos(1, 1, 1);
+            final BlockPos centerPos = new BlockPos(1, 1, 2);
+            final BlockPos nonPushablePos = new BlockPos(1, 1, 3);
+            final BlockPos pushableEntityPos = pushablePos.east();
+            final BlockPos nonPushableEntityPos = nonPushablePos.east();
 
             final AtomicReference<Zombie> pushableEntity = new AtomicReference<>();
             final AtomicReference<Pig> nonPushableEntity = new AtomicReference<>();
@@ -1028,12 +1030,12 @@ public class EntityFluidInteractionTests {
                         helper.setBlock(nonPushablePos, STEAM.blockState());
                     })
                     .thenExecuteAfter(20, () -> {
-                        pushableEntity.set(helper.spawnZombieWithNoFreeWill(pushablePos));
-                        nonPushableEntity.set(helper.spawnWithNoFreeWill(EntityTypes.PIG, nonPushablePos));
+                        pushableEntity.set(helper.spawnZombieWithNoFreeWill(pushableEntityPos));
+                        nonPushableEntity.set(helper.spawnWithNoFreeWill(EntityTypes.PIG, nonPushableEntityPos));
                     })
                     .thenExecuteAfter(40, () -> {
-                        helper.assertEntityPosition(pushableEntity.get(), pushablePos, (p1, p2) -> !p1.equals(p2), "Expected Zombie to be pushed by Steam");
-                        helper.assertEntityPosition(nonPushableEntity.get(), nonPushablePos, BlockPos::equals, "Expected Pig to not be pushed by Steam");
+                        helper.assertEntityPosition(pushableEntity.get(), pushableEntityPos, (p1, p2) -> !p1.equals(p2), "Expected Zombie to be pushed by Steam");
+                        helper.assertEntityPosition(nonPushableEntity.get(), nonPushableEntityPos, BlockPos::equals, "Expected Pig to not be pushed by Steam");
                     })
                     .thenSucceed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/fluid/EntityFluidInteractionTests.java
@@ -8,6 +8,7 @@ package net.neoforged.neoforge.debug.fluid;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 import net.minecraft.client.renderer.entity.NoopRenderer;
 import net.minecraft.core.BlockPos;
@@ -58,6 +59,7 @@ import net.neoforged.neoforge.fluids.FluidType;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.NeoForgeRegistries;
+import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.TestFramework;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.OnInit;
@@ -66,6 +68,7 @@ import net.neoforged.testframework.gametest.EmptyTemplate;
 import net.neoforged.testframework.gametest.ExtendedGameTestHelper;
 import net.neoforged.testframework.gametest.GameTest;
 import net.neoforged.testframework.gametest.GameTestPlayer;
+import net.neoforged.testframework.gametest.StructureTemplateBuilder;
 import net.neoforged.testframework.registration.RegistrationHelper;
 
 @ForEachTest(groups = EntityFluidInteractionTests.GROUP)
@@ -103,6 +106,11 @@ public class EntityFluidInteractionTests {
             .canSwim(true)
             .canExtinguish(true)
             .supportsBoating(true)
+            .isWaterLike(true)));
+
+    /// Steam is a water-like fluid which only pushes zombies.
+    private static final FluidFixture<FluidType> STEAM = new FluidFixture<>("steam", () -> new SteamFluidType(FluidType.Properties.create()
+            .descriptionId("fluid_type.neotests_entity_fluid_interactions.steam")
             .isWaterLike(true)));
 
     private static final Supplier<EntityType<UndrownableZombie>> UNDROWNABLE_ZOMBIE = REG_HELPER.entityTypes()
@@ -995,6 +1003,42 @@ public class EntityFluidInteractionTests {
                 .thenSucceed();
     }
 
+    @GameTest(timeoutTicks = 200)
+    @TestHolder(description = "Tests submerged mining speed in water-like custom fluid against water and lava controls")
+    static void conditionalFluidPushing(final DynamicTest test) {
+        test.registerGameTestTemplate(() -> StructureTemplateBuilder.withSize(7, 4, 5)
+                .fill(0, 0, 0, 6, 0, 4, Blocks.STONE)
+                .fill(0, 1, 0, 0, 1, 4, Blocks.STONE)
+                .fill(6, 1, 0, 6, 1, 4, Blocks.STONE)
+                .fill(0, 1, 0, 6, 1, 0, Blocks.STONE)
+                .fill(0, 1, 4, 6, 1, 4, Blocks.STONE));
+
+        test.onGameTest(TestHelper.class, helper -> {
+            final BlockPos pushablePos = new BlockPos(2, 1, 1);
+            final BlockPos centerPos = new BlockPos(2, 1, 2);
+            final BlockPos nonPushablePos = new BlockPos(2, 1, 3);
+
+            final AtomicReference<Zombie> pushableEntity = new AtomicReference<>();
+            final AtomicReference<Pig> nonPushableEntity = new AtomicReference<>();
+
+            helper.startSequence()
+                    .thenExecute(() -> {
+                        helper.setBlock(pushablePos, STEAM.blockState());
+                        helper.setBlock(centerPos, STEAM.blockState());
+                        helper.setBlock(nonPushablePos, STEAM.blockState());
+                    })
+                    .thenExecuteAfter(20, () -> {
+                        pushableEntity.set(helper.spawnZombieWithNoFreeWill(pushablePos));
+                        nonPushableEntity.set(helper.spawnWithNoFreeWill(EntityTypes.PIG, nonPushablePos));
+                    })
+                    .thenExecuteAfter(40, () -> {
+                        helper.assertEntityPosition(pushableEntity.get(), pushablePos, (p1, p2) -> !p1.equals(p2), "Expected Zombie to be pushed by Steam");
+                        helper.assertEntityPosition(nonPushableEntity.get(), nonPushablePos, BlockPos::equals, "Expected Pig to not be pushed by Steam");
+                    })
+                    .thenSucceed();
+        });
+    }
+
     private static boolean isBoatEyeInBoatableFluid(Boat boat) {
         return boat.getFluidInteraction().isEyeInFluidMatching(boat, (entity, type, _) -> entity.canBoatInFluid(type));
     }
@@ -1096,6 +1140,11 @@ public class EntityFluidInteractionTests {
             this.assertTrue(horse.isGiant(), "Skeleton horse in " + fluidName + " should become giant");
             this.assertTrue(horse.getBbWidth() > normalWidth, "Skeleton horse in " + fluidName + " should grow wider");
             this.assertTrue(horse.getBbHeight() > normalHeight, "Skeleton horse in " + fluidName + " should grow taller");
+        }
+
+        void assertEntityPosition(Entity entity, BlockPos comparePos, BiPredicate<BlockPos, BlockPos> predicate, String message) {
+            // Converting absolute to relative positions is broken, so we do it the stupid way
+            this.assertEntityProperty(entity, e -> predicate.test(this.absolutePos(comparePos), e.blockPosition()), message);
         }
 
         void fillFluidColumn(FluidFixture<?> fluid, BlockPos pos) {
@@ -1283,6 +1332,17 @@ public class EntityFluidInteractionTests {
         public boolean canHydrate(Entity entity) {
             this.hydrationChecks.incrementAndGet();
             return entity instanceof CalciumAbsorbingSkeletonHorse;
+        }
+    }
+
+    private static final class SteamFluidType extends FluidType {
+        private SteamFluidType(Properties properties) {
+            super(properties);
+        }
+
+        @Override
+        public boolean canPushEntity(Entity entity) {
+            return entity.getType() == EntityTypes.ZOMBIE;
         }
     }
 


### PR DESCRIPTION
This PR fixes entity-fluid interactions not using the `FluidType`-dependent `Entity#isPushedByFluid()` method.

The added test works fine in singleplayer but is currently broken on a test server because I cannot figure out how to make the fluids tick such that they actually spread as needed for the test to work.