### PR TITLE
Log and ignore errors from parsing pack overlays

### DIFF
--- a/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
+++ b/src/main/java/net/neoforged/neoforge/resource/ResourcePackLoader.java
@@ -210,14 +210,24 @@ public class ResourcePackLoader {
                     .orElse(FeatureFlagSet.of());
 
             MetadataSectionType<OverlayMetadataSection> vanillaOverlayType = OverlayMetadataSection.forPackType(type);
-            final List<String> vanillaOverlays = Optional.ofNullable(primaryResources.getMetadataSection(vanillaOverlayType))
-                    .map(section -> section.overlaysForVersion(currentVersion))
-                    .orElse(List.of());
+            List<String> vanillaOverlays = List.of();
+            try {
+                vanillaOverlays = Optional.ofNullable(primaryResources.getMetadataSection(vanillaOverlayType))
+                        .map(section -> section.overlaysForVersion(currentVersion))
+                        .orElse(List.of());
+            } catch (JsonParseException exception) {
+                LOGGER.warn("Error reading vanilla overlays for {}, falling back to empty overlays", location.id(), exception);
+            }
 
             MetadataSectionType<OverlayMetadataSection> neoOverlayType = OverlayMetadataSection.forPackTypeNeoForge(type);
-            final List<String> neoOverlays = Optional.ofNullable(primaryResources.getMetadataSection(neoOverlayType))
-                    .map(section -> section.overlaysForVersion(currentVersion))
-                    .orElse(List.of());
+            List<String> neoOverlays = List.of();
+            try {
+                neoOverlays = Optional.ofNullable(primaryResources.getMetadataSection(neoOverlayType))
+                        .map(section -> section.overlaysForVersion(currentVersion))
+                        .orElse(List.of());
+            } catch (JsonParseException exception) {
+                LOGGER.warn("Error reading NeoForge-added overlays for {}, falling back to empty overlays", location.id(), exception);
+            }
 
             List<String> overlays = new ArrayList<>(vanillaOverlays);
             overlays.addAll(neoOverlays);


### PR DESCRIPTION
This PR fixes #3182 by (logging and) simply ignoring errors from parsing the overlay sections, falling back to blank sections.

NeoForge loads `pack.mcmeta` files from mod JARs as resource packs on client startup. This causes issues with `pack.mcmeta` files designed specifically to be for data packs, because while they may be parseable as `pack.mcmeta` for datapacks, they may error out when parsed as pack.mcmeta for resource packs.

14824e6fa ("Handle exception gracefully when reading optional pack meta (#3068)") partially accounted for this when reading the main pack metadata, but it didn't account for pack overlays as well which suffer from a similar problem.

This PR accounts for that deficiency, by applying the same paradigm of "log it and continue" to the overlay sections in addition to the main pack metadata.

Tested by using the sample `pack.mcmeta` from the linked issue and substituting the contents of the test project's `src/generated/resources/pack.mcmeta`.