### PR TITLE
Stop spawning boat at 0,0,0 when boat is dispensed

### DIFF
--- a/patches/net/minecraft/core/dispenser/BoatDispenseItemBehavior.java.patch
+++ b/patches/net/minecraft/core/dispenser/BoatDispenseItemBehavior.java.patch
@@ -1,26 +1,37 @@
 --- a/net/minecraft/core/dispenser/BoatDispenseItemBehavior.java
 +++ b/net/minecraft/core/dispenser/BoatDispenseItemBehavior.java
-@@ -29,11 +_,17 @@
+@@ -29,27 +_,36 @@
          double spawnY = center.y() + direction.getStepY() * 1.125F;
          double spawnZ = center.z() + direction.getStepZ() * justOutsideDispenser;
          BlockPos frontPos = source.pos().relative(direction);
-+        AbstractBoat abstractboat = this.type.create(level, EntitySpawnReason.DISPENSER);
-+        if (abstractboat != null) {
-+            EntityType.<AbstractBoat>createDefaultStackConfig(level, dispensed, null).apply(abstractboat);
-+            abstractboat.setYRot(direction.toYRot());
-+            level.addFreshEntity(abstractboat);
++        // Neo: Move the creation (but not addition to the level) of the boat entity earlier for use in various checks
++        AbstractBoat boat = this.type.create(level, EntitySpawnReason.DISPENSER);
++        if (boat != null) {
++            boat.setInitialPos(spawnX, spawnY, spawnZ);
++            EntityType.<AbstractBoat>createDefaultStackConfig(level, dispensed, null).apply(boat);
++            boat.setYRot(direction.toYRot());
 +        }
          double yOffset;
 -        if (level.getFluidState(frontPos).is(FluidTags.WATER)) {
-+        if (canBoatInFluid(abstractboat, level.getFluidState(frontPos))) {
++        if (canBoatInFluid(boat, level.getFluidState(frontPos))) {
              yOffset = 1.0;
          } else {
 -            if (!level.getBlockState(frontPos).isAir() || !level.getFluidState(frontPos.below()).is(FluidTags.WATER)) {
-+            if (!level.getBlockState(frontPos).isAir() || !canBoatInFluid(abstractboat, level.getFluidState(frontPos.below()))) {
++            if (!level.getBlockState(frontPos).isAir() || !canBoatInFluid(boat, level.getFluidState(frontPos.below()))) {
                  return this.defaultDispenseItemBehavior.dispense(source, dispensed);
              }
  
-@@ -50,6 +_,10 @@
+             yOffset = 0.0;
+         }
+ 
+-        AbstractBoat boat = this.type.create(level, EntitySpawnReason.DISPENSER);
+         if (boat != null) {
++            // Neo: Apply Y offset to the boat, add it to the level, and shrink the stack
+             boat.setInitialPos(spawnX, spawnY + yOffset, spawnZ);
+-            EntityType.<AbstractBoat>createDefaultStackConfig(level, dispensed, null).apply(boat);
+-            boat.setYRot(direction.toYRot());
+             level.addFreshEntity(boat);
+             dispensed.shrink(1);
          }
  
          return dispensed;

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -5,14 +5,13 @@
 
 package net.neoforged.neoforge.debug.item;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.data.models.BlockModelGenerators;
 import net.minecraft.client.data.models.ItemModelGenerators;
@@ -34,6 +33,7 @@ import net.minecraft.tags.ItemTags;
 import net.minecraft.util.Util;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -62,6 +62,7 @@ import net.minecraft.world.level.block.entity.DispenserBlockEntity;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
 import net.neoforged.testframework.DynamicTest;
 import net.neoforged.testframework.annotation.ForEachTest;
 import net.neoforged.testframework.annotation.TestHolder;
@@ -80,11 +81,18 @@ public class ItemTests {
         test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 4, 3)
                 .placeSustainedWater(1, 2, 1, Blocks.IRON_BLOCK.defaultBlockState()));
 
+        final var captureDispensedEntities = new AtomicBoolean();
+        final var dispensedEntities = new ArrayList<Entity>();
+        test.eventListeners().forge().addListener((EntityJoinLevelEvent event) -> {
+            if (captureDispensedEntities.get()) {
+                dispensedEntities.add(event.getEntity());
+            }
+        });
+
         test.onGameTest(helper -> {
             final Component boatName = Component.literal("boat dispenser duplicate test");
             final ItemStack boatStack = Items.OAK_BOAT.getDefaultInstance();
             final BlockPos expectedPos = new BlockPos(1, 2, 1);
-            final var entitiesBeforeDispense = new HashSet<UUID>();
             boatStack.set(DataComponents.CUSTOM_NAME, boatName);
 
             helper.startSequence()
@@ -93,24 +101,28 @@ public class ItemTests {
                             "The expected boat location must be at least 16 blocks from the world origin"))
                     .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.DISPENSER.defaultBlockState().setValue(DispenserBlock.FACING, Direction.UP)))
                     .thenExecute(() -> helper.getBlockEntity(1, 1, 1, DispenserBlockEntity.class).setItem(0, boatStack))
-                    .thenExecute(() -> helper.getLevel().getAllEntities().forEach(entity -> entitiesBeforeDispense.add(entity.getUUID())))
+                    .thenExecute(() -> {
+                        dispensedEntities.clear();
+                        captureDispensedEntities.set(true);
+                    })
                     .thenExecute(() -> helper.pulseRedstone(new BlockPos(1, 1, 2), 3))
                     .thenExecuteAfter(5, () -> {
-                        final var dispensedEntities = StreamSupport.stream(helper.getLevel().getAllEntities().spliterator(), false)
-                                .filter(entity -> !entitiesBeforeDispense.contains(entity.getUUID()))
-                                .toList();
-                        helper.assertTrue(
-                                dispensedEntities.size() == 1,
-                                "Expected exactly one entity to be dispensed, found " + dispensedEntities.size() + ": " + dispensedEntities.stream()
-                                        .map(entity -> entity.getType() + " at " + entity.blockPosition())
-                                        .toList());
-                        final var boat = dispensedEntities.getFirst();
-                        helper.assertTrue(boat.getType() == EntityTypes.OAK_BOAT, "Expected an oak boat to be dispensed, found " + boat.getType());
-                        helper.assertTrue(boatName.equals(boat.getCustomName()), "The dispensed boat did not retain its identifying name");
-                        helper.assertTrue(
-                                boat.blockPosition().closerThan(helper.absolutePos(expectedPos), 2),
-                                "Expected the boat near " + expectedPos + ", found it at " + helper.relativePos(boat.blockPosition()));
-                        boat.discard();
+                        captureDispensedEntities.set(false);
+                        try {
+                            helper.assertTrue(
+                                    dispensedEntities.size() == 1,
+                                    "Expected exactly one entity to be dispensed, found " + dispensedEntities.size() + ": " + dispensedEntities.stream()
+                                            .map(entity -> entity.getType() + " at " + entity.blockPosition())
+                                            .toList());
+                            final var boat = dispensedEntities.getFirst();
+                            helper.assertTrue(boat.getType() == EntityTypes.OAK_BOAT, "Expected an oak boat to be dispensed, found " + boat.getType());
+                            helper.assertTrue(boatName.equals(boat.getCustomName()), "The dispensed boat did not retain its identifying name");
+                            helper.assertTrue(
+                                    boat.blockPosition().closerThan(helper.absolutePos(expectedPos), 2),
+                                    "Expected the boat near " + expectedPos + ", found it at " + helper.relativePos(boat.blockPosition()));
+                        } finally {
+                            dispensedEntities.forEach(Entity::discard);
+                        }
                     })
                     .thenSucceed();
         });

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -19,8 +19,10 @@ import net.minecraft.client.renderer.entity.PigRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.sounds.SoundEvents;
@@ -68,6 +70,38 @@ import net.neoforged.testframework.registration.RegistrationHelper;
 @ForEachTest(groups = ItemTests.GROUP)
 public class ItemTests {
     public static final String GROUP = "level.item";
+
+    @GameTest
+    @TestHolder(description = "Tests that dispensing a boat spawns one boat entity in the expected location")
+    static void boatDispenserDoesNotSpawnDuplicate(final DynamicTest test) {
+        test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 4, 3)
+                .placeSustainedWater(1, 2, 1, Blocks.IRON_BLOCK.defaultBlockState()));
+
+        test.onGameTest(helper -> {
+            final Component boatName = Component.literal("boat dispenser duplicate test");
+            final ItemStack boatStack = Items.OAK_BOAT.getDefaultInstance();
+            final BlockPos expectedPos = new BlockPos(1, 2, 1);
+            boatStack.set(DataComponents.CUSTOM_NAME, boatName);
+
+            helper.startSequence()
+                    .thenExecute(() -> helper.assertFalse(
+                            helper.absolutePos(expectedPos).closerThan(BlockPos.ZERO, 16),
+                            "The expected boat location must be at least 16 blocks from the world origin"))
+                    .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.DISPENSER.defaultBlockState().setValue(DispenserBlock.FACING, Direction.UP)))
+                    .thenExecute(() -> helper.getBlockEntity(1, 1, 1, DispenserBlockEntity.class).setItem(0, boatStack))
+                    .thenExecute(() -> helper.pulseRedstone(new BlockPos(1, 1, 2), 3))
+                    .thenExecuteAfter(5, () -> {
+                        final var boats = helper.getLevel().getEntities(EntityTypes.OAK_BOAT, boat -> boatName.equals(boat.getCustomName()));
+                        helper.assertTrue(boats.size() == 1, "Expected exactly one boat to be spawned, found " + boats.size());
+                        final var boat = boats.getFirst();
+                        helper.assertTrue(
+                                boat.blockPosition().closerThan(helper.absolutePos(expectedPos), 2),
+                                "Expected the boat near " + expectedPos + ", found it at " + helper.relativePos(boat.blockPosition()));
+                        boat.discard();
+                    })
+                    .thenSucceed();
+        });
+    }
 
     @GameTest
     @TestHolder(description = {

--- a/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
+++ b/tests/src/main/java/net/neoforged/neoforge/debug/item/ItemTests.java
@@ -6,10 +6,13 @@
 package net.neoforged.neoforge.debug.item;
 
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.data.models.BlockModelGenerators;
 import net.minecraft.client.data.models.ItemModelGenerators;
@@ -71,7 +74,7 @@ import net.neoforged.testframework.registration.RegistrationHelper;
 public class ItemTests {
     public static final String GROUP = "level.item";
 
-    @GameTest
+    @GameTest(batch = GROUP + ".boat_dispenser") // Isolate this test because it counts every entity added while the dispenser activates
     @TestHolder(description = "Tests that dispensing a boat spawns one boat entity in the expected location")
     static void boatDispenserDoesNotSpawnDuplicate(final DynamicTest test) {
         test.registerGameTestTemplate(StructureTemplateBuilder.withSize(3, 4, 3)
@@ -81,6 +84,7 @@ public class ItemTests {
             final Component boatName = Component.literal("boat dispenser duplicate test");
             final ItemStack boatStack = Items.OAK_BOAT.getDefaultInstance();
             final BlockPos expectedPos = new BlockPos(1, 2, 1);
+            final var entitiesBeforeDispense = new HashSet<UUID>();
             boatStack.set(DataComponents.CUSTOM_NAME, boatName);
 
             helper.startSequence()
@@ -89,11 +93,20 @@ public class ItemTests {
                             "The expected boat location must be at least 16 blocks from the world origin"))
                     .thenExecute(() -> helper.setBlock(1, 1, 1, Blocks.DISPENSER.defaultBlockState().setValue(DispenserBlock.FACING, Direction.UP)))
                     .thenExecute(() -> helper.getBlockEntity(1, 1, 1, DispenserBlockEntity.class).setItem(0, boatStack))
+                    .thenExecute(() -> helper.getLevel().getAllEntities().forEach(entity -> entitiesBeforeDispense.add(entity.getUUID())))
                     .thenExecute(() -> helper.pulseRedstone(new BlockPos(1, 1, 2), 3))
                     .thenExecuteAfter(5, () -> {
-                        final var boats = helper.getLevel().getEntities(EntityTypes.OAK_BOAT, boat -> boatName.equals(boat.getCustomName()));
-                        helper.assertTrue(boats.size() == 1, "Expected exactly one boat to be spawned, found " + boats.size());
-                        final var boat = boats.getFirst();
+                        final var dispensedEntities = StreamSupport.stream(helper.getLevel().getAllEntities().spliterator(), false)
+                                .filter(entity -> !entitiesBeforeDispense.contains(entity.getUUID()))
+                                .toList();
+                        helper.assertTrue(
+                                dispensedEntities.size() == 1,
+                                "Expected exactly one entity to be dispensed, found " + dispensedEntities.size() + ": " + dispensedEntities.stream()
+                                        .map(entity -> entity.getType() + " at " + entity.blockPosition())
+                                        .toList());
+                        final var boat = dispensedEntities.getFirst();
+                        helper.assertTrue(boat.getType() == EntityTypes.OAK_BOAT, "Expected an oak boat to be dispensed, found " + boat.getType());
+                        helper.assertTrue(boatName.equals(boat.getCustomName()), "The dispensed boat did not retain its identifying name");
                         helper.assertTrue(
                                 boat.blockPosition().closerThan(helper.absolutePos(expectedPos), 2),
                                 "Expected the boat near " + expectedPos + ", found it at " + helper.relativePos(boat.blockPosition()));


### PR DESCRIPTION
This PR fixes #3433 by removing the vanilla boat spawing code that was moved to an earlier place in the patch for `BoatDispenseItemBehavior`.

A mis-ported patch caused a boat to always be spawned at 0,0,0 when a dispenser dispenses a boat, whether as an entity or as an item.

Additionally, a fix in included to ensure that the boat entity is only added to the level if the default dispense behavior is not invoked.

---

This needs to be backported to 26.1.x. The additional fix may be backported to 1.21.3 at the earliest; 1.21.1 seems to not be affected, based on a reading of the code.