### PR TITLE
Fix SoundDefinition's SOUND type using the wrong jsonString

### DIFF
--- a/src/main/java/net/neoforged/neoforge/common/data/SoundDefinition.java
+++ b/src/main/java/net/neoforged/neoforge/common/data/SoundDefinition.java
@@ -275,7 +275,7 @@ public final class SoundDefinition {
          * <p>In a "normal" sound, the {@code name} is considered a file name, which
          * the game attempts to load from the currently loaded resource packs.</p>
          */
-        SOUND("sound"),
+        SOUND("file"),
         /**
          * Identifies a "redirect" sound.
          *


### PR DESCRIPTION
sound.json's sound only accept "file" and "event", the SOUND type was using an invalid "sound" jsonString

This wasn't causing any issue for datagen because the generator doesn't include the type if its the default aka SOUND but its better to have it fixed