### PR TITLE
Backport to 1.21.1: Make StackCopySlot take a slot idx and have ItemHandlerCopySlot provide it

### DIFF
--- a/src/main/java/net/neoforged/neoforge/items/ItemHandlerCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/items/ItemHandlerCopySlot.java
@@ -17,12 +17,12 @@ public class ItemHandlerCopySlot extends StackCopySlot {
     private final SlotItemHandler slotItemHandler;
 
     public ItemHandlerCopySlot(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
-        super(xPosition, yPosition);
+        super(index, xPosition, yPosition);
         slotItemHandler = new SlotItemHandler(itemHandler, index, xPosition, yPosition);
     }
 
     public ItemHandlerCopySlot(SlotItemHandler slotItemHandler) {
-        super(slotItemHandler.x, slotItemHandler.y);
+        super(slotItemHandler.getSlotIndex(), slotItemHandler.x, slotItemHandler.y);
         this.slotItemHandler = slotItemHandler;
     }
 

--- a/src/main/java/net/neoforged/neoforge/items/StackCopySlot.java
+++ b/src/main/java/net/neoforged/neoforge/items/StackCopySlot.java
@@ -26,8 +26,19 @@ public abstract class StackCopySlot extends Slot {
     @Nullable
     private ItemStack cachedReturnedStack = null;
 
+    /**
+     * @param slot The slot in the underlying container, whatever it may be; zero if not applicable.
+     */
+    public StackCopySlot(int slot, int x, int y) {
+        super(emptyInventory, slot, x, y);
+    }
+
+    /**
+     * @deprecated Use {@link #StackCopySlot(int, int, int)} instead with the underlying slot index.
+     */
+    @Deprecated
     public StackCopySlot(int x, int y) {
-        super(emptyInventory, 0, x, y);
+        this(0, x, y);
     }
 
     /**


### PR DESCRIPTION
This PR backports #3093 to 1.21.1, which fixes #3092.