### PR TITLE
Fix written_book losing all pages when legacy pages are not valid JSON

### DIFF
--- a/patches/net/minecraft/util/datafix/fixes/ItemStackComponentizationFix.java.patch
+++ b/patches/net/minecraft/util/datafix/fixes/ItemStackComponentizationFix.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/util/datafix/fixes/ItemStackComponentizationFix.java
++++ b/net/minecraft/util/datafix/fixes/ItemStackComponentizationFix.java
+@@ -541,7 +_,7 @@
+         dynamic1 = p_330209_.moveTagInto("resolved", dynamic1, "resolved");
+         dynamic1 = p_330209_.moveTagInto("generation", dynamic1, "generation");
+         if (dynamic != null) {
+-            dynamic1 = dynamic1.set("pages", dynamic);
++            dynamic1 = dynamic1.set("pages", wrapBookPagesAsComponents(dynamic)); // Neo: pages are stringified text components, not raw strings
+         }
+ 
+         p_330209_.setComponent("minecraft:written_book_content", dynamic1);
+@@ -564,6 +_,14 @@
+ 
+             return p_330407_.createList(list1.stream());
+         }
++    }
++
++    // Neo: written_book_content stores pages as stringified text components, but this fixer copies the legacy `pages` strings in
++    // verbatim, so a page that is not valid JSON fails to decode and silently drops every page of the book. Wrap them leniently,
++    // as ItemWrittenBookPagesStrictJsonFix already does at data version 165. Written books only: writable_book pages stay raw.
++    private static Dynamic<?> wrapBookPagesAsComponents(Dynamic<?> pages) {
++        return pages.createList(
++                pages.asStream().map(page -> page.update("raw", ComponentDataFixUtils::rewriteFromLenient).update("filtered", ComponentDataFixUtils::rewriteFromLenient)));
+     }
+ 
+     private static Dynamic<?> createFilteredText(Dynamic<?> p_331589_, String p_330423_, Optional<String> p_330385_) {

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/WrittenBookPagesDataFixTest.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/WrittenBookPagesDataFixTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforge.unittest;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.TagParser;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.datafix.DataFixers;
+import net.minecraft.util.datafix.fixes.References;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.WritableBookContent;
+import net.minecraft.world.item.component.WrittenBookContent;
+import net.neoforged.testframework.junit.EphemeralTestServerProvider;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Tests that {@code ItemStackComponentizationFix} keeps the pages of a pre-1.20.5 {@code written_book}. The component
+ * stores pages as stringified text components, so a legacy page that is not valid JSON fails to decode, and because
+ * {@code pages} is a strict {@code optionalFieldOf} that error silently drops every page of the book.
+ */
+@ExtendWith(EphemeralTestServerProvider.class)
+public class WrittenBookPagesDataFixTest {
+    /** Data version of 1.20.1, i.e. the last release that stored book pages as free-form strings. */
+    private static final int LEGACY_DATA_VERSION = 3465;
+
+    private static ItemStack upgrade(MinecraftServer server, String legacySnbt) throws CommandSyntaxException {
+        CompoundTag legacy = TagParser.parseTag(legacySnbt);
+        Dynamic<Tag> fixed = DataFixers.getDataFixer()
+                .update(
+                        References.ITEM_STACK,
+                        new Dynamic<>(NbtOps.INSTANCE, legacy),
+                        LEGACY_DATA_VERSION,
+                        SharedConstants.getCurrentVersion().getDataVersion().getVersion());
+        return ItemStack.parse(server.registryAccess(), fixed.getValue())
+                .orElseThrow(() -> new AssertionError("Data-fixed item stack failed to parse at all: " + fixed.getValue()));
+    }
+
+    /** Plain text and empty pages are both invalid JSON, and either one used to drop the whole book. */
+    @Test
+    void plainTextPagesSurviveComponentization(MinecraftServer server) throws CommandSyntaxException {
+        ItemStack stack = upgrade(server, """
+                {id:"minecraft:written_book",Count:1b,tag:{pages:["Page 1","","Page 2"],title:"My Book",author:"Author"}}""");
+
+        WrittenBookContent content = stack.get(DataComponents.WRITTEN_BOOK_CONTENT);
+        Assertions.assertThat(content).isNotNull();
+        Assertions.assertThat(content.getPages(false))
+                .withFailMessage("written_book pages were dropped by the componentization fixer, book was: %s", content)
+                .map(Component::getString)
+                .containsExactly("Page 1", "", "Page 2");
+    }
+
+    /** {@code filtered_pages} rides the same path, and pages without one must not gain a filtered variant. */
+    @Test
+    void filteredPagesSurviveComponentization(MinecraftServer server) throws CommandSyntaxException {
+        ItemStack stack = upgrade(server, """
+                {id:"minecraft:written_book",Count:1b,tag:{pages:["Page 1","Page 2"],filtered_pages:{"0":"Redacted"},title:"My Book",author:"Author"}}""");
+
+        WrittenBookContent content = stack.get(DataComponents.WRITTEN_BOOK_CONTENT);
+        Assertions.assertThat(content).isNotNull();
+        Assertions.assertThat(content.getPages(true)).map(Component::getString).containsExactly("Redacted", "Page 2");
+        Assertions.assertThat(content.getPages(false)).map(Component::getString).containsExactly("Page 1", "Page 2");
+    }
+
+    /** Control: a page that already was a valid JSON component must not be wrapped into literal text. */
+    @Test
+    void jsonPagesAreNotDoubleWrapped(MinecraftServer server) throws CommandSyntaxException {
+        ItemStack stack = upgrade(server, """
+                {id:"minecraft:written_book",Count:1b,tag:{pages:['{"text":"Styled","bold":true}'],title:"My Book",author:"Author"}}""");
+
+        WrittenBookContent content = stack.get(DataComponents.WRITTEN_BOOK_CONTENT);
+        Assertions.assertThat(content).isNotNull();
+        Component page = content.getPages(false).get(0);
+        Assertions.assertThat(page.getString()).isEqualTo("Styled");
+        Assertions.assertThat(page.getStyle().isBold())
+                .withFailMessage("An already-JSON page lost its styling, so it was wrapped as literal text")
+                .isTrue();
+    }
+
+    /** Control: {@code writable_book} shares the {@code fixBookPages} helper but stores genuinely raw strings. */
+    @Test
+    void writableBookPagesStayRawText(MinecraftServer server) throws CommandSyntaxException {
+        ItemStack stack = upgrade(server, """
+                {id:"minecraft:writable_book",Count:1b,tag:{pages:["Page 1",'{"text":"not a component here"}']}}""");
+
+        WritableBookContent content = stack.get(DataComponents.WRITABLE_BOOK_CONTENT);
+        Assertions.assertThat(content).isNotNull();
+        Assertions.assertThat(content.getPages(false)).containsExactly("Page 1", "{\"text\":\"not a component here\"}");
+    }
+}


### PR DESCRIPTION
written_book_content stores pages as stringified text components, but the datafixer that upgrades items from 1.20.4 to 1.20.5 copies the legacy `pages` strings in verbatim. A page that is not valid JSON fails to decode, and because `pages` is a strict optionalFieldOf, that error drops every page of the book.

Wrap them with ComponentDataFixUtils.rewriteFromLenient, as ItemWrittenBookPagesStrictJsonFix already does at data version 165. This is applied in fixWrittenBook rather than the shared fixBookPages helper, since writable_book pages are genuinely raw strings.

This only affects Minecraft 1.20.5 until 1.21.4 and is fixed in 1.21.5.

See bug reports https://bugs.mojang.com/browse/MC-270325 and https://bugs.mojang.com/browse/MC-270601