### PR TITLE
Fix keypresses being ignored by KeyBindsList after selecting using mouse

### DIFF
--- a/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
+++ b/patches/net/minecraft/client/gui/screens/options/controls/KeyBindsList.java.patch
@@ -9,18 +9,22 @@
              int width = minecraft.font.width(name);
              if (width > this.maxNameWidth) {
                  this.maxNameWidth = width;
-@@ -113,6 +_,8 @@
-             this.name = name;
-             this.changeButton = Button.builder(name, button -> {
-                     KeyBindsList.this.keyBindsScreen.selectedKey = key;
-+                    // Neo: Mark the key which triggered this button, so its release doesn't trigger the logic to set the key mapping
-+                    KeyBindsList.this.keyBindsScreen.ignoreNextRelease = true;
-                     KeyBindsList.this.resetMappingAndUpdateButtons();
-                 })
-                 .bounds(0, 0, 75, 20)
-@@ -123,6 +_,7 @@
+@@ -121,8 +_,19 @@
+                         ? Component.translatable("narrator.controls.unbound", name)
+                         : Component.translatable("narrator.controls.bound", name, defaultNarrationSupplier.get())
                  )
-                 .build();
+-                .build();
++                .build(builder -> new Button.Plain(builder) {
++                    @Override
++                    public boolean keyPressed(net.minecraft.client.input.KeyEvent event) {
++                        // Neo: Mark the key which triggered this button, so its release doesn't trigger the logic to set the key mapping
++                        var pressed = super.keyPressed(event);
++                        if (pressed) {
++                            KeyBindsList.this.keyBindsScreen.ignoreNextRelease = true;
++                        }
++                        return pressed;
++                    }
++                });
              this.resetButton = Button.builder(RESET_BUTTON_TITLE, button -> {
 +                this.key.setToDefault();
                  key.setKey(key.getDefaultKey());


### PR DESCRIPTION
This PR fixes #3465 by moving the logic to mark the next key for ignoring to the Button's `keyPressed` method via an anonymous class of `Button.Plain`, to ensure it is only triggered for key presses. See the linked issue for details.

Tested by using both mouse click and keyboard navigation to activate the change button for a key bind, and each trying all of (a) a regular (non-modifier) key (a) a single modifier key, (b) a modifier key and a non-modifier key combined. All should work.