### PR TITLE
Fix NestedLootTable not using GLMs

### DIFF
--- a/patches/net/minecraft/world/level/storage/loot/entries/NestedLootTable.java.patch
+++ b/patches/net/minecraft/world/level/storage/loot/entries/NestedLootTable.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/storage/loot/entries/NestedLootTable.java
++++ b/net/minecraft/world/level/storage/loot/entries/NestedLootTable.java
+@@ -47,7 +_,7 @@
+     public void createItemStack(Consumer<ItemStack> output, LootContext context) {
+         this.contents
+             .map(name -> context.getResolver().get((ResourceKey<LootTable>)name).map(Holder::value).orElse(LootTable.EMPTY), table -> (LootTable)table)
+-            .getRandomItemsRaw(context, output);
++            .getRandomItems(context, output);
+     }
+ 
+     @Override


### PR DESCRIPTION
Hi! Noticed a small issue in a mod im working on where if a nested loot table is rolled it doesnt actually call the GLM injection code. Was really hoping to make use of that since the mod im adding to shares a small pool of items across most of its loot tables and this would make it infinitely easier to add my stuff in. 

If this gets merged I would really appreciate if it could get backported to 1.21 too, unless this is considered a breaking change for some reason