### PR TITLE
Automatically register flower-containing pots to empty pot map

### DIFF
--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -4,41 +4,32 @@
      );
      private static final Map<Block, Block> POTTED_BY_CONTENT = Maps.newHashMap();
      private static final VoxelShape SHAPE = Block.column(6.0, 0.0, 6.0);
-+    /** Neo: Field accesses are redirected to {@link #getPotted()} with a coremod. */
++    /// Neo: Field accesses are redirected to {@link #getPotted()} with a coremod.
      private final Block potted;
  
      @Override
-@@ -42,10 +_,31 @@
+@@ -42,10 +_,22 @@
          return CODEC;
      }
  
-+    @Deprecated // Mods should use the constructor below
++    /// @deprecated Neo: Use the [other constructor][FlowerPotBlock#FlowerPotBlock(Supplier, Supplier, Properties)].
++    @Deprecated
      public FlowerPotBlock(Block potted, BlockBehaviour.Properties properties) {
 +        this(Blocks.FLOWER_POT == null ? null : () -> (FlowerPotBlock) Blocks.FLOWER_POT, () -> potted, properties);
-+        if (Blocks.FLOWER_POT != null) {
-+            ((FlowerPotBlock)Blocks.FLOWER_POT).addPlant(net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(potted), () -> this);
-+        }
 +    }
 +
-+    /**
-+     * For mod use, eliminates the need to extend this class, and prevents modded
-+     * flower pots from altering vanilla behavior.
-+     *
-+     * @param emptyPot The empty pot for this pot, or null for self.
-+     */
++    /// Neo: Constructs a flower pot with the given empty pot and potted flower/plant.
++    /// For mod use, eliminates the need to extend this class, and prevents modded flower pots from altering vanilla behavior.
++    ///
++    /// @param emptyPot The empty pot for this pot, or `null` if this is the empty pot.
++    /// @param potted For non-empty pots, the potted flower/plant. For the empty pot, this should be a supplier for [Blocks#AIR].
 +    public FlowerPotBlock(java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot, java.util.function.Supplier<? extends Block> potted, BlockBehaviour.Properties properties) {
          super(properties);
 -        this.potted = potted;
 -        POTTED_BY_CONTENT.put(potted, this);
 +        this.potted = null; // Unused, redirected by coremod
 +        this.flowerDelegate = potted;
-+        if (emptyPot == null) {
-+            this.fullPots = Maps.newHashMap();
-+            this.emptyPot = null;
-+        } else {
-+            this.fullPots = java.util.Collections.emptyMap();
-+            this.emptyPot = emptyPot;
-+        }
++        this.emptyPot = emptyPot;
      }
  
      @Override
@@ -47,7 +38,7 @@
      ) {
          BlockState newContents = (itemStack.getItem() instanceof BlockItem blockItem
 -                ? POTTED_BY_CONTENT.getOrDefault(blockItem.getBlock(), Blocks.AIR)
-+                ? getEmptyPot().fullPots.getOrDefault(net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(blockItem.getBlock()), () -> Blocks.AIR).get()
++                ? getFullPotsView().getOrDefault(net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(blockItem.getBlock()), () -> Blocks.AIR).get()
                  : Blocks.AIR)
              .defaultBlockState();
          if (newContents.isAir()) {
@@ -60,7 +51,7 @@
          level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
          return InteractionResult.SUCCESS;
      }
-@@ -118,12 +_,44 @@
+@@ -118,12 +_,38 @@
      }
  
      public Block getPotted() {
@@ -73,9 +64,6 @@
          return false;
 +    }
 +
-+    // Neo: Maps flower blocks to the filled flower pot equivalent
-+    private final Map<net.minecraft.resources.Identifier, java.util.function.Supplier<? extends Block>> fullPots;
-+
 +    private final java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot;
 +
 +    private final java.util.function.Supplier<? extends Block> flowerDelegate;
@@ -84,25 +72,22 @@
 +         return emptyPot == null ? this : emptyPot.get();
 +    }
 +
-+    /**
-+     * Maps the given flower to the filled pot it is for.
-+     * Call this on the empty pot block. Attempting to call this on a filled pot will throw an exception.
-+     *
-+     * @param flower The Identifier of the flower block. Not flower item
-+     * @param fullPot The filled flower pot to map the flower block to
-+     */
++    /// @deprecated Neo: To be removed in 26.3. Full pots are automatically added to the maps of their respective empty pots.
++    /// This does not support adding arbitrary blocks as 'full pots'. If you use this feature, please raise this in the NeoForge issue tracker.
++    @Deprecated(forRemoval = true, since = "26.3")
 +    public void addPlant(net.minecraft.resources.Identifier flower, java.util.function.Supplier<? extends Block> fullPot) {
 +         if (getEmptyPot() != this) {
-+              throw new IllegalArgumentException("Cannot add plant to non-empty pot: " + this + " (Please call addPlant on the empty pot instead)");
++              throw new IllegalArgumentException("Cannot add plant to non-empty pot: " + this);
 +         }
-+         fullPots.put(flower, fullPot);
++         // No-op
 +    }
 +
-+    /**
-+     * Returns all the filled pots that can be spawned from filling this pot. (If this pot is filled, returned map will be empty)
-+     */
 +    public Map<net.minecraft.resources.Identifier, java.util.function.Supplier<? extends Block>> getFullPotsView() {
-+        return java.util.Collections.unmodifiableMap(fullPots);
++        if (emptyPot != null) {
++            return java.util.Map.of();
++        } else {
++            return java.util.Collections.unmodifiableMap(com.google.common.collect.Maps.transformValues(net.neoforged.neoforge.registries.GameData.getFlowerPotBlockTable().row(getEmptyPot()), block -> (java.util.function.Supplier<? extends Block>) () -> block));
++        }
      }
  
      @Override

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -94,7 +94,7 @@
 +
 +    /// @deprecated Neo: To be removed in 26.3. Full pots are automatically added to the maps of their respective empty pots.
 +    /// This does not support adding arbitrary blocks as 'full pots'. If you use this feature, please raise this in the NeoForge issue tracker.
-+    @Deprecated(forRemoval = true, since = "26.3")
++    @Deprecated(forRemoval = true, since = "26.2")
 +    public void addPlant(net.minecraft.resources.Identifier flower, java.util.function.Supplier<? extends Block> fullPot) {
 +         if (getEmptyPot() != this) {
 +              throw new IllegalArgumentException("Cannot add plant to non-empty pot: " + this);

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -40,7 +40,7 @@
      ) {
          BlockState newContents = (itemStack.getItem() instanceof BlockItem blockItem
 -                ? POTTED_BY_CONTENT.getOrDefault(blockItem.getBlock(), Blocks.AIR)
-+                ? getFullPotsView().getOrDefault(net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(blockItem.getBlock()), () -> Blocks.AIR).get()
++                ? emptyPot == null ? getFullPot(blockItem.getBlock()) : Blocks.AIR
                  : Blocks.AIR)
              .defaultBlockState();
          if (newContents.isAir()) {
@@ -53,7 +53,7 @@
          level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
          return InteractionResult.SUCCESS;
      }
-@@ -118,12 +_,34 @@
+@@ -118,12 +_,58 @@
      }
  
      public Block getPotted() {
@@ -68,6 +68,28 @@
 +
 +    public FlowerPotBlock getEmptyPot() {
 +         return emptyPot == null ? this : emptyPot.get();
++    }
++
++    /// {@return an unmodifiable view of the map of plant blocks to their associated full pot block}
++    ///
++    /// @throws IllegalStateException if this is called on a non-empty pot
++    public Map<net.minecraft.resources.Identifier, Block> getFullPots() {
++        if (emptyPot != null) {
++            throw new IllegalStateException("Full pots can only be queried from the empty pot");
++        }
++        return java.util.Collections.unmodifiableMap(net.neoforged.neoforge.registries.GameData.getFlowerPotBlockTable().row(this));
++    }
++
++    /// Neo: {@return the full pot associated with the given plant block, or [Blocks#AIR] if there is no associated full pot}
++    ///
++    /// @param plant the plant block
++    /// @throws IllegalStateException if this is called on a non-empty pot
++    public Block getFullPot(Block plant) {
++        if (emptyPot != null) {
++            throw new IllegalStateException("Full pots can only be queried from the empty pot");
++        }
++        return net.neoforged.neoforge.registries.GameData.getFlowerPotBlockTable().row(this)
++                .getOrDefault(net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(plant), Blocks.AIR);
 +    }
 +
 +    /// @deprecated Neo: To be removed in 26.3. Full pots are automatically added to the maps of their respective empty pots.

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -1,14 +1,16 @@
 --- a/net/minecraft/world/level/block/FlowerPotBlock.java
 +++ b/net/minecraft/world/level/block/FlowerPotBlock.java
-@@ -35,6 +_,7 @@
+@@ -35,17 +_,32 @@
      );
      private static final Map<Block, Block> POTTED_BY_CONTENT = Maps.newHashMap();
      private static final VoxelShape SHAPE = Block.column(6.0, 0.0, 6.0);
 +    /// Neo: Field accesses are redirected to {@link #getPotted()} with a coremod.
      private final Block potted;
++    private final java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot;
++    private final java.util.function.Supplier<? extends Block> flowerDelegate;
  
      @Override
-@@ -42,10 +_,22 @@
+     public MapCodec<FlowerPotBlock> codec() {
          return CODEC;
      }
  
@@ -51,7 +53,7 @@
          level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
          return InteractionResult.SUCCESS;
      }
-@@ -118,12 +_,38 @@
+@@ -118,12 +_,34 @@
      }
  
      public Block getPotted() {
@@ -63,10 +65,6 @@
      protected boolean isPathfindable(BlockState state, PathComputationType type) {
          return false;
 +    }
-+
-+    private final java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot;
-+
-+    private final java.util.function.Supplier<? extends Block> flowerDelegate;
 +
 +    public FlowerPotBlock getEmptyPot() {
 +         return emptyPot == null ? this : emptyPot.get();

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/FlowerPotBlock.java
 +++ b/net/minecraft/world/level/block/FlowerPotBlock.java
-@@ -35,17 +_,51 @@
+@@ -35,17 +_,52 @@
      );
      private static final Map<Block, Block> POTTED_BY_CONTENT = Maps.newHashMap();
      private static final VoxelShape SHAPE = Block.column(6.0, 0.0, 6.0);
@@ -22,6 +22,7 @@
 -        POTTED_BY_CONTENT.put(potted, this);
 +        this.potted = null; // Unused, redirected by coremod
 +        this.flowerDelegate = () -> potted;
++        // If we're constructing the empty pot at Blocks.FLOWER_POT, then the field will be null
 +        this.emptyPot = Blocks.FLOWER_POT == null ? null : () -> (FlowerPotBlock) Blocks.FLOWER_POT;
 +    }
 +

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/FlowerPotBlock.java
 +++ b/net/minecraft/world/level/block/FlowerPotBlock.java
-@@ -35,17 +_,32 @@
+@@ -35,17 +_,51 @@
      );
      private static final Map<Block, Block> POTTED_BY_CONTENT = Maps.newHashMap();
      private static final VoxelShape SHAPE = Block.column(6.0, 0.0, 6.0);
@@ -14,24 +14,43 @@
          return CODEC;
      }
  
-+    /// @deprecated Neo: Use the [other constructor][FlowerPotBlock#FlowerPotBlock(Supplier, Supplier, Properties)].
++    /// @deprecated Neo: Use the other constructors for [empty pots][#FlowerPotBlock(Properties)] and [full pots][#FlowerPotBlock(java.util.function.Supplier, java.util.function.Supplier, Properties)].
 +    @Deprecated
      public FlowerPotBlock(Block potted, BlockBehaviour.Properties properties) {
-+        this(Blocks.FLOWER_POT == null ? null : () -> (FlowerPotBlock) Blocks.FLOWER_POT, () -> potted, properties);
+         super(properties);
+-        this.potted = potted;
+-        POTTED_BY_CONTENT.put(potted, this);
++        this.potted = null; // Unused, redirected by coremod
++        this.flowerDelegate = () -> potted;
++        this.emptyPot = Blocks.FLOWER_POT == null ? null : () -> (FlowerPotBlock) Blocks.FLOWER_POT;
 +    }
 +
 +    /// Neo: Constructs a flower pot with the given empty pot and potted flower/plant.
 +    /// For mod use, eliminates the need to extend this class, and prevents modded flower pots from altering vanilla behavior.
 +    ///
-+    /// @param emptyPot The empty pot for this pot, or `null` if this is the empty pot.
-+    /// @param potted The potted flower/plant, or `null` if this is the empty pot.
++    /// Use the [other constructor][#FlowerPotBlock(Properties)] for constructing empty pots.
++    ///
++    /// @param emptyPot The empty pot for this pot
++    /// @param potted The potted flower/plant
 +    public FlowerPotBlock(java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot, java.util.function.@org.jspecify.annotations.Nullable Supplier<? extends Block> potted, BlockBehaviour.Properties properties) {
-         super(properties);
--        this.potted = potted;
--        POTTED_BY_CONTENT.put(potted, this);
++        super(properties);
 +        this.potted = null; // Unused, redirected by coremod
 +        this.flowerDelegate = potted != null ? potted : () -> Blocks.AIR;
 +        this.emptyPot = emptyPot;
++        // TODO 26.3: Make this constructor accept non-null suppliers, replace this dev-only warning with an always-active precondition, and adjust javadocs
++        if (emptyPot == null && !net.neoforged.fml.loading.FMLEnvironment.isProduction()) {
++            // No need to translate; this is a dev-only warning
++            //noinspection UnstableApiUsage
++            net.neoforged.fml.ModLoader.addLoadingIssue(net.neoforged.fml.ModLoadingIssue.warning("FlowerPotBlock's full pot constructor is used to create empty pot; use other constructor instead"));
++        }
++    }
++
++    /// Neo: Constructs an empty flower pot.
++    public FlowerPotBlock(BlockBehaviour.Properties properties) {
++        super(properties);
++        this.potted = null; // Unused, redirected by coremod
++        this.flowerDelegate = () -> Blocks.AIR;
++        this.emptyPot = null;
      }
  
      @Override

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -70,7 +70,7 @@
 +         return emptyPot == null ? this : emptyPot.get();
 +    }
 +
-+    /// {@return an unmodifiable view of the map of plant blocks to their associated full pot block}
++    /// Neo: {@return an unmodifiable view of the map of plant blocks to their associated full pot block}
 +    ///
 +    /// @throws IllegalStateException if this is called on a non-empty pot
 +    public Map<Block, Block> getFullPots() {

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -24,13 +24,13 @@
 +    /// For mod use, eliminates the need to extend this class, and prevents modded flower pots from altering vanilla behavior.
 +    ///
 +    /// @param emptyPot The empty pot for this pot, or `null` if this is the empty pot.
-+    /// @param potted For non-empty pots, the potted flower/plant. For the empty pot, this should be a supplier for [Blocks#AIR].
-+    public FlowerPotBlock(java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot, java.util.function.Supplier<? extends Block> potted, BlockBehaviour.Properties properties) {
++    /// @param potted The potted flower/plant, or `null` if this is the empty pot.
++    public FlowerPotBlock(java.util.function.@org.jspecify.annotations.Nullable Supplier<FlowerPotBlock> emptyPot, java.util.function.@org.jspecify.annotations.Nullable Supplier<? extends Block> potted, BlockBehaviour.Properties properties) {
          super(properties);
 -        this.potted = potted;
 -        POTTED_BY_CONTENT.put(potted, this);
 +        this.potted = null; // Unused, redirected by coremod
-+        this.flowerDelegate = potted;
++        this.flowerDelegate = potted != null ? potted : () -> Blocks.AIR;
 +        this.emptyPot = emptyPot;
      }
  

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/FlowerPotBlock.java
 +++ b/net/minecraft/world/level/block/FlowerPotBlock.java
-@@ -35,17 +_,52 @@
+@@ -35,17 +_,50 @@
      );
      private static final Map<Block, Block> POTTED_BY_CONTENT = Maps.newHashMap();
      private static final VoxelShape SHAPE = Block.column(6.0, 0.0, 6.0);
@@ -40,9 +40,7 @@
 +        this.emptyPot = emptyPot;
 +        // TODO 26.3: Make this constructor accept non-null suppliers, replace this dev-only warning with an always-active precondition, and adjust javadocs
 +        if (emptyPot == null && !net.neoforged.fml.loading.FMLEnvironment.isProduction()) {
-+            // No need to translate; this is a dev-only warning
-+            //noinspection UnstableApiUsage
-+            net.neoforged.fml.ModLoader.addLoadingIssue(net.neoforged.fml.ModLoadingIssue.warning("FlowerPotBlock's full pot constructor is used to create empty pot; use other constructor instead"));
++            com.mojang.logging.LogUtils.getLogger().warn("FlowerPotBlock's full pot constructor is used to create empty pot; use other constructor instead", new Exception("Stacktrace"));
 +        }
 +    }
 +

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -102,6 +102,8 @@
 +         // No-op
 +    }
 +
++    /// @deprecated Neo: To be removed in 26.3. Use [#getFullPots()] instead.
++    @Deprecated(forRemoval = true, since = "26.2")
 +    public Map<net.minecraft.resources.Identifier, java.util.function.Supplier<? extends Block>> getFullPotsView() {
 +        if (emptyPot != null) {
 +            return java.util.Map.of();

--- a/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
+++ b/patches/net/minecraft/world/level/block/FlowerPotBlock.java.patch
@@ -73,7 +73,7 @@
 +    /// {@return an unmodifiable view of the map of plant blocks to their associated full pot block}
 +    ///
 +    /// @throws IllegalStateException if this is called on a non-empty pot
-+    public Map<net.minecraft.resources.Identifier, Block> getFullPots() {
++    public Map<Block, Block> getFullPots() {
 +        if (emptyPot != null) {
 +            throw new IllegalStateException("Full pots can only be queried from the empty pot");
 +        }
@@ -108,7 +108,7 @@
 +        if (emptyPot != null) {
 +            return java.util.Map.of();
 +        } else {
-+            return java.util.Collections.unmodifiableMap(com.google.common.collect.Maps.transformValues(net.neoforged.neoforge.registries.GameData.getFlowerPotBlockTable().row(getEmptyPot()), block -> (java.util.function.Supplier<? extends Block>) () -> block));
++            return java.util.Collections.unmodifiableMap(net.neoforged.neoforge.registries.GameData.getLegacyFlowerPotBlockTable().row(getEmptyPot()));
 +        }
      }
  

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforge.registries;
 
+import com.google.common.collect.Table;
 import com.mojang.logging.LogUtils;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -50,6 +51,10 @@ public class GameData {
 
     public static Map<BlockState, Holder<PoiType>> getBlockStatePointOfInterestTypeMap() {
         return NeoForgeRegistryCallbacks.PoiTypeCallbacks.BLOCKSTATE_TO_POI_TYPE_MAP;
+    }
+
+    public static Table<Block, Identifier, Block> getFlowerPotBlockTable() {
+        return NeoForgeRegistryCallbacks.BlockCallbacks.EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE;
     }
 
     public static void vanillaSnapshot() {

--- a/src/main/java/net/neoforged/neoforge/registries/GameData.java
+++ b/src/main/java/net/neoforged/neoforge/registries/GameData.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMapper;
 import net.minecraft.core.MappedRegistry;
@@ -53,8 +54,13 @@ public class GameData {
         return NeoForgeRegistryCallbacks.PoiTypeCallbacks.BLOCKSTATE_TO_POI_TYPE_MAP;
     }
 
-    public static Table<Block, Identifier, Block> getFlowerPotBlockTable() {
+    public static Table<Block, Block, Block> getFlowerPotBlockTable() {
         return NeoForgeRegistryCallbacks.BlockCallbacks.EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE;
+    }
+
+    // TODO 26.3: Remove this and change necessary methods in FlowerPotBlock
+    public static Table<Block, Identifier, Supplier<? extends Block>> getLegacyFlowerPotBlockTable() {
+        return NeoForgeRegistryCallbacks.BlockCallbacks.LEGACY_EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.get();
     }
 
     public static void vanillaSnapshot() {

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
@@ -36,7 +36,7 @@ class NeoForgeRegistryCallbacks {
     static class BlockCallbacks implements AddCallback<Block>, ClearCallback<Block>, BakeCallback<Block> {
         static final BlockCallbacks INSTANCE = new BlockCallbacks();
         static final ClearableObjectIntIdentityMap<BlockState> BLOCKSTATE_TO_ID_MAP = new ClearableObjectIntIdentityMap<>();
-        static final Table<Block, Identifier, Block> EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE = Tables.newCustomTable(new IdentityHashMap<>(), IdentityHashMap::new);
+        static final Table<Block, Identifier, Block> EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE = Tables.newCustomTable(new IdentityHashMap<>(), HashMap::new);
 
         private final Set<Block> addedBlocks = new ReferenceOpenHashSet<>();
 

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
@@ -5,14 +5,18 @@
 
 package net.neoforged.neoforge.registries;
 
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMapper;
 import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.DefaultAttributes;
@@ -20,6 +24,7 @@ import net.minecraft.world.entity.ai.village.poi.PoiType;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.FlowerPotBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.DebugLevelSource;
@@ -31,6 +36,7 @@ class NeoForgeRegistryCallbacks {
     static class BlockCallbacks implements AddCallback<Block>, ClearCallback<Block>, BakeCallback<Block> {
         static final BlockCallbacks INSTANCE = new BlockCallbacks();
         static final ClearableObjectIntIdentityMap<BlockState> BLOCKSTATE_TO_ID_MAP = new ClearableObjectIntIdentityMap<>();
+        static final Table<Block, Identifier, Block> EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE = Tables.newCustomTable(new IdentityHashMap<>(), IdentityHashMap::new);
 
         private final Set<Block> addedBlocks = new ReferenceOpenHashSet<>();
 
@@ -42,6 +48,7 @@ class NeoForgeRegistryCallbacks {
         @Override
         public void onClear(Registry<Block> registry, boolean full) {
             BLOCKSTATE_TO_ID_MAP.clear();
+            EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.clear();
         }
 
         @Override
@@ -59,6 +66,10 @@ class NeoForgeRegistryCallbacks {
             for (Block block : registry) {
                 for (BlockState state : block.getStateDefinition().getPossibleStates()) {
                     BLOCKSTATE_TO_ID_MAP.add(state);
+                }
+
+                if (block instanceof FlowerPotBlock potBlock && potBlock.getEmptyPot() != potBlock) {
+                    EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.put(potBlock.getEmptyPot(), registry.getKey(potBlock.getPotted()), potBlock);
                 }
             }
 

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
@@ -13,9 +13,11 @@ import java.util.IdentityHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import net.minecraft.core.Holder;
 import net.minecraft.core.IdMapper;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -28,6 +30,7 @@ import net.minecraft.world.level.block.FlowerPotBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.DebugLevelSource;
+import net.neoforged.neoforge.common.util.Lazy;
 import net.neoforged.neoforge.registries.callback.AddCallback;
 import net.neoforged.neoforge.registries.callback.BakeCallback;
 import net.neoforged.neoforge.registries.callback.ClearCallback;
@@ -36,7 +39,16 @@ class NeoForgeRegistryCallbacks {
     static class BlockCallbacks implements AddCallback<Block>, ClearCallback<Block>, BakeCallback<Block> {
         static final BlockCallbacks INSTANCE = new BlockCallbacks();
         static final ClearableObjectIntIdentityMap<BlockState> BLOCKSTATE_TO_ID_MAP = new ClearableObjectIntIdentityMap<>();
-        static final Table<Block, Identifier, Block> EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE = Tables.newCustomTable(new IdentityHashMap<>(), HashMap::new);
+        static final Table<Block, Block, Block> EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE = Tables.newCustomTable(new IdentityHashMap<>(), IdentityHashMap::new);
+        // TODO 26.3: Remove this table and change any necessary methods in FlowerPotBlock
+        static final Lazy<Table<Block, Identifier, Supplier<? extends Block>>> LEGACY_EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE = Lazy.of(() -> {
+            var table = Tables.<Block, Identifier, Supplier<? extends Block>>newCustomTable(new IdentityHashMap<>(), HashMap::new);
+            for (Table.Cell<Block, Block, Block> cell : EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.cellSet()) {
+                var value = cell.getValue(); // Avoid capturing the Cell instance in the supplier
+                table.put(cell.getRowKey(), BuiltInRegistries.BLOCK.getKey(cell.getColumnKey()), () -> value);
+            }
+            return table;
+        });
 
         private final Set<Block> addedBlocks = new ReferenceOpenHashSet<>();
 
@@ -49,6 +61,7 @@ class NeoForgeRegistryCallbacks {
         public void onClear(Registry<Block> registry, boolean full) {
             BLOCKSTATE_TO_ID_MAP.clear();
             EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.clear();
+            LEGACY_EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.invalidate();
         }
 
         @Override
@@ -69,7 +82,7 @@ class NeoForgeRegistryCallbacks {
                 }
 
                 if (block instanceof FlowerPotBlock potBlock && potBlock.getEmptyPot() != potBlock) {
-                    EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.put(potBlock.getEmptyPot(), registry.getKey(potBlock.getPotted()), potBlock);
+                    EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.put(potBlock.getEmptyPot(), potBlock.getPotted(), potBlock);
                 }
             }
 

--- a/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
+++ b/src/main/java/net/neoforged/neoforge/registries/NeoForgeRegistryCallbacks.java
@@ -60,8 +60,10 @@ class NeoForgeRegistryCallbacks {
         @Override
         public void onClear(Registry<Block> registry, boolean full) {
             BLOCKSTATE_TO_ID_MAP.clear();
-            EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.clear();
-            LEGACY_EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.invalidate();
+            if (full) {
+                EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.clear();
+                LEGACY_EMPTY_POT_AND_FLOWER_TO_FULL_POT_TABLE.invalidate();
+            }
         }
 
         @Override

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
@@ -27,7 +27,7 @@ public class FlowerPotTest {
     private static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(MODID);
     private static final DeferredRegister.Items ITEMS = DeferredRegister.createItems(MODID);
 
-    public static final DeferredBlock<FlowerPotBlock> EMPTY_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID, props -> new FlowerPotBlock(null, () -> Blocks.AIR, props), () -> Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
+    public static final DeferredBlock<FlowerPotBlock> EMPTY_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID, FlowerPotBlock::new, () -> Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
     public static final DeferredBlock<FlowerPotBlock> OAK_FLOWER_POT = BLOCKS.registerBlock(BLOCK_ID + "_oak", props -> new FlowerPotBlock(EMPTY_FLOWER_POT, () -> Blocks.OAK_SAPLING, props), () -> Block.Properties.ofFullCopy(Blocks.FLOWER_POT));
 
     static {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FlowerPotTest.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.neoforge.oldtest.block;
 
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.BlockItem;
@@ -14,12 +13,10 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FlowerPotBlock;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
-import net.neoforged.neoforge.registries.RegisterEvent;
 
 @EventBusSubscriber
 @Mod(FlowerPotTest.MODID)
@@ -35,13 +32,6 @@ public class FlowerPotTest {
 
     static {
         ITEMS.register(BLOCK_ID, () -> new BlockItem(EMPTY_FLOWER_POT.get(), new Item.Properties().setId(ResourceKey.create(Registries.ITEM, EMPTY_FLOWER_POT.getId())).useBlockDescriptionPrefix()));
-    }
-
-    @SubscribeEvent
-    public static void onItemRegister(RegisterEvent event) {
-        if (event.getRegistryKey().equals(Registries.ITEM)) {
-            EMPTY_FLOWER_POT.get().addPlant(BuiltInRegistries.BLOCK.getKey(Blocks.OAK_SAPLING), OAK_FLOWER_POT);
-        }
     }
 
     public FlowerPotTest(IEventBus modBus) {

--- a/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
+++ b/tests/src/main/java/net/neoforged/neoforge/oldtest/block/FullPotsAccessorDemo.java
@@ -105,7 +105,7 @@ public class FullPotsAccessorDemo {
         @Override
         public InteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
             if (level.getBlockEntity(pos) instanceof DioriteFlowerPotBlockEntity be) {
-                boolean isFlower = stack.getItem() instanceof BlockItem item && ((FlowerPotBlock) Blocks.FLOWER_POT).getFullPotsView().containsKey(BuiltInRegistries.ITEM.getKey(item));
+                boolean isFlower = stack.getItem() instanceof BlockItem item && ((FlowerPotBlock) Blocks.FLOWER_POT).getFullPot(item.getBlock()) != Blocks.AIR;
                 boolean hasFlower = be.plant != Blocks.AIR;
 
                 if (isFlower != hasFlower) {
@@ -267,7 +267,7 @@ public class FullPotsAccessorDemo {
             }
 
             private static void collectPlantParts(Block plant, BlockAndTintGetter level, BlockPos pos, RandomSource random, List<BlockStateModelPart> parts) {
-                BlockState potState = ((FlowerPotBlock) Blocks.FLOWER_POT).getFullPotsView().getOrDefault(BuiltInRegistries.BLOCK.getKey(plant), () -> Blocks.AIR).get().defaultBlockState();
+                BlockState potState = ((FlowerPotBlock) Blocks.FLOWER_POT).getFullPot(plant).defaultBlockState();
                 BlockStateModel potModel = Minecraft.getInstance().getModelManager().getBlockStateModelSet().get(potState);
 
                 List<BlockStateModelPart> srcParts = new ObjectArrayList<>();


### PR DESCRIPTION
This PR closes #3254 by implementing the automatic registration of flower-containing pots (full pots) to the maps of their respective empty pots.

`FlowerPotBlock` no longer stores a map of plants to full pots. Instead, there is a new `Table` which maps the empty pot block and the (identifier of the) plant/flower to the full pot. This is then convereted into the full pot maps view.

For the automatic registration, the registry callback for the `Block` registry now populates the map on bake time, by looking for every non-empty `FlowerPotBlock` and adding it to the table.

This removes the need for mods to call `FlowerPotBlock#addPlant` (either in `RegisterEvent` or `FMLCommonSetupEvent`). To preserve binary compatibility, it remains as a no-op. As a side-effect, it is no longer possible to register a mapping that involves turning an empty pot into an arbitrary block; based on a quick skim of WAIFU, I can find nothing that uses that quirky behavior.

Additionally, a new constructor is made specifically for constructing empty pots, with the view of making the other constructor be only for full pots and accepting non-null suppliers. A dev-only loading warning is issued when the full pots constructor is used for making an empty pot.

---

**Some implementation notes:** 
- We use the bake callback, not the add callback, because the add callback is not fired for the vanilla entries.
- To facilitate binary compatibility with the existing `Map<Identifier, Supplier<? extends Block>> getFullPotsView()` method in `FlowerPotBlock`, we lazily initialize a `Table` with those types derived from the main `Table`.