### PR TITLE
Throw exception in dev if duplicate stacks are added to creative mode tab

### DIFF
--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1129,6 +1129,8 @@ public class EventHooks {
                 throw new IllegalArgumentException("The stack count must be 1");
 
             if (BuildCreativeModeTabContentsEvent.isParentTab(vis)) {
+                if (parentEntries.contains(stack))
+                    throw new IllegalArgumentException("Stack " + stack.getDisplayName() + "has already been added to the tab " + tab.getDisplayName() + " previously");
                 parentEntries.add(stack);
             }
 

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1125,6 +1125,7 @@ public class EventHooks {
         final var searchEntries = new InsertableLinkedOpenCustomHashSet<ItemStack>(ItemStackLinkedSet.TYPE_AND_TAG);
 
         originalGenerator.accept(params, (stack, vis) -> {
+            // This should mirror the checks in CreativeModeTab.ItemDisplayBuilder#accept
             if (stack.getCount() != 1)
                 throw new IllegalArgumentException("The stack count must be 1");
 

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1129,9 +1129,8 @@ public class EventHooks {
                 throw new IllegalArgumentException("The stack count must be 1");
 
             if (BuildCreativeModeTabContentsEvent.isParentTab(vis)) {
-                if (parentEntries.contains(stack))
+                if (!parentEntries.add(stack))
                     throw new IllegalArgumentException("Stack " + stack.getDisplayName() + "has already been added to the tab " + tab.getDisplayName() + " previously");
-                parentEntries.add(stack);
             }
 
             if (BuildCreativeModeTabContentsEvent.isSearchTab(vis)) {

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -1130,7 +1130,7 @@ public class EventHooks {
 
             if (BuildCreativeModeTabContentsEvent.isParentTab(vis)) {
                 if (!parentEntries.add(stack))
-                    throw new IllegalArgumentException("Stack " + stack.getDisplayName() + "has already been added to the tab " + tab.getDisplayName() + " previously");
+                    throw new IllegalArgumentException("Stack " + stack.getDisplayName().getString() + "has already been added to the tab " + tab.getDisplayName().getString() + " previously");
             }
 
             if (BuildCreativeModeTabContentsEvent.isSearchTab(vis)) {

--- a/src/main/java/net/neoforged/neoforge/event/EventHooks.java
+++ b/src/main/java/net/neoforged/neoforge/event/EventHooks.java
@@ -120,6 +120,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemRandomChanceWit
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModLoader;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforge.common.ItemAbility;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.common.extensions.IFluidStateExtension;
@@ -1130,7 +1131,8 @@ public class EventHooks {
                 throw new IllegalArgumentException("The stack count must be 1");
 
             if (BuildCreativeModeTabContentsEvent.isParentTab(vis)) {
-                if (!parentEntries.add(stack))
+                // TODO 26.3: Remove the dev-only check, so this runs in production as well
+                if (!parentEntries.add(stack) && !FMLEnvironment.isProduction())
                     throw new IllegalArgumentException("Stack " + stack.getDisplayName().getString() + "has already been added to the tab " + tab.getDisplayName().getString() + " previously");
             }
 


### PR DESCRIPTION
This PR fixes #3431 by throwing an exception (indirectly) from `BuildCreativeModeTabContentsEvent` when a duplicate stack is attempted to be added (but not if it's only for the search tab).

This brings the behavior in line with vanilla's logic in `CreativeModeTab.ItemDisplayBuilder#accept`.

---

This has been made to throw only in the development environment for now, to avoid breaking users' builds. In 26.3, this will be made to throw regardless of environment.