### PR TITLE
Ignore next key release for new selection by KeyBindsList

### DIFF
--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
@@ -9,6 +9,15 @@
              int width = minecraft.font.width(name);
              if (width > this.maxNameWidth) {
                  this.maxNameWidth = width;
+@@ -113,6 +_,8 @@
+             this.name = name;
+             this.changeButton = Button.builder(name, button -> {
+                     KeyBindsList.this.keyBindsScreen.selectedKey = key;
++                    // Neo: Mark the key which triggered this button, so its release doesn't trigger the logic to set the key mapping
++                    KeyBindsList.this.keyBindsScreen.ignoreNextRelease = true;
+                     KeyBindsList.this.resetMappingAndUpdateButtons();
+                 })
+                 .bounds(0, 0, 75, 20)
 @@ -123,6 +_,7 @@
                  )
                  .build();

--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java
 +++ b/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java
-@@ -24,6 +_,11 @@
+@@ -24,6 +_,13 @@
      public long lastKeySelection;
      private KeyBindsList keyBindsList;
      private Button resetButton;
@@ -9,6 +9,8 @@
 +    private InputConstants.Key lastPressedModifier = InputConstants.UNKNOWN;
 +    private boolean isLastKeyHeldDown = false;
 +    private boolean isLastModifierHeldDown = false;
++    // NEO: Used by KeyBindsList to ensure the key press that assigns selectedKey is ignored on release (doesn't itself get set as the value)
++    boolean ignoreNextRelease = false;
  
      public KeyBindsScreen(Screen lastScreen, Options options) {
          super(lastScreen, options, TITLE);
@@ -21,7 +23,7 @@
              }
  
              this.keyBindsList.resetMappingAndUpdateButtons();
-@@ -73,18 +_,67 @@
+@@ -73,18 +_,68 @@
      @Override
      public boolean keyPressed(KeyEvent event) {
          if (this.selectedKey != null) {
@@ -44,7 +46,7 @@
 +        // We ignore events from keys with the scan code 63 as they're emitted
 +        // (only as RELEASE, not PRESS) by Mac systems to indicate that "Fn" is being pressed
 +        // See https://github.com/neoforged/NeoForge/issues/1683
-+        if (this.selectedKey != null && (!net.minecraft.client.input.InputQuirks.ON_OSX || event.scancode() != 63)) {
++        if (!ignoreNextRelease && this.selectedKey != null && (!net.minecraft.client.input.InputQuirks.ON_OSX || event.scancode() != 63)) {
              if (event.isEscape()) {
 +                this.selectedKey.setKeyModifierAndCode(net.neoforged.neoforge.client.settings.KeyModifier.NONE, InputConstants.UNKNOWN);
                  this.selectedKey.setKey(InputConstants.UNKNOWN);
@@ -88,6 +90,7 @@
              return true;
          } else {
 -            return super.keyPressed(event);
++            this.ignoreNextRelease = false;
 +            return super.keyReleased(event);
          }
      }

--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsScreen.java.patch
@@ -9,7 +9,7 @@
 +    private InputConstants.Key lastPressedModifier = InputConstants.UNKNOWN;
 +    private boolean isLastKeyHeldDown = false;
 +    private boolean isLastModifierHeldDown = false;
-+    // NEO: Used by KeyBindsList to ensure the key press that assigns selectedKey is ignored on release (doesn't itself get set as the value)
++    // Neo: Used by KeyBindsList to ensure the key press that assigns selectedKey is ignored on release (doesn't itself get set as the value)
 +    boolean ignoreNextRelease = false;
  
      public KeyBindsScreen(Screen lastScreen, Options options) {


### PR DESCRIPTION
This PR fixes #3444 by adding a new field used by `KeyBindsList` to communicate to `KeyBindsScreen` to ignore the next key release, as the corresponding key press was consumed by the button in KeyBindsScreen.

When selecting a key mapping through keyboard navigation, the key press is received by the corresponding Button in `KeyBindsList`. The `KeyBindsScreen` is unaware of this, so it processes the key release as if it were the final action to set the key mapping. (This unassigns the key mapping, since the last recorded modifier and key is blank.)

Tested by using keyboard navigation to select the button for the "Jump" keymapping (which is set to <kbd>Space</kbd>) and pressing <kbd>Space</kbd> to begin edit the keybinding (i.e., the key name is underlined and surrounded by yellow chevrons).

For posterity, I did test a fix involving `lastPressedKey` and `isLastKeyHeldDown` being set by `KeyBindsList`, but that works _unless_ the selected key is already mapped to the same key (e.g., pressing <kbd>Space</kbd> to select the "Jump" keymapping which is already mapped to <kbd>Space</kbd>). In that case, the issue remains as it immediately rebinds the keymapping to that key.