### PR TITLE
Mark POI type and game event registries as synced

### DIFF
--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistriesSetup.java
@@ -58,6 +58,8 @@ public class NeoForgeRegistriesSetup {
             BuiltInRegistries.SLOT_DISPLAY, // SlotDisplay.STREAM_CODEC
             BuiltInRegistries.RECIPE_BOOK_CATEGORY, // RecipeDisplayEntry.STREAM_CODEC
             BuiltInRegistries.RECIPE_TYPE, // RecipeContentPayload.STREAM_CODEC
+            BuiltInRegistries.POINT_OF_INTEREST_TYPE, // DebugPoiInfo.STREAM_CODEC
+            BuiltInRegistries.GAME_EVENT, // DebugGameEventInfo.STREAM_CODEC
             BuiltInRegistries.DEBUG_SUBSCRIPTION // ServerboundDebugSubscriptionRequestPacket
     );
 


### PR DESCRIPTION
This PR fixes #3282 by marking the `minecraft:point_of_interest_type` and `minecraft:game_event` registries as synced. These are used by various debug subscriptions, which means they need to be synced between server and client in case both have the debug subscriptions enabled.

Tested by placing both a sculk sensor and a bell in-world, preferrably in a superflat world with the Redstone Ready preset to avoid any preexisting blocks from interfering. With this PR, both can be placed and work; without it, placing either will disconnect the client from the server.